### PR TITLE
Fix deepcopy for ResElem{}

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -191,10 +191,10 @@ end
 function create_accessors(T, S, handle)
    accessor_name = gensym()
    @eval begin
-      function $(symbol(:get, accessor_name))(a::$T)
+      function $(Symbol(:get, accessor_name))(a::$T)
          return a.auxilliary_data[$handle]::$S
       end,
-      function $(symbol(:set, accessor_name))(a::$T, b::$S)
+      function $(Symbol(:set, accessor_name))(a::$T, b::$S)
          if $handle > length(a.auxilliary_data)
             resize(a.auxilliary_data, $handle)
          end

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -113,7 +113,8 @@ function isunit(a::ResElem)
    return g == 1
 end
 
-deepcopy(a::ResElem) = parent(a)(deepcopy(data(a)))
+deepcopy_internal(a::ResElem, dict::ObjectIdDict) =
+   parent(a)(deepcopy(data(a)))
 
 ###############################################################################
 #


### PR DESCRIPTION
Fixed also some deprecation warnings (shows only up if you call the accessor functions).

@wbhart While nemocas.org is responsive, http://nemocas.org/binaries/pari-2.7.4.tar.gz can not be found.