### PR TITLE
Changes for julia 0.6

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -6,15 +6,14 @@ import Base: Array, abs, asin, asinh, atan, atanh, base, bin, call,
              checkbounds, convert, cmp, contains, cos, cosh, dec,
              deepcopy, deepcopy_internal, den, deserialize, det, div, divrem,
              exp, factor, gcd, gcdx, getindex, hash, hcat, hex, intersect, inv,
-             invmod, isequal, isfinite, isless, isprime, isqrt, isreal, lcm,
-             ldexp, length, log, lufact, lufact!, mod, ndigits, nextpow2, norm,
-             nullspace, num, oct, one, parent, parity, parse, precision,
+             invmod, isequal, isfinite, isless, isprime, isqrt, isreal, iszero,
+             lcm, ldexp, length, log, lufact, lufact!, mod, ndigits, nextpow2,
+             norm, nullspace, num, oct, one, parent, parity, parse, precision,
              prevpow2, promote_rule, rank, Rational, rem, reverse, serialize,
              setindex!, show, sign, sin, sinh, size, sqrt, string, sub, tan,
              tanh, trace, trailing_zeros, transpose, transpose!, truncate,
-             typed_hvcat, typed_hcat, var, vcat, zero, zeros,
-             +, -, *, ==, ^, &, |, $, <<, >>, ~, <=, >=, <, >, //,
-             /, !=
+             typed_hvcat, typed_hcat, var, vcat, zero, zeros, +, -, *, ==, ^,
+             &, |, $, <<, >>, ~, <=, >=, <, >, //, /, !=
 
 import Base: floor, ceil, hypot, sqrt,
              log, log1p, exp, expm1, sin, cos, sinpi, cospi, tan, cot,
@@ -154,18 +153,16 @@ end
 ###############################################################################
 
 function create_accessors(T, S, handle)
-   accessor_name = gensym()
-   @eval begin
-      function $(Symbol(:get, accessor_name))(a::$T)
-         return a.auxilliary_data[$handle]::$S
-      end,
-      function $(Symbol(:set, accessor_name))(a::$T, b::$S)
-         if $handle > length(a.auxilliary_data)
-            resize(a.auxilliary_data, $handle)
-         end
-         a.auxilliary_data[$handle] = b
-      end
+   get = function(a)
+      return a.auxilliary_data[handle]
    end
+   set = function(a, b)
+      if handle > length(a.auxilliary_data)
+         resize(a.auxilliary_data, handle)
+      end
+      a.auxilliary_data[handle] = b
+   end
+   return get, set
 end
 
 ###############################################################################
@@ -199,11 +196,11 @@ end # if VERSION
 #
 ###############################################################################
 
-Array(R::Ring, r::Int...) = Array(elem_type(R), r)
+Array(R::Ring, r::Int...) = Array{elem_type(R)}(r)
 
 function zeros(R::Ring, r::Int...)
    T = elem_type(R)
-   A = Array(T, r)
+   A = Array{T}(r)
    for i in eachindex(A)
       A[i] = R()
    end

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -205,7 +205,7 @@ end
 function powers{T <: RingElem}(a::T, d::Int)
    d <= 0 && throw(DomainError())
    S = parent(a)
-   A = Array(T, d + 1)
+   A = Array{T}(d + 1)
    A[1] = one(S)
    if d > 1
       c = a

--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -42,7 +42,7 @@ type AnticNumberField <: Field
             (Ptr{AnticNumberField}, Ptr{fmpq_poly}), &nf, &pol)
          finalizer(nf, _AnticNumberField_clear_fn)
          nf.S = s
-         nf.auxilliary_data = Array(Any, 5)
+         nf.auxilliary_data = Array{Any}(5)
          return nf
       end
    end

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -713,7 +713,7 @@ function sqr_classical(a::GenPoly{nf_elem})
    t = base_ring(a)()
 
    lenz = 2*lena - 1
-   d = Array(nf_elem, lenz)
+   d = Array{nf_elem}(lenz)
 
    for i = 1:lena - 1
       d[2i - 1] = base_ring(a)()
@@ -758,7 +758,7 @@ function mul_classical(a::GenPoly{nf_elem}, b::GenPoly{nf_elem})
    t = base_ring(a)()
 
    lenz = lena + lenb - 1
-   d = Array(nf_elem, lenz)
+   d = Array{nf_elem}(lenz)
 
    for i = 1:lena
       d[i] = base_ring(a)()

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -194,13 +194,13 @@ type acb <: FieldElem
     return z
   end
 
-  function acb{T <: Union{Int, UInt, Float64, fmpz, BigFloat, arb}}(x::T, y::T)
-    z = new()
-    ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
-    _acb_set(z, x, y)
-    finalizer(z, _acb_clear_fn)
-    return z
-  end
+  #function acb{T <: Union{Int, UInt, Float64, fmpz, BigFloat, arb}}(x::T, y::T)
+  #  z = new()
+  #  ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+  #  _acb_set(z, x, y)
+  #  finalizer(z, _acb_clear_fn)
+  #  return z
+  #end
 
   function acb{T <: Union{Int, UInt, Float64, fmpz, fmpq,
                           BigFloat, AbstractString, arb}}(x::T, y::T, p::Int)

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -644,12 +644,13 @@ function (x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, a
   return z
 end
 
-(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString,
-                arb}}(y::Array{Tuple{T, T}, 1}) = x(y'')
+(x::AcbMatSpace){T <: Union{BigFloat, AbstractString, arb}}(y::Array{Tuple{T, T}, 1}) = x(y'')
 
+(x::AcbMatSpace){T <: Union{Int, UInt, Float64, fmpz, fmpq}}(y::Array{Tuple{T, T}, 1}) = x(y'')
 
-(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb,
-                AbstractString}}(y::Array{T, 1}) = x(y'')
+(x::ArbMatSpace){T <: Union{Int, UInt, fmpz, fmpq, Float64}}(y::Array{T, 1}) = x(y'')
+
+(x::ArbMatSpace){T <: Union{BigFloat, arb, acb, AbstractString}}(y::Array{T, 1}) = x(y'')
 
 function (x::AcbMatSpace)(y::Union{Int, UInt, fmpz, fmpq, Float64,
                           BigFloat, arb, acb, AbstractString})

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -607,7 +607,7 @@ function acb_vec(b::Array{acb, 1})
 end
 
 function array(R::AcbField, v::Ptr{acb_struct}, n::Int)
-   r = Array(acb, n)
+   r = Array{acb}(n)
    for i=1:n
        r[i] = R()
        ccall((:acb_set, :libarb), Void, (Ptr{acb}, Ptr{acb_struct}),
@@ -720,7 +720,7 @@ doc"""
 function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_prec=0, max_iter=0)
     deg = degree(x)
     if deg <= 0
-        return Array(acb, 0)
+        return Array{acb}(0)
     end
 
     initial_prec = (initial_prec >= 2) ? initial_prec : 32

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -595,7 +595,7 @@ function arb_vec(b::Array{arb, 1})
 end
 
 function array(R::ArbField, v::Ptr{arb_struct}, n::Int)
-   r = Array(arb, n)
+   r = Array{arb}(n)
    for i=1:n
        r[i] = R()
        ccall((:arb_set, :libarb), Void, (Ptr{arb}, Ptr{arb_struct}),

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2322,7 +2322,7 @@ type perm <: GroupElem
    parent::FlintPermGroup
 
    function perm(n::Int)
-      p = new(Array(Int, n))
+      p = new(Array{Int}(n))
       ccall((:_perm_set_one, :libflint), Void,
             (Ref{Int}, Int), p.d, length(p.d))
       return p
@@ -2330,7 +2330,7 @@ type perm <: GroupElem
 
    function perm(a::Array{Int, 1})
       n = length(a)
-      d = Array(Int, n)
+      d = Array{Int}(n)
       for i = 1:n
          d[i] = a[i] - 1
       end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -627,7 +627,7 @@ function (a::FmpqMatSpace)(arr::Array{fmpq, 1})
    return z
 end
 
-(a::FmpqMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
+(a::FmpqMatSpace){T <: Integer}(arr::Array{T, 1}) = a(reshape(arr, (a.rows, a.cols)))
 
 function (a::FmpqMatSpace)(d::fmpq)
    z = fmpq_mat(a.rows, a.cols, d)

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -625,8 +625,8 @@ doc"""
 > real roots of $f$ and $s$ is half the number of complex roots.
 """
 function signature(f::fmpq_poly)
-   r = Array(Int, 1)
-   s = Array(Int, 1)
+   r = Array{Int}(1)
+   s = Array{Int}(1)
    z = fmpz_poly()
    ccall((:fmpq_poly_get_numerator, :libflint), Void,
          (Ptr{fmpz_poly}, Ptr{fmpq_poly}), &z, &f)

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -15,7 +15,7 @@ export fmpq_rel_series, FmpqRelSeriesRing
 function O(a::fmpq_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   z = fmpq_rel_series(Array(fmpq, 0), 0, val, val)
+   z = fmpq_rel_series(Array{fmpq}(0), 0, val, val)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -40,7 +40,8 @@ export fmpz, FlintZZ, FlintIntegerRing, parent, show, convert, hash, fac, bell,
        gcdinv, isprobabprime, issquare, jacobi, remove, root, size, isqrtrem,
        sqrtmod, trailing_zeros, sigma, eulerphi, fib, moebiusmu, primorial,
        risingfac, numpart, canonical_unit, needs_parentheses, is_negative,
-       show_minus_one, parseint, addeq!, mul!, isunit, isequal, num, den
+       show_minus_one, parseint, addeq!, mul!, isunit, isequal, num, den,
+       iszero
 
 ###############################################################################
 #

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -18,7 +18,7 @@ function O(a::fmpz_abs_series)
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError())
-   z = fmpz_abs_series(Array(fmpz, 0), 0, prec)
+   z = fmpz_abs_series(Array{fmpz}(0), 0, prec)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1070,7 +1070,7 @@ function (a::FmpzMatSpace)(arr::Array{fmpz, 1})
    return z
 end
 
-(a::FmpzMatSpace){T <: Integer}(arr::Array{T, 1}) = a(arr'')
+(a::FmpzMatSpace){T <: Integer}(arr::Array{T, 1}) = a(reshape(arr, (a.rows, a.cols)))
 
 function (a::FmpzMatSpace)(d::fmpz)
    z = fmpz_mat(a.rows, a.cols, d)

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -18,7 +18,7 @@ function O(a::fmpz_mod_abs_series)
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError())
-   z = fmpz_mod_abs_series(modulus(a), Array(fmpz, 0), 0, prec)
+   z = fmpz_mod_abs_series(modulus(a), Array{fmpz}(0), 0, prec)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -625,7 +625,7 @@ end
 
 function integral(x::fmpz_mod_poly)
    len = length(x)
-   v = Array(GenRes{fmpz}, len + 1)
+   v = Array{GenRes{fmpz}}(len + 1)
    v[1] = zero(base_ring(x))
    for i = 1:len
       v[i + 1] = divexact(coeff(x, i - 1), base_ring(x)(i))
@@ -764,7 +764,7 @@ doc"""
 function factor_distinct_deg(x::fmpz_mod_poly)
   !issquarefree(x) && error("Polynomial must be squarefree")
   !isprobabprime(modulus(x)) && error("Modulus not prime in factor_distinct_deg")
-  degs = Array(Int, degree(x))
+  degs = Array{Int}(degree(x))
   degss = [ pointer(degs) ]
   fac = fmpz_mod_poly_factor(parent(x).n)
   ccall((:fmpz_mod_poly_factor_distinct_deg, :libflint), UInt,

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -15,7 +15,7 @@ export fmpz_mod_rel_series, FmpzModRelSeriesRing
 function O(a::fmpz_mod_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   z = fmpz_mod_rel_series(modulus(a), Array(fmpz, 0), 0, val, val)
+   z = fmpz_mod_rel_series(modulus(a), Array{fmpz}(0), 0, val, val)
    z.parent = parent(a)
    return z
 end
@@ -580,7 +580,7 @@ function exp(a::fmpz_mod_rel_series)
    R = base_ring(a)
    vala = valuation(a)
    preca = precision(a)
-   d = Array(fmpz, preca)
+   d = Array{fmpz}(preca)
    c = vala == 0 ? polcoeff(a, 0) : R()
    d[1] = exp(c).data
    len = pol_length(a) + vala

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -387,7 +387,7 @@ function pseudorem(x::fmpz_poly, y::fmpz_poly)
    y == 0 && throw(DivideError())
    diff = length(x) - length(y)
    r = parent(x)()
-   d = Array(Int, 1)
+   d = Array{Int}(1)
    ccall((:fmpz_poly_pseudo_rem, :libflint), Void, 
      (Ptr{fmpz_poly}, Ptr{Int}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &r, d, &x, &y)
    if (diff > d[1])
@@ -403,7 +403,7 @@ function pseudodivrem(x::fmpz_poly, y::fmpz_poly)
    diff = length(x) - length(y)
    q = parent(x)()
    r = parent(x)()
-   d = Array(Int, 1)
+   d = Array{Int}(1)
    ccall((:fmpz_poly_pseudo_divrem_divconquer, :libflint), Void, 
     (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{Int}, Ptr{fmpz_poly}, Ptr{fmpz_poly}),
                &q, &r, d, &x, &y)
@@ -552,8 +552,8 @@ doc"""
 > roots.
 """
 function signature(f::fmpz_poly)
-   r = Array(Int, 1)
-   s = Array(Int, 1)
+   r = Array{Int}(1)
+   s = Array{Int}(1)
    ccall((:fmpz_poly_signature, :libflint), Void,
          (Ptr{Int}, Ptr{Int}, Ptr{fmpz_poly}), r, s, &f)
    return (r[1], s[1])
@@ -569,8 +569,8 @@ function interpolate(R::FmpzPolyRing, x::Array{fmpz, 1},
                                       y::Array{fmpz, 1})
   z = R()
 
-  ax = Array(Int, length(x))
-  ay = Array(Int, length(y))
+  ax = Array{Int}(length(x))
+  ay = Array{Int}(length(y))
 
   t = fmpz()
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -15,7 +15,7 @@ export fmpz_rel_series, FmpzRelSeriesRing
 function O(a::fmpz_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   z = fmpz_rel_series(Array(fmpz, 0), 0, val, val)
+   z = fmpz_rel_series(Array{fmpz}(0), 0, val, val)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -18,7 +18,7 @@ function O(a::fq_abs_series)
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError())
-   z = fq_abs_series(base_ring(a), Array(fq, 0), 0, prec)
+   z = fq_abs_series(base_ring(a), Array{fq}(0), 0, prec)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -18,7 +18,7 @@ function O(a::fq_nmod_abs_series)
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError())
-   z = fq_nmod_abs_series(base_ring(a), Array(fq_nmod, 0), 0, prec)
+   z = fq_nmod_abs_series(base_ring(a), Array{fq_nmod}(0), 0, prec)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -15,7 +15,7 @@ export fq_nmod_rel_series, FqNmodRelSeriesRing
 function O(a::fq_nmod_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   z = fq_nmod_rel_series(base_ring(a), Array(fq_nmod, 0), 0, val, val)
+   z = fq_nmod_rel_series(base_ring(a), Array{fq_nmod}(0), 0, val, val)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -15,7 +15,7 @@ export fq_rel_series, FqRelSeriesRing
 function O(a::fq_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   z = fq_rel_series(base_ring(a), Array(fq, 0), 0, val, val)
+   z = fq_rel_series(base_ring(a), Array{fq}(0), 0, val, val)
    z.parent = parent(a)
    return z
 end

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -526,7 +526,7 @@ end
 ################################################################################
 
 function Array(b::nmod_mat)
-  a = Array(GenRes{fmpz}, b.r, b.c)
+  a = Array{GenRes{fmpz}}(b.r, b.c)
   for i = 1:b.r
     for j = 1:b.c
       a[i,j] = b[i,j]

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -626,8 +626,8 @@ function interpolate(R::NmodPolyRing, x::Array{GenRes{fmpz}, 1},
                                       y::Array{GenRes{fmpz}, 1})
   z = R()
 
-  ax = Array(UInt, length(x))
-  ay = Array(UInt, length(y))
+  ax = Array{UInt}(length(x))
+  ay = Array{UInt}(length(y))
 
   t = fmpz()
 
@@ -785,7 +785,7 @@ doc"""
 function factor_distinct_deg(x::nmod_poly)
   !issquarefree(x) && error("Polynomial must be squarefree")
   !is_prime(modulus(x)) && error("Modulus not prime in factor_distinct_deg")
-  degs = Array(Int, degree(x))
+  degs = Array{Int}(degree(x))
   degss = [ pointer(degs) ]
   fac = nmod_poly_factor(x.mod_n)
   ccall((:nmod_poly_factor_distinct_deg, :libflint), UInt,

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -25,7 +25,7 @@ function O{T}(a::AbsSeriesElem{T})
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError())
-   return parent(a)(Array(T, 0), 0, prec)
+   return parent(a)(Array{T}(0), 0, prec)
 end
 
 parent_type{T}(::Type{GenAbsSeries{T}}) = GenAbsSeriesRing{T}
@@ -120,7 +120,7 @@ function valuation(a::AbsSeriesElem)
 end
 
 function deepcopy_internal{T <: RingElem}(a::GenAbsSeries{T}, dict::ObjectIdDict)
-   coeffs = Array(T, length(a))
+   coeffs = Array{T}(length(a))
    for i = 1:length(a)
       coeffs[i] = deepcopy(coeff(a, i - 1))
    end
@@ -281,11 +281,11 @@ function *{T <: RingElem}(a::AbsSeriesElem{T}, b::AbsSeriesElem{T})
    lenb = min(lenb, prec)
 
    if lena == 0 || lenb == 0
-      return parent(a)(Array(T, 0), 0, prec)
+      return parent(a)(Array{T}(0), 0, prec)
    end
    t = base_ring(a)()
    lenz = min(lena + lenb - 1, prec)
-   d = Array(T, lenz)
+   d = Array{T}(lenz)
    for i = 1:min(lena, lenz)
       d[i] = coeff(a, i - 1)*coeff(b, 0)
    end
@@ -837,7 +837,7 @@ end
 function fit!{T <: RingElem}(c::GenAbsSeries{T}, n::Int)
    if length(c.coeffs) < n
       t = c.coeffs
-      c.coeffs = Array(T, n)
+      c.coeffs = Array{T}(n)
       for i = 1:c.length
          c.coeffs[i] = t[i]
       end
@@ -952,14 +952,14 @@ function (a::GenAbsSeriesRing{T}){T <: RingElem}(b::RingElem)
 end
 
 function (a::GenAbsSeriesRing{T}){T <: RingElem}()
-   z = GenAbsSeries{T}(Array(T, 0), 0, a.prec_max)
+   z = GenAbsSeries{T}(Array{T}(0), 0, a.prec_max)
    z.parent = a
    return z
 end
 
 function (a::GenAbsSeriesRing{T}){T <: RingElem}(b::Integer)
    if b == 0
-      z = GenAbsSeries{T}(Array(T, 0), 0, a.prec_max)
+      z = GenAbsSeries{T}(Array{T}(0), 0, a.prec_max)
    else
       z = GenAbsSeries{T}([base_ring(a)(b)], 1, a.prec_max)
    end
@@ -969,7 +969,7 @@ end
 
 function (a::GenAbsSeriesRing{T}){T <: RingElem}(b::fmpz)
    if b == 0
-      z = GenAbsSeries{T}(Array(T, 0), 0, a.prec_max)
+      z = GenAbsSeries{T}(Array{T}(0), 0, a.prec_max)
    else
       z = GenAbsSeries{T}([base_ring(a)(b)], 1, a.prec_max)
    end
@@ -980,7 +980,7 @@ end
 function (a::GenAbsSeriesRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to power series")
    if b == 0
-      z = GenAbsSeries{T}(Array(T, 0), 0, a.prec_max)
+      z = GenAbsSeries{T}(Array{T}(0), 0, a.prec_max)
    else
       z = GenAbsSeries{T}([b], 1, a.prec_max)
    end

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -34,11 +34,11 @@ type GenPoly{T <: RingElem} <: PolyElem{T}
    length::Int
    parent::GenPolyRing{T}
 
-   GenPoly() = new(Array(T, 0), 0)
+   GenPoly() = new(Array{T}(0), 0)
    
    GenPoly(a::Array{T, 1}) = new(a, length(a))
 
-   GenPoly(a::T) = a == 0 ? new(Array(T, 0), 0) : new([a], 1)
+   GenPoly(a::T) = a == 0 ? new(Array{T}(0), 0) : new([a], 1)
 end
 
 ###############################################################################

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -134,7 +134,7 @@ function isone(a::MatElem)
 end
 
 function deepcopy_internal{T <: RingElem}(d::MatElem{T}, dict::ObjectIdDict)
-   entries = Array(T, rows(d), cols(d))
+   entries = Array{T}(rows(d), cols(d))
    for i = 1:rows(d)
       for j = 1:cols(d)
          entries[i, j] = deepcopy(d[i, j])
@@ -245,7 +245,7 @@ function *{T <: RingElem}(x::MatElem{T}, y::MatElem{T})
    else
       parz = MatrixSpace(base_ring(x), rows(x), cols(y))
    end
-   A = Array(T, rows(x), cols(y))
+   A = Array{T}(rows(x), cols(y))
    C = base_ring(x)()
    for i = 1:rows(x)
       for j = 1:cols(y)
@@ -569,7 +569,7 @@ function powers{T <: RingElem}(a::MatElem{T}, d::Int)
    rows(a) != cols(a) && error("Dimensions do not match in powers")
    d <= 0 && throw(DomainError())
    S = parent(a)
-   A = Array(MatElem{T}, d + 1)
+   A = Array{MatElem{T}}(d + 1)
    A[1] = one(S)
    if d > 1
       c = a
@@ -1143,7 +1143,7 @@ function rref!{T <: RingElem}(A::MatElem{T})
       t = R()
       q = R()
       d = -d
-      pivots = Array(Int, n)
+      pivots = Array{Int}(n)
       np = rank
       j = k = 1
       for i = 1:rank
@@ -1213,7 +1213,7 @@ function rref!{T <: FieldElem}(A::MatElem{T})
    end
    U = MatrixSpace(R, rnk, rnk)()
    V = MatrixSpace(R, rnk, n - rnk)()
-   pivots = Array(Int, n)
+   pivots = Array{Int}(n)
    np = rnk
    j = k = 1
    for i = 1:rnk
@@ -1431,8 +1431,8 @@ end
 function det_clow{T <: RingElem}(M::MatElem{T})
    R = base_ring(M)
    n = rows(M)
-   A = Array(T, n, n)
-   B = Array(T, n, n)
+   A = Array{T}(n, n)
+   B = Array{T}(n, n)
    C = R()
    for i = 1:n
       for j = 1:n
@@ -1848,10 +1848,10 @@ function solve_interpolation{T <: PolyElem}(M::MatElem{T}, b::MatElem{T})
    end
    # bound from xd = (M*)b where d is the det
    bound = (maxlen - 1)*(m - 1) + max(maxlenb, maxlen)
-   V = Array(elem_type(U), bound)
-   d = Array(elem_type(base_ring(R)), bound)
-   y = Array(elem_type(base_ring(R)), bound)
-   bj = Array(elem_type(base_ring(R)), bound)
+   V = Array{elem_type(U)}(bound)
+   d = Array{elem_type(base_ring(R))}(bound)
+   y = Array{elem_type(base_ring(R))}(bound)
+   bj = Array{elem_type(base_ring(R))}(bound)
    X = S()
    Y = U()
    x = parent(b)()
@@ -1930,8 +1930,8 @@ function solve_triu{T <: FieldElem}(U::MatElem{T}, b::MatElem{T}, unit=false)
    m = cols(b)
    R = base_ring(U)
    X = parent(b)()
-   Tinv = Array(elem_type(R), n)
-   tmp = Array(elem_type(R), n)
+   Tinv = Array{elem_type(R)}(n)
+   tmp = Array{elem_type(R)}(n)
    if unit == false
       for i = 1:n
          Tinv[i] = inv(U[i, i])
@@ -2026,8 +2026,8 @@ function nullspace{T <: RingElem}(M::MatElem{T})
          U[i, i] = R(1)
       end
    elseif nullity != 0
-      pivots = Array(Int, rank)
-      nonpivots = Array(Int, nullity)
+      pivots = Array{Int}(rank)
+      nonpivots = Array{Int}(nullity)
       j = k = 1
       for i = 1:rank
          while A[i, j] == 0
@@ -2076,7 +2076,7 @@ function nullspace{T <: FieldElem}(M::MatElem{T})
          X[i, i] = R(1)
       end
    elseif nullity != 0
-      pivots = Array(Int, max(m, n))
+      pivots = Array{Int}(max(m, n))
       np = rank
       j = k = 1
       for i = 1:rank
@@ -2204,7 +2204,7 @@ function charpoly_hessenberg!{T <: RingElem}(S::Ring, A::MatElem{T})
       return gen(S) - A[1, 1]
    end
    hessenberg!(A)
-   P = Array(elem_type(S), n + 1)
+   P = Array{elem_type(S)}(n + 1)
    P[1] = S(1)
    x = gen(S)
    for m = 1:n
@@ -2231,8 +2231,8 @@ function charpoly_danilevsky_ff!{T <: RingElem}(S::Ring, A::MatElem{T})
    end
    d = R(1)
    t = R()
-   V = Array(T, n)
-   W = Array(T, n)
+   V = Array{T}(n)
+   W = Array{T}(n)
    pol = S(1)
    i = 1
    while i < n
@@ -2347,8 +2347,8 @@ function charpoly_danilevsky!{T <: RingElem}(S::Ring, A::MatElem{T})
       return gen(S) - A[1, 1]
    end
    t = R()
-   V = Array(T, n)
-   W = Array(T, n)
+   V = Array{T}(n)
+   W = Array{T}(n)
    pol = S(1)
    i = 1
    while i < n
@@ -2453,9 +2453,9 @@ function charpoly{T <: RingElem}(V::Ring, Y::MatElem{T})
    if n == 0
       return V(1)
    end
-   F = Array(elem_type(R), n)
-   A = Array(elem_type(R), n)
-   M = Array(elem_type(R), n - 1, n)
+   F = Array{elem_type(R)}(n)
+   A = Array{elem_type(R)}(n)
+   M = Array{elem_type(R)}(n - 1, n)
    F[1] = -Y[1, 1]
    for i = 2:n
       F[i] = R()
@@ -2853,7 +2853,7 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::RingElem)
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}()
-   entries = Array(T, a.rows, a.cols)
+   entries = Array{T}(a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
          entries[i, j] = zero(base_ring(a))
@@ -2865,7 +2865,7 @@ function (a::GenMatSpace{T}){T <: RingElem}()
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
-   entries = Array(T, a.rows, a.cols)
+   entries = Array{T}(a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
@@ -2881,7 +2881,7 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz)
-   entries = Array(T, a.rows, a.cols)
+   entries = Array{T}(a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
@@ -2898,7 +2898,7 @@ end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
-   entries = Array(T, a.rows, a.cols)
+   entries = Array{T}(a.rows, a.cols)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
@@ -2949,7 +2949,7 @@ function typed_hvcat(R::Ring, dims, d...)
    T = elem_type(R)
    r = length(dims)
    c = dims[1]
-   A = Array(T, r, c)
+   A = Array{T}(r, c)
    for i = 1:r
       dims[i] != c && throw(ArgumentError("row $i has mismatched number of columns (expected $c, got $(dims[i]))"))
       for j = 1:c
@@ -2963,7 +2963,7 @@ end
 function typed_hcat(R::Ring, d...)
    T = elem_type(R)
    r = length(d)
-   A = Array(T, 1, r)
+   A = Array{T}(1, r)
    for i = 1:r
       A[1, i] = R(d[i])
    end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -153,7 +153,7 @@ doc"""
 isunit(a::PolyElem) = length(a) == 1 && isunit(coeff(a, 0))
 
 function deepcopy_internal{T <: RingElem}(a::GenPoly{T}, dict::ObjectIdDict)
-   coeffs = Array(T, length(a))
+   coeffs = Array{T}(length(a))
    for i = 1:length(a)
       coeffs[i] = deepcopy(a.coeffs[i])
    end
@@ -397,7 +397,7 @@ function mul_ks{T <: PolyElem}(a::PolyElem{T}, b::PolyElem{T})
    end
    m = maxa + maxb - 1
    z = base_ring(base_ring(a))()
-   A1 = Array(elem_type(base_ring(base_ring(a))), m*lena)
+   A1 = Array{elem_type(base_ring(base_ring(a)))}(m*lena)
    for i = 1:lena
       c = coeff(a, i - 1)
       for j = 1:length(c)
@@ -409,7 +409,7 @@ function mul_ks{T <: PolyElem}(a::PolyElem{T}, b::PolyElem{T})
    end
    ksa = base_ring(a)(A1)
    if a !== b
-      A2 = Array(elem_type(base_ring(base_ring(a))), m*lenb)
+      A2 = Array{elem_type(base_ring(base_ring(a)))}(m*lenb)
       for i = 1:lenb
          c = coeff(b, i - 1)
          for j = 1:length(c)
@@ -445,7 +445,7 @@ function mul_classical{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T})
    end
    t = base_ring(a)()
    lenz = lena + lenb - 1
-   d = Array(T, lenz)
+   d = Array{T}(lenz)
    for i = 1:lena
       d[i] = coeff(a, i - 1)*coeff(b, 0)
    end
@@ -623,7 +623,7 @@ function pow_multinomial{T <: RingElem}(a::PolyElem{T}, e::Int)
    e < 0 && throw(DomainError())
    lena = length(a)
    lenz = (lena - 1) * e + 1
-   res = Array(T, lenz)
+   res = Array{T}(lenz)
    for k = 1:lenz
       res[k] = base_ring(a)()
    end
@@ -830,7 +830,7 @@ function mullow{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T}, n::Int)
    end
    t = base_ring(a)()
    lenz = min(lena + lenb - 1, n)
-   d = Array(T, lenz)
+   d = Array{T}(lenz)
    for i = 1:min(lena, lenz)
       d[i] = coeff(a, i - 1)*coeff(b, 0)
    end
@@ -1017,7 +1017,7 @@ function divexact{T <: RingElem}(f::PolyElem{T}, g::PolyElem{T})
       return zero(parent(f))
    end
    lenq = length(f) - length(g) + 1
-   d = Array(T, lenq)
+   d = Array{T}(lenq)
    for i = 1:lenq
       d[i] = zero(base_ring(f))
    end
@@ -1952,7 +1952,7 @@ end
 function fit!{T <: RingElem}(c::GenPoly{T}, n::Int)
    if length(c.coeffs) < n
       t = c.coeffs
-      c.coeffs = Array(T, n)
+      c.coeffs = Array{T}(n)
       for i = 1:length(c)
          c.coeffs[i] = t[i]
       end

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -22,7 +22,7 @@ doc"""
 function O{T}(a::RelSeriesElem{T})
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError())
-   return parent(a)(Array(T, 0), 0, val, val)
+   return parent(a)(Array{T}(0), 0, val, val)
 end
 
 parent_type{T}(::Type{GenRelSeries{T}}) = GenRelSeriesRing{T}
@@ -188,7 +188,7 @@ doc"""
 modulus{T <: ResElem}(a::SeriesElem{T}) = modulus(base_ring(a))
 
 function deepcopy_internal{T <: RingElem}(a::GenRelSeries{T}, dict::ObjectIdDict)
-   coeffs = Array(T, pol_length(a))
+   coeffs = Array{T}(pol_length(a))
    for i = 1:pol_length(a)
       coeffs[i] = deepcopy(polcoeff(a, i - 1))
    end
@@ -437,11 +437,11 @@ function *{T <: RingElem}(a::RelSeriesElem{T}, b::RelSeriesElem{T})
    lena = min(lena, prec)
    lenb = min(lenb, prec)
    if lena == 0 || lenb == 0
-      return parent(a)(Array(T, 0), 0, prec + zval, zval)
+      return parent(a)(Array{T}(0), 0, prec + zval, zval)
    end
    t = base_ring(a)()
    lenz = min(lena + lenb - 1, prec)
-   d = Array(T, lenz)
+   d = Array{T}(lenz)
    for i = 1:min(lena, lenz)
       d[i] = polcoeff(a, i - 1)*polcoeff(b, 0)
    end
@@ -1030,7 +1030,7 @@ end
 function fit!{T <: RingElem}(c::GenRelSeries{T}, n::Int)
    if length(c.coeffs) < n
       t = c.coeffs
-      c.coeffs = Array(T, n)
+      c.coeffs = Array{T}(n)
       for i = 1:c.length
          c.coeffs[i] = t[i]
       end
@@ -1166,14 +1166,14 @@ function (a::GenRelSeriesRing{T}){T <: RingElem}(b::RingElem)
 end
 
 function (a::GenRelSeriesRing{T}){T <: RingElem}()
-   z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max, a.prec_max)
+   z = GenRelSeries{T}(Array{T}(0), 0, a.prec_max, a.prec_max)
    z.parent = a
    return z
 end
 
 function (a::GenRelSeriesRing{T}){T <: RingElem}(b::Integer)
    if b == 0
-      z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max, a.prec_max)
+      z = GenRelSeries{T}(Array{T}(0), 0, a.prec_max, a.prec_max)
    else
       z = GenRelSeries{T}([base_ring(a)(b)], 1, a.prec_max, 0)
    end
@@ -1183,7 +1183,7 @@ end
 
 function (a::GenRelSeriesRing{T}){T <: RingElem}(b::fmpz)
    if b == 0
-      z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max, a.prec_max)
+      z = GenRelSeries{T}(Array{T}(0), 0, a.prec_max, a.prec_max)
    else
       z = GenRelSeries{T}([base_ring(a)(b)], 1, a.prec_max, 0)
    end
@@ -1194,7 +1194,7 @@ end
 function (a::GenRelSeriesRing{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to power series")
    if b == 0
-      z = GenRelSeries{T}(Array(T, 0), 0, a.prec_max, a.prec_max)
+      z = GenRelSeries{T}(Array{T}(0), 0, a.prec_max, a.prec_max)
    else
       z = GenRelSeries{T}([b], 1, a.prec_max, 0)
    end

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -529,6 +529,12 @@ function (a::GenResRing{T}){T <: RingElem}(b::fmpz)
    return z
 end
 
+function (a::GenResRing{fmpz})(b::fmpz)
+   z = GenRes{fmpz}(mod(base_ring(a)(b), modulus(a)))
+   z.parent = a
+   return z
+end
+
 function (a::GenResRing{T}){T <: RingElem}(b::T)
    base_ring(a) != parent(b) && error("Operation on incompatible objects")
    z = GenRes{T}(mod(b, modulus(a)))


### PR DESCRIPTION
Now Nemo tests should pass on julia 0.5 and 0.6. I did not spot any regression in the runtime of our benchmarks.

The changes are almost all of the form `Array(T, n) -> Array{T}(n)`, since the former is deprecated in 0.6. There was one real change. I had to change the `create_accessors` function to use anonymous functions, since without them I got the following error:

```nf_elem.accessors...ERROR: LoadError: MethodError: no method matching set##292(::Nemo.AnticNumberField, ::Nemo.fmpz)
The applicable method may be too new: running in world age 22052, while current world is 22054.
Closest candidates are:
  set##292(::Nemo.AnticNumberField, ::Nemo.fmpz) at /home/thofmann/.julia/v0.6/Nemo/src/Nemo.jl:175 (method too new to be called from this world context.)
Stacktrace:
 [1] test_nf_accessor_functions() at /home/thofmann/.julia/v0.5/Nemo/test/../test/antic/nf_elem-test.jl:10
 [2] test_nf_elem() at /home/thofmann/.julia/v0.5/Nemo/test/../test/antic/nf_elem-test.jl:329
 [3] test_fields() at /home/thofmann/.julia/v0.5/Nemo/test/../test/Fields-test.jl:24
 [4] test_all() at /home/thofmann/.julia/v0.5/Nemo/test/../test/Nemo-test.jl:9
 [5] include_from_node1(::String) at ./loading.jl:539
 [6] include(::String) at ./sysimg.jl:14
while loading /home/thofmann/.julia/v0.5/Nemo/test/runtests.jl, in expression starting on line 5
```
The new version should be equivalent to the old one.

I also had to define `(a::GenResRing{fmpz})(b::fmpz)` because of some ambiguity error.