### PR TITLE
Minor change to MPoly constructors

### DIFF
--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -393,7 +393,7 @@ function PolynomialRing(R::FlintIntegerRing, s::Array{String, 1}; cached::Bool =
    N = (ordering == :deglex || ordering == :degrevlex) ? length(U) + 1 : length(U)
    # default to 8 bit exponent fields
    parent_obj = FmpzMPolyRing{ordering, N}(U, cached)
-   return tuple(parent_obj, gens(parent_obj)...)
+   return tuple(parent_obj, gens(parent_obj))
 end
 
 

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2241,5 +2241,5 @@ function PolynomialRing(R::Ring, s::Array{String, 1}; cached::Bool = true, order
    N = (ordering == :deglex || ordering == :degrevlex) ? length(U) + 1 : length(U)
    parent_obj = GenMPolyRing{T, ordering, N}(R, U, cached)
 
-   return tuple(parent_obj, gens(parent_obj)...)
+   return tuple(parent_obj, gens(parent_obj))
 end


### PR DESCRIPTION
The second return argument is now an array. One can actually do the same as before using brackets and array destruction:
```julia
julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
(Multivariate Polynomial Ring in x, y over Rational Field,Nemo.GenMPoly{Nemo.fmpq,:lex,2}[x,y])

julia> x + y
x+y

julia> R, x = PolynomialRing(QQ, ["x[$i]" for i in 1:10])
(Multivariate Polynomial Ring in 10 variables x[1], x[2], x[3], x[4], ..., x[10] over Rational Field,Nemo.GenMPoly{Nemo.fmpq,:lex,10}[x[1],x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10]])

julia> x[1]
x[1]
```