### PR TITLE
Documentation for arb balls.

### DIFF
--- a/doc/build/arb.md
+++ b/doc/build/arb.md
@@ -1,0 +1,1896 @@
+
+
+
+<a id='Introduction-1'></a>
+
+## Introduction
+
+
+Arbitrary precision real ball arithmetic is supplied by Arb which provides a ball representation which tracks error bounds rigorously. Real numbers are  represented in mid-rad interval form $[m \pm r] = [m-r, m+r]$.
+
+
+The Arb real field is constructed using the `ArbField` constructor. This constructs the parent object for the Arb real field.
+
+
+The types of real balls in Nemo are given in the following table, along with the libraries that provide them and the associated types of the parent objects.
+
+
+Library |                Field | Element type | Parent type
+------: | -------------------: | -----------: | ----------:
+    Arb | $\mathbb{R}$ (balls) |        `arb` |  `ArbField`
+
+
+All the real field types belong to the `Field` abstract type and the types of elements in this field, i.e. balls in this case, belong to the `FieldElem` abstract type.
+
+
+<a id='Real-field-constructors-1'></a>
+
+## Real field constructors
+
+
+In order to construct real balls in Nemo, one must first construct the Arb real field itself. This is accomplished with the following constructor.
+
+
+```
+ArbField(prec::Int)
+```
+
+
+Return the Arb field with precision in bits `prec` used for operations on interval midpoints. The precision used for interval radii is a fixed implementation-defined constant (30 bits).
+
+
+Here is an example of creating an Arb real field and using the resulting parent object to coerce values into the resulting field.
+
+
+```
+RR = ArbField(64)
+
+a = RR("0.25")
+b = RR("0.1")
+c = RR(0.5)
+d = RR(12)
+```
+
+
+Note that whilst one can coerce double precision floating point values into an Arb real field, unless those values can be represented exactly in double precision, the resulting ball can't be any more precise than the double precision supplied.
+
+
+If instead, values can be represented precisely using decimal arithmetic then one can supply them to Arb using a string. In this case, Arb will store them to the precision specified when creating the Arb field.
+
+
+If the values can be stored precisely as a binary floating point number, Arb will store the values exactly. See the function `isexact` below for more information.
+
+
+<a id='Real-ball-constructors-1'></a>
+
+## Real ball constructors
+
+
+Once an Arb real field is constructed, there are various ways to construct balls in that field.
+
+
+Apart from coercing elements into the Arb real field as above, we offer the following functions.
+
+<a id='Base.zero-Tuple{Nemo.ArbField}' href='#Base.zero-Tuple{Nemo.ArbField}'>#</a>
+**`Base.zero`** &mdash; *Method*.
+
+
+
+```
+zero(R::ArbField)
+```
+
+> Return exact zero in the given Arb field.
+
+
+<a id='Base.one-Tuple{Nemo.ArbField}' href='#Base.one-Tuple{Nemo.ArbField}'>#</a>
+**`Base.one`** &mdash; *Method*.
+
+
+
+```
+one(R::ArbField)
+```
+
+> Return exact one in the given Arb field.
+
+
+<a id='Nemo.ball-Tuple{Nemo.arb,Nemo.arb}' href='#Nemo.ball-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Nemo.ball`** &mdash; *Method*.
+
+
+
+```
+ball(mid::arb, rad::arb)
+```
+
+> Constructs an `arb` enclosing the range $[m-|r|, m+|r|]$, given the pair $(m, r)$.
+
+
+
+Here are some examples of constructing balls.
+
+
+```
+RR = ArbField(64)
+
+a = zero(RR)
+b = one(RR)
+c = ball(RR(3), RR("0.0001"))
+```
+
+
+<a id='Basic-functionality-1'></a>
+
+## Basic functionality
+
+
+The following basic functionality is provided by the default Arb real field implementation in Nemo, to support construction of generic rings over real fields. Any custom real field implementation in Nemo should provide analogues of these functions along with the usual arithmetic operations.
+
+
+```
+parent_type(::Type{arb})
+```
+
+
+Gives the type of the parent object of an Arb real field element.
+
+
+```
+elem_type(R::ArbField)
+```
+
+
+Given the parent object for a Arb field, return the type of elements of the field.
+
+
+```
+mul!(c::arb, a::arb, b::arb)
+```
+
+
+Multiply $a$ by $b$ and set the existing Arb field element $c$ to the result. This function is provided for performance reasons as it saves allocating a new object for the result and eliminates associated garbage collection.
+
+
+```
+addeq!(c::arb, a::arb)
+```
+
+
+In-place addition. Adds $a$ to $c$ and sets $c$ to the result. This function is provided for performance reasons as it saves allocating a new object for the result and eliminates associated garbage collection.
+
+
+Given the parent object `R` for an Arb real field, the following coercion functions are provided to coerce various elements into the Arb field. Developers provide these by overloading the `call` operator for the real field parent objects.
+
+
+```
+R()
+```
+
+
+Coerce zero into the Arb field.
+
+
+```
+R(n::Integer)
+R(f::fmpz)
+R(q::fmpq)
+```
+
+
+Coerce an integer or rational value into the Arb field.
+
+
+```
+R(f::Float64)
+R(f::BigFloat)
+```
+
+
+Coerce the given floating point number into the Arb field.
+
+
+```
+R(f::AbstractString)
+```
+
+
+Coerce the decimal number, given as a string, into the Arb field.
+
+
+```
+R(f::arb)
+```
+
+
+Take an Arb field element that is already in the Arb field and simply return it. A copy of the original is not made.
+
+
+Here are some examples of coercing elements into the Arb field.
+
+
+```
+RR = ArbField(64)
+
+a = RR(3)
+b = RR(QQ(2,3))
+c = ball(RR(3), RR("0.0001"))
+d = RR("3 +/- 0.0001")
+f = RR("-1.24e+12345")
+g = RR("nan +/- inf")
+```
+
+
+In addition to the above, developers of custom real field types must ensure that they provide the equivalent of the function `base_ring(R::ArbField)` which should return `Union{}`. In addition to this they should ensure that each real field element contains a field `parent` specifying the parent object of the real field element, or at least supply the equivalent of the function `parent(a::arb)` to return the parent object of a real field element.
+
+
+<a id='Conversions-1'></a>
+
+## Conversions
+
+<a id='Base.convert-Tuple{Type{Float64},Nemo.arb}' href='#Base.convert-Tuple{Type{Float64},Nemo.arb}'>#</a>
+**`Base.convert`** &mdash; *Method*.
+
+
+
+```
+convert(::Type{Float64}, x::arb)
+```
+
+> Return the midpoint of $x$ rounded down to a machine double.
+
+
+
+<a id='Basic-manipulation-1'></a>
+
+## Basic manipulation
+
+
+Numerous functions are provided to manipulate Arb field elements. Also see the section on basic functionality above.
+
+<a id='Nemo.base_ring-Tuple{Nemo.ArbField}' href='#Nemo.base_ring-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.base_ring`** &mdash; *Method*.
+
+
+
+```
+base_ring(R::ArbField)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+<a id='Nemo.base_ring-Tuple{Nemo.arb}' href='#Nemo.base_ring-Tuple{Nemo.arb}'>#</a>
+**`Nemo.base_ring`** &mdash; *Method*.
+
+
+
+```
+base_ring(x::arb)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+<a id='Base.parent-Tuple{Nemo.arb}' href='#Base.parent-Tuple{Nemo.arb}'>#</a>
+**`Base.parent`** &mdash; *Method*.
+
+
+
+```
+parent(A)
+```
+
+Returns the "parent array" of an array view type (e.g., `SubArray`), or the array itself if it is not a view
+
+```
+parent(a::padic)
+```
+
+> Returns the parent of the given p-adic field element.
+
+
+```
+parent(a::nf_elem)
+```
+
+> Return the parent of the given number field element.
+
+
+```
+parent(a::fq)
+```
+
+> Returns the parent of the given finite field element.
+
+
+```
+parent(a::FracElem)
+```
+
+> Return the parent object of the given fraction element.
+
+
+```
+parent(a::MatElem)
+```
+
+> Return the parent object of the given matrix.
+
+
+```
+parent(a::SeriesElem)
+```
+
+> Return the parent of the given power series.
+
+
+```
+parent(a::PolyElem)
+```
+
+> Return the parent of the given polynomial.
+
+
+```
+parent(a::ResElem)
+```
+
+> Return the parent object of the given residue element.
+
+
+```
+parent(a::fmpz)
+```
+
+> Returns the unique Flint integer parent object `FlintZZ`.
+
+
+```
+parent(a::perm)
+```
+
+> Return the parent of the given permutation group element.
+
+
+<a id='Nemo.iszero-Tuple{Nemo.arb}' href='#Nemo.iszero-Tuple{Nemo.arb}'>#</a>
+**`Nemo.iszero`** &mdash; *Method*.
+
+
+
+```
+iszero(x::arb)
+```
+
+> Return `true` if $x$ is certainly zero, otherwise return `false`.
+
+
+<a id='Nemo.isnonzero-Tuple{Nemo.arb}' href='#Nemo.isnonzero-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isnonzero`** &mdash; *Method*.
+
+
+
+```
+isnonzero(x::arb)
+```
+
+> Return `true` if $x$ is certainly not equal to zero, otherwise return `false`.
+
+
+<a id='Nemo.isone-Tuple{Nemo.arb}' href='#Nemo.isone-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isone`** &mdash; *Method*.
+
+
+
+```
+isone(x::arb)
+```
+
+> Return `true` if $x$ is certainly not equal to oneo, otherwise return `false`.
+
+
+<a id='Base.isfinite-Tuple{Nemo.arb}' href='#Base.isfinite-Tuple{Nemo.arb}'>#</a>
+**`Base.isfinite`** &mdash; *Method*.
+
+
+
+```
+isfinite(x::arb)
+```
+
+> Return `true` if $x$ is finite, i.e. having finite midpoint and radius, otherwise return `false`.
+
+
+<a id='Nemo.isexact-Tuple{Nemo.arb}' href='#Nemo.isexact-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isexact`** &mdash; *Method*.
+
+
+
+```
+isexact(x::arb)
+```
+
+> Return `true` if $x$ is exact, i.e. has zero radius, otherwise return `false`.
+
+
+<a id='Nemo.isint-Tuple{Nemo.arb}' href='#Nemo.isint-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isint`** &mdash; *Method*.
+
+
+
+```
+isint(x::arb)
+```
+
+> Return `true` if $x$ is an exact integer, otherwise return `false`.
+
+
+<a id='Nemo.ispositive-Tuple{Nemo.arb}' href='#Nemo.ispositive-Tuple{Nemo.arb}'>#</a>
+**`Nemo.ispositive`** &mdash; *Method*.
+
+
+
+```
+ispositive(x::arb)
+```
+
+> Return `true` if $x$ is certainly positive, otherwise return `false`.
+
+
+<a id='Nemo.isnonnegative-Tuple{Nemo.arb}' href='#Nemo.isnonnegative-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isnonnegative`** &mdash; *Method*.
+
+
+
+```
+isnonnegative(x::arb)
+```
+
+> Return `true` if $x$ is certainly nonnegative, otherwise return `false`.
+
+
+<a id='Nemo.isnegative-Tuple{Nemo.arb}' href='#Nemo.isnegative-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isnegative`** &mdash; *Method*.
+
+
+
+```
+isnegative(x::arb)
+```
+
+> Return `true` if $x$ is certainly negative, otherwise return `false`.
+
+
+<a id='Nemo.isnonpositive-Tuple{Nemo.arb}' href='#Nemo.isnonpositive-Tuple{Nemo.arb}'>#</a>
+**`Nemo.isnonpositive`** &mdash; *Method*.
+
+
+
+```
+isnonpositive(x::arb)
+```
+
+> Return `true` if $x$ is certainly nonpositive, otherwise return `false`.
+
+
+<a id='Nemo.midpoint-Tuple{Nemo.arb}' href='#Nemo.midpoint-Tuple{Nemo.arb}'>#</a>
+**`Nemo.midpoint`** &mdash; *Method*.
+
+
+
+```
+midpoint(x::arb)
+```
+
+> Return the midpoint of the ball $x$ as an Arb ball.
+
+
+<a id='Nemo.radius-Tuple{Nemo.arb}' href='#Nemo.radius-Tuple{Nemo.arb}'>#</a>
+**`Nemo.radius`** &mdash; *Method*.
+
+
+
+```
+radius(x::arb)
+```
+
+> Return the radius of the ball $x$ as an Arb ball.
+
+
+<a id='Nemo.accuracy_bits-Tuple{Nemo.arb}' href='#Nemo.accuracy_bits-Tuple{Nemo.arb}'>#</a>
+**`Nemo.accuracy_bits`** &mdash; *Method*.
+
+
+
+```
+accuracy_bits(x::arb)
+```
+
+> Return the relative accuracy of $x$ measured in bits, capped between `typemax(Int)` and `-typemax(Int)`.
+
+
+
+Here are some examples of basic manipulation of Arb balls.
+
+
+```
+RR = ArbField(64)
+
+a = RR("1.2 +/- 0.001")
+b = RR(3)
+
+iszero(a)
+isone(b)
+ispositive(a)
+isfinite(b)
+isint(b)
+isnegative(a)
+c = radius(a)
+d = midpoint(b)
+f = accuracy_bits(a)
+S = parent(a)
+T = base_ring(RR)
+```
+
+
+<a id='Arithmetic-operations-1'></a>
+
+## Arithmetic operations
+
+
+Nemo provides all the standard field operations for Arb field elements, as follows. Note that division is represented by `//` since a field is its own fraction field and since exact division is not generally possible in an inexact field.
+
+
+          Function |      Operation
+-----------------: | -------------:
+         -(a::arb) |    unary minus
+ +(a::arb, b::arb) |       addition
+ -(a::arb, b::arb) |    subtraction
+ *(a::arb, b::arb) | multiplication
+//(a::arb, b::arb) |       division
+ ^(a::arb, b::arb) |       powering
+
+
+In addition, the following ad hoc field operations are defined.
+
+
+              Function |      Operation
+---------------------: | -------------:
+ +(a::arb, b::Integer) |       addition
+ +(a::Integer, b::arb) |       addition
+    +(a::arb, b::fmpz) |       addition
+    +(a::fmpz, b::arb) |       addition
+ -(a::arb, b::Integer) |    subtraction
+ -(a::Integer, b::arb) |    subtraction
+    -(a::arb, b::fmpz) |    subtraction
+    -(a::fmpz, b::arb) |    subtraction
+ *(a::arb, b::Integer) | multiplication
+ *(a::Integer, b::arb) | multiplication
+    *(a::arb, b::fmpz) | multiplication
+    *(a::fmpz, b::arb) | multiplication
+//(a::arb, b::Integer) |       division
+   //(a::arb, b::fmpz) |       division
+//(a::Integer, b::arb) |       division
+   //(a::fmpz, b::arb) |       division
+ ^(a::arb, b::Integer) |       powering
+    ^(a::arb, b::fmpz) |       powering
+    ^(a::arb, b::fmpq) |       powering
+
+
+Here are some examples of arithmetic operations on Arb balls.
+
+
+```
+RR = ArbField(64)
+
+x = RR(3)
+y = RR(QQ(2,3))
+
+a = x + y
+b = x*y
+d = 1//y - x
+d = 3x + ZZ(100)//y
+f = (x^2 + y^2) ^ QQ(1,2)
+```
+
+
+<a id='Containment-1'></a>
+
+## Containment
+
+
+It is often necessary to determine whether a given exact value or ball is contained in a given real ball or whether two balls overlap. The following functions are provided for this purpose.
+
+<a id='Nemo.overlaps-Tuple{Nemo.arb,Nemo.arb}' href='#Nemo.overlaps-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Nemo.overlaps`** &mdash; *Method*.
+
+
+
+```
+overlaps(x::arb, y::arb)
+```
+
+> Returns `true` if any part of the ball $x$ overlaps any part of the ball $y$, otherwise return `false`.
+
+
+<a id='Base.contains-Tuple{Nemo.arb,Nemo.arb}' href='#Base.contains-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Base.contains`** &mdash; *Method*.
+
+
+
+```
+contains(x::arb, y::arb)
+```
+
+> Returns `true` if the ball $x$ contains the ball $y$, otherwise return `false`.
+
+
+<a id='Base.contains-Tuple{Nemo.arb,Integer}' href='#Base.contains-Tuple{Nemo.arb,Integer}'>#</a>
+**`Base.contains`** &mdash; *Method*.
+
+
+
+```
+contains(x::arb, y::Integer)
+```
+
+> Returns `true` if the ball $x$ contains the given integer value, otherwise return `false`.
+
+
+<a id='Base.contains-Tuple{Nemo.arb,Nemo.fmpz}' href='#Base.contains-Tuple{Nemo.arb,Nemo.fmpz}'>#</a>
+**`Base.contains`** &mdash; *Method*.
+
+
+
+```
+contains(x::arb, y::fmpz)
+```
+
+> Returns `true` if the ball $x$ contains the given integer value, otherwise return `false`.
+
+
+<a id='Base.contains-Tuple{Nemo.arb,Nemo.fmpq}' href='#Base.contains-Tuple{Nemo.arb,Nemo.fmpq}'>#</a>
+**`Base.contains`** &mdash; *Method*.
+
+
+
+```
+contains(x::arb, y::fmpq)
+```
+
+> Returns `true` if the ball $x$ contains the given rational value, otherwise return `false`.
+
+
+<a id='Base.contains-Tuple{Nemo.arb,BigFloat}' href='#Base.contains-Tuple{Nemo.arb,BigFloat}'>#</a>
+**`Base.contains`** &mdash; *Method*.
+
+
+
+```
+contains(x::arb, y::BigFloat)
+```
+
+> Returns `true` if the ball $x$ contains the given floating point value,  otherwise return `false`.
+
+
+
+The following functions are also provided for determining if a ball intersects a certain part of the real number line.
+
+<a id='Nemo.contains_zero-Tuple{Nemo.arb}' href='#Nemo.contains_zero-Tuple{Nemo.arb}'>#</a>
+**`Nemo.contains_zero`** &mdash; *Method*.
+
+
+
+```
+contains_zero(x::arb)
+```
+
+> Returns `true` if the ball $x$ contains zero, otherwise return `false`.
+
+
+<a id='Nemo.contains_negative-Tuple{Nemo.arb}' href='#Nemo.contains_negative-Tuple{Nemo.arb}'>#</a>
+**`Nemo.contains_negative`** &mdash; *Method*.
+
+
+
+```
+contains_negative(x::arb)
+```
+
+> Returns `true` if the ball $x$ contains any negative value, otherwise return `false`.
+
+
+<a id='Nemo.contains_positive-Tuple{Nemo.arb}' href='#Nemo.contains_positive-Tuple{Nemo.arb}'>#</a>
+**`Nemo.contains_positive`** &mdash; *Method*.
+
+
+
+```
+contains_positive(x::arb)
+```
+
+> Returns `true` if the ball $x$ contains any positive value, otherwise return `false`.
+
+
+<a id='Nemo.contains_nonnegative-Tuple{Nemo.arb}' href='#Nemo.contains_nonnegative-Tuple{Nemo.arb}'>#</a>
+**`Nemo.contains_nonnegative`** &mdash; *Method*.
+
+
+
+```
+contains_nonnegative(x::arb)
+```
+
+> Returns `true` if the ball $x$ contains any nonnegative value, otherwise return `false`.
+
+
+<a id='Nemo.contains_nonpositive-Tuple{Nemo.arb}' href='#Nemo.contains_nonpositive-Tuple{Nemo.arb}'>#</a>
+**`Nemo.contains_nonpositive`** &mdash; *Method*.
+
+
+
+```
+contains_nonpositive(x::arb)
+```
+
+> Returns `true` if the ball $x$ contains any nonpositive value, otherwise return `false`.
+
+
+
+Here are some examples of testing containment.
+
+
+```
+RR = ArbField(64)
+x = RR("1 +/- 0.001")
+y = RR("3")
+
+overlaps(x, y)
+contains(x, y)
+contains(y, 3)
+contains(x, ZZ(1)//2)
+contains_zero(x)
+contains_positive(y)
+```
+
+
+<a id='Comparison-1'></a>
+
+## Comparison
+
+
+Nemo provides a full range of comparison operations for Arb balls. Note that a ball is considered less than another ball if every value in the first ball is less than every value in the second ball, etc.
+
+
+Firstly, we introduce an exact equality which is distinct from arithmetic equality. This is distinct from arithmetic equality implemented by `==`, which merely compares up to the minimum of the precisions of its operands.
+
+<a id='Base.isequal-Tuple{Nemo.arb,Nemo.arb}' href='#Base.isequal-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Base.isequal`** &mdash; *Method*.
+
+
+
+```
+isequal(x::arb, y::arb)
+```
+
+> Return `true` if the balls $x$ and $y$ are precisely equal, i.e. have the same midpoints and radii.
+
+
+
+A full range of functions is available for comparing balls, i.e. `==`, `!=`, `<`, `<=`, `>=`, `>`. In fact, all these are implemented directly in C. In the table below we document these as though only `==` and `isless` had been provided to Julia.
+
+
+<a id='Function-1'></a>
+
+## Function
+
+
+`isless(x::arb, y::arb)`  `==(x::arb, y::arb)`
+
+
+As well as these, we provide a full range of ad hoc comparison operators. Again, these are implemented directly in Julia, but we document them as though `isless` and `==` were provided.
+
+
+<a id='Function-2'></a>
+
+## Function
+
+
+`isless(x::arb, y::Integer)` `isless(x::Integer, y::arb)` `isless(x::arb, y::fmpz)` `isless(x::fmpz, y::arb)` `isless(x::arb, y::Float64)` `isless(x::Float64, y::arb)`
+
+
+Here are some examples of comparison.
+
+
+```
+RR = ArbField(64)
+x = RR("1 +/- 0.001")
+y = RR("3")
+z = RR("4")
+
+isequal(y, z)
+x <= z
+x == 3
+ZZ(3) < z
+x != 1.23
+```
+
+
+<a id='Absolute-value-1'></a>
+
+## Absolute value
+
+<a id='Base.abs-Tuple{Nemo.arb}' href='#Base.abs-Tuple{Nemo.arb}'>#</a>
+**`Base.abs`** &mdash; *Method*.
+
+
+
+```
+abs(x::arb)
+```
+
+> Return the absolute value of $x$.
+
+
+
+Here are some examples of taking the absolute value.
+
+
+```
+RR = ArbField(64)
+x = RR("-1 +/- 0.001")
+
+a = abs(x)
+```
+
+
+<a id='Inverse-1'></a>
+
+## Inverse
+
+<a id='Base.inv-Tuple{Nemo.arb}' href='#Base.inv-Tuple{Nemo.arb}'>#</a>
+**`Base.inv`** &mdash; *Method*.
+
+
+
+```
+inv(x::arb)
+```
+
+> Return the multiplicative inverse of $x$, i.e. $1/x$.
+
+
+
+Here are some examples of taking the inverse.
+
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+
+a = inv(x)
+```
+
+
+<a id='Shifting-1'></a>
+
+## Shifting
+
+<a id='Base.Math.ldexp-Tuple{Nemo.arb,Int64}' href='#Base.Math.ldexp-Tuple{Nemo.arb,Int64}'>#</a>
+**`Base.Math.ldexp`** &mdash; *Method*.
+
+
+
+```
+ldexp(x::arb, y::Int)
+```
+
+> Return $2^yx$. Note that $y$ can be positive, zero or negative.
+
+
+<a id='Base.Math.ldexp-Tuple{Nemo.arb,Nemo.fmpz}' href='#Base.Math.ldexp-Tuple{Nemo.arb,Nemo.fmpz}'>#</a>
+**`Base.Math.ldexp`** &mdash; *Method*.
+
+
+
+```
+ldexp(x::arb, y::fmpz)
+```
+
+> Return $2^yx$. Note that $y$ can be positive, zero or negative.
+
+
+
+Here are some examples of shifting.
+
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+
+a = ldexp(x, 23)
+b = ldexp(x, -ZZ(15))
+```
+
+
+<a id='Miscellaneous-operations-1'></a>
+
+## Miscellaneous operations
+
+<a id='Nemo.trim-Tuple{Nemo.arb}' href='#Nemo.trim-Tuple{Nemo.arb}'>#</a>
+**`Nemo.trim`** &mdash; *Method*.
+
+
+
+```
+trim(x::arb)
+```
+
+> Return an `arb` interval containing $x$ but which may be more economical, by rounding off insignificant bits from the midpoint.
+
+
+<a id='Nemo.unique_integer-Tuple{Nemo.arb}' href='#Nemo.unique_integer-Tuple{Nemo.arb}'>#</a>
+**`Nemo.unique_integer`** &mdash; *Method*.
+
+
+
+```
+unique_integer(x::arb)
+```
+
+> Return a pair where the first value is a boolean and the second is an `fmpz` integer. The boolean indicates whether the interval $x$ contains a unique integer. If this is the case, the second return value is set to this unique integer.
+
+
+<a id='Nemo.setunion-Tuple{Nemo.arb,Nemo.arb}' href='#Nemo.setunion-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Nemo.setunion`** &mdash; *Method*.
+
+
+
+```
+setunion(x::arb, y::arb)
+```
+
+> Return an `arb` containing the union of the intervals represented by $x$ and $y$.
+
+
+
+Here are some examples of miscellaneous operations.
+
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+y = RR("2 +/- 0.5")
+
+a = trim(x)
+b, c = unique_integer(x)
+d = setunion(x, y)
+```
+
+
+<a id='Constants-1'></a>
+
+## Constants
+
+<a id='Nemo.const_pi-Tuple{Nemo.ArbField}' href='#Nemo.const_pi-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_pi`** &mdash; *Method*.
+
+
+
+```
+const_pi(r::ArbField)
+```
+
+> Return $\pi = 3.14159\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_e-Tuple{Nemo.ArbField}' href='#Nemo.const_e-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_e`** &mdash; *Method*.
+
+
+
+```
+const_e(r::ArbField)
+```
+
+> Return $e = 2.71828\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_log2-Tuple{Nemo.ArbField}' href='#Nemo.const_log2-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_log2`** &mdash; *Method*.
+
+
+
+```
+const_log2(r::ArbField)
+```
+
+> Return $\log(2) = 0.69314\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_log10-Tuple{Nemo.ArbField}' href='#Nemo.const_log10-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_log10`** &mdash; *Method*.
+
+
+
+```
+const_log10(r::ArbField)
+```
+
+> Return $\log(10) = 2.302585\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_euler-Tuple{Nemo.ArbField}' href='#Nemo.const_euler-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_euler`** &mdash; *Method*.
+
+
+
+```
+const_euler(r::ArbField)
+```
+
+> Return Euler's constant $\gamma = 0.577215\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_catalan-Tuple{Nemo.ArbField}' href='#Nemo.const_catalan-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_catalan`** &mdash; *Method*.
+
+
+
+```
+const_catalan(r::ArbField)
+```
+
+> Return Catalan's constant $C = 0.915965\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_khinchin-Tuple{Nemo.ArbField}' href='#Nemo.const_khinchin-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_khinchin`** &mdash; *Method*.
+
+
+
+```
+const_khinchin(r::ArbField)
+```
+
+> Return Khinchin's constant $K = 2.685452\ldots$ as an element of $r$.
+
+
+<a id='Nemo.const_glaisher-Tuple{Nemo.ArbField}' href='#Nemo.const_glaisher-Tuple{Nemo.ArbField}'>#</a>
+**`Nemo.const_glaisher`** &mdash; *Method*.
+
+
+
+```
+const_glaisher(r::ArbField)
+```
+
+> Return Glaisher's constant $A = 1.282427\ldots$ as an element of $r$.
+
+
+
+Here are some examples of computing real constants.
+
+
+```
+RR = ArbField(200)
+
+a = const_pi(RR)
+b = const_e(RR)
+c = const_euler(RR)
+d = const_glaisher(RR)
+```
+
+
+<a id='Mathematical-functions-1'></a>
+
+## Mathematical functions
+
+<a id='Base.floor-Tuple{Nemo.arb}' href='#Base.floor-Tuple{Nemo.arb}'>#</a>
+**`Base.floor`** &mdash; *Method*.
+
+
+
+```
+floor(x::arb)
+```
+
+> Compute the floor of $x$, i.e. the greatest integer not exceeding $x$, as an Arb.
+
+
+<a id='Base.ceil-Tuple{Nemo.arb}' href='#Base.ceil-Tuple{Nemo.arb}'>#</a>
+**`Base.ceil`** &mdash; *Method*.
+
+
+
+```
+ceil(x::arb)
+```
+
+> Return the ceiling of $x$, i.e. the least integer not less than $x$, as an Arb.
+
+
+<a id='Base.sqrt-Tuple{Nemo.arb}' href='#Base.sqrt-Tuple{Nemo.arb}'>#</a>
+**`Base.sqrt`** &mdash; *Method*.
+
+
+
+```
+sqrt(x::arb)
+```
+
+> Return the square root of $x$.
+
+
+<a id='Nemo.rsqrt-Tuple{Nemo.arb}' href='#Nemo.rsqrt-Tuple{Nemo.arb}'>#</a>
+**`Nemo.rsqrt`** &mdash; *Method*.
+
+
+
+```
+rsqrt(x::arb)
+```
+
+> Return the inverse of the square root of $x$, i.e. $1/\sqrt{x}$.
+
+
+<a id='Nemo.sqrt1pm1-Tuple{Nemo.arb}' href='#Nemo.sqrt1pm1-Tuple{Nemo.arb}'>#</a>
+**`Nemo.sqrt1pm1`** &mdash; *Method*.
+
+
+
+```
+sqrt1pm1(x::arb)
+```
+
+> Return $\sqrt{1+x}-1$, evaluated accurately for small $x$.
+
+
+<a id='Base.log-Tuple{Nemo.arb}' href='#Base.log-Tuple{Nemo.arb}'>#</a>
+**`Base.log`** &mdash; *Method*.
+
+
+
+```
+log(x::arb)
+```
+
+> Return the principal branch of the logarithm of $x$.
+
+
+```
+log(x)
+```
+
+Compute the natural logarithm of `x`. Throws `DomainError` for negative `Real` arguments. Use complex negative arguments to obtain complex results.
+
+There is an experimental variant in the `Base.Math.JuliaLibm` module, which is typically faster and more accurate.
+
+<a id='Base.log1p-Tuple{Nemo.arb}' href='#Base.log1p-Tuple{Nemo.arb}'>#</a>
+**`Base.log1p`** &mdash; *Method*.
+
+
+
+```
+log1p(x::arb)
+```
+
+> Return $\log(1+x)$, evaluated accurately for small $x$.
+
+
+<a id='Base.exp-Tuple{Nemo.arb}' href='#Base.exp-Tuple{Nemo.arb}'>#</a>
+**`Base.exp`** &mdash; *Method*.
+
+
+
+```
+exp(x::arb)
+```
+
+> Return the exponential of $x$.
+
+
+<a id='Base.expm1-Tuple{Nemo.arb}' href='#Base.expm1-Tuple{Nemo.arb}'>#</a>
+**`Base.expm1`** &mdash; *Method*.
+
+
+
+```
+expm1(x::arb)
+```
+
+> Return $\exp(x)-1$, evaluated accurately for small $x$.
+
+
+<a id='Base.sin-Tuple{Nemo.arb}' href='#Base.sin-Tuple{Nemo.arb}'>#</a>
+**`Base.sin`** &mdash; *Method*.
+
+
+
+```
+sin(x::arb)
+```
+
+> Return the sine of $x$.
+
+
+<a id='Base.cos-Tuple{Nemo.arb}' href='#Base.cos-Tuple{Nemo.arb}'>#</a>
+**`Base.cos`** &mdash; *Method*.
+
+
+
+```
+cos(x::arb)
+```
+
+> Return the cosine of $x$.
+
+
+<a id='Base.Math.sinpi-Tuple{Nemo.arb}' href='#Base.Math.sinpi-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.sinpi`** &mdash; *Method*.
+
+
+
+```
+sinpi(x::arb)
+```
+
+> Return the sine of $\pi x$.
+
+
+<a id='Base.Math.cospi-Tuple{Nemo.arb}' href='#Base.Math.cospi-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.cospi`** &mdash; *Method*.
+
+
+
+```
+cospi(x::arb)
+```
+
+> Return the cosine of $\pi x$.
+
+
+<a id='Base.tan-Tuple{Nemo.arb}' href='#Base.tan-Tuple{Nemo.arb}'>#</a>
+**`Base.tan`** &mdash; *Method*.
+
+
+
+```
+tan(x::arb)
+```
+
+> Return the tangent of $x$.
+
+
+<a id='Base.Math.cot-Tuple{Nemo.arb}' href='#Base.Math.cot-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.cot`** &mdash; *Method*.
+
+
+
+```
+cot(x::arb)
+```
+
+> Return the cotangent of $x$.
+
+
+<a id='Nemo.tanpi-Tuple{Nemo.arb}' href='#Nemo.tanpi-Tuple{Nemo.arb}'>#</a>
+**`Nemo.tanpi`** &mdash; *Method*.
+
+
+
+```
+tanpi(x::arb)
+```
+
+> Return the tangent of $\pi x$.
+
+
+<a id='Nemo.cotpi-Tuple{Nemo.arb}' href='#Nemo.cotpi-Tuple{Nemo.arb}'>#</a>
+**`Nemo.cotpi`** &mdash; *Method*.
+
+
+
+```
+cotpi(x::arb)
+```
+
+> Return the cotangent of $\pi x$.
+
+
+<a id='Base.sinh-Tuple{Nemo.arb}' href='#Base.sinh-Tuple{Nemo.arb}'>#</a>
+**`Base.sinh`** &mdash; *Method*.
+
+
+
+```
+sinh(x::arb)
+```
+
+> Return the hyperbolic sine of $x$.
+
+
+<a id='Base.cosh-Tuple{Nemo.arb}' href='#Base.cosh-Tuple{Nemo.arb}'>#</a>
+**`Base.cosh`** &mdash; *Method*.
+
+
+
+```
+cosh(x::arb)
+```
+
+> Return the hyperbolic cosine of $x$.
+
+
+<a id='Base.tanh-Tuple{Nemo.arb}' href='#Base.tanh-Tuple{Nemo.arb}'>#</a>
+**`Base.tanh`** &mdash; *Method*.
+
+
+
+```
+tanh(x::arb)
+```
+
+> Return the hyperbolic tangent of $x$.
+
+
+<a id='Base.Math.coth-Tuple{Nemo.arb}' href='#Base.Math.coth-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.coth`** &mdash; *Method*.
+
+
+
+```
+coth(x::arb)
+```
+
+> Return the hyperbolic cotangent of $x$.
+
+
+<a id='Base.atan-Tuple{Nemo.arb}' href='#Base.atan-Tuple{Nemo.arb}'>#</a>
+**`Base.atan`** &mdash; *Method*.
+
+
+
+```
+atan(x::arb)
+```
+
+> Return the arctangent of $x$.
+
+
+<a id='Base.asin-Tuple{Nemo.arb}' href='#Base.asin-Tuple{Nemo.arb}'>#</a>
+**`Base.asin`** &mdash; *Method*.
+
+
+
+```
+asin(x::arb)
+```
+
+> Return the arcsine of $x$.
+
+
+<a id='Base.acos-Tuple{Nemo.arb}' href='#Base.acos-Tuple{Nemo.arb}'>#</a>
+**`Base.acos`** &mdash; *Method*.
+
+
+
+```
+acos(x::arb)
+```
+
+> Return the arccosine of $x$.
+
+
+<a id='Base.atanh-Tuple{Nemo.arb}' href='#Base.atanh-Tuple{Nemo.arb}'>#</a>
+**`Base.atanh`** &mdash; *Method*.
+
+
+
+```
+atanh(x::arb)
+```
+
+> Return the hyperbolic arctangent of $x$.
+
+
+<a id='Base.asinh-Tuple{Nemo.arb}' href='#Base.asinh-Tuple{Nemo.arb}'>#</a>
+**`Base.asinh`** &mdash; *Method*.
+
+
+
+```
+asinh(x::arb)
+```
+
+> Return the hyperbolic arcsine of $x$.
+
+
+<a id='Base.acosh-Tuple{Nemo.arb}' href='#Base.acosh-Tuple{Nemo.arb}'>#</a>
+**`Base.acosh`** &mdash; *Method*.
+
+
+
+```
+acosh(x::arb)
+```
+
+> Return the hyperbolic arccosine of $x$.
+
+
+<a id='Base.Math.gamma-Tuple{Nemo.arb}' href='#Base.Math.gamma-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.gamma`** &mdash; *Method*.
+
+
+
+```
+gamma(x::arb)
+```
+
+> Return the Gamma function evaluated at $x$.
+
+
+<a id='Base.Math.lgamma-Tuple{Nemo.arb}' href='#Base.Math.lgamma-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.lgamma`** &mdash; *Method*.
+
+
+
+```
+lgamma(x::arb)
+```
+
+> Return the logarithm of the Gamma function evaluated at $x$.
+
+
+<a id='Nemo.rgamma-Tuple{Nemo.arb}' href='#Nemo.rgamma-Tuple{Nemo.arb}'>#</a>
+**`Nemo.rgamma`** &mdash; *Method*.
+
+
+
+```
+rgamma(x::arb)
+```
+
+> Return the reciprocal of the Gamma function evaluated at $x$.
+
+
+<a id='Base.Math.digamma-Tuple{Nemo.arb}' href='#Base.Math.digamma-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.digamma`** &mdash; *Method*.
+
+
+
+```
+digamma(x::arb)
+```
+
+> Return the  logarithmic derivative of the gamma function evaluated at $x$, i.e. $\psi(x)$.
+
+
+<a id='Base.Math.zeta-Tuple{Nemo.arb}' href='#Base.Math.zeta-Tuple{Nemo.arb}'>#</a>
+**`Base.Math.zeta`** &mdash; *Method*.
+
+
+
+```
+zeta(x::arb)
+```
+
+> Return the Riemann zeta function evaluated at $x$.
+
+
+```
+zeta(s)
+```
+
+Riemann zeta function $\zeta(s)$.
+
+<a id='Nemo.sincos-Tuple{Nemo.arb}' href='#Nemo.sincos-Tuple{Nemo.arb}'>#</a>
+**`Nemo.sincos`** &mdash; *Method*.
+
+
+
+```
+sincos(x::arb)
+```
+
+> Return a tuple $s, c$ consisting of the sine $s$ and cosine $c$ of $x$.
+
+
+<a id='Nemo.sincospi-Tuple{Nemo.arb}' href='#Nemo.sincospi-Tuple{Nemo.arb}'>#</a>
+**`Nemo.sincospi`** &mdash; *Method*.
+
+
+
+```
+sincospi(x::arb)
+```
+
+> Return a tuple $s, c$ consisting of the sine $s$ and cosine $c$ of $\pi x$.
+
+
+<a id='Base.Math.sinpi-Tuple{Nemo.fmpq,Nemo.ArbField}' href='#Base.Math.sinpi-Tuple{Nemo.fmpq,Nemo.ArbField}'>#</a>
+**`Base.Math.sinpi`** &mdash; *Method*.
+
+
+
+```
+sinpi(x::fmpq, r::ArbField)
+```
+
+> Return the sine of $\pi x$ in the given Arb field.
+
+
+<a id='Base.Math.cospi-Tuple{Nemo.fmpq,Nemo.ArbField}' href='#Base.Math.cospi-Tuple{Nemo.fmpq,Nemo.ArbField}'>#</a>
+**`Base.Math.cospi`** &mdash; *Method*.
+
+
+
+```
+cospi(x::fmpq, r::ArbField)
+```
+
+> Return the cosine of $\pi x$ in the given Arb field.
+
+
+<a id='Nemo.sincospi-Tuple{Nemo.fmpq,Nemo.ArbField}' href='#Nemo.sincospi-Tuple{Nemo.fmpq,Nemo.ArbField}'>#</a>
+**`Nemo.sincospi`** &mdash; *Method*.
+
+
+
+```
+sincospi(x::fmpq, r::ArbField)
+```
+
+> Return a tuple $s, c$ consisting of the sine and cosine of $\pi x$ in the given Arb field.
+
+
+<a id='Nemo.sinhcosh-Tuple{Nemo.arb}' href='#Nemo.sinhcosh-Tuple{Nemo.arb}'>#</a>
+**`Nemo.sinhcosh`** &mdash; *Method*.
+
+
+
+```
+sinhcosh(x::arb)
+```
+
+> Return a tuple $s, c$ consisting of the hyperbolic sine and cosine of $x$.
+
+
+<a id='Base.Math.atan2-Tuple{Nemo.arb,Nemo.arb}' href='#Base.Math.atan2-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Base.Math.atan2`** &mdash; *Method*.
+
+
+
+```
+atan2(x::arb, y::arb)
+```
+
+> Return atan2$(b,a) = \arg(a+bi)$.
+
+
+<a id='Nemo.agm-Tuple{Nemo.arb,Nemo.arb}' href='#Nemo.agm-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Nemo.agm`** &mdash; *Method*.
+
+
+
+```
+agm(x::arb, y::arb)
+```
+
+> Return the arithmetic-geometric mean of $x$ and $y$
+
+
+<a id='Base.Math.zeta-Tuple{Nemo.arb,Nemo.arb}' href='#Base.Math.zeta-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Base.Math.zeta`** &mdash; *Method*.
+
+
+
+```
+zeta(s::arb, a::arb)
+```
+
+> Return the Hurwitz zeta function $\zeta(s,a)$..
+
+
+```
+zeta(s, z)
+```
+
+Hurwitz zeta function $\zeta(s, z)$.  (This is equivalent to the Riemann zeta function $\zeta(s)$ for the case of `z=1`.)
+
+<a id='Base.Math.hypot-Tuple{Nemo.arb,Nemo.arb}' href='#Base.Math.hypot-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Base.Math.hypot`** &mdash; *Method*.
+
+
+
+```
+hypot(x::arb, y::arb)
+```
+
+> Return $\sqrt{x^2 + y^2}$.
+
+
+<a id='Nemo.root-Tuple{Nemo.arb,Int64}' href='#Nemo.root-Tuple{Nemo.arb,Int64}'>#</a>
+**`Nemo.root`** &mdash; *Method*.
+
+
+
+```
+root(x::arb, n::Int)
+```
+
+> Return the $n$-th root of $x$. We require $x \geq 0$.
+
+
+<a id='Nemo.fac-Tuple{Nemo.arb}' href='#Nemo.fac-Tuple{Nemo.arb}'>#</a>
+**`Nemo.fac`** &mdash; *Method*.
+
+
+
+```
+fac(x::arb)
+```
+
+> Return the factorial of $x$.
+
+
+<a id='Nemo.fac-Tuple{Int64,Nemo.ArbField}' href='#Nemo.fac-Tuple{Int64,Nemo.ArbField}'>#</a>
+**`Nemo.fac`** &mdash; *Method*.
+
+
+
+```
+fac(n::Int, r::ArbField)
+```
+
+> Return the factorial of $n$ in the given Arb field.
+
+
+<a id='Nemo.binom-Tuple{Nemo.arb,UInt64}' href='#Nemo.binom-Tuple{Nemo.arb,UInt64}'>#</a>
+**`Nemo.binom`** &mdash; *Method*.
+
+
+
+```
+binom(x::arb, n::UInt)
+```
+
+> Return the binomial coefficient ${x \choose n}$.
+
+
+<a id='Nemo.binom-Tuple{UInt64,UInt64,Nemo.ArbField}' href='#Nemo.binom-Tuple{UInt64,UInt64,Nemo.ArbField}'>#</a>
+**`Nemo.binom`** &mdash; *Method*.
+
+
+
+```
+binom(n::UInt, k::UInt, r::ArbField)
+```
+
+> Return the binomial coefficient ${n \choose k}$ in the given Arb field.
+
+
+<a id='Nemo.fib-Tuple{Nemo.fmpz,Nemo.ArbField}' href='#Nemo.fib-Tuple{Nemo.fmpz,Nemo.ArbField}'>#</a>
+**`Nemo.fib`** &mdash; *Method*.
+
+
+
+```
+fib(n::fmpz, r::ArbField)
+```
+
+> Return the $n$-th Fibonacci number in the given Arb field.
+
+
+<a id='Nemo.fib-Tuple{Int64,Nemo.ArbField}' href='#Nemo.fib-Tuple{Int64,Nemo.ArbField}'>#</a>
+**`Nemo.fib`** &mdash; *Method*.
+
+
+
+```
+fib(n::Int, r::ArbField)
+```
+
+> Return the $n$-th Fibonacci number in the given Arb field.
+
+
+<a id='Base.Math.gamma-Tuple{Nemo.fmpz,Nemo.ArbField}' href='#Base.Math.gamma-Tuple{Nemo.fmpz,Nemo.ArbField}'>#</a>
+**`Base.Math.gamma`** &mdash; *Method*.
+
+
+
+```
+gamma(x::fmpz, r::ArbField)
+```
+
+> Return the Gamma function evaluated at $x$ in the given Arb field.
+
+
+<a id='Base.Math.gamma-Tuple{Nemo.fmpq,Nemo.ArbField}' href='#Base.Math.gamma-Tuple{Nemo.fmpq,Nemo.ArbField}'>#</a>
+**`Base.Math.gamma`** &mdash; *Method*.
+
+
+
+```
+gamma(x::fmpq, r::ArbField)
+```
+
+> Return the Gamma function evaluated at $x$ in the given Arb field.
+
+
+<a id='Base.Math.zeta-Tuple{Int64,Nemo.ArbField}' href='#Base.Math.zeta-Tuple{Int64,Nemo.ArbField}'>#</a>
+**`Base.Math.zeta`** &mdash; *Method*.
+
+
+
+```
+zeta(n::Int, r::ArbField)
+```
+
+> Return the Riemann zeta function $\zeta(n)$ as an element of the given Arb field.
+
+
+```
+zeta(s, z)
+```
+
+Hurwitz zeta function $\zeta(s, z)$.  (This is equivalent to the Riemann zeta function $\zeta(s)$ for the case of `z=1`.)
+
+<a id='Nemo.bernoulli-Tuple{Int64,Nemo.ArbField}' href='#Nemo.bernoulli-Tuple{Int64,Nemo.ArbField}'>#</a>
+**`Nemo.bernoulli`** &mdash; *Method*.
+
+
+
+```
+bernoulli(n::Int, r::ArbField)
+```
+
+> Return the $n$-th Bernoulli number as an element of the given Arb field.
+
+
+<a id='Nemo.risingfac-Tuple{Nemo.arb,Int64}' href='#Nemo.risingfac-Tuple{Nemo.arb,Int64}'>#</a>
+**`Nemo.risingfac`** &mdash; *Method*.
+
+
+
+```
+risingfac(x::arb, n::Int)
+```
+
+> Return the rising factorial $x(x + 1)\ldots (x + n - 1)$ as an Arb.
+
+
+<a id='Nemo.risingfac-Tuple{Nemo.fmpq,Int64,Nemo.ArbField}' href='#Nemo.risingfac-Tuple{Nemo.fmpq,Int64,Nemo.ArbField}'>#</a>
+**`Nemo.risingfac`** &mdash; *Method*.
+
+
+
+```
+risingfac(x::fmpq, n::Int, r::ArbField)
+```
+
+> Return the rising factorial $x(x + 1)\ldots (x + n - 1)$ as an element of the given Arb field.
+
+
+<a id='Nemo.risingfac2-Tuple{Nemo.arb,Int64}' href='#Nemo.risingfac2-Tuple{Nemo.arb,Int64}'>#</a>
+**`Nemo.risingfac2`** &mdash; *Method*.
+
+
+
+```
+risingfac2(x::arb, n::Int)
+```
+
+> Return a tuple containing the rising factorial $x(x + 1)\ldots (x + n - 1)$ and its derivative.
+
+
+<a id='Nemo.polylog-Tuple{Nemo.arb,Nemo.arb}' href='#Nemo.polylog-Tuple{Nemo.arb,Nemo.arb}'>#</a>
+**`Nemo.polylog`** &mdash; *Method*.
+
+
+
+```
+polylog(s::arb, a::arb)
+```
+
+> Return the polylogarithm Li$_s(a)$.
+
+
+<a id='Nemo.polylog-Tuple{Int64,Nemo.arb}' href='#Nemo.polylog-Tuple{Int64,Nemo.arb}'>#</a>
+**`Nemo.polylog`** &mdash; *Method*.
+
+
+
+```
+polylog(s::Int, a::arb)
+```
+
+> Return the polylogarithm Li$_s(a)$.
+
+
+<a id='Nemo.chebyshev_t-Tuple{Int64,Nemo.arb}' href='#Nemo.chebyshev_t-Tuple{Int64,Nemo.arb}'>#</a>
+**`Nemo.chebyshev_t`** &mdash; *Method*.
+
+
+
+```
+chebyshev_t(n::Int, x::arb)
+```
+
+> Return the value of the Chebyshev polynomial $T_n(x)$.
+
+
+<a id='Nemo.chebyshev_u-Tuple{Int64,Nemo.arb}' href='#Nemo.chebyshev_u-Tuple{Int64,Nemo.arb}'>#</a>
+**`Nemo.chebyshev_u`** &mdash; *Method*.
+
+
+
+```
+chebyshev_u(n::Int, x::arb)
+```
+
+> Return the value of the Chebyshev polynomial $U_n(x)$.
+
+
+<a id='Nemo.chebyshev_t2-Tuple{Int64,Nemo.arb}' href='#Nemo.chebyshev_t2-Tuple{Int64,Nemo.arb}'>#</a>
+**`Nemo.chebyshev_t2`** &mdash; *Method*.
+
+
+
+```
+chebyshev_t2(n::Int, x::arb)
+```
+
+> Return the tuple $(T_{n}(x), T_{n-1}(x))$.
+
+
+<a id='Nemo.chebyshev_u2-Tuple{Int64,Nemo.arb}' href='#Nemo.chebyshev_u2-Tuple{Int64,Nemo.arb}'>#</a>
+**`Nemo.chebyshev_u2`** &mdash; *Method*.
+
+
+
+```
+chebyshev_u2(n::Int, x::arb)
+```
+
+> Return the tuple $(U_{n}(x), U_{n-1}(x))$
+
+
+<a id='Nemo.bell-Tuple{Nemo.fmpz,Nemo.ArbField}' href='#Nemo.bell-Tuple{Nemo.fmpz,Nemo.ArbField}'>#</a>
+**`Nemo.bell`** &mdash; *Method*.
+
+
+
+```
+bell(n::fmpz, r::ArbField)
+```
+
+> Return the Bell number $B_n$ as an element of $r$.
+
+
+<a id='Nemo.bell-Tuple{Int64,Nemo.ArbField}' href='#Nemo.bell-Tuple{Int64,Nemo.ArbField}'>#</a>
+**`Nemo.bell`** &mdash; *Method*.
+
+
+
+```
+bell(n::Int, r::ArbField)
+```
+
+> Return the Bell number $B_n$ as an element of $r$.
+
+
+
+Here are some examples of real valued mathematical functions.
+
+
+```
+RR = ArbField(64)
+
+a = floor(exp(RR(1)))
+b = sinpi(QQ(5,6), RR)
+c = gamma(QQ(1,3), ArbField(256))
+d = bernoulli(1000, ArbField(53))
+f = polylog(3, RR(-10))
+```
+

--- a/doc/build/matrix.md
+++ b/doc/build/matrix.md
@@ -285,6 +285,20 @@ base_ring(a::FlintPadicField)
 
 
 ```
+base_ring(x::arb)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+```
+base_ring(R::ArbField)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+```
 base_ring(a::nf_elem)
 ```
 

--- a/doc/build/residue.md
+++ b/doc/build/residue.md
@@ -258,6 +258,20 @@ base_ring(a::FlintPadicField)
 
 
 ```
+base_ring(x::arb)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+```
+base_ring(R::ArbField)
+```
+
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+
+
+```
 base_ring(a::nf_elem)
 ```
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -20,6 +20,7 @@ pages:
 - Finite fields:                build/finitefield.md
 - P-adic fields:                build/padic.md
 - Number fields:                build/numberfield.md
+- Real balls:                   build/arb.md
 - Permutation groups:           build/perm.md
 
 markdown_extensions:

--- a/doc/src/arb.md
+++ b/doc/src/arb.md
@@ -1,0 +1,838 @@
+```@meta
+CurrentModule = Nemo
+```
+
+## Introduction
+
+Arbitrary precision real ball arithmetic is supplied by Arb which provides a
+ball representation which tracks error bounds rigorously. Real numbers are 
+represented in mid-rad interval form $[m \pm r] = [m-r, m+r]$.
+
+The Arb real field is constructed using the `ArbField` constructor. This
+constructs the parent object for the Arb real field.
+
+The types of real balls in Nemo are given in the following table, along with
+the libraries that provide them and the associated types of the parent objects.
+
+ Library | Field                | Element type  | Parent type
+---------|----------------------|---------------|--------------
+Arb      | $\mathbb{R}$ (balls) | `arb`         | `ArbField`
+
+All the real field types belong to the `Field` abstract type and the types of
+elements in this field, i.e. balls in this case, belong to the `FieldElem`
+abstract type.
+
+## Real field constructors
+
+In order to construct real balls in Nemo, one must first construct the Arb
+real field itself. This is accomplished with the following constructor.
+
+```
+ArbField(prec::Int)
+```
+
+Return the Arb field with precision in bits `prec` used for operations on
+interval midpoints. The precision used for interval radii is a fixed
+implementation-defined constant (30 bits).
+
+Here is an example of creating an Arb real field and using the resulting
+parent object to coerce values into the resulting field.
+
+```
+RR = ArbField(64)
+
+a = RR("0.25")
+b = RR("0.1")
+c = RR(0.5)
+d = RR(12)
+```
+
+Note that whilst one can coerce double precision floating point values into an
+Arb real field, unless those values can be represented exactly in double
+precision, the resulting ball can't be any more precise than the double
+precision supplied.
+
+If instead, values can be represented precisely using decimal arithmetic then
+one can supply them to Arb using a string. In this case, Arb will store them to
+the precision specified when creating the Arb field.
+
+If the values can be stored precisely as a binary floating point number, Arb
+will store the values exactly. See the function `isexact` below for more
+information.
+
+## Real ball constructors
+
+Once an Arb real field is constructed, there are various ways to construct
+balls in that field.
+
+Apart from coercing elements into the Arb real field as above, we offer the
+following functions.
+
+```@docs
+zero(::ArbField)
+```
+
+```@docs
+one(::ArbField)
+```
+
+```@docs
+ball(::arb, ::arb)
+```
+
+Here are some examples of constructing balls.
+
+```
+RR = ArbField(64)
+
+a = zero(RR)
+b = one(RR)
+c = ball(RR(3), RR("0.0001"))
+```
+
+## Basic functionality
+
+The following basic functionality is provided by the default Arb real field
+implementation in Nemo, to support construction of generic rings over real
+fields. Any custom real field implementation in Nemo should provide analogues
+of these functions along with the usual arithmetic operations.
+
+```
+parent_type(::Type{arb})
+```
+
+Gives the type of the parent object of an Arb real field element.
+
+```
+elem_type(R::ArbField)
+```
+
+Given the parent object for a Arb field, return the type of elements
+of the field.
+
+```
+mul!(c::arb, a::arb, b::arb)
+```
+
+Multiply $a$ by $b$ and set the existing Arb field element $c$ to the
+result. This function is provided for performance reasons as it saves
+allocating a new object for the result and eliminates associated garbage
+collection.
+
+```
+addeq!(c::arb, a::arb)
+```
+
+In-place addition. Adds $a$ to $c$ and sets $c$ to the result. This function
+is provided for performance reasons as it saves allocating a new object for
+the result and eliminates associated garbage collection.
+
+Given the parent object `R` for an Arb real field, the following coercion
+functions are provided to coerce various elements into the Arb field.
+Developers provide these by overloading the `call` operator for the real
+field parent objects.
+
+```
+R()
+```
+
+Coerce zero into the Arb field.
+
+```
+R(n::Integer)
+R(f::fmpz)
+R(q::fmpq)
+```
+
+Coerce an integer or rational value into the Arb field.
+
+```
+R(f::Float64)
+R(f::BigFloat)
+```
+
+Coerce the given floating point number into the Arb field.
+
+```
+R(f::AbstractString)
+```
+
+Coerce the decimal number, given as a string, into the Arb field.
+
+```
+R(f::arb)
+```
+
+Take an Arb field element that is already in the Arb field and simply
+return it. A copy of the original is not made.
+
+Here are some examples of coercing elements into the Arb field.
+
+```
+RR = ArbField(64)
+
+a = RR(3)
+b = RR(QQ(2,3))
+c = ball(RR(3), RR("0.0001"))
+d = RR("3 +/- 0.0001")
+f = RR("-1.24e+12345")
+g = RR("nan +/- inf")
+```
+
+In addition to the above, developers of custom real field types must ensure
+that they provide the equivalent of the function `base_ring(R::ArbField)`
+which should return `Union{}`. In addition to this they should ensure that
+each real field element contains a field `parent` specifying the parent
+object of the real field element, or at least supply the equivalent of the
+function `parent(a::arb)` to return the parent object of a real field element.
+
+## Conversions
+
+```@docs
+convert(::Type{Float64}, ::arb)
+```
+
+## Basic manipulation
+
+Numerous functions are provided to manipulate Arb field elements. Also see
+the section on basic functionality above.
+
+```@docs
+base_ring(::ArbField)
+```
+
+```@docs
+base_ring(::arb)
+```
+
+```@docs
+parent(::arb)
+```
+
+```@docs
+iszero(::arb)
+```
+
+```@docs
+isnonzero(::arb)
+```
+
+```@docs
+isone(::arb)
+```
+
+```@docs
+isfinite(::arb)
+```
+
+```@docs
+isexact(::arb)
+```
+
+```@docs
+isint(::arb)
+```
+
+```@docs
+ispositive(::arb)
+```
+
+```@docs
+isnonnegative(::arb)
+```
+
+```@docs
+isnegative(::arb)
+```
+
+```@docs
+isnonpositive(::arb)
+```
+
+```@docs
+midpoint(::arb)
+```
+
+```@docs
+radius(::arb)
+```
+
+```@docs
+accuracy_bits(::arb)
+```
+
+Here are some examples of basic manipulation of Arb balls.
+
+```
+RR = ArbField(64)
+
+a = RR("1.2 +/- 0.001")
+b = RR(3)
+
+iszero(a)
+isone(b)
+ispositive(a)
+isfinite(b)
+isint(b)
+isnegative(a)
+c = radius(a)
+d = midpoint(b)
+f = accuracy_bits(a)
+S = parent(a)
+T = base_ring(RR)
+```
+
+## Arithmetic operations
+
+Nemo provides all the standard field operations for Arb field elements, as
+follows. Note that division is represented by `//` since a field is its own
+fraction field and since exact division is not generally possible in an
+inexact field.
+
+Function                 | Operation
+-------------------------|----------------
+-(a::arb)                | unary minus
++(a::arb, b::arb)        | addition
+-(a::arb, b::arb)        | subtraction
+*(a::arb, b::arb)        | multiplication
+//(a::arb, b::arb)       | division
+^(a::arb, b::arb)        | powering
+
+In addition, the following ad hoc field operations are defined.
+
+Function               | Operation
+-----------------------|----------------
++(a::arb, b::Integer)  | addition
++(a::Integer, b::arb)  | addition
++(a::arb, b::fmpz)     | addition
++(a::fmpz, b::arb)     | addition
+-(a::arb, b::Integer)  | subtraction
+-(a::Integer, b::arb)  | subtraction
+-(a::arb, b::fmpz)     | subtraction
+-(a::fmpz, b::arb)     | subtraction
+*(a::arb, b::Integer)  | multiplication
+*(a::Integer, b::arb)  | multiplication
+*(a::arb, b::fmpz)     | multiplication
+*(a::fmpz, b::arb)     | multiplication
+//(a::arb, b::Integer) | division
+//(a::arb, b::fmpz)    | division
+//(a::Integer, b::arb) | division
+//(a::fmpz, b::arb)    | division
+^(a::arb, b::Integer)  | powering
+^(a::arb, b::fmpz)     | powering
+^(a::arb, b::fmpq)     | powering
+
+
+Here are some examples of arithmetic operations on Arb balls.
+
+```
+RR = ArbField(64)
+
+x = RR(3)
+y = RR(QQ(2,3))
+
+a = x + y
+b = x*y
+d = 1//y - x
+d = 3x + ZZ(100)//y
+f = (x^2 + y^2) ^ QQ(1,2)
+```
+
+## Containment
+
+It is often necessary to determine whether a given exact value or ball is
+contained in a given real ball or whether two balls overlap. The following
+functions are provided for this purpose.
+
+```@docs
+overlaps(::arb, ::arb)
+```
+
+```@docs
+contains(::arb, ::arb)
+```
+
+```@docs
+contains(::arb, ::Integer)
+contains(::arb, ::fmpz)
+contains(::arb, ::fmpq)
+contains(::arb, ::BigFloat)
+```
+
+The following functions are also provided for determining if a ball intersects
+a certain part of the real number line.
+
+```@docs
+contains_zero(::arb)
+```
+
+```@docs
+contains_negative(::arb)
+```
+
+```@docs
+contains_positive(::arb)
+```
+
+```@docs
+contains_nonnegative(::arb)
+```
+
+```@docs
+contains_nonpositive(::arb)
+```
+
+Here are some examples of testing containment.
+
+```
+RR = ArbField(64)
+x = RR("1 +/- 0.001")
+y = RR("3")
+
+overlaps(x, y)
+contains(x, y)
+contains(y, 3)
+contains(x, ZZ(1)//2)
+contains_zero(x)
+contains_positive(y)
+```
+
+## Comparison
+
+Nemo provides a full range of comparison operations for Arb balls. Note that a
+ball is considered less than another ball if every value in the first ball is
+less than every value in the second ball, etc.
+
+Firstly, we introduce an exact equality which is distinct from arithmetic
+equality. This is distinct from arithmetic equality implemented by `==`, which
+merely compares up to the minimum of the precisions of its operands.
+
+```@docs
+isequal(::arb, ::arb)
+```
+
+A full range of functions is available for comparing balls, i.e. `==`, `!=`,
+`<`, `<=`, `>=`, `>`. In fact, all these are implemented directly in C. In the
+table below we document these as though only `==` and `isless` had been
+provided to Julia.
+
+Function                
+-------------------------
+`isless(x::arb, y::arb)` 
+`==(x::arb, y::arb)`
+
+As well as these, we provide a full range of ad hoc comparison operators.
+Again, these are implemented directly in Julia, but we document them as though
+`isless` and `==` were provided.
+
+Function
+-----------------------------
+`isless(x::arb, y::Integer)`
+`isless(x::Integer, y::arb)`
+`isless(x::arb, y::fmpz)`
+`isless(x::fmpz, y::arb)`
+`isless(x::arb, y::Float64)`
+`isless(x::Float64, y::arb)`
+
+Here are some examples of comparison.
+
+```
+RR = ArbField(64)
+x = RR("1 +/- 0.001")
+y = RR("3")
+z = RR("4")
+
+isequal(y, z)
+x <= z
+x == 3
+ZZ(3) < z
+x != 1.23
+```
+
+## Absolute value
+
+```@docs
+abs(::arb)
+```
+
+Here are some examples of taking the absolute value.
+
+```
+RR = ArbField(64)
+x = RR("-1 +/- 0.001")
+
+a = abs(x)
+```
+
+## Inverse
+
+```@docs
+inv(::arb)
+```
+
+Here are some examples of taking the inverse.
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+
+a = inv(x)
+```
+
+## Shifting
+
+```@docs
+ldexp(x::arb, y::Int)
+ldexp(x::arb, y::fmpz)
+```
+
+Here are some examples of shifting.
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+
+a = ldexp(x, 23)
+b = ldexp(x, -ZZ(15))
+```
+
+## Miscellaneous operations
+
+```@docs
+trim(::arb)
+```
+
+```@docs
+unique_integer(::arb)
+```
+
+```@docs
+setunion(::arb, ::arb)
+```
+
+Here are some examples of miscellaneous operations.
+
+```
+RR = ArbField(64)
+x = RR("-3 +/- 0.001")
+y = RR("2 +/- 0.5")
+
+a = trim(x)
+b, c = unique_integer(x)
+d = setunion(x, y)
+```
+
+## Constants
+
+```@docs
+const_pi(::ArbField)
+```
+
+```@docs
+const_e(::ArbField)
+```
+
+```@docs
+const_log2(::ArbField)
+```
+
+```@docs
+const_log10(::ArbField)
+```
+
+```@docs
+const_euler(::ArbField)
+```
+
+```@docs
+const_catalan(::ArbField)
+```
+
+```@docs
+const_khinchin(::ArbField)
+```
+
+```@docs
+const_glaisher(::ArbField)
+```
+
+Here are some examples of computing real constants.
+
+```
+RR = ArbField(200)
+
+a = const_pi(RR)
+b = const_e(RR)
+c = const_euler(RR)
+d = const_glaisher(RR)
+```
+
+## Mathematical functions
+
+```@docs
+floor(::arb)
+```
+
+```@docs
+ceil(::arb)
+```
+
+```@docs
+sqrt(::arb)
+```
+
+```@docs
+rsqrt(::arb)
+```
+
+```@docs
+sqrt1pm1(::arb)
+```
+
+```@docs
+log(::arb)
+```
+
+```@docs
+log1p(::arb)
+```
+
+```@docs
+exp(::arb)
+```
+
+```@docs
+expm1(::arb)
+```
+
+```@docs
+sin(::arb)
+```
+
+```@docs
+cos(::arb)
+```
+
+```@docs
+sinpi(::arb)
+```
+
+```@docs
+cospi(::arb)
+```
+
+```@docs
+tan(::arb)
+```
+
+```@docs
+cot(::arb)
+```
+
+```@docs
+tanpi(::arb)
+```
+
+```@docs
+cotpi(::arb)
+```
+
+```@docs
+sinh(::arb)
+```
+
+```@docs
+cosh(::arb)
+```
+
+```@docs
+tanh(::arb)
+```
+
+```@docs
+coth(::arb)
+```
+
+```@docs
+atan(::arb)
+```
+
+```@docs
+asin(::arb)
+```
+
+```@docs
+acos(::arb)
+```
+
+```@docs
+atanh(::arb)
+```
+
+```@docs
+asinh(::arb)
+```
+
+```@docs
+acosh(::arb)
+```
+
+```@docs
+gamma(::arb)
+```
+
+```@docs
+lgamma(::arb)
+```
+
+```@docs
+rgamma(::arb)
+```
+
+```@docs
+digamma(::arb)
+```
+
+```@docs
+zeta(::arb)
+```
+
+```@docs
+sincos(::arb)
+```
+
+```@docs
+sincospi(::arb)
+```
+
+```@docs
+sinpi(::fmpq, ::ArbField)
+```
+
+```@docs
+cospi(::fmpq, ::ArbField)
+```
+
+```@docs
+sincospi(::fmpq, ::ArbField)
+```
+
+```@docs
+sinhcosh(::arb)
+```
+
+```@docs
+atan2(::arb, ::arb)
+```
+
+```@docs
+agm(::arb, ::arb)
+```
+
+```@docs
+zeta(::arb, ::arb)
+```
+
+```@docs
+hypot(::arb, ::arb)
+```
+
+```@docs
+root(::arb, ::Int)
+```
+
+```@docs
+fac(::arb)
+```
+
+```@docs
+fac(::Int, ::ArbField)
+```
+
+```@docs
+binom(::arb, ::UInt)
+```
+
+```@docs
+binom(::UInt, ::UInt, ::ArbField)
+```
+
+```@docs
+fib(::fmpz, ::ArbField)
+```
+
+```@docs
+fib(::Int, ::ArbField)
+```
+
+```@docs
+gamma(::fmpz, ::ArbField)
+```
+
+```@docs
+gamma(::fmpq, ::ArbField)
+```
+
+```@docs
+zeta(::Int, ::ArbField)
+```
+
+```@docs
+bernoulli(::Int, ::ArbField)
+```
+
+```@docs
+risingfac(::arb, ::Int)
+```
+
+```@docs
+risingfac(::fmpq, ::Int, ::ArbField)
+```
+
+```@docs
+risingfac2(::arb, ::Int)
+```
+
+```@docs
+polylog(::arb, ::arb)
+```
+
+```@docs
+polylog(::Int, ::arb)
+```
+
+```@docs
+chebyshev_t(::Int, ::arb)
+```
+
+```@docs
+chebyshev_u(::Int, ::arb)
+```
+
+```@docs
+chebyshev_t2(::Int, ::arb)
+```
+
+```@docs
+chebyshev_u2(::Int, ::arb)
+```
+
+```@docs
+bell(::fmpz, ::ArbField)
+```
+
+```@docs
+bell(::Int, ::ArbField)
+```
+
+Here are some examples of real valued mathematical functions.
+
+```
+RR = ArbField(64)
+
+a = floor(exp(RR(1)))
+b = sinpi(QQ(5,6), RR)
+c = gamma(QQ(1,3), ArbField(256))
+d = bernoulli(1000, ArbField(53))
+f = polylog(3, RR(-10))
+```

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -14,7 +14,7 @@ import Base: real, imag, abs, conj, angle,
        erf, erfi, erfc, gamma,
        besselj, bessely, besseli, besselk
 
-export one, onei, real, imag, conj, abs, inv, angle, strongequal
+export one, onei, real, imag, conj, abs, inv, angle
 
 export sqrt, rsqrt, log, log1p, exp, exppii, sin, cos, tan, cot,
        sinpi, cospi, tanpi, cotpi, sincos, sincospi, sinh, cosh, tanh, coth,
@@ -101,7 +101,7 @@ end
 #
 ################################################################################
 
-function strongequal(x::acb, y::acb)
+function isequal(x::acb, y::acb)
   r = ccall((:acb_equal, :libarb), Cint, (Ptr{acb}, Ptr{acb}), &x, &y)
   return Bool(r)
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -36,87 +36,39 @@ elem_type(::ArbField) = arb
 
 parent_type(::Type{arb}) = ArbField
 
+doc"""
+    base_ring(R::ArbField)
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+"""
 base_ring(R::ArbField) = Union{} 
 
+doc"""
+    base_ring(x::arb)
+> Returns `Union{}` since an Arb field does not depend on any other ring.
+"""
+base_ring(x::arb) = Union{}
+
+doc"""
+    zero(R::ArbField)
+> Return exact zero in the given Arb field. 
+"""
 zero(R::ArbField) = R(0)
 
+doc"""
+    one(R::ArbField)
+> Return exact one in the given Arb field. 
+"""
 one(R::ArbField) = R(1)
 
-################################################################################
-#
-#  Parent object overloading
-#
-################################################################################
+# TODO: Add deepcopy and hash (and document under arb basic functionality)
 
-function call(r::ArbField)
-  z = arb()
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::Int)
-  z = arb(fmpz(x), r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::UInt)
-  z = arb(fmpz(x), r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::fmpz)
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::fmpq)
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
-end
-  
-#function call(r::ArbField, x::arf)
-#  z = arb(arb(x), r.prec)
-#  z.parent = r
-#  return z
-#end
-
-function call(r::ArbField, x::Float64)
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::arb)
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::AbstractString)
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
-end
-
-function call(r::ArbField, x::Irrational)
-  if x == pi
-    return const_pi(r)
-  elseif x == e
-    return const_e(r.prec)
-  else
-    error("constant not supported")
-  end
-end
-
-function call(r::ArbField, x::Union{Int, UInt, fmpz, fmpq, Float64, arb,
-                                    AbstractString, BigFloat})
-  z = arb(x, r.prec)
-  z.parent = r
-  return z
+doc"""
+    accuracy_bits(x::arb)
+> Return the relative accuracy of $x$ measured in bits, capped between
+> `typemax(Int)` and `-typemax(Int)`.
+"""
+function accuracy_bits(x::arb)
+  return ccall((:arb_rel_accuracy_bits, :libarb), Int, (Ptr{arb},), &x)
 end
 
 ################################################################################
@@ -125,6 +77,10 @@ end
 #
 ################################################################################
 
+doc"""
+    convert(::Type{Float64}, x::arb)
+> Return the midpoint of $x$ rounded down to a machine double.
+"""
 function convert(::Type{Float64}, x::arb)
     t = arf_struct(0, 0, 0, 0)
     t.exp = x.mid_exp
@@ -151,15 +107,15 @@ end
 
 ################################################################################
 #
-#  Comparison and containment
+#  Containment
 #
 ################################################################################
 
-function strongequal(x::arb, y::arb)
-  r = ccall((:arb_equal, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
-  return Bool(r)
-end
-
+doc"""
+    overlaps(x::arb, y::arb)
+> Returns `true` if any part of the ball $x$ overlaps any part of the ball $y$,
+> otherwise return `false`.
+"""
 function overlaps(x::arb, y::arb)
   r = ccall((:arb_overlaps, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
   return Bool(r)
@@ -170,11 +126,21 @@ end
 #  return Bool(r)
 #end
 
+doc"""
+    contains(x::arb, y::fmpq)
+> Returns `true` if the ball $x$ contains the given rational value, otherwise
+> return `false`.
+"""
 function contains(x::arb, y::fmpq)
   r = ccall((:arb_contains_fmpq, :libarb), Cint, (Ptr{arb}, Ptr{fmpq}), &x, &y)
   return Bool(r)
 end
 
+doc"""
+    contains(x::arb, y::fmpz)
+> Returns `true` if the ball $x$ contains the given integer value, otherwise
+> return `false`.
+"""
 function contains(x::arb, y::fmpz)
   r = ccall((:arb_contains_fmpz, :libarb), Cint, (Ptr{arb}, Ptr{fmpz}), &x, &y)
   return Bool(r)
@@ -185,28 +151,97 @@ function contains(x::arb, y::Int)
   return Bool(r)
 end
 
+doc"""
+    contains(x::arb, y::Integer)
+> Returns `true` if the ball $x$ contains the given integer value, otherwise
+> return `false`.
+"""
+contains(x::arb, y::Integer) = contains(x, fmpz(y))
+
+doc"""
+    contains(x::arb, y::BigFloat)
+> Returns `true` if the ball $x$ contains the given floating point value, 
+> otherwise return `false`.
+"""
 function contains(x::arb, y::BigFloat)
   r = ccall((:arb_contains_mpfr, :libarb), Cint,
               (Ptr{arb}, Ptr{BigFloat}), &x, &y)
   return Bool(r)
 end
 
+doc"""
+    contains(x::arb, y::arb)
+> Returns `true` if the ball $x$ contains the ball $y$, otherwise return
+> `false`.
+"""
 function contains(x::arb, y::arb)
   r = ccall((:arb_contains, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
   return Bool(r)
 end
 
-for (s,f) in (("contains_zero", "arb_contains_zero"),
-              ("contains_negative", "arb_contains_negative"),
-              ("contains_positive", "arb_contains_positive"),
-              ("contains_nonpositive", "arb_contains_nonpositive"),
-              ("contains_nonnegative", "arb_contains_nonnegative"))
-  @eval begin
-    function($(Symbol(s)))(x::arb)
-      r = ccall(($f, :libarb), Cint, (Ptr{arb}, ), &x)
-      return Bool(r)
-    end
-  end
+doc"""
+    contains_zero(x::arb)
+> Returns `true` if the ball $x$ contains zero, otherwise return `false`.
+"""
+function contains_zero(x::arb)
+   r = ccall((:arb_contains_zero, :libarb), Cint, (Ptr{arb}, ), &x)
+   return Bool(r)
+end
+
+doc"""
+    contains_negative(x::arb)
+> Returns `true` if the ball $x$ contains any negative value, otherwise return
+> `false`.
+"""
+function contains_negative(x::arb)
+   r = ccall((:arb_contains_negative, :libarb), Cint, (Ptr{arb}, ), &x)
+   return Bool(r)
+end
+
+doc"""
+    contains_positive(x::arb)
+> Returns `true` if the ball $x$ contains any positive value, otherwise return
+> `false`.
+"""
+function contains_positive(x::arb)
+   r = ccall((:arb_contains_positive, :libarb), Cint, (Ptr{arb}, ), &x)
+   return Bool(r)
+end
+
+doc"""
+    contains_nonnegative(x::arb)
+> Returns `true` if the ball $x$ contains any nonnegative value, otherwise
+> return `false`.
+"""
+function contains_nonnegative(x::arb)
+   r = ccall((:arb_contains_nonnegative, :libarb), Cint, (Ptr{arb}, ), &x)
+   return Bool(r)
+end
+
+doc"""
+    contains_nonpositive(x::arb)
+> Returns `true` if the ball $x$ contains any nonpositive value, otherwise
+> return `false`.
+"""
+function contains_nonpositive(x::arb)
+   r = ccall((:arb_contains_nonpositive, :libarb), Cint, (Ptr{arb}, ), &x)
+   return Bool(r)
+end
+
+################################################################################
+#
+#  Comparison
+#
+################################################################################
+
+doc"""
+    isequal(x::arb, y::arb)
+> Return `true` if the balls $x$ and $y$ are precisely equal, i.e. have the
+> same midpoints and radii.
+"""
+function isequal(x::arb, y::arb)
+  r = ccall((:arb_equal, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
+  return Bool(r)
 end
 
 function ==(x::arb, y::arb)
@@ -254,12 +289,26 @@ end
 <(x::arb, y::fmpz) = x < arb(y)
 >(x::arb, y::fmpz) = x > arb(y)
 
+==(x::arb, y::Integer) = x == fmpz(y)
+!=(x::arb, y::Integer) = x != fmpz(y)
+<=(x::arb, y::Integer) = x <= fmpz(y)
+>=(x::arb, y::Integer) = x >= fmpz(y)
+<(x::arb, y::Integer) = x < fmpz(y)
+>(x::arb, y::Integer) = x > fmpz(y)
+
 ==(x::fmpz, y::arb) = arb(x) == y
 !=(x::fmpz, y::arb) = arb(x) != y
 <=(x::fmpz, y::arb) = arb(x) <= y
 >=(x::fmpz, y::arb) = arb(x) >= y
 <(x::fmpz, y::arb) = arb(x) < y
 >(x::fmpz, y::arb) = arb(x) > y
+
+==(x::Integer, y::arb) = fmpz(x) == y
+!=(x::Integer, y::arb) = fmpz(x) != y
+<=(x::Integer, y::arb) = fmpz(x) <= y
+>=(x::Integer, y::arb) = fmpz(x) >= y
+<(x::Integer, y::arb) = fmpz(x) < y
+>(x::Integer, y::arb) = fmpz(x) > y
 
 ==(x::arb, y::Float64) = x == arb(y)
 !=(x::arb, y::Float64) = x != arb(y)
@@ -281,21 +330,88 @@ end
 #
 ################################################################################
 
-for (s,f) in (("iszero", "arb_is_zero"),
-              ("isnonzero", "arb_is_nonzero"),
-              ("isone", "arb_is_one"),
-              ("isfinite", "arb_is_finite"),
-              ("isexact", "arb_is_exact"),
-              ("isint", "arb_is_int"),
-              ("ispositive", "arb_is_positive"),
-              ("isnonnegative", "arb_is_nonnegative"),
-              ("isnegative", "arb_is_negative"),
-              ("isnonpositive", "arb_is_nonpositive"))
-  @eval begin
-    function($(Symbol(s)))(x::arb)
-      return Bool(ccall(($f, :libarb), Cint, (Ptr{arb},), &x))
-    end
-  end
+doc"""
+    iszero(x::arb)
+> Return `true` if $x$ is certainly zero, otherwise return `false`.
+"""
+function iszero(x::arb)
+   return Bool(ccall((:arb_is_zero, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isnonzero(x::arb)
+> Return `true` if $x$ is certainly not equal to zero, otherwise return
+> `false`.
+"""
+function isnonzero(x::arb)
+   return Bool(ccall((:arb_is_nonzero, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isone(x::arb)
+> Return `true` if $x$ is certainly not equal to oneo, otherwise return
+> `false`.
+"""
+function isone(x::arb)
+   return Bool(ccall((:arb_is_one, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isfinite(x::arb)
+> Return `true` if $x$ is finite, i.e. having finite midpoint and radius,
+> otherwise return `false`.
+"""
+function isfinite(x::arb)
+   return Bool(ccall((:arb_is_finite, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isexact(x::arb)
+> Return `true` if $x$ is exact, i.e. has zero radius, otherwise return
+> `false`.
+"""
+function isexact(x::arb)
+   return Bool(ccall((:arb_is_exact, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isint(x::arb)
+> Return `true` if $x$ is an exact integer, otherwise return `false`.
+"""
+function isint(x::arb)
+   return Bool(ccall((:arb_is_int, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    ispositive(x::arb)
+> Return `true` if $x$ is certainly positive, otherwise return `false`.
+"""
+function ispositive(x::arb)
+   return Bool(ccall((:arb_is_positive, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isnonnegative(x::arb)
+> Return `true` if $x$ is certainly nonnegative, otherwise return `false`.
+"""
+function isnonnegative(x::arb)
+   return Bool(ccall((:arb_is_nonnegative, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isnegative(x::arb)
+> Return `true` if $x$ is certainly negative, otherwise return `false`.
+"""
+function isnegative(x::arb)
+   return Bool(ccall((:arb_is_negative, :libarb), Cint, (Ptr{arb},), &x))
+end
+
+doc"""
+    isnonpositive(x::arb)    
+> Return `true` if $x$ is certainly nonpositive, otherwise return `false`.
+"""
+function isnonpositive(x::arb)
+   return Bool(ccall((:arb_is_nonpositive, :libarb), Cint, (Ptr{arb},), &x))
 end
 
 ################################################################################
@@ -304,18 +420,31 @@ end
 #
 ################################################################################
 
+doc"""
+    ball(mid::arb, rad::arb)
+> Constructs an `arb` enclosing the range $[m-|r|, m+|r|]$, given the pair
+> $(m, r)$.
+"""
 function ball(mid::arb, rad::arb)
   z = arb(mid, rad)
   z.parent = parent(mid)
   return z
 end
 
+doc"""
+    radius(x::arb)
+> Return the radius of the ball $x$ as an Arb ball.
+"""
 function radius(x::arb)
   z = parent(x)()
   ccall((:arb_get_rad_arb, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
   return z
 end
 
+doc"""
+    midpoint(x::arb)
+> Return the midpoint of the ball $x$ as an Arb ball.
+"""
 function midpoint(x::arb)
   z = parent(x)()
   ccall((:arb_get_mid_arb, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
@@ -334,12 +463,20 @@ function -(x::arb)
   return z
 end
 
+doc"""
+    abs(x::arb)
+> Return the absolute value of $x$.
+"""
 function abs(x::arb)
   z = parent(x)()
   ccall((:arb_abs, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
   return z
 end
 
+doc"""
+    inv(x::arb)
+> Return the multiplicative inverse of $x$, i.e. $1/x$.
+"""
 function inv(x::arb)
   z = parent(x)()
   ccall((:arb_inv, :libarb), Void,
@@ -444,6 +581,22 @@ end
 
 -(x::fmpz, y::arb) = -(y-x)
 
++(x::arb, y::Integer) = x + fmpz(y)
+
+-(x::arb, y::Integer) = x - fmpz(y)
+
+*(x::arb, y::Integer) = x*fmpz(y)
+
+//(x::arb, y::Integer) = x//fmpz(y)
+
++(x::Integer, y::arb) = fmpz(x) + y
+
+-(x::Integer, y::arb) = fmpz(x) - y
+
+*(x::Integer, y::arb) = fmpz(x)*y
+
+//(x::Integer, y::arb) = fmpz(x)//y
+
 #function //(x::arb, y::arf)
 #  z = parent(x)()
 #  ccall((:arb_div_arf, :libarb), Void,
@@ -511,7 +664,7 @@ function ^(x::arb, y::fmpz)
   return z
 end
 
-^(x::arb, y::Int) = ^(x, fmpz(y))
+^(x::arb, y::Integer) = x^fmpz(y)
 
 function ^(x::arb, y::UInt)
   z = parent(x)()
@@ -534,6 +687,10 @@ end
 #
 ################################################################################
 
+doc"""
+    ldexp(x::arb, y::Int)
+> Return $2^yx$. Note that $y$ can be positive, zero or negative.
+"""
 function ldexp(x::arb, y::Int)
   z = parent(x)()
   ccall((:arb_mul_2exp_si, :libarb), Void,
@@ -541,6 +698,10 @@ function ldexp(x::arb, y::Int)
   return z
 end
 
+doc"""
+    ldexp(x::arb, y::fmpz)
+> Return $2^yx$. Note that $y$ can be positive, zero or negative.
+"""
 function ldexp(x::arb, y::fmpz)
   z = parent(x)()
   ccall((:arb_mul_2exp_fmpz, :libarb), Void,
@@ -548,16 +709,24 @@ function ldexp(x::arb, y::fmpz)
   return z
 end
 
+doc"""
+    trim(x::arb)
+> Return an `arb` interval containing $x$ but which may be more economical,
+> by rounding off insignificant bits from the midpoint.
+"""
 function trim(x::arb)
   z = parent(x)()
   ccall((:arb_trim, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
   return z
 end
 
-function accuracy_bits(x::arb)
-  return ccall((:arb_rel_accuracy_bits, :libarb), Int, (Ptr{arb},), &x)
-end
-
+doc"""
+    unique_integer(x::arb)
+> Return a pair where the first value is a boolean and the second is an `fmpz`
+> integer. The boolean indicates whether the interval $x$ contains a unique
+> integer. If this is the case, the second return value is set to this unique
+> integer.
+"""
 function unique_integer(x::arb)
   z = fmpz()
   unique = ccall((:arb_get_unique_fmpz, :libarb), Int,
@@ -565,6 +734,11 @@ function unique_integer(x::arb)
   return (unique != 0, z)
 end
 
+doc"""
+    setunion(x::arb, y::arb)
+> Return an `arb` containing the union of the intervals represented by $x$ and
+> $y$.
+"""
 function setunion(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_union, :libarb), Void,
@@ -578,48 +752,80 @@ end
 #
 ################################################################################
 
+doc"""
+    const_pi(r::ArbField)
+> Return $\pi = 3.14159\ldots$ as an element of $r$.
+"""
 function const_pi(r::ArbField)
   z = r()
   ccall((:arb_const_pi, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_e(r::ArbField)
+> Return $e = 2.71828\ldots$ as an element of $r$.
+"""
 function const_e(r::ArbField)
   z = r()
   ccall((:arb_const_e, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_log2(r::ArbField)
+> Return $\log(2) = 0.69314\ldots$ as an element of $r$.
+"""
 function const_log2(r::ArbField)
   z = r()
   ccall((:arb_const_log2, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_log10(r::ArbField)
+> Return $\log(10) = 2.302585\ldots$ as an element of $r$.
+"""
 function const_log10(r::ArbField)
   z = r()
   ccall((:arb_const_log10, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_euler(r::ArbField)
+> Return Euler's constant $\gamma = 0.577215\ldots$ as an element of $r$.
+"""
 function const_euler(r::ArbField)
   z = r()
   ccall((:arb_const_euler, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_catalan(r::ArbField)
+> Return Catalan's constant $C = 0.915965\ldots$ as an element of $r$.
+"""
 function const_catalan(r::ArbField)
   z = r()
   ccall((:arb_const_catalan, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_khinchin(r::ArbField)
+> Return Khinchin's constant $K = 2.685452\ldots$ as an element of $r$.
+"""
 function const_khinchin(r::ArbField)
   z = r()
   ccall((:arb_const_khinchin, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
   return z
 end
 
+doc"""
+    const_glaisher(r::ArbField)
+> Return Glaisher's constant $A = 1.282427\ldots$ as an element of $r$.
+"""
 function const_glaisher(r::ArbField)
   z = r()
   ccall((:arb_const_glaisher, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
@@ -633,48 +839,334 @@ end
 ################################################################################
 
 # real - real functions
-for (s,f) in (("floor", "arb_floor"),
-              ("ceil", "arb_ceil"),
-              ("sqrt", "arb_sqrt"),
-              ("rsqrt", "arb_rsqrt"),
-              ("sqrt1pm1", "arb_sqrt1pm1"),
-              ("log", "arb_log"),
-              ("log1p", "arb_log1p"),
-              ("exp", "arb_exp"),
-              ("expm1", "arb_expm1"),
-              ("sin", "arb_sin"),
-              ("cos", "arb_cos"),
-              ("sinpi", "arb_sin_pi"),
-              ("cospi", "arb_cos_pi"),
-              ("tan", "arb_tan"),
-              ("cot", "arb_cot"),
-              ("tanpi", "arb_tan_pi"),
-              ("cotpi", "arb_cot_pi"),
-              ("sinh", "arb_sinh"),
-              ("cosh", "arb_cosh"),
-              ("tanh", "arb_tanh"),
-              ("coth", "arb_coth"),
-              ("atan", "arb_atan"),
-              ("asin", "arb_asin"),
-              ("acos", "arb_acos"),
-              ("atanh", "arb_atanh"),
-              ("asinh", "arb_asinh"),
-              ("acosh", "arb_acosh"),
-              ("gamma", "arb_gamma"),
-              ("lgamma", "arb_lgamma"),
-              ("rgamma", "arb_rgamma"),
-              ("digamma", "arb_digamma"),
-              ("zeta", "arb_zeta"),
-             )
-  @eval begin
-    function($(Symbol(s)))(x::arb)
-      z = parent(x)()
-      ccall(($f, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
-      return z
-    end
-  end
+
+doc"""
+    floor(x::arb)
+> Compute the floor of $x$, i.e. the greatest integer not exceeding $x$, as an
+> Arb.
+"""
+function floor(x::arb)
+   z = parent(x)()
+   ccall((:arb_floor, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
 end
 
+doc"""
+    ceil(x::arb)
+> Return the ceiling of $x$, i.e. the least integer not less than $x$, as an
+> Arb.
+"""
+function ceil(x::arb)
+   z = parent(x)()
+   ccall((:arb_ceil, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sqrt(x::arb)
+> Return the square root of $x$.
+"""
+function sqrt(x::arb)
+   z = parent(x)()
+   ccall((:arb_sqrt, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    rsqrt(x::arb)
+> Return the inverse of the square root of $x$, i.e. $1/\sqrt{x}$.
+"""
+function rsqrt(x::arb)
+   z = parent(x)()
+   ccall((:arb_rsqrt, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sqrt1pm1(x::arb)
+> Return $\sqrt{1+x}-1$, evaluated accurately for small $x$.
+"""
+function sqrt1pm1(x::arb)
+   z = parent(x)()
+   ccall((:arb_sqrt1pm1, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    log(x::arb)
+> Return the principal branch of the logarithm of $x$.
+"""
+function log(x::arb)
+   z = parent(x)()
+   ccall((:arb_log, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    log1p(x::arb)
+> Return $\log(1+x)$, evaluated accurately for small $x$.
+"""
+function log1p(x::arb)
+   z = parent(x)()
+   ccall((:arb_log1p, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    exp(x::arb)
+> Return the exponential of $x$.
+"""
+function exp(x::arb)
+   z = parent(x)()
+   ccall((:arb_exp, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    expm1(x::arb)
+> Return $\exp(x)-1$, evaluated accurately for small $x$.
+"""
+function expm1(x::arb)
+   z = parent(x)()
+   ccall((:arb_expm1, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sin(x::arb)
+> Return the sine of $x$.
+"""
+function sin(x::arb)
+   z = parent(x)()
+   ccall((:arb_sin, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    cos(x::arb)
+> Return the cosine of $x$.
+"""
+function cos(x::arb)
+   z = parent(x)()
+   ccall((:arb_cos, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sinpi(x::arb)
+> Return the sine of $\pi x$.
+"""
+function sinpi(x::arb)
+   z = parent(x)()
+   ccall((:arb_sin_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    cospi(x::arb)
+> Return the cosine of $\pi x$.
+"""
+function cospi(x::arb)
+   z = parent(x)()
+   ccall((:arb_cos_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    tan(x::arb)
+> Return the tangent of $x$.
+"""
+function tan(x::arb)
+   z = parent(x)()
+   ccall((:arb_tan, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    cot(x::arb)
+> Return the cotangent of $x$.
+"""
+function cot(x::arb)
+   z = parent(x)()
+   ccall((:arb_cot, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    tanpi(x::arb)
+> Return the tangent of $\pi x$.
+"""
+function tanpi(x::arb)
+   z = parent(x)()
+   ccall((:arb_tan_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    cotpi(x::arb)
+> Return the cotangent of $\pi x$.
+"""
+function cotpi(x::arb)
+   z = parent(x)()
+   ccall((:arb_cot_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sinh(x::arb)
+> Return the hyperbolic sine of $x$.
+"""
+function sinh(x::arb)
+   z = parent(x)()
+   ccall((:arb_sinh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    cosh(x::arb)
+> Return the hyperbolic cosine of $x$.
+"""
+function cosh(x::arb)
+   z = parent(x)()
+   ccall((:arb_cosh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    tanh(x::arb)
+> Return the hyperbolic tangent of $x$.
+"""
+function tanh(x::arb)
+   z = parent(x)()
+   ccall((:arb_tanh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    coth(x::arb)
+> Return the hyperbolic cotangent of $x$.
+"""
+function coth(x::arb)
+   z = parent(x)()
+   ccall((:arb_coth, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    atan(x::arb)
+> Return the arctangent of $x$.
+"""
+function atan(x::arb)
+   z = parent(x)()
+   ccall((:arb_atan, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    asin(x::arb)
+> Return the arcsine of $x$.
+"""
+function asin(x::arb)
+   z = parent(x)()
+   ccall((:arb_asin, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    acos(x::arb)
+> Return the arccosine of $x$.
+"""
+function acos(x::arb)
+   z = parent(x)()
+   ccall((:arb_acos, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    atanh(x::arb)
+> Return the hyperbolic arctangent of $x$.
+"""
+function atanh(x::arb)
+   z = parent(x)()
+   ccall((:arb_atanh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    asinh(x::arb)
+> Return the hyperbolic arcsine of $x$.
+"""
+function asinh(x::arb)
+   z = parent(x)()
+   ccall((:arb_asinh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    acosh(x::arb)
+> Return the hyperbolic arccosine of $x$.
+"""
+function acosh(x::arb)
+   z = parent(x)()
+   ccall((:arb_acosh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    gamma(x::arb)
+> Return the Gamma function evaluated at $x$.
+"""
+function gamma(x::arb)
+   z = parent(x)()
+   ccall((:arb_gamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    lgamma(x::arb)
+> Return the logarithm of the Gamma function evaluated at $x$.
+"""
+function lgamma(x::arb)
+   z = parent(x)()
+   ccall((:arb_lgamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    rgamma(x::arb)
+> Return the reciprocal of the Gamma function evaluated at $x$.
+"""
+function rgamma(x::arb)
+   z = parent(x)()
+   ccall((:arb_rgamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    digamma(x::arb)
+> Return the  logarithmic derivative of the gamma function evaluated at $x$,
+> i.e. $\psi(x)$.
+"""
+function digamma(x::arb)
+   z = parent(x)()
+   ccall((:arb_digamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    zeta(x::arb)
+> Return the Riemann zeta function evaluated at $x$.
+"""
+function zeta(x::arb)
+   z = parent(x)()
+   ccall((:arb_zeta, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   return z
+end
+
+doc"""
+    sincos(x::arb)
+> Return a tuple $s, c$ consisting of the sine $s$ and cosine $c$ of $x$.
+"""
 function sincos(x::arb)
   s = parent(x)()
   c = parent(x)()
@@ -683,6 +1175,10 @@ function sincos(x::arb)
   return (s, c)
 end
 
+doc"""
+    sincospi(x::arb)
+> Return a tuple $s, c$ consisting of the sine $s$ and cosine $c$ of $\pi x$.
+"""
 function sincospi(x::arb)
   s = parent(x)()
   c = parent(x)()
@@ -691,6 +1187,10 @@ function sincospi(x::arb)
   return (s, c)
 end
 
+doc"""
+    sinpi(x::fmpq, r::ArbField)
+> Return the sine of $\pi x$ in the given Arb field.
+"""
 function sinpi(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_sin_pi_fmpq, :libarb), Void,
@@ -698,6 +1198,10 @@ function sinpi(x::fmpq, r::ArbField)
   return z
 end
 
+doc"""
+    cospi(x::fmpq, r::ArbField)
+>  Return the cosine of $\pi x$ in the given Arb field.
+"""
 function cospi(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_cos_pi_fmpq, :libarb), Void,
@@ -705,6 +1209,11 @@ function cospi(x::fmpq, r::ArbField)
   return z
 end
 
+doc"""
+    sincospi(x::fmpq, r::ArbField)
+> Return a tuple $s, c$ consisting of the sine and cosine of $\pi x$ in the
+> given Arb field.
+"""
 function sincospi(x::fmpq, r::ArbField)
   s = r()
   c = r()
@@ -713,6 +1222,10 @@ function sincospi(x::fmpq, r::ArbField)
   return (s, c)
 end
 
+doc"""
+    sinhcosh(x::arb)
+> Return a tuple $s, c$ consisting of the hyperbolic sine and cosine of $x$.
+"""
 function sinhcosh(x::arb)
   s = parent(x)()
   c = parent(x)()
@@ -721,6 +1234,10 @@ function sinhcosh(x::arb)
   return (s, c)
 end
 
+doc"""
+    atan2(x::arb, y::arb)
+> Return atan2$(b,a) = \arg(a+bi)$.
+"""
 function atan2(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_atan2, :libarb), Void,
@@ -728,6 +1245,10 @@ function atan2(x::arb, y::arb)
   return z
 end
 
+doc"""
+    agm(x::arb, y::arb)
+> Return the arithmetic-geometric mean of $x$ and $y$
+"""
 function agm(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_agm, :libarb), Void,
@@ -735,6 +1256,10 @@ function agm(x::arb, y::arb)
   return z
 end
 
+doc"""
+    zeta(s::arb, a::arb)
+> Return the Hurwitz zeta function $\zeta(s,a)$..
+"""
 function zeta(s::arb, a::arb)
   z = parent(s)()
   ccall((:arb_hurwitz_zeta, :libarb), Void,
@@ -742,6 +1267,10 @@ function zeta(s::arb, a::arb)
   return z
 end
 
+doc"""
+    hypot(x::arb, y::arb)
+> Return $\sqrt{x^2 + y^2}$.
+"""
 function hypot(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_hypot, :libarb), Void,
@@ -756,8 +1285,16 @@ function root(x::arb, n::UInt)
   return z
 end
 
+doc"""
+    root(x::arb, n::Int)
+> Return the $n$-th root of $x$. We require $x \geq 0$.
+"""
 root(x::arb, n::Int) = x < 0 ? throw(DomainError()) : root(x, UInt(n))
 
+doc"""
+    fac(x::arb)
+> Return the factorial of $x$.
+"""
 fac(x::arb) = gamma(x+1)
 
 function fac(n::UInt, r::ArbField)
@@ -766,8 +1303,16 @@ function fac(n::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    fac(n::Int, r::ArbField)
+> Return the factorial of $n$ in the given Arb field.
+"""
 fac(n::Int, r::ArbField) = n < 0 ? fac(r(n)) : fac(UInt(n), r)
 
+doc"""
+    binom(x::arb, n::UInt)
+> Return the binomial coefficient ${x \choose n}$.
+"""
 function binom(x::arb, n::UInt)
   z = parent(x)()
   ccall((:arb_bin_ui, :libarb), Void,
@@ -775,6 +1320,10 @@ function binom(x::arb, n::UInt)
   return z
 end
 
+doc"""
+    binom(n::UInt, k::UInt, r::ArbField)
+> Return the binomial coefficient ${n \choose k}$ in the given Arb field.
+"""
 function binom(n::UInt, k::UInt, r::ArbField)
   z = r()
   ccall((:arb_bin_uiui, :libarb), Void,
@@ -782,6 +1331,10 @@ function binom(n::UInt, k::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    fib(n::fmpz, r::ArbField)
+> Return the $n$-th Fibonacci number in the given Arb field.
+"""
 function fib(n::fmpz, r::ArbField)
   z = r()
   ccall((:arb_fib_fmpz, :libarb), Void,
@@ -796,8 +1349,16 @@ function fib(n::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    fib(n::Int, r::ArbField)
+> Return the $n$-th Fibonacci number in the given Arb field.
+"""
 fib(n::Int, r::ArbField) = n >= 0 ? fib(UInt(n), r) : fib(fmpz(n), r)
 
+doc"""
+    gamma(x::fmpz, r::ArbField)
+> Return the Gamma function evaluated at $x$ in the given Arb field.
+"""
 function gamma(x::fmpz, r::ArbField)
   z = r()
   ccall((:arb_gamma_fmpz, :libarb), Void,
@@ -805,12 +1366,17 @@ function gamma(x::fmpz, r::ArbField)
   return z
 end
 
+doc"""
+    gamma(x::fmpq, r::ArbField)
+> Return the Gamma function evaluated at $x$ in the given Arb field.
+"""
 function gamma(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_gamma_fmpq, :libarb), Void,
               (Ptr{arb}, Ptr{fmpq}, Int), &z, &x, r.prec)
   return z
 end
+
 
 function zeta(n::UInt, r::ArbField)
   z = r()
@@ -819,6 +1385,11 @@ function zeta(n::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    zeta(n::Int, r::ArbField)
+> Return the Riemann zeta function $\zeta(n)$ as an element of the given Arb
+> field.
+"""
 zeta(n::Int, r::ArbField) = n >= 0 ? zeta(UInt(n), r) : zeta(r(n))
 
 function bernoulli(n::UInt, r::ArbField)
@@ -828,6 +1399,10 @@ function bernoulli(n::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    bernoulli(n::Int, r::ArbField)
+> Return the $n$-th Bernoulli number as an element of the given Arb field.
+"""
 bernoulli(n::Int, r::ArbField) = n >= 0 ? bernoulli(UInt(n), r) : throw(DomainError)
 
 function risingfac(x::arb, n::UInt)
@@ -837,6 +1412,10 @@ function risingfac(x::arb, n::UInt)
   return z
 end
 
+doc"""
+    risingfac(x::arb, n::Int)
+> Return the rising factorial $x(x + 1)\ldots (x + n - 1)$ as an Arb.
+"""
 risingfac(x::arb, n::Int) = n < 0 ? throw(DomainError()) : risingfac(x, UInt(n))
 
 function risingfac(x::fmpq, n::UInt, r::ArbField)
@@ -846,6 +1425,11 @@ function risingfac(x::fmpq, n::UInt, r::ArbField)
   return z
 end
 
+doc"""
+    risingfac(x::fmpq, n::Int, r::ArbField)
+> Return the rising factorial $x(x + 1)\ldots (x + n - 1)$ as an element of the
+> given Arb field.
+"""
 risingfac(x::fmpq, n::Int, r::ArbField) = n < 0 ? throw(DomainError()) : risingfac(x, UInt(n), r)
 
 function risingfac2(x::arb, n::UInt)
@@ -856,8 +1440,17 @@ function risingfac2(x::arb, n::UInt)
   return (z, w)
 end
 
+doc"""
+    risingfac2(x::arb, n::Int)
+> Return a tuple containing the rising factorial $x(x + 1)\ldots (x + n - 1)$
+> and its derivative.
+"""
 risingfac2(x::arb, n::Int) = n < 0 ? throw(DomainError()) : risingfac2(x, UInt(n))
 
+doc"""
+    polylog(s::arb, a::arb)
+> Return the polylogarithm Li$_s(a)$.
+"""
 function polylog(s::arb, a::arb)
   z = parent(s)()
   ccall((:arb_polylog, :libarb), Void,
@@ -865,6 +1458,10 @@ function polylog(s::arb, a::arb)
   return z
 end
 
+doc"""
+    polylog(s::Int, a::arb)
+> Return the polylogarithm Li$_s(a)$.
+"""
 function polylog(s::Int, a::arb)
   z = parent(a)()
   ccall((:arb_polylog_si, :libarb), Void,
@@ -902,11 +1499,34 @@ function chebyshev_u2(n::UInt, x::arb)
   return z, w
 end
 
+doc"""
+    chebyshev_t(n::Int, x::arb)
+> Return the value of the Chebyshev polynomial $T_n(x)$.
+"""
 chebyshev_t(n::Int, x::arb) = n < 0 ? throw(DomainError()) : chebyshev_t(UInt(n), x)
+
+doc"""
+    chebyshev_u(n::Int, x::arb)
+> Return the value of the Chebyshev polynomial $U_n(x)$.
+"""
 chebyshev_u(n::Int, x::arb) = n < 0 ? throw(DomainError()) : chebyshev_u(UInt(n), x)
+
+doc"""
+    chebyshev_t2(n::Int, x::arb)
+> Return the tuple $(T_{n}(x), T_{n-1}(x))$.
+"""
 chebyshev_t2(n::Int, x::arb) = n < 0 ? throw(DomainError()) : chebyshev_t2(UInt(n), x)
+
+doc"""
+    chebyshev_u2(n::Int, x::arb)
+> Return the tuple $(U_{n}(x), U_{n-1}(x))$ 
+"""
 chebyshev_u2(n::Int, x::arb) = n < 0 ? throw(DomainError()) : chebyshev_u2(UInt(n), x)
 
+doc"""
+    bell(n::fmpz, r::ArbField)
+> Return the Bell number $B_n$ as an element of $r$.
+"""
 function bell(n::fmpz, r::ArbField)
   z = r()
   ccall((:arb_bell_fmpz, :libarb), Void,
@@ -914,11 +1534,15 @@ function bell(n::fmpz, r::ArbField)
   return z
 end
 
+doc"""
+    bell(n::Int, r::ArbField)
+> Return the Bell number $B_n$ as an element of $r$.
+"""
 bell(n::Int, r::ArbField) = bell(fmpz(n), r)
 
 ################################################################################
 #
-#  Unsafe binary operations
+#  Unsafe operations
 #
 ################################################################################
 
@@ -930,6 +1554,11 @@ for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
                            &z, &x, &y, parent(x).prec)
     end
   end
+end
+
+function addeq!(z::arb, x::arb)
+    ccall((:arb_add, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
+                           &z, &z, &y, parent(x).prec)
 end
 
 ################################################################################
@@ -1007,3 +1636,88 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
   end
 end
 
+################################################################################
+#
+#  Parent object overloading
+#
+################################################################################
+
+function call(r::ArbField)
+  z = arb()
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::Int)
+  z = arb(fmpz(x), r.prec)
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::UInt)
+  z = arb(fmpz(x), r.prec)
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::fmpz)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+
+call(r::ArbField, x::Integer) = r(fmpz(x))
+
+function call(r::ArbField, x::fmpq)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+  
+#function call(r::ArbField, x::arf)
+#  z = arb(arb(x), r.prec)
+#  z.parent = r
+#  return z
+#end
+
+function call(r::ArbField, x::Float64)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::arb)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::AbstractString)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+
+function call(r::ArbField, x::Irrational)
+  if x == pi
+    return const_pi(r)
+  elseif x == e
+    return const_e(r.prec)
+  else
+    error("constant not supported")
+  end
+end
+
+function call(r::ArbField, x::BigFloat)
+  z = arb(x, r.prec)
+  z.parent = r
+  return z
+end
+
+################################################################################
+#
+#  Arb real field constructor
+#
+################################################################################
+
+# see inner constructor for ArbField

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -57,8 +57,8 @@ function test_acb_comparison()
    @test !(exact3 == approx3)
    @test !(exact3 != approx3)
 
-   @test strongequal(approx3, approx3)
-   @test !strongequal(approx3, exact3)
+   @test isequal(approx3, approx3)
+   @test !isequal(approx3, exact3)
 
    @test overlaps(approx3, exact3)
    @test overlaps(exact3, approx3)

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -65,8 +65,8 @@ function test_arb_comparison()
    @test !(exact3 < approx3)
    @test !(exact3 <= approx3)
 
-   @test strongequal(approx3, approx3)
-   @test !strongequal(approx3, exact3)
+   @test isequal(approx3, approx3)
+   @test !isequal(approx3, exact3)
 
    @test overlaps(approx3, exact3)
    @test overlaps(exact3, approx3)


### PR DESCRIPTION
* I changed strong_equals to isequal, in line with other modules.

* I recommend we look at adding / as well as //, since Arb balls are basically a floating point format, so division can be denoted /.