### PR TITLE
Minor fixes in docs and build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -142,7 +142,7 @@ if is_windows()
    try
       run(`ln -sf $vdir\\lib\\libflint.dll $vdir\\lib\\libflint-13.dll`)
    catch
-      cp(joinpath(vdir, "lib", "libflint.dll"), joinpath(vdir, "lib", "libflint-13.dll"))
+      cp(joinpath(vdir, "lib", "libflint.dll"), joinpath(vdir, "lib", "libflint-13.dll"), remove_destination=true)
    end
 else
    cd(joinpath("$wdir", "flint2"))

--- a/doc/src/factor.md
+++ b/doc/src/factor.md
@@ -1,5 +1,8 @@
 ```@meta
 CurrentModule = Nemo
+DocTestSetup = quote
+  using Nemo
+end
 ```
 
 ## Introduction
@@ -8,9 +11,9 @@ Nemo provides a unified interface to handle factorizations using the
 `Fact` objects. These can only be constructed using the factor function for
 the respective ring elements. This is best illustrated by an example.
 
-```julia
-julia> fac = factor(-6000361807272228723606)
--1 * 2 * 229^100 * 43669^100 * 3
+```jldoctest
+julia> fac = factor(ZZ(-6000361807272228723606))
+-1 * 2 * 229^3 * 43669^3 * 3
 
 julia> unit(fac)
 -1

--- a/doc/src/finitefield.md
+++ b/doc/src/finitefield.md
@@ -49,12 +49,12 @@ the finite field itself. This is accomplished with one of the following
 constructors.
 
 ```@docs
-FlintFiniteField(::fmpz, ::Int, ::AbstractString{})
-FlintFiniteField(::Integer, ::Int, ::AbstractString{})
+FlintFiniteField(::fmpz, ::Int, ::AbstractString)
+FlintFiniteField(::Integer, ::Int, ::AbstractString)
 ```
 
 ```@docs
-FlintFiniteField(::fmpz_mod_poly, ::AbstractString{})
+FlintFiniteField(::fmpz_mod_poly, ::AbstractString)
 ```
 
 Here are some examples of creating finite fields and making use of the

--- a/doc/src/numberfield.md
+++ b/doc/src/numberfield.md
@@ -35,15 +35,15 @@ the number field itself. This is accomplished with one of the following
 constructors.
 
 ```@docs
-AnticNumberField(::fmpq_poly, ::AbstractString{})
+AnticNumberField(::fmpq_poly, ::AbstractString)
 ```
 
 ```@docs
-AnticCyclotomicField(::Int, ::AbstractString{}, AbstractString{})
+AnticCyclotomicField(::Int, ::AbstractString, AbstractString)
 ```
 
 ```@docs
-AnticMaximalRealSubfield(::Int, ::AbstractString{}, ::AbstractString{})
+AnticMaximalRealSubfield(::Int, ::AbstractString, ::AbstractString)
 ```
 
 For convenience we define

--- a/doc/src/polynomial.md
+++ b/doc/src/polynomial.md
@@ -39,7 +39,7 @@ In order to construct polynomials in Nemo, one must first construct the
 polynomial ring itself. This is accomplished with the following constructor.
 
 ```@docs
-PolynomialRing(::Ring, ::AbstractString{}, ::Bool)
+PolynomialRing(::Ring, ::AbstractString, ::Bool)
 ```
 
 A shorthand version of this function is provided: given a base ring `R`, we

--- a/doc/src/series.md
+++ b/doc/src/series.md
@@ -134,7 +134,7 @@ In order to construct power series in Nemo, one must first construct the
 power series ring itself. This is accomplished with the following constructor.
 
 ```@docs
-PowerSeriesRing(::Ring, ::Int, ::AbstractString{}; ::Bool, ::Symbol)
+PowerSeriesRing(::Ring, ::Int, ::AbstractString; ::Bool, ::Symbol)
 ```
 
 Here are some examples of creating a power series ring using the constructor


### PR DESCRIPTION
Some types in the docs were not 0.6 compatible. Fix `Pkg.buld("Nemo")` in case Nemo has been built before.