### PR TITLE
add elem_type(::NmodMatSpace)

### DIFF
--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -18,6 +18,8 @@ export nmod_mat, NmodMatSpace, getindex, setindex!, set_entry!, deepcopy, rows,
 
 parent_type(::Type{nmod_mat}) = NmodMatSpace
 
+elem_type(::NmodMatSpace) = nmod_mat
+
 function _checkbounds(I::Int, J::Int)
    J >= 1 && J <= I
 end


### PR DESCRIPTION
`elem_type(R::NmodMatSpace)` gives `MethodError`, in contrast to e.g. `elem_type(R::FmpzMatSpace)`:

```julia
R = MatrixSpace(Nemo.ZZ,2,2)
@show elem_type(R)
F = Nemo.ResidueRing(Nemo.ZZ, 3)
R = MatrixSpace(F,2,2)
@show elem_type(R)
```