### PR TITLE
Byebye julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,10 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - release
+  - 0.5
   - nightly
 notifications:
   - email: false
-#script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.test("Nemo")'
-
 after_success:
   - julia -e 'Pkg.clone("https://github.com/MichaelHatherly/Documenter.jl")'
   - julia -e 'cd(Pkg.dir("Nemo")); include(joinpath("doc", "build.jl"))'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,14 @@
 environment:
   matrix:
   # Releases
-#  - JULIAVERSION: "stable/win32"
-  - JULIAVERSION: "stable/win64"
+   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   # Nightlies
-#  - JULIAVERSION: "download/win32"
-#  - JULIAVERSION: "download/win64"
 
 install:
 # Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,3 @@
-on_windows = @windows ? true : false
-on_osx = @osx ? true : false
-
 oldwdir = pwd()
 
 pkgdir = Pkg.dir("Nemo") 
@@ -29,7 +26,7 @@ end
 
 #install libpthreads
 
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libwinpthread-1.dll", joinpath(vdir, "lib", "libwinpthread-1.dll"))
    else
@@ -41,7 +38,7 @@ cd(wdir)
 
 # install M4
 
-if !on_windows
+if !is_windows()
    try
       run(`m4 --version`)
    catch
@@ -63,7 +60,7 @@ if !ispath(Pkg.dir("Nemo", "local", "mpir-2.7.2"))
    download("http://mpir.org/mpir-2.7.2.tar.bz2", joinpath(wdir, "mpir-2.7.2.tar.bz2"))
 end
 
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libgmp-16.dll", joinpath(vdir, "lib", "libgmp-16.dll"))
    else
@@ -93,7 +90,7 @@ if !ispath(Pkg.dir("Nemo", "local", "mpfr-3.1.4"))
    download("http://ftp.gnu.org/gnu/mpfr/mpfr-3.1.4.tar.bz2", joinpath(wdir, "mpfr-3.1.4.tar.bz2"))
 end
 
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libmpfr-4.dll", joinpath(vdir, "lib", "libmpfr-4.dll"))
    else
@@ -115,24 +112,28 @@ cd(wdir)
 
 # install ANTIC
 
-try
-  run(`git clone https://github.com/wbhart/antic.git`)
-catch
-  cd(joinpath("$wdir", "antic"))
-  run(`git pull`)
-end          
+if !is_windows()
+  try
+    run(`git clone https://github.com/wbhart/antic.git`)
+  catch
+    cd(joinpath("$wdir", "antic"))
+    run(`git pull`)
+  end          
+end
 
 cd(wdir)
 
 # install FLINT
-try
-  run(`git clone https://github.com/wbhart/flint2.git`)
-catch
-  cd(joinpath("$wdir", "flint2"))
-  run(`git pull`)
-end          
+if !is_windows()
+  try
+    run(`git clone https://github.com/wbhart/flint2.git`)
+  catch
+    cd(joinpath("$wdir", "flint2"))
+    run(`git pull`)
+  end          
+end
 
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libflint.dll", joinpath(vdir, "lib", "libflint.dll"))
    else
@@ -140,6 +141,8 @@ if on_windows
    end
    try
       run(`ln -sf $vdir\\lib\\libflint.dll $vdir\\lib\\libflint-13.dll`)
+   catch
+      cp("libflint.dll", "libflint-13.dll")
    end
 else
    cd(joinpath("$wdir", "flint2"))
@@ -154,15 +157,17 @@ cd(wdir)
 
 # INSTALL ARB 
 
-try
-  run(`git clone https://github.com/fredrik-johansson/arb.git`)
-catch
-  cd(joinpath("$wdir", "arb"))
-  run(`git pull`)
-  cd(wdir)
-end          
+if !is_windows()
+  try
+    run(`git clone https://github.com/fredrik-johansson/arb.git`)
+  catch
+    cd(joinpath("$wdir", "arb"))
+    run(`git pull`)
+    cd(wdir)
+  end          
+end
  
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libarb.dll", joinpath(vdir, "lib", "libarb.dll"))
    else
@@ -189,13 +194,13 @@ if !ispath(Pkg.dir("Nemo", "local", "pari-2.7.4"))
    download("http://nemocas.org/binaries/pari-2.7.4.tar.gz", joinpath(wdir, "pari-2.7.4.tar.gz"))
 end
 
-if on_windows
+if is_windows()
    if Int == Int32
       download_dll("http://nemocas.org/binaries/w32-libpari.dll", joinpath(vdir, "lib", "libpari.dll"))
    else
       download_dll("http://nemocas.org/binaries/w64-libpari.dll", joinpath(vdir, "lib", "libpari.dll"))
    end
-elseif on_osx
+elseif is_apple()
    run(`tar -xvf pari-2.7.4.tar.gz`)
    run(`rm pari-2.7.4.tar.gz`)
    cd(joinpath("$wdir", "pari-2.7.4"))

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -8,7 +8,7 @@ import Base: Array, abs, asin, asinh, atan, atanh, base, bin, call,
              exp, factor, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
              invmod, isequal, isfinite, isless, isprime, isqrt, isreal, lcm,
              ldexp, length, log, lufact, lufact!, mod, ndigits, nextpow2, norm,
-             nullspace, num, oct, one, parent, parity, parseint, precision,
+             nullspace, num, oct, one, parent, parity, parse, precision,
              prevpow2, promote_rule, rank, Rational, rem, reverse, serialize,
              setindex!, show, sign, sin, sinh, size, sqrt, string, sub, tan,
              tanh, trace, trailing_zeros, transpose, transpose!, truncate,
@@ -40,7 +40,7 @@ export flint_cleanup, flint_set_num_threads
 
 export error_dim_negative
 
-export on_windows64
+export is_windows64
 
 include("AbstractTypes.jl")
 
@@ -50,11 +50,11 @@ include("AbstractTypes.jl")
 #
 ###############################################################################
 
-on_windows64 = (@windows ? true : false) && (Int == Int64)
+is_windows64() = (is_windows() ? true : false) && (Int == Int64)
 
 const pkgdir = realpath(joinpath(dirname(@__FILE__), ".."))
 const libdir = joinpath(pkgdir, "local", "lib")
-if (@windows ? true : false)
+if is_windows()
    const libgmp = joinpath(pkgdir, "local", "lib", "libgmp-16")
 else
    const libgmp = joinpath(pkgdir, "local", "lib", "libgmp")
@@ -79,12 +79,9 @@ end
 
 function __init__()
 
-   on_windows = @windows ? true : false
-   on_linux = @linux ? true : false
-
    if "HOSTNAME" in keys(ENV) && ENV["HOSTNAME"] == "juliabox"
        push!(Libdl.DL_LOAD_PATH, "/usr/local/lib")
-   elseif on_linux
+   elseif is_linux()
        push!(Libdl.DL_LOAD_PATH, libdir)
        Libdl.dlopen(libgmp)
        Libdl.dlopen(libmpfr)
@@ -95,7 +92,7 @@ function __init__()
       push!(Libdl.DL_LOAD_PATH, libdir)
    end
  
-   if !on_windows
+   if !is_windows()
       ccall((:pari_set_memory_functions, libpari), Void,
          (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Void}),
          cglobal(:jl_malloc),
@@ -116,7 +113,7 @@ function __init__()
 
    unsafe_store!(pari_sigint, cfunction(pari_sigint_handler, Void, ()), 1)
 
-   if !on_windows
+   if !is_windows()
       ccall((:__gmp_set_memory_functions, libgmp), Void,
          (Ptr{Void},Ptr{Void},Ptr{Void}),
          cglobal(:jl_gc_counted_malloc),
@@ -135,7 +132,7 @@ function __init__()
       (Ptr{Void},), cfunction(flint_abort, Void, ()))
 
    println("")
-   println("Welcome to Nemo version 0.5.1")
+   println("Welcome to Nemo version 0.5.2")
    println("")
    println("Nemo comes with absolutely no warranty whatsoever")
    println("")
@@ -191,10 +188,10 @@ end
 function create_accessors(T, S, handle)
    accessor_name = gensym()
    @eval begin
-      function $(symbol(:get, accessor_name))(a::$T)
+      function $(Symbol(:get, accessor_name))(a::$T)
          return a.auxilliary_data[$handle]::$S
       end,
-      function $(symbol(:set, accessor_name))(a::$T, b::$S)
+      function $(Symbol(:set, accessor_name))(a::$T, b::$S)
          if $handle > length(a.auxilliary_data)
             resize(a.auxilliary_data, $handle)
          end

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -219,9 +219,9 @@ end
 function show(io::IO, x::nf_elem)
    cstr = ccall((:nf_elem_get_str_pretty, :libflint), Ptr{UInt8},
                 (Ptr{nf_elem}, Ptr{UInt8}, Ptr{AnticNumberField}),
-                 &x, bytestring(string(var(parent(x)))), &parent(x))
+                 &x, string(var(parent(x))), &parent(x))
 
-   print(io, bytestring(cstr))
+   print(io, unsafe_string(cstr))
 
    ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 end
@@ -832,42 +832,42 @@ Base.promote_rule(::Type{nf_elem}, ::Type{fmpq_poly}) = nf_elem
 #
 ###############################################################################
 
-function Base.call(a::AnticNumberField)
+function (a::AnticNumberField)()
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
          (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, 0, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, c::Int)
+function (a::AnticNumberField)(c::Int)
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
          (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, c, &a)
    return z
 end
 
-Base.call(a::AnticNumberField, c::Integer) = a(fmpz(c))
+(a::AnticNumberField)(c::Integer) = a(fmpz(c))
 
-function Base.call(a::AnticNumberField, c::fmpz)
+function (a::AnticNumberField)(c::fmpz)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpz, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}), &z, &c, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, c::fmpq)
+function (a::AnticNumberField)(c::fmpq)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpq, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}), &z, &c, &a)
    return z
 end
 
-function Base.call(a::AnticNumberField, b::nf_elem)
+function (a::AnticNumberField)(b::nf_elem)
    parent(b) != a && error("Cannot coerce number field element")
    return b
 end
 
-function Base.call(a::AnticNumberField, pol::fmpq_poly)
+function (a::AnticNumberField)(pol::fmpq_poly)
    pol = parent(a.pol)(pol) # check pol has correct parent
    z = nf_elem(a)
    if length(pol) >= length(a.pol)
@@ -878,7 +878,7 @@ function Base.call(a::AnticNumberField, pol::fmpq_poly)
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::nf_elem)
+function (a::FmpqPolyRing)(b::nf_elem)
    parent(parent(b).pol) != a && error("Cannot coerce from number field to polynomial ring")
    r = a()
    ccall((:nf_elem_get_fmpq_poly, :libflint), Void,

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1496,21 +1496,23 @@ end
 #
 ################################################################################
 
-function call(r::AcbField)
+function (r::AcbField)()
   z = acb()
   z.parent = r
   return z
 end
 
-function call(r::AcbField, x::Union{Int, UInt, fmpz, fmpq, arb, acb, Float64, BigFloat, AbstractString})
+function (r::AcbField)(x::Union{Int, UInt, fmpz, fmpq, arb, acb, Float64,
+                                BigFloat, AbstractString})
   z = acb(x, r.prec)
   z.parent = r
   return z
 end
 
-call(r::AcbField, x::Integer) = r(fmpz(x))
+(r::AcbField)(x::Integer) = r(fmpz(x))
 
-function call{T <: Union{Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}(r::AcbField, x::T, y::T)
+function (r::AcbField){T <: Union{Int, UInt, fmpz, fmpq, arb, Float64,
+                                              BigFloat, AbstractString}}(x::T, y::T)
   z = acb(x, y, r.prec)
   z.parent = r
   return z

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -601,13 +601,13 @@ end
 #
 ###############################################################################
 
-function call(x::AcbMatSpace)
+function (x::AcbMatSpace)()
   z = acb_mat(x.rows, x.cols)
   z.parent = x
   return z
 end
 
-function call(x::AcbMatSpace, y::fmpz_mat)
+function (x::AcbMatSpace)(y::fmpz_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = acb_mat(y, prec(x))
@@ -615,7 +615,7 @@ function call(x::AcbMatSpace, y::fmpz_mat)
   return z
 end
 
-function call(x::AcbMatSpace, y::arb_mat)
+function (x::AcbMatSpace)(y::arb_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = acb_mat(y, prec(x))
@@ -624,35 +624,34 @@ function call(x::AcbMatSpace, y::arb_mat)
 end
 
 
-function call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
-                         AbstractString}}(x::AcbMatSpace, y::Array{T, 2})
+function (x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
+                         AbstractString}}(y::Array{T, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = acb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
-                AbstractString}}(x::AcbMatSpace, y::Array{T, 1}) = x(y'')
+(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb, acb,
+                AbstractString}}(y::Array{T, 1}) = x(y'')
 
 
-function call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb,
-                         AbstractString}}(x::AcbMatSpace,
-                                          y::Array{Tuple{T, T}, 2})
+function (x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, arb,
+                         AbstractString}}(y::Array{Tuple{T, T}, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = acb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString,
-                arb}}(x::AcbMatSpace, y::Array{Tuple{T, T}, 1}) = x(y'')
+(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString,
+                arb}}(y::Array{Tuple{T, T}, 1}) = x(y'')
 
 
-call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb,
-                AbstractString}}(x::ArbMatSpace, y::Array{T, 1}) = x(y'')
+(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb,
+                AbstractString}}(y::Array{T, 1}) = x(y'')
 
-function call(x::AcbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
+function (x::AcbMatSpace)(y::Union{Int, UInt, fmpz, fmpq, Float64,
                           BigFloat, arb, acb, AbstractString})
   z = x()
   for i in 1:rows(z)
@@ -667,7 +666,7 @@ function call(x::AcbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
    return z
 end
 
-call(x::AcbMatSpace, y::acb_mat) = y
+(x::AcbMatSpace)(y::acb_mat) = y
 
 ###############################################################################
 #

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -81,10 +81,10 @@ function show(io::IO, f::acb_poly)
   else
     print(io, "[ ")
     for i in 0:degree(f)-1
-      show(io, coeff(f,i))
+      print(io, coeff(f,i))
       print(io, ", ")
     end
-    show(coeff(f,degree(f)))
+    print(io, coeff(f,degree(f)))
     print(io, " ]")
   end
 end
@@ -867,43 +867,43 @@ Base.promote_rule(::Type{acb_poly}, ::Type{arb_poly}) = acb_poly
 #
 ################################################################################
 
-function Base.call(a::AcbPolyRing)
+function (a::AcbPolyRing)()
    z = acb_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::Union{Int,fmpz,fmpq,Float64,Complex{Float64},Complex{Int},arb,acb})
+function (a::AcbPolyRing)(b::Union{Int,fmpz,fmpq,Float64,Complex{Float64},Complex{Int},arb,acb})
    z = acb_poly(base_ring(a)(b), a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::Array{acb, 1})
+function (a::AcbPolyRing)(b::Array{acb, 1})
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::fmpz_poly)
+function (a::AcbPolyRing)(b::fmpz_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::fmpq_poly)
+function (a::AcbPolyRing)(b::fmpq_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::arb_poly)
+function (a::AcbPolyRing)(b::arb_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::AcbPolyRing, b::acb_poly)
+function (a::AcbPolyRing)(b::acb_poly)
    z = acb_poly(b, a.base_ring.prec)
    z.parent = a
    return z

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -115,7 +115,7 @@ function show(io::IO, x::arb)
   d = ceil(parent(x).prec * 0.30102999566398119521)
   cstr = ccall((:arb_get_str, :libarb), Ptr{UInt8}, (Ptr{arb}, Int, UInt),
                                                   &x, Int(d), UInt(0))
-  print(io, bytestring(cstr))
+  print(io, unsafe_string(cstr))
   ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 end
 
@@ -1657,7 +1657,7 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
     end
 
     function _arb_set(x::($typeofx), y::AbstractString, p::Int)
-      s = bytestring(y)
+      s = string(y)
       err = ccall((:arb_set_str, :libarb), Int32,
                   (($passtoc), Ptr{UInt8}, Int), x, s, p)
       err == 0 || error("Invalid real string: $(repr(s))")
@@ -1691,33 +1691,33 @@ end
 #
 ################################################################################
 
-function call(r::ArbField)
+function (r::ArbField)()
   z = arb()
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::Int)
+function (r::ArbField)(x::Int)
   z = arb(fmpz(x), r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::UInt)
+function (r::ArbField)(x::UInt)
   z = arb(fmpz(x), r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::fmpz)
+function (r::ArbField)(x::fmpz)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-call(r::ArbField, x::Integer) = r(fmpz(x))
+(r::ArbField)(x::Integer) = r(fmpz(x))
 
-function call(r::ArbField, x::fmpq)
+function (r::ArbField)(x::fmpq)
   z = arb(x, r.prec)
   z.parent = r
   return z
@@ -1729,25 +1729,25 @@ end
 #  return z
 #end
 
-function call(r::ArbField, x::Float64)
+function (r::ArbField)(x::Float64)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::arb)
+function (r::ArbField)(x::arb)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::AbstractString)
+function (r::ArbField)(x::AbstractString)
   z = arb(x, r.prec)
   z.parent = r
   return z
 end
 
-function call(r::ArbField, x::Irrational)
+function (r::ArbField)(x::Irrational)
   if x == pi
     return const_pi(r)
   elseif x == e
@@ -1757,7 +1757,7 @@ function call(r::ArbField, x::Irrational)
   end
 end
 
-function call(r::ArbField, x::BigFloat)
+function (r::ArbField)(x::BigFloat)
   z = arb(x, r.prec)
   z.parent = r
   return z

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -564,13 +564,13 @@ end
 #
 ###############################################################################
 
-function call(x::ArbMatSpace)
+function (x::ArbMatSpace)()
   z = arb_mat(x.rows, x.cols)
   z.parent = x
   return z
 end
 
-function call(x::ArbMatSpace, y::fmpz_mat)
+function (x::ArbMatSpace)(y::fmpz_mat)
   (x.cols != cols(y) || x.rows != rows(y)) &&
       error("Dimensions are wrong")
   z = arb_mat(y, prec(x))
@@ -578,18 +578,18 @@ function call(x::ArbMatSpace, y::fmpz_mat)
   return z
 end
 
-function call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
-                         AbstractString}}(x::ArbMatSpace, y::Array{T, 2})
+function (x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat,
+                                     arb, AbstractString}}(y::Array{T, 2})
   (x.rows, x.cols) != size(y) && error("Dimensions are wrong")
   z = arb_mat(x.rows, x.cols, y, prec(x))
   z.parent = x
   return z
 end
 
-call{T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
-                AbstractString}}(x::ArbMatSpace, y::Array{T, 1}) = x(y'')
+(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb,
+                AbstractString}}(y::Array{T, 1}) = x(y'')
 
-function call(x::ArbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
+function (x::ArbMatSpace)(y::Union{Int, UInt, fmpz, fmpq, Float64,
                           BigFloat, arb, AbstractString})
   z = x()
   for i in 1:rows(z)
@@ -604,7 +604,7 @@ function call(x::ArbMatSpace, y::Union{Int, UInt, fmpz, fmpq, Float64,
    return z
 end
 
-call(x::ArbMatSpace, y::arb_mat) = y
+(x::ArbMatSpace)(y::arb_mat) = y
 
 ###############################################################################
 #

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -81,10 +81,10 @@ function show(io::IO, f::arb_poly)
   else
     print(io, "[ ")
     for i in 0:degree(f)-1
-      show(io, coeff(f,i))
+      print(io, coeff(f,i))
       print(io, ", ")
     end
-    show(coeff(f,degree(f)))
+    print(io, coeff(f,degree(f)))
     print(io, " ]")
   end
 end
@@ -743,37 +743,37 @@ Base.promote_rule(::Type{arb_poly}, ::Type{fmpq_poly}) = arb_poly
 #
 ################################################################################
 
-function Base.call(a::ArbPolyRing)
+function (a::ArbPolyRing)()
    z = arb_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::Union{Int,fmpz,fmpq,Float64,arb})
+function (a::ArbPolyRing)(b::Union{Int,fmpz,fmpq,Float64,arb})
    z = arb_poly(base_ring(a)(b), a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::Array{arb, 1})
+function (a::ArbPolyRing)(b::Array{arb, 1})
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::fmpz_poly)
+function (a::ArbPolyRing)(b::fmpz_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::fmpq_poly)
+function (a::ArbPolyRing)(b::fmpq_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::ArbPolyRing, b::arb_poly)
+function (a::ArbPolyRing)(b::arb_poly)
    z = arb_poly(b, a.base_ring.prec)
    z.parent = a
    return z

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -623,7 +623,7 @@ type FqNmodFiniteField <: FinField
          d = new()
          ccall((:fq_nmod_ctx_init, :libflint), Void, 
                (Ptr{FqNmodFiniteField}, Ptr{fmpz}, Int, Ptr{UInt8}), 
-			    &d, &c, deg, bytestring(string(s)))
+			    &d, &c, deg, string(s))
          FqNmodFiniteFieldID[c, deg, s] = d
          finalizer(d, _FqNmodFiniteField_clear_fn)
          return d
@@ -637,7 +637,7 @@ type FqNmodFiniteField <: FinField
          z = new()
          ccall((:fq_nmod_ctx_init_modulus, :libflint), Void, 
             (Ptr{FqNmodFiniteField}, Ptr{nmod_poly}, Ptr{UInt8}), 
-	      &z, &f, bytestring(string(s)))
+	      &z, &f, string(s))
          FqNmodFiniteFieldIDPol[parent(f), f, s] = z
          finalizer(z, _FqNmodFiniteField_clear_fn)
          return z
@@ -737,7 +737,7 @@ type FqFiniteField <: FinField
          finalizer(d, _FqFiniteField_clear_fn)
          ccall((:fq_ctx_init, :libflint), Void,
                (Ptr{FqFiniteField}, Ptr{fmpz}, Int, Ptr{UInt8}),
-                  &d, &char, deg, bytestring(string(s)))
+                  &d, &char, deg, string(s))
          return d
       end
    end
@@ -749,7 +749,7 @@ type FqFiniteField <: FinField
          z = new()
          ccall((:fq_ctx_init_modulus, :libflint), Void,
                (Ptr{FqFiniteField}, Ptr{fmpz_mod_poly}, Ptr{UInt8}),
-                  &z, &f, bytestring(string(s)))
+                  &z, &f, string(s))
          FqFiniteFieldIDPol[f, s] = z
          finalizer(z, _FqFiniteField_clear_fn)
          return z

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -683,25 +683,25 @@ end
 #
 ###############################################################################
 
-call(a::FlintRationalField) = fmpq(fmpz(0), fmpz(1))
+(a::FlintRationalField)() = fmpq(fmpz(0), fmpz(1))
 
-call(a::FlintRationalField, b::Rational{BigInt}) = fmpq(b) 
+(a::FlintRationalField)(b::Rational{BigInt}) = fmpq(b) 
 
-call(a::FlintRationalField, b::Integer) = fmpq(b)
+(a::FlintRationalField)(b::Integer) = fmpq(b)
 
-call(a::FlintRationalField, b::Int, c::Int) = fmpq(b, c)
+(a::FlintRationalField)(b::Int, c::Int) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz) = fmpq(b)
+(a::FlintRationalField)(b::fmpz) = fmpq(b)
 
-call(a::FlintRationalField, b::Integer, c::Integer) = fmpq(b, c)
+(a::FlintRationalField)(b::Integer, c::Integer) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz, c::Integer) = fmpq(b, c)
+(a::FlintRationalField)(b::fmpz, c::Integer) = fmpq(b, c)
 
-call(a::FlintRationalField, b::Integer, c::fmpz) = fmpq(b, c)
+(a::FlintRationalField)(b::Integer, c::fmpz) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpz, c::fmpz) = fmpq(b, c)
+(a::FlintRationalField)(b::fmpz, c::fmpz) = fmpq(b, c)
 
-call(a::FlintRationalField, b::fmpq) = b
+(a::FlintRationalField)(b::fmpq) = b
 
 ###############################################################################
 #

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -603,58 +603,58 @@ end
 #
 ###############################################################################
 
-function Base.call(a::FmpqMatSpace)
+function (a::FmpqMatSpace)()
    z = fmpq_mat(a.rows, a.cols)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, arr::Array{fmpq, 2})
+function (a::FmpqMatSpace)(arr::Array{fmpq, 2})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call{T <: Integer}(a::FmpqMatSpace, arr::Array{T, 2})
+function (a::FmpqMatSpace){T <: Integer}(arr::Array{T, 2})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, arr::Array{fmpq, 1})
+function (a::FmpqMatSpace)(arr::Array{fmpq, 1})
    z = fmpq_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-Base.call{T <: Integer}(a::FmpqMatSpace, arr::Array{T, 1}) = a(arr'')
+(a::FmpqMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
 
-function Base.call(a::FmpqMatSpace, d::fmpq)
+function (a::FmpqMatSpace)(d::fmpq)
    z = fmpq_mat(a.rows, a.cols, d)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, d::fmpz)
+function (a::FmpqMatSpace)(d::fmpz)
    z = fmpq_mat(a.rows, a.cols, fmpq(d))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, d::Integer)
+function (a::FmpqMatSpace)(d::Integer)
    z = fmpq_mat(a.rows, a.cols, fmpq(d))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqMatSpace, M::fmpz_mat)
+function (a::FmpqMatSpace)(M::fmpz_mat)
    (a.cols == cols(M) && a.rows == rows(M)) || error("wrong matrix dimension")
    z = a()
    ccall((:fmpq_mat_set_fmpz_mat, :libflint), Void, (Ptr{fmpq_mat}, Ptr{fmpz_mat}), &z, &M)
    return z
 end
 
-Base.call(a::FmpqMatSpace, d::fmpq_mat) = d
+(a::FmpqMatSpace)(d::fmpq_mat) = d
 
 ###############################################################################
 #

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -86,9 +86,9 @@ function show(io::IO, x::fmpq_poly)
       print(io, "0")
    else
       cstr = ccall((:fmpq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-          (Ptr{fmpq_poly}, Ptr{UInt8}), &x, bytestring(string(var(parent(x)))))
+          (Ptr{fmpq_poly}, Ptr{UInt8}), &x, string(var(parent(x))))
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -661,7 +661,7 @@ Base.promote_rule(::Type{fmpq_poly}, ::Type{fmpq}) = fmpq_poly
 #
 ###############################################################################
 
-Base.call(f::fmpq_poly, a::fmpq) = evaluate(f, a)
+(f::fmpq_poly)(a::fmpq) = evaluate(f, a)
 
 ###############################################################################
 #
@@ -669,45 +669,45 @@ Base.call(f::fmpq_poly, a::fmpq) = evaluate(f, a)
 #
 ###############################################################################
 
-function Base.call(a::FmpqPolyRing)
+function (a::FmpqPolyRing)()
    z = fmpq_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Int)
+function (a::FmpqPolyRing)(b::Int)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Integer)
+function (a::FmpqPolyRing)(b::Integer)
    z = fmpq_poly(fmpz(b))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::fmpz)
+function (a::FmpqPolyRing)(b::fmpz)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::fmpq)
+function (a::FmpqPolyRing)(b::fmpq)
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqPolyRing, b::Array{fmpq, 1})
+function (a::FmpqPolyRing)(b::Array{fmpq, 1})
    z = fmpq_poly(b)
    z.parent = a
    return z
 end
 
-Base.call(a::FmpqPolyRing, b::fmpq_poly) = b
+(a::FmpqPolyRing)(b::fmpq_poly) = b
 
-function Base.call(a::FmpqPolyRing, b::fmpz_poly)
+function (a::FmpqPolyRing)(b::fmpz_poly)
    z = fmpq_poly(b)
    z.parent = a
    return z

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -99,9 +99,9 @@ function show(io::IO, x::fmpq_rel_series)
       print(io, "0")
    else
       cstr = ccall((:fmpq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-        (Ptr{fmpq_rel_series}, Ptr{UInt8}), &x, bytestring(string(var(parent(x)))))
+        (Ptr{fmpq_rel_series}, Ptr{UInt8}), &x, string(var(parent(x))))
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -732,14 +732,14 @@ Base.promote_rule(::Type{fmpq_rel_series}, ::Type{fmpq}) = fmpq_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FmpqRelSeriesRing)
+function (a::FmpqRelSeriesRing)()
    z = fmpq_rel_series()
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::Integer)
+function (a::FmpqRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -750,7 +750,7 @@ function Base.call(a::FmpqRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpz)
+function (a::FmpqRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -761,7 +761,7 @@ function Base.call(a::FmpqRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpq)
+function (a::FmpqRelSeriesRing)(b::fmpq)
    if b == 0
       z = fmpq_rel_series()
       z.prec = a.prec_max
@@ -772,12 +772,12 @@ function Base.call(a::FmpqRelSeriesRing, b::fmpq)
    return z
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::fmpq_rel_series)
+function (a::FmpqRelSeriesRing)(b::fmpq_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpqRelSeriesRing, b::Array{fmpq, 1}, len::Int, prec::Int)
+function (a::FmpqRelSeriesRing)(b::Array{fmpq, 1}, len::Int, prec::Int)
    z = fmpq_rel_series(b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1173,7 +1173,7 @@ doc"""
 > Windows 64.
 """
 function numpart(x::Int) 
-   if (@windows? true : false) && Int == Int64
+   if (is_windows() ? true : false) && Int == Int64
       error("not yet supported on win64")
    end
    x < 0 && throw(DomainError())
@@ -1189,7 +1189,7 @@ doc"""
 > Windows 64.
 """
 function numpart(x::fmpz) 
-   if (@windows? true : false) && Int == Int64
+   if (is_windows() ? true : false) && Int == Int64
       error("not yet supported on win64")
    end
    x < 0 && throw(DomainError())
@@ -1237,7 +1237,7 @@ function base(n::fmpz, b::Integer)
     2 <= b <= 62 || error("invalid base: $b")
     p = ccall((:fmpz_get_str,:libflint), Ptr{UInt8}, 
               (Ptr{UInt8}, Cint, Ptr{fmpz}), C_NULL, b, &n)
-    s = bytestring(p)
+    s = unsafe_string(p)
     ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), p)
     return s
 end
@@ -1360,36 +1360,36 @@ end
 #
 ###############################################################################
 
-call(::FlintIntegerRing) = fmpz()
+(::FlintIntegerRing)() = fmpz()
 
-call(::FlintIntegerRing, a::Integer) = fmpz(a)
+(::FlintIntegerRing)(a::Integer) = fmpz(a)
 
-call(::FlintIntegerRing, a::AbstractString{}) = fmpz(a)
+(::FlintIntegerRing)(a::AbstractString{}) = fmpz(a)
 
-call(::FlintIntegerRing, a::fmpz) = a
+(::FlintIntegerRing)(a::fmpz) = a
 
-call(::FlintIntegerRing, a::Float64) = fmpz(a)
+(::FlintIntegerRing)(a::Float64) = fmpz(a)
 
-call(::FlintIntegerRing, a::Float32) = fmpz(Float64(a))
+(::FlintIntegerRing)(a::Float32) = fmpz(Float64(a))
 
-call(::FlintIntegerRing, a::Float16) = fmpz(Float64(a))
+(::FlintIntegerRing)(a::Float16) = fmpz(Float64(a))
 
-call(::FlintIntegerRing, a::BigFloat) = fmpz(BigInt(a))
+(::FlintIntegerRing)(a::BigFloat) = fmpz(BigInt(a))
 
 ###############################################################################
 #
-#   AbstractString{} parser
+#   String parser
 #
 ###############################################################################
 
-function parseint(::Type{fmpz}, s::AbstractString{}, base::Int = 10)
-    s = bytestring(s)
+function parse(::Type{fmpz}, s::String, base::Int = 10)
+    s = string(s)
     sgn = s[1] == '-' ? -1 : 1
     i = 1 + (sgn == -1)
     z = fmpz()
     err = ccall((:fmpz_set_str, :libflint),
                Int32, (Ptr{fmpz}, Ptr{UInt8}, Int32),
-               &z, bytestring(SubString{}{}(s, i)), base)
+               &z, string(SubString(s, i)), base)
     err == 0 || error("Invalid big integer: $(repr(s))")
     return sgn < 0 ? -z : z
 end
@@ -1400,7 +1400,7 @@ end
 #
 ###############################################################################
 
-fmpz(s::AbstractString{}) = parseint(fmpz, s)
+fmpz(s::AbstractString{}) = parse(fmpz, s)
 
 fmpz(z::Integer) = fmpz(BigInt(z))
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1046,45 +1046,45 @@ end
 #
 ###############################################################################
 
-function Base.call(a::FmpzMatSpace)
+function (a::FmpzMatSpace)()
    z = fmpz_mat(a.rows, a.cols)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, arr::Array{fmpz, 2})
+function (a::FmpzMatSpace)(arr::Array{fmpz, 2})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call{T <: Integer}(a::FmpzMatSpace, arr::Array{T, 2})
+function (a::FmpzMatSpace){T <: Integer}(arr::Array{T, 2})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, arr::Array{fmpz, 1})
+function (a::FmpzMatSpace)(arr::Array{fmpz, 1})
    z = fmpz_mat(a.rows, a.cols, arr)
    z.parent = a
    return z
 end
 
-Base.call{T <: Integer}(a::FmpzMatSpace, arr::Array{T, 1}) = a(arr'')
+(a::FmpzMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
 
-function Base.call(a::FmpzMatSpace, d::fmpz)
+function (a::FmpzMatSpace)(d::fmpz)
    z = fmpz_mat(a.rows, a.cols, d)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzMatSpace, d::Integer)
+function (a::FmpzMatSpace)(d::Integer)
    z = fmpz_mat(a.rows, a.cols, fmpz(d))
    z.parent = a
    return z
 end
 
-Base.call(a::FmpzMatSpace, d::fmpz_mat) = d
+(a::FmpzMatSpace)(d::fmpz_mat) = d
 
 ###############################################################################
 #

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -842,7 +842,7 @@ Base.promote_rule(::Type{fmpz_mod_poly}, ::Type{GenRes{fmpz}}) = fmpz_mod_poly
 #
 ###############################################################################
 
-function Base.call(f::fmpz_mod_poly, a::GenRes{fmpz})
+function (f::fmpz_mod_poly)(a::GenRes{fmpz})
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -855,38 +855,38 @@ end
 #
 ################################################################################
 
-function Base.call(R::FmpzModPolyRing)
+function (R::FmpzModPolyRing)()
   z = fmpz_mod_poly(R.n)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::fmpz)
+function (R::FmpzModPolyRing)(x::fmpz)
   z = fmpz_mod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::Integer)
+function (R::FmpzModPolyRing)(x::Integer)
   z = fmpz_mod_poly(R.n, fmpz(x))
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::GenRes{fmpz})
+function (R::FmpzModPolyRing)(x::GenRes{fmpz})
   base_ring(R) != parent(x) && error("Wrong parents")
   z = fmpz_mod_poly(R.n, x.data)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, arr::Array{fmpz, 1})
+function (R::FmpzModPolyRing)(arr::Array{fmpz, 1})
   z = fmpz_mod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, arr::Array{GenRes{fmpz}, 1})
+function (R::FmpzModPolyRing)(arr::Array{GenRes{fmpz}, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
@@ -895,13 +895,13 @@ function Base.call(R::FmpzModPolyRing, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, x::fmpz_poly)
+function (R::FmpzModPolyRing)(x::fmpz_poly)
   z = fmpz_mod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FmpzModPolyRing, f::fmpz_mod_poly)
+function (R::FmpzModPolyRing)(f::fmpz_mod_poly)
    parent(f) != R && error("Unable to coerce polynomial")
    return f
 end

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -99,9 +99,9 @@ function show(io::IO, x::fmpz_mod_rel_series)
       print(io, "0")
    else
       cstr = ccall((:fmpz_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-        (Ptr{fmpz_mod_rel_series}, Ptr{UInt8}), &x, bytestring(string(var(parent(x)))))
+        (Ptr{fmpz_mod_rel_series}, Ptr{UInt8}), &x, string(var(parent(x))))
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -497,14 +497,14 @@ Base.promote_rule(::Type{fmpz_mod_rel_series}, ::Type{GenRes{fmpz}}) = fmpz_mod_
 #
 ###############################################################################
 
-function Base.call(a::FmpzModRelSeriesRing)
+function (a::FmpzModRelSeriesRing)()
    z = fmpz_mod_rel_series(modulus(base_ring(a)))
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Integer)
+function (a::FmpzModRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -515,7 +515,7 @@ function Base.call(a::FmpzModRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::fmpz)
+function (a::FmpzModRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -526,7 +526,7 @@ function Base.call(a::FmpzModRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::GenRes{fmpz})
+function (a::FmpzModRelSeriesRing)(b::GenRes{fmpz})
    if b == 0
       z = fmpz_mod_rel_series(modulus(base_ring(a)))
       z.prec = a.prec_max
@@ -537,18 +537,18 @@ function Base.call(a::FmpzModRelSeriesRing, b::GenRes{fmpz})
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::fmpz_mod_rel_series)
+function (a::FmpzModRelSeriesRing)(b::fmpz_mod_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Array{fmpz, 1}, len::Int, prec::Int)
+function (a::FmpzModRelSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int)
    z = fmpz_mod_rel_series(modulus(base_ring(a)), b, len, prec)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzModRelSeriesRing, b::Array{GenRes{fmpz}, 1}, len::Int, prec::Int)
+function (a::FmpzModRelSeriesRing)(b::Array{GenRes{fmpz}, 1}, len::Int, prec::Int)
    z = fmpz_mod_rel_series(modulus(base_ring(a)), b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -734,37 +734,37 @@ Base.promote_rule(::Type{fmpz_poly}, ::Type{fmpz}) = fmpz_poly
 #
 ###############################################################################
 
-function Base.call(a::FmpzPolyRing)
+function (a::FmpzPolyRing)()
    z = fmpz_poly()
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Int)
+function (a::FmpzPolyRing)(b::Int)
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Integer)
+function (a::FmpzPolyRing)(b::Integer)
    z = fmpz_poly(fmpz(b))
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::fmpz)
+function (a::FmpzPolyRing)(b::fmpz)
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzPolyRing, b::Array{fmpz, 1})
+function (a::FmpzPolyRing)(b::Array{fmpz, 1})
    z = fmpz_poly(b)
    z.parent = a
    return z
 end
 
-Base.call(a::FmpzPolyRing, b::fmpz_poly) = b
+(a::FmpzPolyRing)(b::fmpz_poly) = b
 
 ###############################################################################
 #

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -97,9 +97,9 @@ function show(io::IO, x::fmpz_rel_series)
       print(io, "0")
    else
       cstr = ccall((:fmpz_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-        (Ptr{fmpz_rel_series}, Ptr{UInt8}), &x, bytestring(string(var(parent(x)))))
+        (Ptr{fmpz_rel_series}, Ptr{UInt8}), &x, string(var(parent(x))))
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -503,14 +503,14 @@ Base.promote_rule(::Type{fmpz_rel_series}, ::Type{fmpz}) = fmpz_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FmpzRelSeriesRing)
+function (a::FmpzRelSeriesRing)()
    z = fmpz_rel_series()
    z.prec = a.prec_max
    z.parent = a
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::Integer)
+function (a::FmpzRelSeriesRing)(b::Integer)
    if b == 0
       z = fmpz_rel_series()
       z.prec = a.prec_max
@@ -521,7 +521,7 @@ function Base.call(a::FmpzRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::fmpz)
+function (a::FmpzRelSeriesRing)(b::fmpz)
    if b == 0
       z = fmpz_rel_series()
       z.prec = a.prec_max
@@ -532,12 +532,12 @@ function Base.call(a::FmpzRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::fmpz_rel_series)
+function (a::FmpzRelSeriesRing)(b::fmpz_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FmpzRelSeriesRing, b::Array{fmpz, 1}, len::Int, prec::Int)
+function (a::FmpzRelSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int)
    z = fmpz_rel_series(b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -183,7 +183,7 @@ function show(io::IO, x::fq)
    cstr = ccall((:fq_get_str_pretty, :libflint), Ptr{UInt8}, 
                 (Ptr{fq}, Ptr{FqFiniteField}), &x, &x.parent)
 
-   print(io, bytestring(cstr))
+   print(io, unsafe_string(cstr))
 
    ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 end
@@ -475,24 +475,24 @@ Base.promote_rule(::Type{fq}, ::Type{fmpz}) = fq
 #
 ###############################################################################
 
-function Base.call(a::FqFiniteField)
+function (a::FqFiniteField)()
    z = fq(a)
    return z
 end
 
-Base.call(a::FqFiniteField, b::Integer) = a(fmpz(b))
+(a::FqFiniteField)(b::Integer) = a(fmpz(b))
 
-function Base.call(a::FqFiniteField, b::Int)
+function (a::FqFiniteField)(b::Int)
    z = fq(a, b)
    return z
 end
 
-function Base.call(a::FqFiniteField, b::fmpz)
+function (a::FqFiniteField)(b::fmpz)
    z = fq(a, b)
    return z
 end
 
-function Base.call(a::FqFiniteField, b::fq)
+function (a::FqFiniteField)(b::fq)
    parent(b) != a && error("Coercion between finite fields not implemented")
    return b
 end

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -122,7 +122,7 @@ function show(io::IO, x::fq_nmod)
    cstr = ccall((:fq_nmod_get_str_pretty, :libflint), Ptr{UInt8}, 
                 (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &x, &x.parent)
 
-   print(io, bytestring(cstr))
+   print(io, unsafe_string(cstr))
 
    ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 end
@@ -399,27 +399,27 @@ Base.promote_rule(::Type{fq_nmod}, ::Type{fmpz}) = fq_nmod
 #
 ###############################################################################
 
-function Base.call(a::FqNmodFiniteField)
+function (a::FqNmodFiniteField)()
    z = fq_nmod(a)
    z.parent = a
    return z
 end
 
-Base.call(a::FqNmodFiniteField, b::Integer) = a(fmpz(b))
+(a::FqNmodFiniteField)(b::Integer) = a(fmpz(b))
 
-function Base.call(a::FqNmodFiniteField, b::Int)
+function (a::FqNmodFiniteField)(b::Int)
    z = fq_nmod(a, b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FqNmodFiniteField, b::fmpz)
+function (a::FqNmodFiniteField)(b::fmpz)
    z = fq_nmod(a, b)
    z.parent = a
    return z
 end
 
-function Base.call(a::FqNmodFiniteField, b::fq_nmod)
+function (a::FqNmodFiniteField)(b::fq_nmod)
    parent(b) != a && error("Coercion between finite fields not implemented")
    return b
 end

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -95,9 +95,9 @@ function show(io::IO, x::fq_nmod_poly)
    else
       cstr = ccall((:fq_nmod_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
                   (Ptr{fq_nmod_poly}, Ptr{UInt8}, Ptr{FqNmodFiniteField}),
-                  &x, bytestring(string(var(parent(x)))),
+                  &x, string(var(parent(x))),
                   &((x.parent).base_ring))
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
 end
@@ -616,7 +616,7 @@ Base.promote_rule(::Type{fq_nmod_poly}, ::Type{fq_nmod}) = fq_nmod_poly
 #
 ###############################################################################
 
-function Base.call(f::fq_nmod_poly, a::fq_nmod)
+function (f::fq_nmod_poly)(a::fq_nmod)
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -629,27 +629,27 @@ end
 #
 ################################################################################
 
-function Base.call(R::FqNmodPolyRing)
+function (R::FqNmodPolyRing)()
    z = fq_nmod_poly()
    z.parent = R
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fq_nmod)
+function (R::FqNmodPolyRing)(x::fq_nmod)
   z = fq_nmod_poly(x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fmpz)
+function (R::FqNmodPolyRing)(x::fmpz)
    return R(base_ring(R)(x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::Integer)
+function (R::FqNmodPolyRing)(x::Integer)
    return R(fmpz(x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::Array{fq_nmod, 1})
+function (R::FqNmodPolyRing)(x::Array{fq_nmod, 1})
    length(x) == 0 && error("Array must be non-empty")
    base_ring(R) != parent(x[1]) && error("Coefficient rings must coincide")
    z = fq_nmod_poly(x)
@@ -657,25 +657,25 @@ function Base.call(R::FqNmodPolyRing, x::Array{fq_nmod, 1})
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::Array{fmpz, 1})
+function (R::FqNmodPolyRing)(x::Array{fmpz, 1})
    length(x) == 0 && error("Array must be non-empty")
    z = fq_nmod_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call{T <: Integer}(R::FqNmodPolyRing, x::Array{T, 1})
+function (R::FqNmodPolyRing){T <: Integer}(x::Array{T, 1})
    length(x) == 0 && error("Array must be non-empty")
    return R(map(fmpz, x))
 end
 
-function Base.call(R::FqNmodPolyRing, x::fmpz_poly)
+function (R::FqNmodPolyRing)(x::fmpz_poly)
    z = fq_nmod_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call(R::FqNmodPolyRing, x::fq_nmod_poly)
+function (R::FqNmodPolyRing)(x::fq_nmod_poly)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -111,9 +111,9 @@ function show(io::IO, x::fq_nmod_rel_series)
       ctx = base_ring(x)
       cstr = ccall((:fq_nmod_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
         (Ptr{fq_nmod_rel_series}, Ptr{UInt8}, Ptr{FqNmodFiniteField}), 
-                     &x, bytestring(string(var(parent(x)))), &ctx)
+                     &x, string(var(parent(x))), &ctx)
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -501,7 +501,7 @@ Base.promote_rule(::Type{fq_nmod_rel_series}, ::Type{fq_nmod}) = fq_nmod_rel_ser
 #
 ###############################################################################
 
-function Base.call(a::FqNmodRelSeriesRing)
+function (a::FqNmodRelSeriesRing)()
    ctx = base_ring(a)
    z = fq_nmod_rel_series(ctx)
    z.prec = a.prec_max
@@ -509,7 +509,7 @@ function Base.call(a::FqNmodRelSeriesRing)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::Integer)
+function (a::FqNmodRelSeriesRing)(b::Integer)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -521,7 +521,7 @@ function Base.call(a::FqNmodRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fmpz)
+function (a::FqNmodRelSeriesRing)(b::fmpz)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -533,7 +533,7 @@ function Base.call(a::FqNmodRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod)
+function (a::FqNmodRelSeriesRing)(b::fq_nmod)
    ctx = base_ring(a)
    if b == 0
       z = fq_nmod_rel_series(ctx)
@@ -545,12 +545,12 @@ function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod)
    return z
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::fq_nmod_rel_series)
+function (a::FqNmodRelSeriesRing)(b::fq_nmod_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FqNmodRelSeriesRing, b::Array{fq_nmod, 1}, len::Int, prec::Int)
+function (a::FqNmodRelSeriesRing)(b::Array{fq_nmod, 1}, len::Int, prec::Int)
    ctx = base_ring(a)
    z = fq_nmod_rel_series(ctx, b, len, prec)
    z.parent = a

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -95,9 +95,9 @@ function show(io::IO, x::fq_poly)
    else
       cstr = ccall((:fq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
                   (Ptr{fq_poly}, Ptr{UInt8}, Ptr{FqFiniteField}),
-                  &x, bytestring(string(var(parent(x)))),
+                  &x, string(var(parent(x))),
                   &((x.parent).base_ring))
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
 end
@@ -603,7 +603,7 @@ Base.promote_rule(::Type{fq_poly}, ::Type{fq}) = fq_poly
 #
 ###############################################################################
 
-function Base.call(f::fq_poly, a::fq)
+function (f::fq_poly)(a::fq)
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -616,27 +616,27 @@ end
 #
 ################################################################################
 
-function Base.call(R::FqPolyRing)
+function (R::FqPolyRing)()
    z = fq_poly()
    z.parent = R
    return z
 end
 
-function Base.call(R::FqPolyRing, x::fq)
+function (R::FqPolyRing)(x::fq)
   z = fq_poly(x)
   z.parent = R
   return z
 end
 
-function Base.call(R::FqPolyRing, x::fmpz)
+function (R::FqPolyRing)(x::fmpz)
    return R(base_ring(R)(x))
 end
 
-function Base.call(R::FqPolyRing, x::Integer)
+function (R::FqPolyRing)(x::Integer)
    return R(fmpz(x))
 end
 
-function Base.call(R::FqPolyRing, x::Array{fq, 1})
+function (R::FqPolyRing)(x::Array{fq, 1})
    length(x) == 0 && error("Array must be non-empty")
    base_ring(R) != parent(x[1]) && error("Coefficient rings must coincide")
    z = fq_poly(x)
@@ -644,25 +644,25 @@ function Base.call(R::FqPolyRing, x::Array{fq, 1})
    return z
 end
 
-function Base.call(R::FqPolyRing, x::Array{fmpz, 1})
+function (R::FqPolyRing)(x::Array{fmpz, 1})
    length(x) == 0 && error("Array must be non-empty")
    z = fq_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call{T <: Integer}(R::FqPolyRing, x::Array{T, 1})
+function (R::FqPolyRing){T <: Integer}(x::Array{T, 1})
    length(x) == 0 && error("Array must be non-empty")
    return R(map(fmpz, x))
 end
 
-function Base.call(R::FqPolyRing, x::fmpz_poly)
+function (R::FqPolyRing)(x::fmpz_poly)
    z = fq_poly(x, base_ring(R))
    z.parent = R
    return z
 end
 
-function Base.call(R::FqPolyRing, x::fq_poly)
+function (R::FqPolyRing)(x::fq_poly)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -110,9 +110,9 @@ function show(io::IO, x::fq_rel_series)
       ctx = base_ring(x)
       cstr = ccall((:fq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
         (Ptr{fq_rel_series}, Ptr{UInt8}, Ptr{FqFiniteField}), 
-                     &x, bytestring(string(var(parent(x)))), &ctx)
+                     &x, string(var(parent(x))), &ctx)
 
-      print(io, bytestring(cstr))
+      print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -500,7 +500,7 @@ Base.promote_rule(::Type{fq_rel_series}, ::Type{fq}) = fq_rel_series
 #
 ###############################################################################
 
-function Base.call(a::FqRelSeriesRing)
+function (a::FqRelSeriesRing)()
    ctx = base_ring(a)
    z = fq_rel_series(ctx)
    z.prec = a.prec_max
@@ -508,7 +508,7 @@ function Base.call(a::FqRelSeriesRing)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::Integer)
+function (a::FqRelSeriesRing)(b::Integer)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -520,7 +520,7 @@ function Base.call(a::FqRelSeriesRing, b::Integer)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fmpz)
+function (a::FqRelSeriesRing)(b::fmpz)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -532,7 +532,7 @@ function Base.call(a::FqRelSeriesRing, b::fmpz)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fq)
+function (a::FqRelSeriesRing)(b::fq)
    ctx = base_ring(a)
    if b == 0
       z = fq_rel_series(ctx)
@@ -544,12 +544,12 @@ function Base.call(a::FqRelSeriesRing, b::fq)
    return z
 end
 
-function Base.call(a::FqRelSeriesRing, b::fq_rel_series)
+function (a::FqRelSeriesRing)(b::fq_rel_series)
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call(a::FqRelSeriesRing, b::Array{fq, 1}, len::Int, prec::Int)
+function (a::FqRelSeriesRing)(b::Array{fq, 1}, len::Int, prec::Int)
    ctx = base_ring(a)
    z = fq_rel_series(ctx, b, len, prec)
    z.parent = a

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -604,13 +604,13 @@ Base.promote_rule(::Type{nmod_mat}, ::Type{fmpz}) = nmod_mat
 #
 ################################################################################
 
-function Base.call(a::NmodMatSpace)
+function (a::NmodMatSpace)()
   z = nmod_mat(a.rows, a.cols, a.n)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, b::Integer)
+function (a::NmodMatSpace)(b::Integer)
    M = a()
    for i = 1:a.rows
       for j = 1:a.cols
@@ -624,7 +624,7 @@ function Base.call(a::NmodMatSpace, b::Integer)
    return M
 end
 
-function Base.call(a::NmodMatSpace, b::fmpz)
+function (a::NmodMatSpace)(b::fmpz)
    M = a()
    for i = 1:a.rows
       for j = 1:a.cols
@@ -638,7 +638,7 @@ function Base.call(a::NmodMatSpace, b::fmpz)
    return M
 end
 
-function Base.call(a::NmodMatSpace, b::GenRes{fmpz})
+function (a::NmodMatSpace)(b::GenRes{fmpz})
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
    M = a()
    for i = 1:a.rows
@@ -653,28 +653,28 @@ function Base.call(a::NmodMatSpace, b::GenRes{fmpz})
    return M
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{BigInt, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{BigInt, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{fmpz, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{fmpz, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{Int, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{Int, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   z = nmod_mat(a.rows, a.cols, a.n, arr, transpose)
   z.parent = a
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 2}, transpose::Bool = false)
+function (a::NmodMatSpace)(arr::Array{GenRes{fmpz}, 2}, transpose::Bool = false)
   _check_dim(a.rows, a.cols, arr, transpose)
   length(arr) == 0 && error("Array must be nonempty")
   (base_ring(a) != parent(arr[1])) && error("Elements must have same base ring")
@@ -683,7 +683,7 @@ function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 2}, transpose::Bool
   return z
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{Int, 1})
+function (a::NmodMatSpace)(arr::Array{Int, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
 
@@ -691,21 +691,21 @@ function Base.call(a::NmodMatSpace, arr::Array{Int, 1})
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{BigInt, 1})
+function (a::NmodMatSpace)(arr::Array{BigInt, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   arr = reshape(arr,a.cols,a.rows)
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{fmpz, 1})
+function (a::NmodMatSpace)(arr::Array{fmpz, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   arr = reshape(arr,a.cols,a.rows)
   return a(arr, true)
 end
 
-function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 1})
+function (a::NmodMatSpace)(arr::Array{GenRes{fmpz}, 1})
   (length(arr) != a.cols * a.rows) &&
           error("Array must be of length ", a.cols * a.rows)
   z = nmod_mat(a.rows, a.cols, a.n, arr)
@@ -714,7 +714,7 @@ function Base.call(a::NmodMatSpace, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(a::NmodMatSpace, b::fmpz_mat)
+function (a::NmodMatSpace)(b::fmpz_mat)
   (a.cols != b.c || a.rows != b.r) && error("Dimensions do not fit")
   z = nmod_mat(a.n, b)
   z.parent = a

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -120,8 +120,8 @@ function show(io::IO, x::nmod_poly)
     print(io, "0")
   else
     cstr = ccall((:nmod_poly_get_str_pretty, :libflint), Ptr{UInt8},
-            (Ptr{nmod_poly}, Ptr{UInt8}), &x, bytestring(string(var(parent(x)))))
-    print(io, bytestring(cstr))
+            (Ptr{nmod_poly}, Ptr{UInt8}), &x, string(var(parent(x))))
+    print(io, unsafe_string(cstr))
     ccall((:flint_free, :libflint), Void, (Ptr{UInt8}, ), cstr)
   end
 end
@@ -930,7 +930,7 @@ Base.promote_rule(::Type{nmod_poly}, ::Type{GenRes{fmpz}}) = nmod_poly
 #
 ###############################################################################
 
-function Base.call(f::nmod_poly, a::GenRes{fmpz})
+function (f::nmod_poly)(a::GenRes{fmpz})
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -943,51 +943,51 @@ end
 #
 ################################################################################
 
-function Base.call(R::NmodPolyRing)
+function (R::NmodPolyRing)()
   z = nmod_poly(R.n)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::fmpz)
+function (R::NmodPolyRing)(x::fmpz)
   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &x, R.n)
   z = nmod_poly(R.n, r)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::UInt)
+function (R::NmodPolyRing)(x::UInt)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::Integer)
+function (R::NmodPolyRing)(x::Integer)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::GenRes{fmpz})
+function (R::NmodPolyRing)(x::GenRes{fmpz})
   base_ring(R) != parent(x) && error("Wrong parents")
   z = nmod_poly(R.n, UInt(x.data))
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{fmpz, 1})
+function (R::NmodPolyRing)(arr::Array{fmpz, 1})
   z = nmod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{UInt, 1})
+function (R::NmodPolyRing)(arr::Array{UInt, 1})
   z = nmod_poly(R.n, arr)
   z.parent = R
   return z
 end
 
-function Base.call(R::NmodPolyRing, arr::Array{GenRes{fmpz}, 1})
+function (R::NmodPolyRing)(arr::Array{GenRes{fmpz}, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
@@ -996,7 +996,7 @@ function Base.call(R::NmodPolyRing, arr::Array{GenRes{fmpz}, 1})
   return z
 end
 
-function Base.call(R::NmodPolyRing, x::fmpz_poly)
+function (R::NmodPolyRing)(x::fmpz_poly)
   z = nmod_poly(R.n, x)
   z.parent = R
   return z

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -207,7 +207,7 @@ function show(io::IO, x::padic)
                (Ptr{Void}, Ptr{padic}, Ptr{FlintPadicField}),
                    C_NULL, &x, &ctx)
 
-   print(io, bytestring(cstr))
+   print(io, unsafe_string(cstr))
 
    ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    print(io, " + O(")
@@ -592,13 +592,13 @@ promote_rule(::Type{padic}, ::Type{fmpq}) = padic
 #
 ###############################################################################
 
-function Base.call(R::FlintPadicField)
+function (R::FlintPadicField)()
    z = padic(R.prec_max)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPadicField, n::fmpz)
+function (R::FlintPadicField)(n::fmpz)
    if n == 1
       N = 0
    else
@@ -612,7 +612,7 @@ function Base.call(R::FlintPadicField, n::fmpz)
    return z
 end
 
-function Base.call(R::FlintPadicField, n::fmpq)
+function (R::FlintPadicField)(n::fmpq)
    m = den(n)
    if m == 1
       return R(num(n))
@@ -630,9 +630,9 @@ function Base.call(R::FlintPadicField, n::fmpq)
    return z
 end
 
-Base.call(R::FlintPadicField, n::Integer) = R(fmpz(n))
+(R::FlintPadicField)(n::Integer) = R(fmpz(n))
 
-function Base.call(R::FlintPadicField, n::padic)
+function (R::FlintPadicField)(n::padic)
    parent(n) != R && error("Unable to coerce into p-adic field")
    return n
 end

--- a/src/flint/perm.jl
+++ b/src/flint/perm.jl
@@ -161,20 +161,20 @@ end
 #
 ###############################################################################
 
-function Base.call(R::FlintPermGroup)
+function (R::FlintPermGroup)()
    z = perm(R.n)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPermGroup, a::Array{Int, 1})
+function (R::FlintPermGroup)(a::Array{Int, 1})
    length(a) != R.n && error("Unable to coerce to permutation")
    z = perm(a)
    z.parent = R
    return z
 end
 
-function Base.call(R::FlintPermGroup, a::perm)
+function (R::FlintPermGroup)(a::perm)
    parent(a) != R && error("Unable to coerce to permutation")
    return a
 end

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -710,30 +710,30 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::RingElem)
+function (a::GenFracField{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T})
+function (a::GenFracField{T}){T <: RingElem}()
    z = GenFrac{T}(zero(base_ring(a)), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::fmpz)
+function (a::GenFracField{T}){T <: RingElem}(b::fmpz)
    z = GenFrac{T}(base_ring(a)(b), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T)
+function (a::GenFracField{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::T)
+function (a::GenFracField{T}){T <: RingElem}(b::T, c::T)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, c)
@@ -741,33 +741,33 @@ function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::T, c::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::T, c::Integer)
    parent(b) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(b, base_ring(a)(c))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer, c::T)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer, c::T)
    parent(c) != base_ring(a) && error("Could not coerce to fraction")
    z = GenFrac{T}(base_ring(a)(b), c)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer)
    z = GenFrac{T}(base_ring(a)(b), one(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::Integer, c::Integer)
+function (a::GenFracField{T}){T <: RingElem}(b::Integer, c::Integer)
    z = GenFrac{T}(base_ring(a)(b), base_ring(a)(c))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenFracField{T}, b::GenFrac{T})
+function (a::GenFracField{T}){T <: RingElem}(b::GenFrac{T})
    a != parent(b) && error("Could not coerce to fraction")
    return b
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -785,7 +785,7 @@ function transpose(x::MatElem)
    else
       par = MatrixSpace(base_ring(x), cols(x), rows(x))
    end
-   return par(x.entries')
+   return par(permutedims(x.entries, [2, 1]))
 end
 
 ###############################################################################
@@ -2830,7 +2830,7 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz_mat)
+function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz_mat)
   if a.rows != rows(b) || a.cols != cols(b)
     error("incompatible matrix dimensions")
   end
@@ -2844,11 +2844,11 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz_mat)
   return A
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::RingElem)
+function (a::GenMatSpace{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T})
+function (a::GenMatSpace{T}){T <: RingElem}()
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2860,7 +2860,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T})
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Integer)
+function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2876,7 +2876,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Integer)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz)
+function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz)
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
@@ -2892,7 +2892,7 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::fmpz)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::T)
+function (a::GenMatSpace{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
    entries = Array(T, a.rows, a.cols)
    for i = 1:a.rows
@@ -2909,12 +2909,12 @@ function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::GenMat{T})
+function (a::GenMatSpace{T}){T <: RingElem}(b::GenMat{T})
    parent(b) != a && error("Unable to coerce matrix")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenMatSpace{T}, b::Array{T, 2})
+function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 2})
    if length(b) > 0
       parent(b[1, 1]) != base_ring(a) && error("Unable to coerce to matrix")
    end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2088,35 +2088,35 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::RingElem)
+function (a::GenPolyRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T})
+function (a::GenPolyRing{T}){T <: RingElem}()
    z = GenPoly{T}()
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::Integer)
+function (a::GenPolyRing{T}){T <: RingElem}(b::Integer)
    z = GenPoly{T}(base_ring(a)(b))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::T)
+function (a::GenPolyRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
    z = GenPoly{T}(b)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::PolyElem{T})
+function (a::GenPolyRing{T}){T <: RingElem}(b::PolyElem{T})
    parent(b) != a && error("Unable to coerce polynomial")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenPolyRing{T}, b::Array{T, 1})
+function (a::GenPolyRing{T}){T <: RingElem}(b::Array{T, 1})
    if length(b) > 0
       parent(b[1]) != base_ring(a) && error("Unable to coerce to polynomial")
    end
@@ -2149,6 +2149,6 @@ function PolynomialRing(R::Ring, s::AbstractString{}; cached::Bool = true)
 end
 
 # S, x = R["x"] syntax
-getindex(R::Ring, s::ASCIIString) = PolynomialRing(R, s)
+getindex(R::Ring, s::String) = PolynomialRing(R, s)
 
-getindex{T}(R::Tuple{Ring,T}, s::ASCIIString) = PolynomialRing(R[1], s)
+getindex{T}(R::Tuple{Ring,T}, s::String) = PolynomialRing(R[1], s)

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1038,17 +1038,17 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::RingElem)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T})
+function (a::GenRelSeriesRing{T}){T <: RingElem}()
    z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Integer)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::Integer)
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    else
@@ -1058,7 +1058,7 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Integer)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::fmpz)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::fmpz)
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
    else
@@ -1068,7 +1068,7 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::fmpz)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::T)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to power series")
    if b == 0
       z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max)
@@ -1079,12 +1079,12 @@ function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::T)
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::SeriesElem{T})
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::SeriesElem{T})
    parent(b) != a && error("Unable to coerce power series")
    return b
 end
 
-function Base.call{T <: RingElem}(a::GenRelSeriesRing{T}, b::Array{T, 1}, len::Int, prec::Int)
+function (a::GenRelSeriesRing{T}){T <: RingElem}(b::Array{T, 1}, len::Int, prec::Int)
    if length(b) > 0
       parent(b[1]) != base_ring(a) && error("Unable to coerce to power series")
    end

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -507,36 +507,36 @@ end
 #
 ###############################################################################
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::RingElem)
+function (a::GenResRing{T}){T <: RingElem}(b::RingElem)
    return a(base_ring(a)(b))
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T})
+function (a::GenResRing{T}){T <: RingElem}()
    z = GenRes{T}(zero(base_ring(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::Integer)
+function (a::GenResRing{T}){T <: RingElem}(b::Integer)
    z = GenRes{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::fmpz)
+function (a::GenResRing{T}){T <: RingElem}(b::fmpz)
    z = GenRes{T}(mod(base_ring(a)(b), modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::T)
+function (a::GenResRing{T}){T <: RingElem}(b::T)
    base_ring(a) != parent(b) && error("Operation on incompatible objects")
    z = GenRes{T}(mod(b, modulus(a)))
    z.parent = a
    return z
 end
 
-function Base.call{T <: RingElem}(a::GenResRing{T}, b::ResElem{T})
+function (a::GenResRing{T}){T <: RingElem}(b::ResElem{T})
    a != parent(b) && error("Operation on incompatible objects")
    return b
 end

--- a/src/pari/PariIdeal.jl
+++ b/src/pari/PariIdeal.jl
@@ -405,7 +405,7 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariIdealSet, id::Ptr{Int})
+function (ord::PariIdealSet)(id::Ptr{Int})
    return PariIdeal(id, PariIdealSet(ord))
 end
 

--- a/src/pari/code_words.jl
+++ b/src/pari/code_words.jl
@@ -135,12 +135,12 @@ debug(a::Ptr{Int}) = ccall((:dbgGEN, :libpari), Void, (Ptr{Int}, Int), a, -1)
 
 function pari_print(a::Ptr{Int})
    cstr = ccall((:GENtostr, :libpari), Ptr{UInt8}, (Ptr{Int},), a)
-   print(bytestring(cstr))
+   print(unsafe_string(cstr))
    ccall((:pari_free, :libpari), Void, (Ptr{UInt8},), cstr)
 end
    
 function pari_print(io::IO, a::Ptr{Int})
    cstr = ccall((:GENtostr, :libpari), Ptr{UInt8}, (Ptr{Int},), a)
-   print(io, bytestring(cstr))
+   print(io, unsafe_string(cstr))
    ccall((:pari_free, :libpari), Void, (Ptr{UInt8},), cstr)
 end

--- a/src/pari/pari_frac.jl
+++ b/src/pari/pari_frac.jl
@@ -92,7 +92,7 @@ function fmpq!(z::fmpq, g::Ptr{Int})
    end
 end
 
-function call(::FlintRationalField, g::pari_rat)
+function (::FlintRationalField)(g::pari_rat)
    r = fmpq()
    fmpq!(r, g.d)
    return r

--- a/src/pari/pari_int.jl
+++ b/src/pari/pari_int.jl
@@ -92,7 +92,7 @@ function fmpz!(z::fmpz, g::Ptr{Int})
    return z
 end
 
-function call(::FlintIntegerRing, g::pari_int)
+function (::FlintIntegerRing)(g::pari_int)
    z = fmpz()
    fmpz!(z, g.d)
    return z
@@ -118,7 +118,7 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariIntegerRing, n::Ptr{Int})
+function (ord::PariIntegerRing)(n::Ptr{Int})
    return fmpz!(fmpz(), n)
 end
 

--- a/src/pari/pari_maximal_order_elem.jl
+++ b/src/pari/pari_maximal_order_elem.jl
@@ -74,7 +74,7 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariMaximalOrder)
+function (ord::PariMaximalOrder)()
    av = unsafe_load(avma, 1)
    data = ccall((:algtobasis, :libpari), Ptr{Int}, 
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(fmpz()).d)
@@ -82,7 +82,7 @@ function Base.call(ord::PariMaximalOrder)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::fmpq_poly)
+function (ord::PariMaximalOrder)(b::fmpq_poly)
    av = unsafe_load(avma, 1)
    data = ccall((:algtobasis, :libpari), Ptr{Int}, 
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(b).d)
@@ -90,7 +90,7 @@ function Base.call(ord::PariMaximalOrder, b::fmpq_poly)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::nf_elem)
+function (ord::PariMaximalOrder)(b::nf_elem)
    av = unsafe_load(avma, 1)
    par = b.parent.pol.parent
    data = ccall((:algtobasis, :libpari), Ptr{Int}, 
@@ -99,7 +99,7 @@ function Base.call(ord::PariMaximalOrder, b::nf_elem)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::fmpz)
+function (ord::PariMaximalOrder)(b::fmpz)
    av = unsafe_load(avma, 1)
    data = ccall((:algtobasis, :libpari), Ptr{Int}, 
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(b).d)
@@ -107,7 +107,7 @@ function Base.call(ord::PariMaximalOrder, b::fmpz)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::Integer)
+function (ord::PariMaximalOrder)(b::Integer)
    av = unsafe_load(avma, 1)
    data = ccall((:algtobasis, :libpari), Ptr{Int}, 
                  (Ptr{Int}, Ptr{Int}), ord.pari_nf.data, pari(fmpz(b)).d)
@@ -115,7 +115,7 @@ function Base.call(ord::PariMaximalOrder, b::Integer)
    return pari_maximal_order_elem(data, ord)
 end
 
-function Base.call(ord::PariMaximalOrder, b::pari_maximal_order_elem)
+function (ord::PariMaximalOrder)(b::pari_maximal_order_elem)
    parent(b) != ord && error("Unable to coerce maximal order element")
    return b
 end

--- a/src/pari/pari_polmod.jl
+++ b/src/pari/pari_polmod.jl
@@ -26,7 +26,7 @@ end
 #
 ###########################################################################################
 
-function Base.call{S <: RingElem}(ord::PariPolModRing{S}, b::Ptr{Int})
+function (ord::PariPolModRing{S}){S <: RingElem}(b::Ptr{Int})
    z = pari_polmod{S}(b)
    z.parent = ord
    return z

--- a/src/pari/pari_poly.jl
+++ b/src/pari/pari_poly.jl
@@ -106,14 +106,14 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariPolyRing{pari_int}, n::Ptr{Int})
+function (ord::PariPolyRing{pari_int})(n::Ptr{Int})
    pol = pari_poly{pari_int}(n)
    pol.parent = PariPolyRing{pari_int}(PariZZ, var(ord))
    return pol
 end
 
 
-function Base.call(a::FmpzPolyRing, g::pari_poly{pari_int})
+function (a::FmpzPolyRing)(g::pari_poly{pari_int})
    z = fmpz_poly()
    z.parent = a
    fmpz_poly!(z, g.d)

--- a/src/pari/pari_poly2.jl
+++ b/src/pari/pari_poly2.jl
@@ -73,13 +73,13 @@ end
 #
 ###############################################################################
 
-function Base.call(ord::PariPolyRing{pari_rat}, n::Ptr{Int})
+function (ord::PariPolyRing{pari_rat})(n::Ptr{Int})
    pol = pari_poly{pari_rat}(n)
    pol.parent = PariPolyRing{pari_rat}(PariQQ, var(ord))
    return pol
 end
 
-function Base.call(a::FmpqPolyRing, g::pari_poly{pari_rat})
+function (a::FmpqPolyRing)(g::pari_poly{pari_rat})
    z = fmpq_poly()
    z.parent = a
    fmpq_poly!(z, g.d)

--- a/test/antic/nf_elem-test.jl
+++ b/test/antic/nf_elem-test.jl
@@ -47,6 +47,18 @@ function test_nf_elem_constructors()
    println("PASS")
 end
 
+function test_nf_elem_printing()
+   print("nf_elem.constructors...")
+ 
+   R, x = PolynomialRing(QQ, "x")
+   K, a = NumberField(x^3 + 3x + 1, "a")
+   g = K(x^2 + 2x - 7)
+
+   @test string(g) == "a^2 + 2*a - 7"
+
+   println("PASS")
+end
+
 function test_nf_elem_fmpz_mat_conversions()
    print("nf_elem.fmpz_mat_conversions...")
 
@@ -316,6 +328,7 @@ end
 function test_nf_elem()
    test_nf_accessor_functions()
    test_nf_elem_constructors()
+   test_nf_elem_printing()
    test_nf_elem_fmpz_mat_conversions()
    test_nf_elem_fmpq_poly_conversion()
    test_nf_elem_denominator()

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -13,6 +13,16 @@ function test_acb_constructors()
    println("PASS")
 end
 
+function test_acb_printing()
+   print("acb.printing()...")
+
+   a = CC(1) + onei(CC)
+
+   @test string(a) == "1.0000000000000000000 + i*1.0000000000000000000"
+
+   println("PASS")
+end
+
 function test_acb_basic_ops()
    print("acb.basic_ops()...")
 
@@ -423,6 +433,7 @@ end
 
 function test_acb()
    test_acb_constructors()
+   test_acb_printing()
    test_acb_basic_ops()
    test_acb_comparison()
    test_acb_predicates()

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -48,6 +48,17 @@ function test_acb_mat_constructors()
    println("PASS")
 end
 
+function test_acb_mat_printing()
+   print("acb_mat.constructors...")
+ 
+   S = MatrixSpace(CC, 3, 3)
+   f = S(fmpz(3))
+
+   @test string(f) == "[3.0000000000000000000 + i*0 0 + i*0 0 + i*0]\n[0 + i*0 3.0000000000000000000 + i*0 0 + i*0]\n[0 + i*0 0 + i*0 3.0000000000000000000 + i*0]"
+
+   println("PASS")
+end
+
 function test_acb_mat_manipulation()
    print("acb_mat.manipulation...")
 
@@ -404,6 +415,7 @@ end
 
 function test_acb_mat()
    test_acb_mat_constructors()
+   test_acb_mat_printing()
    test_acb_mat_manipulation()
    test_acb_mat_unary_ops()
    test_acb_mat_transpose()

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -2,7 +2,7 @@ RR = AcbField(64)
 CC = AcbField(64)
 
 function test_acb_poly_constructors()
-   print("acb_poly.constructors()...")
+   print("acb_poly.constructors...")
 
    R, x = PolynomialRing(CC, "x")
 
@@ -25,6 +25,17 @@ function test_acb_poly_constructors()
    k = R([CC(1), CC(0), CC(3)])
 
    @test isa(k, PolyElem)
+
+   println("PASS")
+end
+
+function test_acb_poly_printing()
+   print("acb_poly.constructors...")
+
+   R, x = PolynomialRing(CC, "x")
+   f = x^3 + 2x^2 + x + 1
+
+   @test string(f) == "[ 1.0000000000000000000 + i*0, 1.0000000000000000000 + i*0, 2.0000000000000000000 + i*0, 1.0000000000000000000 + i*0 ]"
 
    println("PASS")
 end
@@ -446,6 +457,7 @@ end
 
 function test_acb_poly()
    test_acb_poly_constructors()
+   test_acb_poly_printing()
    test_acb_poly_manipulation()
    test_acb_poly_binary_ops()
    test_acb_poly_adhoc_binary()

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -12,6 +12,16 @@ function test_arb_constructors()
    println("PASS")
 end
 
+function test_arb_printing()
+   print("arb.printing()...")
+
+   a = RR(2)
+
+   @test string(a) == "2.0000000000000000000"
+
+   println("PASS")
+end
+
 function test_arb_basic_ops()
    print("arb.basic_ops()...")
 
@@ -530,6 +540,7 @@ end
 
 function test_arb()
    test_arb_constructors()
+   test_arb_printing()
    test_arb_basic_ops()
    test_arb_comparison()
    test_arb_adhoc_comparison()

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -47,6 +47,17 @@ function test_arb_mat_constructors()
    println("PASS")
 end
 
+function test_arb_mat_printing()
+   print("arb_mat.constructors...")
+ 
+   S = MatrixSpace(RR, 3, 3)
+   f = S(fmpz(3))
+
+   @test string(f) == "[3.0000000000000000000 0 0]\n[0 3.0000000000000000000 0]\n[0 0 3.0000000000000000000]"
+
+   println("PASS")
+end
+
 function test_arb_mat_manipulation()
    print("arb_mat.manipulation...")
 
@@ -388,6 +399,7 @@ end
 
 function test_arb_mat()
    test_arb_mat_constructors()
+   test_arb_mat_printing()
    test_arb_mat_manipulation()
    test_arb_mat_unary_ops()
    test_arb_mat_transpose()

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -1,7 +1,7 @@
 RR = ArbField(64)
 
 function test_arb_poly_constructors()
-   print("arb_poly.constructors()...")
+   print("arb_poly.constructors...")
 
    R, x = PolynomialRing(RR, "x")
 
@@ -24,6 +24,17 @@ function test_arb_poly_constructors()
    k = R([RR(1), RR(0), RR(3)])
 
    @test isa(k, PolyElem)
+
+   println("PASS")
+end
+
+function test_arb_poly_printing()
+   print("arb_poly.printing...")
+
+   R, x = PolynomialRing(RR, "x")
+   f = x^3 + 2x^2 + x + 1
+
+   @test string(f) == "[ 1.0000000000000000000, 1.0000000000000000000, 2.0000000000000000000, 1.0000000000000000000 ]"
 
    println("PASS")
 end
@@ -415,6 +426,7 @@ end
 
 function test_arb_poly()
    test_arb_poly_constructors()
+   test_arb_poly_printing()
    test_arb_poly_manipulation()
    test_arb_poly_binary_ops()
    test_arb_poly_adhoc_binary()

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -40,6 +40,16 @@ function test_fmpq_constructors()
    println("PASS")
 end
 
+function test_fmpq_printing()
+   print("fmpq.constructors()...")
+
+   a = FlintQQ(1, 2)
+
+   @test string(a) == "1//2"
+   
+   println("PASS")
+end
+
 function test_fmpq_conversions()
    print("fmpq.conversions()...")
 
@@ -323,6 +333,7 @@ end
 
 function test_fmpq()
    test_fmpq_constructors()
+   test_fmpq_printing()
    test_fmpq_conversions()
    test_fmpq_manipulation()
    test_fmpq_unary_ops()

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -32,6 +32,16 @@ function test_fmpq_mat_constructors()
    println("PASS")
 end
 
+function test_fmpq_mat_printing()
+   print("fmpq_mat.printing...")
+ 
+   a = MatrixSpace(QQ, 2, 2)(1)
+   
+   @test string(a) == "[1 0]\n[0 1]"
+
+   println("PASS")
+end
+
 function test_fmpq_mat_manipulation()
    print("fmpq_mat.manipulation...")
 
@@ -392,6 +402,7 @@ end
 
 function test_fmpq_mat()
    test_fmpq_mat_constructors()
+   test_fmpq_mat_printing()
    test_fmpq_mat_manipulation()
    test_fmpq_mat_unary_ops()
    test_fmpq_mat_binary_ops()

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -52,6 +52,16 @@ function test_fmpq_poly_constructors()
    println("PASS")
 end
 
+function test_fmpq_poly_printing()
+   print("fmpq_poly.printing...")
+ 
+   S, y = PolynomialRing(QQ, "y")
+
+   @test string(y + y^2) == "y^2 + 1*y"
+
+   println("PASS")
+end
+
 function test_fmpq_poly_manipulation()
    print("fmpq_poly.manipulation...")
 
@@ -468,6 +478,7 @@ end
 
 function test_fmpq_poly()
    test_fmpq_poly_constructors()
+   test_fmpq_poly_printing()
    test_fmpq_poly_manipulation()
    test_fmpq_poly_binary_ops()
    test_fmpq_poly_adhoc_binary()

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -25,6 +25,18 @@ function test_fmpq_rel_series_constructors()
    println("PASS")
 end
 
+function test_fmpq_rel_series_printing()
+   print("fmpq_rel_series.printing...")
+
+   R, x = PowerSeriesRing(QQ, 30, "x")
+
+   a = x^3 + 2x + 1
+
+   @test string(a) == "x^3 + 2*x + 1+O(x^30)"
+   
+   println("PASS")
+end
+
 function test_fmpq_rel_series_manipulation()
    print("fmpq_rel_series.manipulation...")
 
@@ -297,6 +309,7 @@ end
 
 function test_fmpq_rel_series()
    test_fmpq_rel_series_constructors()
+   test_fmpq_rel_series_printing()
    test_fmpq_rel_series_manipulation()
    test_fmpq_rel_series_unary_ops()
    test_fmpq_rel_series_binary_ops()

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -35,6 +35,16 @@ function test_fmpz_constructors()
    println("PASS")
 end
 
+function test_fmpz_printing()
+   print("fmpz.printing...")
+
+   a = fmpz(-123)
+
+   @test string(a) == "-123"
+
+   println("PASS")
+end
+
 function test_fmpz_convert()
    print("fmpz.convert...")
 
@@ -498,7 +508,7 @@ function test_fmpz_number_theoretic()
 
    @test jacobi(fmpz(2), fmpz(5)) == -1
 
-   if !on_windows64
+   if !is_windows64()
 
       @test numpart(10) == 42
 
@@ -512,6 +522,7 @@ end
 function test_fmpz()
    test_fmpz_abstract_types()
    test_fmpz_constructors()
+   test_fmpz_printing()
    test_fmpz_convert()
    test_fmpz_manipulation()
    test_fmpz_binary_ops()

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -28,6 +28,17 @@ function test_fmpz_mat_constructors()
    println("PASS")
 end
 
+function test_fmpz_mat_printing()
+   print("fmpz_mat.printing...")
+ 
+   S = MatrixSpace(ZZ, 3, 3)
+   f = S(fmpz(3))
+
+   @test string(f) == "[3 0 0]\n[0 3 0]\n[0 0 3]"
+
+   println("PASS")
+end
+
 function test_fmpz_mat_manipulation()
    print("fmpz_mat.manipulation...")
 
@@ -469,6 +480,7 @@ end
 
 function test_fmpz_mat()
    test_fmpz_mat_constructors()
+   test_fmpz_mat_printing()
    test_fmpz_mat_manipulation()
    test_fmpz_mat_unary_ops()
    test_fmpz_mat_binary_ops()

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -46,6 +46,18 @@ function test_fmpz_mod_poly_constructors()
    println("PASS")
 end
 
+function test_fmpz_mod_poly_printing()
+   print("fmpz_mod_poly.printing...")
+ 
+   R = ResidueRing(ZZ, 123456789012345678949)
+   S, x = PolynomialRing(R, "x")
+   f = x^3 + 2x^2 + x + 1
+
+   @test string(f) == "x^3+2*x^2+x+1"
+
+   println("PASS")
+end
+
 function test_fmpz_mod_poly_manipulation()
    print("fmpz_mod_poly.manipulation...")
 
@@ -524,6 +536,7 @@ end
 
 function test_fmpz_mod_poly()
    test_fmpz_mod_poly_constructors()
+   test_fmpz_mod_poly_printing()
    test_fmpz_mod_poly_manipulation()
    test_fmpz_mod_poly_binary_ops()
    test_fmpz_mod_poly_adhoc_binary()

--- a/test/flint/fmpz_mod_rel_series-test.jl
+++ b/test/flint/fmpz_mod_rel_series-test.jl
@@ -36,6 +36,18 @@ function test_fmpz_mod_rel_series_constructors()
    println("PASS")
 end
 
+function test_fmpz_mod_rel_series_printing()
+   print("fmpz_mod_rel_series.printing...")
+
+   R = ResidueRing(ZZ, 123456789012345678949)
+   S, x = PowerSeriesRing(R, 30, "x")
+   b = x^2 + x + O(x^4)
+
+   @test string(b) == "x^2+x+O(x^4)"
+
+   println("PASS")
+end
+
 function test_fmpz_mod_rel_series_manipulation()
    print("fmpz_mod_rel_series.manipulation...")
 
@@ -335,6 +347,7 @@ end
 
 function test_fmpz_mod_rel_series()
    test_fmpz_mod_rel_series_constructors()
+   test_fmpz_mod_rel_series_printing()
    test_fmpz_mod_rel_series_manipulation()
    test_fmpz_mod_rel_series_unary_ops()
    test_fmpz_mod_rel_series_binary_ops()

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -26,6 +26,17 @@ function test_fmpz_poly_constructors()
    println("PASS")
 end
 
+function test_fmpz_poly_printing()
+   print("fmpz_poly.printing...")
+ 
+   R, x = PolynomialRing(ZZ, "x")
+   f = x^3 + 2x^2 + x + 1
+
+   @test string(f) == "x^3+2*x^2+x+1"
+
+   println("PASS")
+end
+
 function test_fmpz_poly_manipulation()
    print("fmpz_poly.manipulation...")
 
@@ -421,6 +432,7 @@ end
 
 function test_fmpz_poly()
    test_fmpz_poly_constructors()
+   test_fmpz_poly_printing()
    test_fmpz_poly_manipulation()
    test_fmpz_poly_binary_ops()
    test_fmpz_poly_adhoc_binary()

--- a/test/flint/fmpz_rel_series-test.jl
+++ b/test/flint/fmpz_rel_series-test.jl
@@ -23,6 +23,17 @@ function test_fmpz_rel_series_constructors()
    println("PASS")
 end
 
+function test_fmpz_rel_series_printing()
+   print("fmpz_rel_series.printing...")
+
+   R, x = PowerSeriesRing(ZZ, 30, "x")
+   a = x^3 + 2x + 1
+
+   @test string(a) == "x^3+2*x+1+O(x^30)"
+
+   println("PASS")
+end
+
 function test_fmpz_rel_series_manipulation()
    print("fmpz_rel_series.manipulation...")
 
@@ -270,6 +281,7 @@ function test_fmpz_rel_series_inversion()
 end
 function test_fmpz_rel_series()
    test_fmpz_rel_series_constructors()
+   test_fmpz_rel_series_printing()
    test_fmpz_rel_series_manipulation()
    test_fmpz_rel_series_unary_ops()
    test_fmpz_rel_series_binary_ops()

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -31,6 +31,18 @@ function test_fq_constructors()
    println("PASS")
 end
 
+function test_fq_printing()
+   print("fq.printing()...")
+
+   R, x = FiniteField(fmpz(7), 5, "x")
+
+   a = 3x^4 + 2x^3 + 4x^2 + x + 1
+
+   @test string(a) == "3*x^4+2*x^3+4*x^2+x+1"
+
+   println("PASS")
+end
+
 function test_fq_manipulation()
    print("fq.manipulation()...")
 
@@ -205,6 +217,7 @@ end
 
 function test_fq()
    test_fq_constructors()
+   test_fq_printing()
    test_fq_manipulation()
    test_fq_unary_ops()
    test_fq_binary_ops()

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -31,6 +31,18 @@ function test_fq_nmod_constructors()
    println("PASS")
 end
 
+function test_fq_nmod_printing()
+   print("fq_nmod.printing()...")
+
+   R, x = FiniteField(7, 5, "x")
+
+   a = 3x^4 + 2x^3 + 4x^2 + x + 1
+
+   @test string(a) == "3*x^4+2*x^3+4*x^2+x+1"
+
+   println("PASS")
+end
+
 function test_fq_nmod_manipulation()
    print("fq_nmod.manipulation()...")
 
@@ -205,6 +217,7 @@ end
 
 function test_fq_nmod()
    test_fq_nmod_constructors()
+   test_fq_nmod_printing()
    test_fq_nmod_manipulation()
    test_fq_nmod_unary_ops()
    test_fq_nmod_binary_ops()

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -55,6 +55,19 @@ function test_fq_nmod_poly_constructors()
    println("PASS")
 end
 
+function test_fq_nmod_poly_printing()
+   print("fq_nmod_poly.printing...")
+ 
+   R, x = FiniteField(23, 5, "x")
+   S, y = PolynomialRing(R, "y")
+
+   f = x^2 + y^3 + 1
+   
+   @test string(f) == "y^3+(x^2+1)"
+
+   println("PASS")
+end
+
 function test_fq_nmod_poly_manipulation()
    print("fq_nmod_poly.manipulation...")
 
@@ -517,6 +530,7 @@ end
 
 function test_fq_nmod_poly()
    test_fq_nmod_poly_constructors()
+   test_fq_nmod_poly_printing()
    test_fq_nmod_poly_manipulation()
    test_fq_nmod_poly_binary_ops()
    test_fq_nmod_poly_adhoc_binary()

--- a/test/flint/fq_nmod_rel_series-test.jl
+++ b/test/flint/fq_nmod_rel_series-test.jl
@@ -33,6 +33,19 @@ function test_fq_nmod_rel_series_constructors()
    println("PASS")
 end
 
+function test_fq_nmod_rel_series_printing()
+   print("fq_nmod_rel_series.printing...")
+
+   R, t = FiniteField(23, 5, "t")
+   S, x = PowerSeriesRing(R, 30, "x")
+
+   b = (t^2 + 1)*x^2 + (t + 3)x + O(x^4)
+
+   @test string(b) == "(t^2+1)*x^2+(t+3)*x+O(x^4)"
+
+   println("PASS")
+end
+
 function test_fq_nmod_rel_series_manipulation()
    print("fq_nmod_rel_series.manipulation...")
 
@@ -332,6 +345,7 @@ end
 
 function test_fq_nmod_rel_series()
    test_fq_nmod_rel_series_constructors()
+   test_fq_nmod_rel_series_printing()
    test_fq_nmod_rel_series_manipulation()
    test_fq_nmod_rel_series_unary_ops()
    test_fq_nmod_rel_series_binary_ops()

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -55,6 +55,20 @@ function test_fq_poly_constructors()
    println("PASS")
 end
 
+function test_fq_poly_printing()
+   print("fq_poly.printing...")
+ 
+   R, x = FiniteField(fmpz(23), 5, "x")
+   S, y = PolynomialRing(R, "y")
+   T, z = PolynomialRing(S, "z")
+
+   f = x^2 + y^3 + z + 1
+
+   @test string(f) == "z+(y^3+(x^2+1))"
+
+   println("PASS")
+end
+
 function test_fq_poly_manipulation()
    print("fq_poly.manipulation...")
 
@@ -501,6 +515,7 @@ end
 
 function test_fq_poly()
    test_fq_poly_constructors()
+   test_fq_poly_printing()
    test_fq_poly_manipulation()
    test_fq_poly_binary_ops()
    test_fq_poly_adhoc_binary()

--- a/test/flint/fq_rel_series-test.jl
+++ b/test/flint/fq_rel_series-test.jl
@@ -33,6 +33,19 @@ function test_fq_rel_series_constructors()
    println("PASS")
 end
 
+function test_fq_rel_series_printing()
+   print("fq_rel_series.printing...")
+
+   R, t = FiniteField(fmpz(23), 5, "t")
+   S, x = PowerSeriesRing(R, 30, "x")
+
+   b = (t^2 + 1)*x^2 + (t + 3)x + O(x^4)
+
+   @test string(b) == "(t^2+1)*x^2+(t+3)*x+O(x^4)"
+
+   println("PASS")
+end
+
 function test_fq_rel_series_manipulation()
    print("fq_rel_series.manipulation...")
 
@@ -332,6 +345,7 @@ end
 
 function test_fq_rel_series()
    test_fq_rel_series_constructors()
+   test_fq_rel_series_printing()
    test_fq_rel_series_manipulation()
    test_fq_rel_series_unary_ops()
    test_fq_rel_series_binary_ops()

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -116,6 +116,19 @@ function test_nmod_mat_constructors()
   println("PASS")
 end
 
+function test_nmod_mat_printing()
+  print("nmod_mat.printing...")
+  
+  Z2 = ResidueRing(ZZ, 2)
+  R = NmodMatSpace(Z2, 2, 2)
+
+  a = R(1)
+
+  @test string(a) == "[1 0]\n[0 1]"
+
+  println("PASS")
+end
+
 function test_nmod_mat_manipulation()
   print("nmod_mat.manipulation...")
   Z10 = ResidueRing(ZZ, 10)
@@ -672,6 +685,7 @@ end
 
 function test_nmod_mat()
   test_nmod_mat_constructors()
+  test_nmod_mat_printing()
   test_nmod_mat_manipulation()
   test_nmod_mat_unary_ops()
   test_nmod_mat_binary_ops()

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -81,6 +81,19 @@ function test_nmod_poly_constructors()
   println("PASS")
 end
 
+function test_nmod_poly_printing()
+  print("nmod_poly.printing...")
+
+  R = ResidueRing(ZZ, 17)
+  Rx, x = PolynomialRing(R, "x")
+
+  a = x^3 + x + 1
+
+  @test string(a) == "x^3+x+1"
+
+  println("PASS")
+end
+
 function test_nmod_poly_manipulation()
   print("nmod_poly.manipulation...")
 
@@ -692,6 +705,7 @@ end
 
 function test_nmod_poly()
   test_nmod_poly_constructors()
+  test_nmod_poly_printing()
   test_nmod_poly_manipulation()
   test_nmod_poly_unary_ops()
   test_nmod_poly_binary_ops()

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -26,6 +26,18 @@ function test_padic_constructors()
    println("PASS")
 end
 
+function test_padic_printing()
+   print("padic.constructors()...")  
+
+   R = PadicField(7, 30)
+   
+   a = 1 + 2*7 + 4*7^2 + O(R, 7^3)
+
+   @test string(a) == "1 + 2*7^1 + 4*7^2 + O(7^3)"
+
+   println("PASS")
+end
+
 function test_padic_manipulation()
    print("padic.manipulation()...")  
 
@@ -312,6 +324,7 @@ end
 
 function test_padic()
    test_padic_constructors()
+   test_padic_printing()
    test_padic_manipulation()
    test_padic_unary_ops()
    test_padic_binary_ops()

--- a/test/flint/perm-test.jl
+++ b/test/flint/perm-test.jl
@@ -24,6 +24,18 @@ function test_perm_constructors()
    println("PASS")
 end
 
+function test_perm_printing()
+   print("perm.printing...")
+
+   R = PermutationGroup(10)
+
+   b = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
+
+   @test string(b) == "[2, 3, 5, 4, 6, 7, 1, 9, 10, 8]"
+
+   println("PASS")
+end
+
 function test_perm_basic_manipulation()
    print("perm.basic_manipulation...")
 
@@ -83,6 +95,7 @@ end
 function test_perm()
    test_perm_abstract_types()
    test_perm_constructors()
+   test_perm_printing()
    test_perm_basic_manipulation()
    test_perm_comparison()
    test_perm_binary_ops()

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -663,7 +663,7 @@ function test_gen_mat_solve()
    U = MatrixSpace(S, 3, 1)
 
    M = T([3y*a^2 + (y + 1)*a + 2y (5y+1)*a^2 + 2a + y - 1 a^2 + (-a) + 2y; (y + 1)*a^2 + 2y - 4 3y*a^2 + (2y - 1)*a + y (4y - 1)*a^2 + (y - 1)*a + 5; 2a + y + 1 (2y + 2)*a^2 + 3y*a + 3y a^2 + (-y-1)*a + (-y - 3)])
-   b = U([4y*a^2 + 4y*a + 2y + 1 5y*a^2 + (2y + 1)*a + 6y + 1 (y + 1)*a^2 + 3y*a + 2y + 4]')
+   b = U(permutedims([4y*a^2 + 4y*a + 2y + 1 5y*a^2 + (2y + 1)*a + 6y + 1 (y + 1)*a^2 + 3y*a + 2y + 4], [2, 1]))
 
    x, d = solve(M, b)
 


### PR DESCRIPTION
- Fixes bug in `show(::io, ::arb_poly)` and `show(::io, ::acb_poly)`
- Tests for printing of flint/arb/antic types.
- `symbol` -> `Symbol`
- `bytestring` -> `string` and `unsafe_string` respectively.
- Removes `Base.call` (fix #28)
- Bumps version number
- Fixes the Windows build (hopefully)
(close #95)