### PR TITLE
use UInt rather than Int for mantissa_struct fields

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -39,8 +39,8 @@ prec(x::ArbField) = x.prec
 type arf_struct
   exp::Int # fmpz
   size::UInt # mp_size_t
-  d1::Int # mantissa_struct
-  d2::Int
+  d1::UInt # mantissa_struct
+  d2::UInt
 end
 
 type mag_struct
@@ -51,8 +51,8 @@ end
 type arb_struct
   mid_exp::Int # fmpz
   mid_size::UInt # mp_size_t
-  mid_d1::Int # mantissa_struct
-  mid_d2::Int
+  mid_d1::UInt # mantissa_struct
+  mid_d2::UInt
   rad_exp::Int # fmpz
   rad_man::UInt
 end


### PR DESCRIPTION
[see this discussion for the rationale](https://groups.google.com/forum/#!topic/nemo-devel/IZgiipBxyPU)

The only changes were within arb_struct and arf_struct.  A quick look at the other source files in the arb subdirectory did not alert me to other places that should change to be consonant with the types' internal changes from UInt to Int.  
Someone more familiar with Nemo/Arb should recheck that.