### PR TITLE
Adjust to changes in Base.transpose

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -229,6 +229,14 @@ function exp{T <: RingElem}(a::T)
    return one(parent(a))
 end
 
+################################################################################
+#
+#   Transpose for ring elements
+#
+################################################################################
+
+transpose{T <: RingElem}(x::T) = deepcopy(x)
+
 ###############################################################################
 #
 #   Generic and specific rings and fields


### PR DESCRIPTION
Fix #103 

I think the `deepcopy` is necessary since julia will set `A[i, j] = transpose(B[j, i])` when computing `A = tranpose(B)`.