### PR TITLE
promote_type -> promote_rule. 

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -15,18 +15,25 @@ end
 ###############################################################################
 
 function +{S <: RingElem, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       +(x, parent(x)(y))
    elseif T == T1
       +(parent(y)(x), y)
    else
-      error("Unable to promote ", S, " and ", T, " to common type")
+      T1 = Base.promote_rule(T, S)
+      if S == T1
+         +(x, parent(x)(y))
+      elseif T == T1
+         +(parent(y)(x), y)
+      else
+         error("Unable to promote ", S, " and ", T, " to common type")
+      end
    end
 end
 
 function +{S <: RingElem, T <: Integer}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       +(x, parent(x)(y))
    else
@@ -35,7 +42,7 @@ function +{S <: RingElem, T <: Integer}(x::S, y::T)
 end
 
 function +{S <: Integer, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(T, S)
    if T == T1
       +(parent(y)(x), y)
    else
@@ -44,18 +51,25 @@ function +{S <: Integer, T <: RingElem}(x::S, y::T)
 end
 
 function -{S <: RingElem, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       -(x, parent(x)(y))
    elseif T == T1
       -(parent(y)(x), y)
    else
-      error("Unable to promote ", S, " and ", T, " to common type")
+      T1 = Base.promote_rule(T, S)
+      if S == T1
+         -(x, parent(x)(y))
+      elseif T == T1
+         -(parent(y)(x), y)
+      else
+         error("Unable to promote ", S, " and ", T, " to common type")
+      end
    end
 end
 
 function -{S <: RingElem, T <: Integer}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       -(x, parent(x)(y))
    else
@@ -64,7 +78,7 @@ function -{S <: RingElem, T <: Integer}(x::S, y::T)
 end
 
 function -{S <: Integer, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(T, S)
    if T == T1
       -(parent(y)(x), y)
    else
@@ -73,18 +87,25 @@ function -{S <: Integer, T <: RingElem}(x::S, y::T)
 end
 
 function *{S <: RingElem, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       *(x, parent(x)(y))
    elseif T == T1
       *(parent(y)(x), y)
    else
-      error("Unable to promote ", S, " and ", T, " to common type")
+      T1 = Base.promote_rule(T, S)
+      if S == T1
+         *(x, parent(x)(y))
+      elseif T == T1
+         *(parent(y)(x), y)
+      else
+         error("Unable to promote ", S, " and ", T, " to common type")
+      end
    end
 end
 
 function *{S <: RingElem, T <: Integer}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       *(x, parent(x)(y))
    else
@@ -93,7 +114,7 @@ function *{S <: RingElem, T <: Integer}(x::S, y::T)
 end
 
 function *{S <: Integer, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(T, S)
    if T == T1
       *(parent(y)(x), y)
    else
@@ -102,18 +123,25 @@ function *{S <: Integer, T <: RingElem}(x::S, y::T)
 end
 
 function divexact{S <: RingElem, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       divexact(x, parent(x)(y))
    elseif T == T1
       divexact(parent(y)(x), y)
    else
-      error("Unable to promote ", S, " and ", T, " to common type")
+      T1 = Base.promote_rule(T, S)
+      if S == T1
+         divexact(x, parent(x)(y))
+      elseif T == T1
+         divexact(parent(y)(x), y)
+      else
+         error("Unable to promote ", S, " and ", T, " to common type")
+      end
    end
 end
 
 function divexact{S <: RingElem, T <: Integer}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       divexact(x, parent(x)(y))
    else
@@ -122,7 +150,7 @@ function divexact{S <: RingElem, T <: Integer}(x::S, y::T)
 end
 
 function divexact{S <: Integer, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(T, S)
    if T == T1
       divexact(parent(y)(x), y)
    else
@@ -131,18 +159,25 @@ function divexact{S <: Integer, T <: RingElem}(x::S, y::T)
 end
 
 function =={S <: RingElem, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       ==(x, parent(x)(y))
    elseif T == T1
       ==(parent(y)(x), y)
    else
-      error("Unable to promote ", S, " and ", T, " to common type")
+      T1 = Base.promote_rule(T, S)
+      if S == T1
+         ==(x, parent(x)(y))
+      elseif T == T1
+         ==(parent(y)(x), y)
+      else
+         error("Unable to promote ", S, " and ", T, " to common type")
+      end
    end
 end
 
 function =={S <: RingElem, T <: Integer}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(S, T)
    if S == T1
       ==(x, parent(x)(y))
    else
@@ -151,7 +186,7 @@ function =={S <: RingElem, T <: Integer}(x::S, y::T)
 end
 
 function =={S <: Integer, T <: RingElem}(x::S, y::T) 
-   T1 = promote_type(S, T)
+   T1 = Base.promote_rule(T, S)
    if T == T1
       ==(parent(y)(x), y)
    else


### PR DESCRIPTION
The former doesn't really do what we thought it did and this is why we were getting segfaults in some cases and possibly even explains some type inference issues.

In short, promote_type promotes types to a type large enough to contain both types, which may not even be a concrete type, e.g. it might be promote_type(fmpz_poly, Poly{fmpz_poly}) = PolyElem{T}, which is totally useless for us.

promote_rule on the other hand only returns a value if there is an explicit promote_rule designed to specify what type should be used. And this is how Nemo is designed.