### PR TITLE
Add some functionality to test only one module

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -42,6 +42,8 @@ export error_dim_negative
 
 export is_windows64
 
+export test_module
+
 include("AbstractTypes.jl")
 
 ###############################################################################
@@ -304,5 +306,33 @@ const error_dim_negative = ErrorException("Dimensions must be non-negative")
 ###############################################################################
 
 include("../benchmarks/runbenchmarks.jl")
+
+function test_module(x, y)
+   julia_exe = Base.julia_cmd()
+   test_file = joinpath(pkgdir, "test/$x/")
+   test_file = test_file * "$y-test.jl";
+   test_function_name = "test_"
+   if x in ["flint", "arb", "antic"]
+     test_function_name *= y
+   else x == "generic"
+     if y == "RelSeries" 
+       test_function_name *= "gen_rel_series"
+     elseif y == "AbsSeries"
+       test_function_name *= "gen_abs_series"
+     elseif y == "Matrix"
+       test_function_name *= "gen_mat"
+     elseif y == "Fraction"
+       test_function_name *= "gen_frac"
+     elseif y == "Residue"
+       test_function_name *= "gen_res"
+     else
+       test_function_name *= "gen_$(lowercase(y))"
+     end
+   end
+
+   cmd = "using Base.Test; using Nemo; include(\"$test_file\"); $test_function_name();"
+   info("spawning ", `$julia_exe -e \"$cmd\"`)
+   run(`$julia_exe -e $cmd`)
+end
 
 end # module


### PR DESCRIPTION
I think its very helpful when working only on one module. It behaves similar to `Pkg.test`. Since it spawns a new julia process, one does not have to restart julia.

```julia
julia> using Nemo
julia> test_module("arb", "arb_poly")
INFO: spawning `/home/bla/julia-0.5.0/bin/julia -Cx86-64 -J/home/bla/julia-0.5.0/lib/julia/sys.so --compile=yes --depwarn=yes -e '"using Base.Test; using Nemo; include("/home/bla/.julia/v0.5/Nemo/test/arb/arb_poly-test.jl"); test_arb_poly();"'`

Welcome to Nemo version 0.5.2

Nemo comes with absolutely no warranty whatsoever

arb_poly.constructors...PASS
arb_poly.printing...PASS
arb_poly.manipulation...PASS
arb_poly.binary_ops...PASS
arb_poly.adhoc_binary...PASS
arb_poly.comparison...PASS
arb_poly.adhoc_comparison...PASS
arb_poly.unary_ops...PASS
arb_poly.truncation...PASS
arb_poly.reverse...PASS
arb_poly.shift...PASS
arb_poly.powering...PASS
arb_poly.exact_division...PASS
arb_poly_scalar_division...PASS
arb_poly.evaluation...PASS
arb_poly.composition...PASS
arb_poly.derivative_integral...PASS
arb_poly.evaluation_interpolation...PASS


julia> test_module("generic", "AbsSeries")
INFO: spawning `/home/bla/julia-0.5.0/bin/julia -Cx86-64 -J/home/bla/julia-0.5.0/lib/julia/sys.so --compile=yes --depwarn=yes -e '"using Base.Test; using Nemo; include("/home/bla/.julia/v0.5/Nemo/test/generic/AbsSeries-test.jl"); test_gen_abs_series();"'`

Welcome to Nemo version 0.5.2

Nemo comes with absolutely no warranty whatsoever

GenAbsSeries.constructors...PASS
GenAbsSeries.manipulation...PASS
GenAbsSeries.unary_ops...PASS
GenAbsSeries.binary_ops...PASS
GenAbsSeries.adhoc_binary_ops...PASS
GenAbsSeries.comparison...PASS
GenAbsSeries.adhoc_comparison...PASS
GenAbsSeries.powering...PASS
GenAbsSeries.shift...PASS
GenAbsSeries.truncation...PASS
GenAbsSeries.exact_division...PASS
GenAbsSeries.adhoc_exact_division...PASS
GenAbsSeries.inversion...PASS
GenAbsSeries.special_functions...PASS
```