### PR TITLE
Support gcd and lcm for arrays of fmpzs

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -456,10 +456,12 @@ d = clog(a, 3)
 
 ```@docs
 gcd(::fmpz, ::fmpz)
+gcd(::Array{fmpz, 1})
 ```
 
 ```@docs
 lcm(::fmpz, ::fmpz)
+lcm(::Array{fmpz, 1})
 ```
 
 ```@docs

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -835,6 +835,34 @@ function gcd(x::fmpz, y::fmpz)
 end
 
 doc"""
+    gcd(x::Array{fmpz, 1})
+> Return the greatest common divisor of the elements of $x$. The returned
+> result will always be nonnegative and will be zero iff all elements of $x$
+> are zero.
+"""
+function gcd(x::Array{fmpz, 1})
+   if length(x) == 0
+     return fmpz(1)
+   elseif length(x) == 1
+     return x[1]
+   end
+
+   z = fmpz()
+   ccall((:fmpz_gcd, :libflint), Void, 
+         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x[1], &x[2])
+
+   for i in 3:length(x)
+      ccall((:fmpz_gcd, :libflint), Void, 
+            (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x[i])
+      if z == 1
+        return z
+      end
+   end
+
+   return z
+end
+
+doc"""
     lcm(x::fmpz, y::fmpz)
 > Return the least common multiple of $x$ and $y$. The returned result will
 > always be nonnegative and will be zero iff $x$ and $y$ are zero. 
@@ -843,6 +871,30 @@ function lcm(x::fmpz, y::fmpz)
    z = fmpz()
    ccall((:fmpz_lcm, :libflint), Void, 
          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+   return z
+end
+
+doc"""
+    lcm(x::Array{fmpz, 1})
+> Return the least common multiple of the elements of $x$. The returned result
+> will always be nonnegative and will be zero iff the elements of $x$ are zero.
+"""
+function lcm(x::Array{fmpz, 1})
+   if length(x) == 0
+      return fmpz(1)
+   elseif length(x) == 1
+      return x[1]
+   end
+
+   z = fmpz()
+   ccall((:fmpz_lcm, :libflint), Void, 
+         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x[1], &x[2])
+   
+   for i in 3:length(x)
+      ccall((:fmpz_lcm, :libflint), Void, 
+            (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x[i])
+   end
+
    return z
 end
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -168,8 +168,27 @@ function test_fmpz_gcd_lcm()
 
    @test gcd(a, b) == 2
 
+   @test gcd(fmpz[]) == 1
+
+   @test gcd(fmpz[8]) == 8
+
+   @test gcd([fmpz(10), fmpz(2)]) == 2
+
+   @test gcd([fmpz(1), fmpz(2), fmpz(3)]) == 1
+
+   @test gcd([fmpz(9), fmpz(27), fmpz(3)]) == 3
+
    @test lcm(a, b) == 156
  
+   @test lcm(fmpz[]) == 1
+
+   @test lcm(fmpz[2]) == 2
+
+   @test lcm(fmpz[2, 3]) == 6
+
+   @test lcm(fmpz[2, 2, 2]) == 2
+
+   @test lcm(fmpz[2, 3, 2]) == 6
    println("PASS")
 end
 


### PR DESCRIPTION
The functions are pretty useful. Moreover there is something similar in Base:
```
julia> methods(gcd)
...
gcd{T<:Integer}(abc::AbstractArray{T,N<:Any}) at intfuncs.jl:47
...
```
So it makes sense to do the same for `fmpz`.