### PR TITLE
Add minor fixes related to fmpz/fmpq

### DIFF
--- a/doc/nemo.tex
+++ b/doc/nemo.tex
@@ -5048,7 +5048,7 @@ end
 
 \subsubsection{Ad hoc comparison operators}
 
-We overload the comparison operators to more easily deal with values of type \code{Int}.
+We overload the comparison operators to more easily deal with values of type \code{Int} and \code{UInt}.
 
 \begin{lstlisting}
 ==(a::fmpz, b::Int)
@@ -5063,6 +5063,19 @@ We overload the comparison operators to more easily deal with values of type \co
 >=(a::Int, b::fmpz)
 \end{lstlisting}
 
+\begin{lstlisting}
+==(a::fmpz, b::UInt)
+==(a::UInt, b::fmpz)
+>(a::fmpz, b::UInt)
+>(a::UInt, b::fmpz)
+<(a::fmpz, b::UInt)
+<(a::UInt, b::fmpz)
+<=(a::fmpz, b::UInt)
+<=(a::UInt, b::fmpz)
+>=(a::fmpz, b::UInt)
+>=(a::UInt, b::fmpz)
+\end{lstlisting}
+
 \textbf{Examples.}
 
 Here are some examples of the ad hoc comparison operators.
@@ -5070,7 +5083,7 @@ Here are some examples of the ad hoc comparison operators.
 \begin{lstlisting}
 a = fmpz(-12)
 
-if a < 7
+if a < UInt(7)
    println("a < 7")
 end
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -122,7 +122,7 @@ end
 function show(io::IO, a::fmpq)
    print(io, num(a))
    if den(a) != 1
-      print("//", den(a))
+      print(io, "//", den(a))
    end
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -282,10 +282,10 @@ end
 ###############################################################################
 
 function rem(x::fmpz, c::Int)
-   c < 0 && throw(DomainError())
-   c == 0 && throw(DivideError())
-   r = ccall((:fmpz_tdiv_ui, :libflint), Int, (Ptr{fmpz}, Int), &x, c)
-   return sign(x) < 0 ? -r : r
+    c < 0 && throw(DomainError())
+    c == 0 && throw(DivideError())
+    r = ccall((:fmpz_tdiv_ui, :libflint), Int, (Ptr{fmpz}, Int), &x, c)
+    return sign(x) < 0 ? -r : r
 end
 
 function tdivpow2(x::fmpz, c::Int)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1030,11 +1030,13 @@ function convert(::Type{BigInt}, a::fmpz)
 end
 
 function convert(::Type{Int}, a::fmpz) 
+   (a > typemax(Int) || a < typemin(Int)) && throw(InexactError())
    return ccall((:fmpz_get_si, :libflint), Int, (Ptr{fmpz},), &a)
 end
 
-function convert(::Type{UInt}, x::fmpz)
-   return ccall((:fmpz_get_ui, :libflint), UInt, (Ptr{fmpz}, ), &x)
+function convert(::Type{UInt}, a::fmpz)
+   (a > typemax(UInt) || a < 0) && throw(InexactError())
+   return ccall((:fmpz_get_ui, :libflint), UInt, (Ptr{fmpz}, ), &a)
 end
 
 function convert(::Type{Float64}, n::fmpz)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -600,6 +600,30 @@ end
 
 >(x::Int, y::fmpz) = cmp(y,x) < 0
 
+function cmp(x::fmpz, y::UInt)
+    Int(ccall((:fmpz_cmp_ui, :libflint), Cint, (Ptr{fmpz}, UInt), &x, y))
+end
+
+==(x::fmpz, y::UInt) = cmp(x,y) == 0
+
+<=(x::fmpz, y::UInt) = cmp(x,y) <= 0
+
+>=(x::fmpz, y::UInt) = cmp(x,y) >= 0
+
+<(x::fmpz, y::UInt) = cmp(x,y) < 0
+
+>(x::fmpz, y::UInt) = cmp(x,y) > 0
+
+==(x::UInt, y::fmpz) = cmp(y,x) == 0
+
+<=(x::UInt, y::fmpz) = cmp(y,x) >= 0
+
+>=(x::UInt, y::fmpz) = cmp(y,x) <= 0
+
+<(x::UInt, y::fmpz) = cmp(y,x) > 0
+
+>(x::UInt, y::fmpz) = cmp(y,x) < 0
+
 ###############################################################################
 #
 #   Bit fiddling

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -304,6 +304,32 @@ function test_fmpz_adhoc_comparison()
 
    @test 4 != a
 
+   a = fmpz(2)
+   
+   @test a < UInt(7)
+
+   @test a > UInt(1) 
+
+   @test UInt(7) > a
+
+   @test UInt(1) < a
+
+   @test a <= UInt(7)
+
+   @test a >= UInt(2)
+
+   @test UInt(7) >= a
+
+   @test UInt(1) <= a
+
+   @test a == UInt(2)
+
+   @test a != UInt(4)
+
+   @test UInt(2) == a
+
+   @test UInt(4) != a
+
    println("PASS")
 end
 


### PR DESCRIPTION
1. Add ad hoc comparision for `fmpz` and `UInt`. Without this every comparison between `fmpz` and `UInt` has to allocate a temporay `fmpz` (stolen from Claus).
2. Fix the printing of arrays of `fmpq`.
3. Add some checks for the conversion of `fmpz` to `Int` and `UInt` respectively. Thanks to ad hoc comparison the checks are not expensive.

Edit: We don't have travis here. Let us add travis support before merging this.
Edit2: Travis is working.