### PR TITLE
Unbreak build under gcc -pie for flint2 and arb

### DIFF
--- a/deps-PIE-ftbfs.patch
+++ b/deps-PIE-ftbfs.patch
@@ -1,0 +1,17 @@
+Description: invoke $(CC) with -r and not -Wl,-r to fix FTBFS with PIE enabled
+Author: Logan Rosen <logan@ubuntu.com>
+Forwarded: yes
+
+diff --git a/Makefile.subdirs b/Makefile.subdirs
+index ec05fb0..f2d8b37 100644
+--- a/Makefile.subdirs
++++ b/Makefile.subdirs
+@@ -59,7 +59,7 @@ $(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
+ 	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@ -MMD -MP -MF "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$@"
+ 
+ $(MOD_LOBJ): $(LOBJS)
+-	$(QUIET_CC) $(CC) $(ABI_FLAG) -Wl,-r $^ -o $@ -nostdlib
++	$(QUIET_CC) $(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+ 
+ -include $(LOBJS:.lo=.d)
+

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -192,7 +192,8 @@ if !is_windows()
        run(`git checkout 768d1aaa54516ddb351a06683e532ead54d47470`)
        cd(wdir)
     end
-  end          
+  end
+  open(`patch --forward -d flint2 -r -`, "r", open("../deps-PIE-ftbfs.patch"))
   println("DONE")
 end
 
@@ -239,6 +240,7 @@ if !is_windows()
       cd(wdir)
     end
   end
+  open(`patch --forward -d arb -r -`, "r", open("../deps-PIE-ftbfs.patch"))
   println("DONE")
 end
  


### PR DESCRIPTION
The -pie option has recently been enabled by default (Ubuntu 16.10 and
later): https://wiki.ubuntu.com/SecurityTeam/PIE

Rather than waiting for an update to those libraries, just consider Nemo
a distributor of them and apply a build-time patch. This patch is just
copied from the Ubuntu flint package.