### PR TITLE
Make !-functions return the changed value

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -202,8 +202,8 @@ function =={S <: Integer, T <: RingElem}(x::S, y::T)
 end
 
 function addmul!{T <: RingElem}(z::T, x::T, y::T, c::T)
-   mul!(c, x, y)
-   addeq!(z, c)
+   c = mul!(c, x, y)
+   z = addeq!(z, c)
    return z
 end
 

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -204,7 +204,7 @@ end
 function addmul!{T <: RingElem}(z::T, x::T, y::T, c::T)
    mul!(c, x, y)
    addeq!(z, c)
-   return
+   return z
 end
 
 ###############################################################################

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -611,41 +611,41 @@ end
 function zero!(a::nf_elem)
    ccall((:nf_elem_zero, :libflint), Void,
          (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &parent(a))
-   nothing
+   return a
 end
 
 function mul!(z::nf_elem, x::nf_elem, y::nf_elem)
    ccall((:nf_elem_mul, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
                                                   &z, &x, &y, &parent(x))
-   nothing
+   return z
 end
 
 function mul_red!(z::nf_elem, x::nf_elem, y::nf_elem, red::Bool)
    ccall((:nf_elem_mul_red, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}, Cint),
                                                 &z, &x, &y, &parent(x), red)
-   nothing
+   return z
 end
 
 function addeq!(z::nf_elem, x::nf_elem)
    ccall((:nf_elem_add, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
                                                   &z, &z, &x, &parent(x))
-   nothing
+   return z
 end
 
 function add!(a::nf_elem, b::nf_elem, c::nf_elem)
    ccall((:nf_elem_add, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
          &a, &b, &c, &a.parent)
-   nothing
+  return a
 end
 
 function reduce!(x::nf_elem)
    ccall((:nf_elem_reduce, :libflint), Void,
          (Ptr{nf_elem}, Ptr{AnticNumberField}), &x, &parent(x))
-   nothing
+   return x
 end
 
 ###############################################################################
@@ -658,18 +658,21 @@ function add!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_add_fmpq, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_add_fmpz, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_add_si, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
          &c, &a, b, &a.parent)
+   return c
 end
 
 add!(c::nf_elem, a::nf_elem, b::Integer) = add!(c, a, fmpz(b))
@@ -678,18 +681,21 @@ function sub!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_sub_fmpq, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_sub_fmpz, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_sub_si, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
          &c, &a, b, &a.parent)
+   return c
 end
 
 sub!(c::nf_elem, a::nf_elem, b::Integer) = sub!(c, a, fmpz(b))
@@ -698,18 +704,21 @@ function sub!(c::nf_elem, a::fmpq, b::nf_elem)
    ccall((:nf_elem_fmpq_sub, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpq}, Ptr{nf_elem}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function sub!(c::nf_elem, a::fmpz, b::nf_elem)
    ccall((:nf_elem_fmpz_sub, :libflint), Void,
          (Ptr{nf_elem}, Ptr{fmpz}, Ptr{nf_elem}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function sub!(c::nf_elem, a::Int, b::nf_elem)
    ccall((:nf_elem_si_sub, :libflint), Void,
          (Ptr{nf_elem}, Int, Ptr{nf_elem}, Ptr{AnticNumberField}),
          &c, a, &b, &b.parent)
+   return c
 end
 
 sub!(c::nf_elem, a::Integer, b::nf_elem) = sub!(c, fmpz(a), b)
@@ -718,18 +727,21 @@ function mul!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_scalar_mul_fmpq, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_scalar_mul_fmpz, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
          &c, &a, &b, &a.parent)
+   return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_scalar_mul_si, :libflint), Void,
          (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
          &c, &a, b, &a.parent)
+   return c
 end
 
 mul!(c::nf_elem, a::nf_elem, b::Integer) = mul!(c, a, fmpz(b))

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -763,21 +763,21 @@ function sqr_classical(a::GenPoly{nf_elem})
    for i = 1:lena - 1
       d[2i - 1] = base_ring(a)()
       d[2i] = base_ring(a)()
-      mul_red!(d[2i - 1], coeff(a, i - 1), coeff(a, i - 1), false)
+      d[2i - 1] = mul_red!(d[2i - 1], coeff(a, i - 1), coeff(a, i - 1), false)
    end
    d[2*lena - 1] = base_ring(a)()
-   mul_red!(d[2*lena - 1], coeff(a, lena - 1), coeff(a, lena - 1), false)
+   d[2*lena - 1] = mul_red!(d[2*lena - 1], coeff(a, lena - 1), coeff(a, lena - 1), false)
 
    for i = 1:lena
       for j = i + 1:lena
-         mul_red!(t, coeff(a, i - 1), coeff(a, j - 1), false)
-         addeq!(d[i + j - 1], t)
-         addeq!(d[i + j - 1], t)
+         t = mul_red!(t, coeff(a, i - 1), coeff(a, j - 1), false)
+         d[i + j - 1] = addeq!(d[i + j - 1], t)
+         d[i + j - 1] = addeq!(d[i + j - 1], t)
       end
    end
 
    for i = 1:lenz
-      reduce!(d[i])
+      d[i] = reduce!(d[i])
    end
 
    z = parent(a)(d)
@@ -807,23 +807,23 @@ function mul_classical(a::GenPoly{nf_elem}, b::GenPoly{nf_elem})
 
    for i = 1:lena
       d[i] = base_ring(a)()
-      mul_red!(d[i], coeff(a, i - 1), coeff(b, 0), false)
+      d[i] = mul_red!(d[i], coeff(a, i - 1), coeff(b, 0), false)
    end
 
    for i = 2:lenb
       d[lena + i - 1] = base_ring(a)()
-      mul_red!(d[lena + i - 1], a.coeffs[lena], coeff(b, i - 1), false)
+      d[lena + i - 1] = mul_red!(d[lena + i - 1], a.coeffs[lena], coeff(b, i - 1), false)
    end
 
    for i = 1:lena - 1
       for j = 2:lenb
-         mul_red!(t, coeff(a, i - 1), b.coeffs[j], false)
-         addeq!(d[i + j - 1], t)
+         t = mul_red!(t, coeff(a, i - 1), b.coeffs[j], false)
+         d[i + j - 1] = addeq!(d[i + j - 1], t)
       end
    end
 
    for i = 1:lenz
-      reduce!(d[i])
+      d[i] = reduce!(d[i])
    end
 
    z = parent(a)(d)
@@ -853,14 +853,14 @@ function *(a::GenPoly{nf_elem}, b::GenPoly{nf_elem})
    f = S()
    fit!(f, lena)
    for i = 1:lena
-      setcoeff!(f, i - 1, R(coeff(a, i - 1)))
+      f = setcoeff!(f, i - 1, R(coeff(a, i - 1)))
    end
    set_length!(f, lena)
    if a !== b
       g = S()
       fit!(g, lenb)
       for i = 1:lenb
-         setcoeff!(g, i - 1, R(coeff(b, i - 1)))
+         g = setcoeff!(g, i - 1, R(coeff(b, i - 1)))
       end
       set_length!(g, lenb)
    else

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1370,32 +1370,37 @@ end
 
 function zero!(z::acb)
    ccall((:acb_zero, :libarb), Void, (Ptr{acb},), &z)
-   nothing
+   return z
 end
 
 function add!(z::acb, x::acb, y::acb)
   ccall((:acb_add, :libarb), Void, (Ptr{acb}, Ptr{acb}, Ptr{acb}, Int),
          &z, &x, &y, parent(z).prec)
+  return z
 end
 
 function addeq!(z::acb, y::acb)
   ccall((:acb_add, :libarb), Void, (Ptr{acb}, Ptr{acb}, Ptr{acb}, Int),
          &z, &z, &y, parent(z).prec)
+  return z
 end
 
 function sub!(z::acb, x::acb, y::acb)
   ccall((:acb_sub, :libarb), Void, (Ptr{acb}, Ptr{acb}, Ptr{acb}, Int),
         &z, &x, &y, parent(z).prec)
+  return z
 end
 
 function mul!(z::acb, x::acb, y::acb)
   ccall((:acb_mul, :libarb), Void, (Ptr{acb}, Ptr{acb}, Ptr{acb}, Int),
         &z, &x, &y, parent(z).prec)
+  return z
 end
 
 function div!(z::acb, x::acb, y::acb)
   ccall((:acb_div, :libarb), Void, (Ptr{acb}, Ptr{acb}, Ptr{acb}, Int),
         &z, &x, &y, parent(z).prec)
+  return z
 end
 
 ################################################################################

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -595,6 +595,7 @@ for (s,f) in (("add!","acb_mat_add"), ("mul!","acb_mat_mul"),
       ccall(($f, :libarb), Void,
                   (Ptr{acb_mat}, Ptr{acb_mat}, Ptr{acb_mat}, Int),
                   &z, &x, &y, prec(parent(x)))
+      return z
     end
   end
 end

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -810,46 +810,46 @@ end
 
 function zero!(z::acb_poly)
    ccall((:acb_poly_zero, :libarb), Void, (Ptr{acb_poly},), &z)
-   nothing
+   return z
 end
 
 function fit!(z::acb_poly, n::Int)
    ccall((:acb_poly_fit_length, :libarb), Void, 
                     (Ptr{acb_poly}, Int), &z, n)
-   nothing
+   return z
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::fmpz)
    ccall((:acb_poly_set_coeff_fmpz, :libarb), Void, 
                     (Ptr{acb_poly}, Int, Ptr{fmpz}), &z, n, &x)
-   nothing
+   return z
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::acb)
    ccall((:acb_poly_set_coeff_acb, :libarb), Void, 
                     (Ptr{acb_poly}, Int, Ptr{acb}), &z, n, &x)
-   nothing
+   return z
 end
 
 function mul!(z::acb_poly, x::acb_poly, y::acb_poly)
    ccall((:acb_poly_mul, :libarb), Void, 
                 (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
                     &z, &x, &y, prec(parent(z)))
-   nothing
+   return z
 end
 
 function addeq!(z::acb_poly, x::acb_poly)
    ccall((:acb_poly_add, :libarb), Void, 
                 (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
                     &z, &z, &x, prec(parent(z)))
-   nothing
+   return z
 end
 
 function add!(z::acb_poly, x::acb_poly, y::acb_poly)
    ccall((:acb_poly_add, :libarb), Void, 
                 (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
                     &z, &x, &y, prec(parent(z)))
-   nothing
+   return z
 end
 
 ###############################################################################

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -816,7 +816,7 @@ end
 function fit!(z::acb_poly, n::Int)
    ccall((:acb_poly_fit_length, :libarb), Void, 
                     (Ptr{acb_poly}, Int), &z, n)
-   return z
+   return nothing
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::fmpz)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1631,7 +1631,7 @@ numpart(n::Int, r::ArbField) = numpart(fmpz(n), r)
 
 function zero!(z::arb)
    ccall((:arb_zero, :libarb), Void, (Ptr{arb},), &z)
-   nothing
+   return z
 end
 
 for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
@@ -1640,7 +1640,7 @@ for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
     function ($(Symbol(s)))(z::arb, x::arb, y::arb)
       ccall(($f, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
                            &z, &x, &y, parent(x).prec)
-      nothing
+      return z
     end
   end
 end
@@ -1648,7 +1648,7 @@ end
 function addeq!(z::arb, x::arb)
     ccall((:arb_add, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
                            &z, &z, &x, parent(x).prec)
-    nothing
+    return z
 end
 
 ################################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -558,6 +558,7 @@ for (s,f) in (("add!","arb_mat_add"), ("mul!","arb_mat_mul"),
       ccall(($f, :libarb), Void,
                   (Ptr{arb_mat}, Ptr{arb_mat}, Ptr{arb_mat}, Int),
                   &z, &x, &y, prec(parent(x)))
+      return z
     end
   end
 end

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -695,46 +695,46 @@ end
 function zero!(z::arb_poly)
    ccall((:arb_poly_zero, :libarb), Void, 
                     (Ptr{arb_poly}, ), &z)
-   nothing
+   return z
 end
 
 function fit!(z::arb_poly, n::Int)
    ccall((:arb_poly_fit_length, :libarb), Void, 
                     (Ptr{arb_poly}, Int), &z, n)
-   nothing
+   return z
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::fmpz)
    ccall((:arb_poly_set_coeff_fmpz, :libarb), Void, 
                     (Ptr{arb_poly}, Int, Ptr{fmpz}), &z, n, &x)
-   nothing
+   return z
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::arb)
    ccall((:arb_poly_set_coeff_arb, :libarb), Void, 
                     (Ptr{arb_poly}, Int, Ptr{arb}), &z, n, &x)
-   nothing
+   return z
 end
 
 function mul!(z::arb_poly, x::arb_poly, y::arb_poly)
    ccall((:arb_poly_mul, :libarb), Void, 
                 (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
                     &z, &x, &y, prec(parent(z)))
-   nothing
+   return z
 end
 
 function addeq!(z::arb_poly, x::arb_poly)
    ccall((:arb_poly_add, :libarb), Void, 
                 (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
                     &z, &z, &x, prec(parent(z)))
-   nothing
+   return z
 end
 
 function add!(z::arb_poly, x::arb_poly, y::arb_poly)
    ccall((:arb_poly_add, :libarb), Void, 
                 (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
                     &z, &x, &y, prec(parent(z)))
-   nothing
+   return z
 end
 
 ###############################################################################

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -701,7 +701,7 @@ end
 function fit!(z::arb_poly, n::Int)
    ccall((:arb_poly_fit_length, :libarb), Void, 
                     (Ptr{arb_poly}, Int), &z, n)
-   return z
+   return nothing
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::fmpz)

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -705,21 +705,25 @@ dedekind_sum(h::Integer, k::Integer) = dedekind_sum(fmpz(h), fmpz(k))
 function zero!(c::fmpq)
    ccall((:fmpq_zero, :libflint), Void,
          (Ptr{fmpq},), &c)
+   return c
 end
 
 function mul!(c::fmpq, a::fmpq, b::fmpq)
    ccall((:fmpq_mul, :libflint), Void,
          (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &a, &b)
+   return c
 end
 
 function addeq!(c::fmpq, a::fmpq)
    ccall((:fmpq_add, :libflint), Void,
          (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &c, &a)
+   return c
 end
 
 function add!(c::fmpq, a::fmpq, b::fmpq)
    ccall((:fmpq_add, :libflint), Void,
          (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &a, &b)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -712,6 +712,7 @@ function setcoeff!(z::fmpq_abs_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void, 
                 (Ptr{fmpq_abs_series}, Int, Ptr{fmpq}), 
                &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpq_abs_series, a::fmpq_abs_series, b::fmpq_abs_series)
@@ -736,6 +737,7 @@ function mul!(z::fmpq_abs_series, a::fmpq_abs_series, b::fmpq_abs_series)
    ccall((:fmpq_poly_mullow, :libflint), Void, 
                 (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int), 
                &z, &a, &b, lenz)
+   return z
 end
 
 function addeq!(a::fmpq_abs_series, b::fmpq_abs_series)
@@ -752,6 +754,7 @@ function addeq!(a::fmpq_abs_series, b::fmpq_abs_series)
    ccall((:fmpq_poly_add_series, :libflint), Void, 
                 (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int), 
                &a, &a, &b, lenz)
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -595,6 +595,7 @@ end
 function mul!(z::fmpq_mat, x::fmpq_mat, y::fmpq_mat)
    ccall((:fmpq_mat_mul, :libflint), Void,
                 (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x, &y)
+   return z
 end
 
 function mul!(y::fmpq_mat, x::Int)
@@ -612,11 +613,13 @@ end
 function addeq!(z::fmpq_mat, x::fmpq_mat)
    ccall((:fmpq_mat_add, :libflint), Void,
                 (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &z, &x)
+   return z
 end
 
 function zero!(z::fmpq_mat)
    ccall((:fmpq_mat_zero, :libflint), Void,
                 (Ptr{fmpq_mat},), &z)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -687,36 +687,43 @@ end
 function zero!(z::fmpq_poly)
    ccall((:fmpq_poly_zero, :libflint), Void, 
                     (Ptr{fmpq_poly},), &z)
+   return z
 end
 
 function fit!(z::fmpq_poly, n::Int)
    ccall((:fmpq_poly_fit_length, :libflint), Void, 
                     (Ptr{fmpq_poly}, Int), &z, n)
+   return z
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpz)
    ccall((:fmpq_poly_set_coeff_fmpz, :libflint), Void, 
                     (Ptr{fmpq_poly}, Int, Ptr{fmpz}), &z, n, &x)
+   return z
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void, 
                     (Ptr{fmpq_poly}, Int, Ptr{fmpq}), &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
    ccall((:fmpq_poly_mul, :libflint), Void, 
                 (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+   return z
 end
 
 function addeq!(z::fmpq_poly, x::fmpq_poly)
    ccall((:fmpq_poly_add, :libflint), Void, 
                 (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &z, &x)
+   return z
 end
 
 function add!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
    ccall((:fmpq_poly_add, :libflint), Void, 
                 (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -693,7 +693,7 @@ end
 function fit!(z::fmpq_poly, n::Int)
    ccall((:fmpq_poly_fit_length, :libflint), Void, 
                     (Ptr{fmpq_poly}, Int), &z, n)
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpz)

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -384,7 +384,7 @@ function ^(a::fmpq_rel_series, b::Int)
    b < 0 && throw(DomainError())
    if isgen(a)
       z = parent(a)()
-      setcoeff!(z, 0, fmpq(1))
+      z = setcoeff!(z, 0, fmpq(1))
       z.prec = a.prec + b - 1
       z.val = b
    elseif pol_length(a) == 0

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -897,12 +897,14 @@ function zero!(z::fmpq_rel_series)
    ccall((:fmpq_poly_zero, :libflint), Void, 
                 (Ptr{fmpq_rel_series},), &z)
    z.prec = parent(z).prec_max
+   return z
 end
 
 function setcoeff!(z::fmpq_rel_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void, 
                 (Ptr{fmpq_rel_series}, Int, Ptr{fmpq}), 
                &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
@@ -922,7 +924,7 @@ function mul!(z::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
    ccall((:fmpq_poly_mullow, :libflint), Void, 
                 (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int), 
                &z, &a, &b, lenz)
-   return nothing
+   return z
 end
 
 function addeq!(a::fmpq_rel_series, b::fmpq_rel_series)
@@ -964,7 +966,7 @@ function addeq!(a::fmpq_rel_series, b::fmpq_rel_series)
    a.prec = prec
    a.val = val
    renormalize!(a)
-   return nothing
+   return a
 end
 
 function add!(c::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
@@ -981,6 +983,7 @@ function add!(c::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
    ccall((:fmpq_poly_add_series, :libflint), Void, 
                 (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int), 
                &c, &a, &b, lenc)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1448,31 +1448,31 @@ end
 function mul!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_mul, :libflint), Void, 
          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
-   return
+   return z
 end
 
 function addmul!(z::fmpz, x::fmpz, y::fmpz, c::fmpz)
    ccall((:fmpz_addmul, :libflint), Void, 
          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
-   return
+   return z
 end
 
 function addeq!(z::fmpz, x::fmpz)
    ccall((:fmpz_add, :libflint), Void, 
          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x)
-   return
+   return z
 end
 
 function add!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_add, :libflint), Void, 
          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
-   return
+   return z
 end
 
 function zero!(z::fmpz)
    ccall((:fmpz_zero, :libflint), Void, 
          (Ptr{fmpz},), &z)
-   return
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -458,6 +458,7 @@ function setcoeff!(z::fmpz_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fmpz_abs_series}, Int, Ptr{fmpz}), 
                &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpz_abs_series, a::fmpz_abs_series, b::fmpz_abs_series)
@@ -482,6 +483,7 @@ function mul!(z::fmpz_abs_series, a::fmpz_abs_series, b::fmpz_abs_series)
    ccall((:fmpz_poly_mullow, :libflint), Void, 
                 (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int), 
                &z, &a, &b, lenz)
+   return z
 end
 
 function addeq!(a::fmpz_abs_series, b::fmpz_abs_series)
@@ -498,6 +500,7 @@ function addeq!(a::fmpz_abs_series, b::fmpz_abs_series)
    ccall((:fmpz_poly_add_series, :libflint), Void, 
                 (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int), 
                &a, &a, &b, lenz)
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1116,6 +1116,7 @@ end
 function mul!(z::fmpz_mat, x::fmpz_mat, y::fmpz_mat)
    ccall((:fmpz_mat_mul, :libflint), Void,
                 (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x, &y)
+   return z
 end
 
 function mul!(y::fmpz_mat, x::Int)
@@ -1145,11 +1146,13 @@ end
 function addeq!(z::fmpz_mat, x::fmpz_mat)
    ccall((:fmpz_mat_add, :libflint), Void,
                 (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &z, &x)
+   return z
 end
 
 function zero!(z::fmpz_mat)
    ccall((:fmpz_mat_zero, :libflint), Void,
                 (Ptr{fmpz_mat},), &z)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -480,6 +480,7 @@ function setcoeff!(z::fmpz_mod_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fmpz_mod_abs_series}, Int, Ptr{fmpz}), 
                &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpz_mod_abs_series, a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
@@ -504,6 +505,7 @@ function mul!(z::fmpz_mod_abs_series, a::fmpz_mod_abs_series, b::fmpz_mod_abs_se
    ccall((:fmpz_mod_poly_mullow, :libflint), Void, 
                 (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int), 
                &z, &a, &b, lenz)
+   return z
 end
 
 function addeq!(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
@@ -520,6 +522,7 @@ function addeq!(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    ccall((:fmpz_mod_poly_add_series, :libflint), Void, 
                 (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int), 
                &a, &a, &b, lenz)
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -847,13 +847,9 @@ function setcoeff!(x::fmpz_mod_poly, n::Int, y::fmpz)
   return x
 end
 
-function setcoeff!(x::fmpz_mod_poly, n::Int, y::Integer)
-  return setcoeff!(x, n, fmpz(y))
-end
-  
-function setcoeff!(x::fmpz_mod_poly, n::Int, y::GenRes{fmpz})
-  return setcoeff!(x, n, y.data)
-end
+setcoeff!(x::fmpz_mod_poly, n::Int, y::Integer) = setcoeff!(x, n, fmpz(y))
+
+setcoeff!(x::fmpz_mod_poly, n::Int, y::GenRes{fmpz}) = setcoeff!(x, n, y.data)
 
 function add!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_add, :libflint), Void, 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -826,7 +826,7 @@ end
 function fit!(x::fmpz_mod_poly, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, Int), &x, n)
-  return x
+  return nothing
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::UInt)

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -820,54 +820,63 @@ end
 function zero!(x::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_zero, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, ), &x)
+  return x
 end
 
 function fit!(x::fmpz_mod_poly, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, Int), &x, n)
+  return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::UInt)
   ccall((:fmpz_mod_poly_set_coeff_ui, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, Int, UInt), &x, n, y)
+  return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::Int)
   ccall((:fmpz_mod_poly_set_coeff_ui, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, Int, UInt), &x, n, mod(y, x.n))
+  return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::fmpz)
   ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void, 
                    (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz}), &x, n, &y)
+  return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::Integer)
-  setcoeff!(x, n, fmpz(y))
+  return setcoeff!(x, n, fmpz(y))
 end
   
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::GenRes{fmpz})
-  setcoeff!(x, n, y.data)
+  return setcoeff!(x, n, y.data)
 end
 
 function add!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_add, :libflint), Void, 
      (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+  return z
 end
 
 function addeq!(z::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_add, :libflint), Void, 
      (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &z, &y)
+  return z
 end
 
 function sub!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_sub, :libflint), Void, 
      (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+  return z
 end
 
 function mul!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_mul, :libflint), Void, 
      (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+  return z
 end
 
 ################################################################################

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -610,23 +610,27 @@ function zero!(x::fmpz_mod_rel_series)
   ccall((:fmpz_mod_poly_zero, :libflint), Void, 
                    (Ptr{fmpz_mod_rel_series},), &x)
   x.prec = parent(x).prec_max
+  return x
 end
 
 function fit!(x::fmpz_mod_rel_series, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void, 
                    (Ptr{fmpz_mod_rel_series}, Int), &x, n)
+  return x
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::fmpz)
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}), 
                &z, n, &x)
+   return z
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::GenRes{fmpz})
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}), 
                &z, n, &x.data)
+   return z
 end
 
 function mul!(z::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
@@ -647,7 +651,7 @@ function mul!(z::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
                 (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int), 
                &z, &a, &b, lenz)
    renormalize!(z)
-   return nothing
+   return z
 end
 
 function addeq!(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
@@ -690,7 +694,7 @@ function addeq!(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    a.prec = prec
    a.val = val
    renormalize!(a)
-   return nothing
+   return a
 end
 
 function add!(c::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
@@ -707,6 +711,7 @@ function add!(c::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
    ccall((:fmpz_mod_poly_add_series, :libflint), Void, 
                 (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int), 
                &c, &a, &b, lenc)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -367,7 +367,7 @@ function ^(a::fmpz_mod_rel_series, b::Int)
    b < 0 && throw(DomainError())
    if isgen(a)
       z = parent(a)()
-      setcoeff!(z, 0, fmpz(1))
+      z = setcoeff!(z, 0, fmpz(1))
       z.prec = a.prec + b - 1
       z.val = b
    elseif pol_length(a) == 0

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -616,7 +616,7 @@ end
 function fit!(x::fmpz_mod_rel_series, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void, 
                    (Ptr{fmpz_mod_rel_series}, Int), &x, n)
-  return x
+  return nothing
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::fmpz)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -363,25 +363,27 @@ function addeq!{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    ccall((:fmpz_mpoly_add, :libflint), Void,
          (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
           Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &a, &b, &a.parent)
-   return nothing
+   return a
 end
 
 function mul!{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N}, c::fmpz_mpoly{S, N})
    ccall((:fmpz_mpoly_mul_johnson, :libflint), Void,
          (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
           Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &b, &c, &a.parent)
-   return nothing
+   return a
 end
 
 function setcoeff!(a::fmpz_mpoly, i::Int, c::Int)
    ccall((:fmpz_mpoly_set_coeff_si, :libflint), Void,
         (Ptr{fmpz_mpoly}, Int, Int, Ptr{FmpzMPolyRing}), &a, i, c, &a.parent)
+   return a
 end
 
 function setcoeff!(a::fmpz_mpoly, i::Int, c::fmpz)
    ccall((:fmpz_mpoly_set_coeff_fmpz, :libflint), Void,
         (Ptr{fmpz_mpoly}, Int, Ptr{fmpz}, Ptr{FmpzMPolyRing}),
                                                           &a, i, &c, &a.parent)
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -755,7 +755,7 @@ end
 function fit!(z::fmpz_poly, n::Int)
    ccall((:fmpz_poly_fit_length, :libflint), Void, 
                     (Ptr{fmpz_poly}, Int), &z, n)
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fmpz_poly, n::Int, x::fmpz)

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -749,31 +749,37 @@ end
 function zero!(z::fmpz_poly)
    ccall((:fmpz_poly_zero, :libflint), Void, 
                     (Ptr{fmpz_poly},), &z)
+   return z
 end
 
 function fit!(z::fmpz_poly, n::Int)
    ccall((:fmpz_poly_fit_length, :libflint), Void, 
                     (Ptr{fmpz_poly}, Int), &z, n)
+   return z
 end
 
 function setcoeff!(z::fmpz_poly, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void, 
                     (Ptr{fmpz_poly}, Int, Ptr{fmpz}), &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
    ccall((:fmpz_poly_mul, :libflint), Void, 
                 (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+   return z
 end
 
 function addeq!(z::fmpz_poly, x::fmpz_poly)
    ccall((:fmpz_poly_add, :libflint), Void, 
                 (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &z, &x)
+   return z
 end
 
 function add!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
    ccall((:fmpz_poly_add, :libflint), Void, 
                 (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -357,7 +357,7 @@ function ^(a::fmpz_rel_series, b::Int)
    b < 0 && throw(DomainError())
    if isgen(a)
       z = parent(a)()
-      setcoeff!(z, 0, fmpz(1))
+      z = setcoeff!(z, 0, fmpz(1))
       z.prec = a.prec + b - 1
       z.val = b
    elseif pol_length(a) == 0

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -538,12 +538,14 @@ function zero!(x::fmpz_rel_series)
   ccall((:fmpz_poly_zero, :libflint), Void, 
                    (Ptr{fmpz_rel_series},), &x)
   x.prec = parent(x).prec_max
+  return x
 end
 
 function setcoeff!(z::fmpz_rel_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fmpz_rel_series}, Int, Ptr{fmpz}), 
                &z, n, &x)
+   return z
 end
 
 function mul!(z::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
@@ -563,7 +565,7 @@ function mul!(z::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
    ccall((:fmpz_poly_mullow, :libflint), Void, 
                 (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int), 
                &z, &a, &b, lenz)
-   return nothing
+   return z
 end
 
 function addeq!(a::fmpz_rel_series, b::fmpz_rel_series)
@@ -605,7 +607,7 @@ function addeq!(a::fmpz_rel_series, b::fmpz_rel_series)
    a.prec = prec
    a.val = val
    renormalize!(a)
-   return nothing
+   return a
 end
 
 function add!(c::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
@@ -622,6 +624,7 @@ function add!(c::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
    ccall((:fmpz_poly_add_series, :libflint), Void, 
                 (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int), 
                &c, &a, &b, lenc)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -457,21 +457,25 @@ end
 function zero!(z::fq)
    ccall((:fq_zero, :libflint), Void, 
         (Ptr{fq}, Ptr{FqFiniteField}), &z, &z.parent)
+   return z
 end
 
 function mul!(z::fq, x::fq, y::fq)
    ccall((:fq_mul, :libflint), Void, 
         (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+   return z
 end
 
 function addeq!(z::fq, x::fq)
    ccall((:fq_add, :libflint), Void, 
         (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &z, &x, &x.parent)
+   return z
 end
 
 function add!(z::fq, x::fq, y::fq)
    ccall((:fq_add, :libflint), Void, 
         (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &x.parent)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -452,7 +452,7 @@ function fit!(z::fq_abs_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(z))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_abs_series, n::Int, x::fq)

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -452,12 +452,14 @@ function fit!(z::fq_abs_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_abs_series, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void, 
                 (Ptr{fq_abs_series}, Int, Ptr{fq}, Ptr{FqFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function mul!(z::fq_abs_series, a::fq_abs_series, b::fq_abs_series)
@@ -478,6 +480,7 @@ function mul!(z::fq_abs_series, a::fq_abs_series, b::fq_abs_series)
          (Ptr{fq_abs_series}, Ptr{fq_abs_series},
           Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}), 
                &z, &a, &b, lenz, &base_ring(z))
+   return z
 end
 
 function addeq!(a::fq_abs_series, b::fq_abs_series)
@@ -492,6 +495,7 @@ function addeq!(a::fq_abs_series, b::fq_abs_series)
          (Ptr{fq_abs_series}, Ptr{fq_abs_series},
           Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}), 
                &a, &a, &b, lenz, &base_ring(a))
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -379,24 +379,28 @@ end
 function zero!(z::fq_nmod)
    ccall((:fq_nmod_zero, :libflint), Void, 
         (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &z.parent)
+   return z
 end
 
 function mul!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
    ccall((:fq_nmod_mul, :libflint), Void, 
          (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), 
                                                        &z, &x, &y, &y.parent)
+   return z
 end
 
 function addeq!(z::fq_nmod, x::fq_nmod)
    ccall((:fq_nmod_add, :libflint), Void, 
          (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), 
                                                        &z, &z, &x, &x.parent)
+   return z
 end
 
 function add!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
    ccall((:fq_nmod_add, :libflint), Void, 
          (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), 
                                                        &z, &x, &y, &x.parent)
+   return z
 end
 
 ###############################################################################

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -452,7 +452,7 @@ function fit!(z::fq_nmod_abs_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(z))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_nmod_abs_series, n::Int, x::fq_nmod)

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -452,12 +452,14 @@ function fit!(z::fq_nmod_abs_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_nmod_abs_series, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void, 
                 (Ptr{fq_nmod_abs_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function mul!(z::fq_nmod_abs_series, a::fq_nmod_abs_series, b::fq_nmod_abs_series)
@@ -478,6 +480,7 @@ function mul!(z::fq_nmod_abs_series, a::fq_nmod_abs_series, b::fq_nmod_abs_serie
          (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
           Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}), 
                &z, &a, &b, lenz, &base_ring(z))
+   return z
 end
 
 function addeq!(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
@@ -492,6 +495,7 @@ function addeq!(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
          (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
           Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}), 
                &a, &a, &b, lenz, &base_ring(a))
+   return a
 end
 
 ###############################################################################

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -673,7 +673,7 @@ function fit!(z::fq_nmod_poly, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(parent(z)))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_nmod_poly, n::Int, x::fq_nmod)

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -666,36 +666,42 @@ function zero!(z::fq_nmod_poly)
    ccall((:fq_nmod_poly_zero, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
          &z, &base_ring(parent(z)))
+   return z
 end
 
 function fit!(z::fq_nmod_poly, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(parent(z)))
+   return z
 end
 
 function setcoeff!(z::fq_nmod_poly, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
          &z, n, &x, &base_ring(parent(z)))
+   return z
 end
 
 function mul!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_mul, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
          Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 function add!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_add, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
          Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 function sub!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_sub, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
          Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 
@@ -703,6 +709,7 @@ function addeq!(z::fq_nmod_poly, x::fq_nmod_poly)
    ccall((:fq_nmod_poly_add, :libflint), Void, 
          (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
          Ptr{FqNmodFiniteField}), &z, &z, &x, &base_ring(parent(x)))
+   return z
 end
 
 ################################################################################

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -363,7 +363,7 @@ function ^(a::fq_nmod_rel_series, b::Int)
    b < 0 && throw(DomainError())
    if isgen(a)
       z = parent(a)()
-      setcoeff!(z, 0, base_ring(a)(1))
+      z = setcoeff!(z, 0, base_ring(a)(1))
       z.prec = a.prec + b - 1
       z.val = b
    elseif pol_length(a) == 0

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -510,24 +510,28 @@ function zero!(x::fq_nmod_rel_series)
   ccall((:fq_nmod_poly_zero, :libflint), Void, 
                    (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &x, &base_ring(x))
   x.prec = parent(x).prec_max
+  return x
 end
 
 function fit!(z::fq_nmod_rel_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fmpz)
    ccall((:fq_nmod_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fq_nmod_rel_series}, Int, Ptr{fmpz}, Ptr{FqNmodFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void, 
                 (Ptr{fq_nmod_rel_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function mul!(z::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_series)
@@ -548,7 +552,7 @@ function mul!(z::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
          (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
           Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}), 
                &z, &a, &b, lenz, &base_ring(z))
-   return nothing
+   return z
 end
 
 function addeq!(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
@@ -594,7 +598,7 @@ function addeq!(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    a.prec = prec
    a.val = val
    renormalize!(a)
-   return nothing
+   return a
 end
 
 function add!(c::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_series)
@@ -612,6 +616,7 @@ function add!(c::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
    ccall((:fq_nmod_poly_add_series, :libflint), Void, 
      (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
                &c, &a, &b, lenc, &ctx)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -517,7 +517,7 @@ function fit!(z::fq_nmod_rel_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
          (Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
          &z, n, &base_ring(z))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fmpz)

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -671,7 +671,7 @@ function fit!(z::fq_poly, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(parent(z)))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_poly, n::Int, x::fq)

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -664,36 +664,42 @@ function zero!(z::fq_poly)
    ccall((:fq_poly_zero, :libflint), Void, 
          (Ptr{fq_poly}, Ptr{FqFiniteField}),
          &z, &base_ring(parent(z)))
+   return z
 end
 
 function fit!(z::fq_poly, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(parent(z)))
+   return z
 end
 
 function setcoeff!(z::fq_poly, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void, 
          (Ptr{fq_poly}, Int, Ptr{fq}, Ptr{FqFiniteField}),
          &z, n, &x, &base_ring(parent(z)))
+   return z
 end
 
 function mul!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_mul, :libflint), Void, 
          (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
          Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 function add!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_add, :libflint), Void, 
          (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
          Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 function sub!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_sub, :libflint), Void, 
          (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
          Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+   return z
 end
 
 
@@ -701,6 +707,7 @@ function addeq!(z::fq_poly, x::fq_poly)
    ccall((:fq_poly_add, :libflint), Void, 
          (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
          Ptr{FqFiniteField}), &z, &z, &x, &base_ring(parent(x)))
+   return z
 end
 
 ################################################################################

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -363,7 +363,7 @@ function ^(a::fq_rel_series, b::Int)
    b < 0 && throw(DomainError())
    if isgen(a)
       z = parent(a)()
-      setcoeff!(z, 0, base_ring(a)(1))
+      z = setcoeff!(z, 0, base_ring(a)(1))
       z.prec = a.prec + b - 1
       z.val = b
    elseif pol_length(a) == 0

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -510,24 +510,28 @@ function zero!(x::fq_rel_series)
   ccall((:fq_poly_zero, :libflint), Void, 
                    (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &x, &base_ring(x))
   x.prec = parent(x).prec_max
+  return x
 end
 
 function fit!(z::fq_rel_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fmpz)
    ccall((:fq_poly_set_coeff_fmpz, :libflint), Void, 
                 (Ptr{fq_rel_series}, Int, Ptr{fmpz}, Ptr{FqFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void, 
                 (Ptr{fq_rel_series}, Int, Ptr{fq}, Ptr{FqFiniteField}), 
                &z, n, &x, &base_ring(z))
+   return z
 end
 
 function mul!(z::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
@@ -548,7 +552,7 @@ function mul!(z::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
          (Ptr{fq_rel_series}, Ptr{fq_rel_series},
           Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}), 
                &z, &a, &b, lenz, &base_ring(z))
-   return nothing
+   return z
 end
 
 function addeq!(a::fq_rel_series, b::fq_rel_series)
@@ -594,7 +598,7 @@ function addeq!(a::fq_rel_series, b::fq_rel_series)
    a.prec = prec
    a.val = val
    renormalize!(a)
-   return nothing
+   return a
 end
 
 function add!(c::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
@@ -612,6 +616,7 @@ function add!(c::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
    ccall((:fq_poly_add_series, :libflint), Void, 
      (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
                &c, &a, &b, lenc, &ctx)
+   return c
 end
 
 ###############################################################################

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -517,7 +517,7 @@ function fit!(z::fq_rel_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
          (Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
          &z, n, &base_ring(z))
-   return z
+   return nothing
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fmpz)

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -247,14 +247,17 @@ end
 
 function mul!(a::nmod_mat, b::nmod_mat, c::nmod_mat)
   ccall((:nmod_mat_mul, :libflint), Void, (Ptr{nmod_mat}, Ptr{nmod_mat}, Ptr{nmod_mat}), &a, &b, &c)
+  return a
 end
 
 function add!(a::nmod_mat, b::nmod_mat, c::nmod_mat)
   ccall((:nmod_mat_add, :libflint), Void, (Ptr{nmod_mat}, Ptr{nmod_mat}, Ptr{nmod_mat}), &a, &b, &c)
+  return a
 end
 
 function zero!(a::nmod_mat)
   ccall((:nmod_mat_zero, :libflint), Void, (Ptr{nmod_mat}, ), &a)
+  return a
 end
 
 ################################################################################

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -916,9 +916,7 @@ end
   
 setcoeff!(x::nmod_poly, n::Int, y::Integer) = setcoeff!(x, n, fmpz(y))
   
-function setcoeff!(x::nmod_poly, n::Int, y::GenRes{fmpz})
-  return setcoeff!(x, n, y.data)
-end
+setcoeff!(x::nmod_poly, n::Int, y::GenRes{fmpz}) = setcoeff!(x, n, y.data)
 
 function add!(z::nmod_poly, x::nmod_poly, y::nmod_poly)
   ccall((:nmod_poly_add, :libflint), Void, 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -892,7 +892,7 @@ end
 function fit!(x::nmod_poly, n::Int)
   ccall((:nmod_poly_fit_length, :libflint), Void, 
                    (Ptr{nmod_poly}, Int), &x, n)
-  return x
+  return nothing
 end
 
 function setcoeff!(x::nmod_poly, n::Int, y::UInt)

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -881,37 +881,43 @@ end
 function zero!(x::nmod_poly)
   ccall((:nmod_poly_zero, :libflint), Void, 
                    (Ptr{nmod_poly},), &x)
+  return x
 end
 
 function one!(a::nmod_poly)
   ccall((:nmod_poly_one, :libflint), Void, (Ptr{nmod_poly}, ), &a)
+  return a
 end
 
 function fit!(x::nmod_poly, n::Int)
   ccall((:nmod_poly_fit_length, :libflint), Void, 
                    (Ptr{nmod_poly}, Int), &x, n)
+  return x
 end
 
 function setcoeff!(x::nmod_poly, n::Int, y::UInt)
   ccall((:nmod_poly_set_coeff_ui, :libflint), Void, 
                    (Ptr{nmod_poly}, Int, UInt), &x, n, y)
+  return x
 end
 
 function setcoeff!(x::nmod_poly, n::Int, y::Int)
   ccall((:nmod_poly_set_coeff_ui, :libflint), Void, 
                    (Ptr{nmod_poly}, Int, UInt), &x, n, mod(y, x.mod_n))
+  return x
 end
   
 function setcoeff!(x::nmod_poly, n::Int, y::fmpz)
   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &y, x.mod_n)
   ccall((:nmod_poly_set_coeff_ui, :libflint), Void, 
                    (Ptr{nmod_poly}, Int, UInt), &x, n, r)
+  return x
 end
   
 setcoeff!(x::nmod_poly, n::Int, y::Integer) = setcoeff!(x, n, fmpz(y))
   
 function setcoeff!(x::nmod_poly, n::Int, y::GenRes{fmpz})
-  setcoeff!(x, n, y.data)
+  return setcoeff!(x, n, y.data)
 end
 
 function add!(z::nmod_poly, x::nmod_poly, y::nmod_poly)

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -582,6 +582,7 @@ function zero!(z::padic)
    ctx = parent(z)
    ccall((:padic_zero, :libflint), Void, 
          (Ptr{padic}, Ptr{FlintPadicField}), &z, &ctx)
+   return z
 end
 
 function mul!(z::padic, x::padic, y::padic)
@@ -590,6 +591,7 @@ function mul!(z::padic, x::padic, y::padic)
    ccall((:padic_mul, :libflint), Void, 
          (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), 
                &z, &x, &y, &ctx)
+   return z
 end
 
 function addeq!(x::padic, y::padic)
@@ -598,6 +600,7 @@ function addeq!(x::padic, y::padic)
    ccall((:padic_add, :libflint), Void, 
          (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), 
                &x, &x, &y, &ctx)
+   return x
 end
 
 function addeq!(z::padic, x::padic, y::padic)
@@ -606,6 +609,7 @@ function addeq!(z::padic, x::padic, y::padic)
    ccall((:padic_add, :libflint), Void, 
          (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), 
                &z, &x, &y, &ctx)
+   return z
 end
 
 ###############################################################################

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -186,7 +186,7 @@ function -{T <: RingElem}(a::AbsSeriesElem{T})
    set_prec!(z, precision(a))
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, -coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, -coeff(a, i - 1))
    end
    return z
 end
@@ -214,15 +214,15 @@ function +{T <: RingElem}(a::AbsSeriesElem{T}, b::AbsSeriesElem{T})
    set_prec!(z, prec)
    i = 1
    while i <= min(lena, lenb)
-      setcoeff!(z, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
       i += 1
    end
    while i <= lena
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(z, i - 1, coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(b, i - 1))
       i += 1
    end
    set_length!(z, normalise(z, i - 1))
@@ -246,15 +246,15 @@ function -{T <: RingElem}(a::AbsSeriesElem{T}, b::AbsSeriesElem{T})
    set_prec!(z, prec)
    i = 1
    while i <= min(lena, lenb)
-      setcoeff!(z, i - 1, coeff(a, i - 1) - coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1) - coeff(b, i - 1))
       i += 1
    end
    while i <= lena
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(z, i - 1, -coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, -coeff(b, i - 1))
       i += 1
    end
    set_length!(z, normalise(z, i - 1))
@@ -297,8 +297,8 @@ function *{T <: RingElem}(a::AbsSeriesElem{T}, b::AbsSeriesElem{T})
    for i = 1:lena - 1
       if lenz > i
          for j = 2:min(lenb, lenz - i + 1)
-            mul!(t, coeff(a, i - 1), coeff(b, j - 1))
-            addeq!(d[i + j - 1], t)
+            t = mul!(t, coeff(a, i - 1), coeff(b, j - 1))
+            d[i + j - 1] = addeq!(d[i + j - 1], t)
          end
       end
    end
@@ -323,7 +323,7 @@ function *{T <: RingElem}(a::T, b::AbsSeriesElem{T})
    fit!(z, len)
    set_prec!(z, precision(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -339,7 +339,7 @@ function *{T <: RingElem}(a::Integer, b::AbsSeriesElem{T})
    fit!(z, len)
    set_prec!(z, precision(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -355,7 +355,7 @@ function *{T <: RingElem}(a::fmpz, b::AbsSeriesElem{T})
    fit!(z, len)
    set_prec!(z, precision(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -477,10 +477,10 @@ function shift_left{T <: RingElem}(x::AbsSeriesElem{T}, len::Int)
    fit!(z, zlen)
    set_prec!(z, prec)
    for i = 1:len
-      setcoeff!(z, i - 1, zero(base_ring(x)))
+      z = setcoeff!(z, i - 1, zero(base_ring(x)))
    end
    for i = 1:xlen
-      setcoeff!(z, i + len - 1, coeff(x, i - 1))
+      z = setcoeff!(z, i + len - 1, coeff(x, i - 1))
    end
    set_length!(z, normalise(z, zlen))
    return z
@@ -503,7 +503,7 @@ function shift_right{T <: RingElem}(x::AbsSeriesElem{T}, len::Int)
    fit!(z, xlen - len)
    set_prec!(z, precision(x) - len)
    for i = 1:xlen - len
-      setcoeff!(z, i - 1, coeff(x, i + len - 1))
+      z = setcoeff!(z, i - 1, coeff(x, i + len - 1))
    end
    return z
 end
@@ -528,10 +528,10 @@ function truncate{T <: RingElem}(a::AbsSeriesElem{T}, prec::Int)
    fit!(z, prec)
    set_prec!(z, prec)
    for i = 1:min(prec, len)
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
    end
    for i = len + 1:prec
-      setcoeff!(z, i - 1, zero(base_ring(a)))
+      z = setcoeff!(z, i - 1, zero(base_ring(a)))
    end
    set_length!(z, normalise(z, prec))
    return z
@@ -726,7 +726,7 @@ function divexact{T <: RingElem}(x::AbsSeriesElem{T}, y::Integer)
    fit!(z, lenx)
    set_prec!(z, precision(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
    end
    return z
 end
@@ -742,7 +742,7 @@ function divexact{T <: RingElem}(x::AbsSeriesElem{T}, y::fmpz)
    fit!(z, lenx)
    set_prec!(z, precision(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
    end
    return z
 end
@@ -758,7 +758,7 @@ function divexact{T <: RingElem}(x::AbsSeriesElem{T}, y::T)
    fit!(z, lenx)
    set_prec!(z, precision(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(coeff(x, i - 1), y))
    end
    return z
 end
@@ -781,7 +781,7 @@ function inv(a::AbsSeriesElem)
    fit!(ainv, precision(a))
    set_prec!(ainv, precision(a))
    if precision(a) != 0
-      setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
+      ainv = setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
    end
    a1 = -a1
    for n = 2:precision(a)
@@ -789,7 +789,7 @@ function inv(a::AbsSeriesElem)
       for i = 2:min(n, length(a)) - 1
          s += coeff(a, i)*coeff(ainv, n - i - 1)
       end
-      setcoeff!(ainv, n - 1, divexact(s, a1))
+      ainv = setcoeff!(ainv, n - 1, divexact(s, a1))
    end
    set_length!(ainv, normalise(ainv, precision(a)))
    return ainv
@@ -814,7 +814,7 @@ function exp(a::AbsSeriesElem)
    z = parent(a)()
    fit!(z, precision(a))
    set_prec!(z, precision(a))
-   setcoeff!(z, 0, exp(coeff(a, 0)))
+   z = setcoeff!(z, 0, exp(coeff(a, 0)))
    len = length(a)
    for k = 1 : precision(a) - 1
       s = zero(base_ring(a))
@@ -822,7 +822,7 @@ function exp(a::AbsSeriesElem)
          s += j * coeff(a, j) * coeff(z, k - j)
       end
       !isunit(base_ring(a)(k)) && error("Unable to divide in exp")
-      setcoeff!(z, k, divexact(s, k))
+      z = setcoeff!(z, k, divexact(s, k))
    end
    set_length!(z, normalise(z, precision(a)))
    return z
@@ -880,20 +880,20 @@ function mul!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T}, b::GenAbsSe
       fit!(c, lenc)
 
       for i = 1:min(lena, lenc)
-         mul!(c.coeffs[i], coeff(a, i - 1), coeff(b, 0))
+         c.coeffs[i] = mul!(c.coeffs[i], coeff(a, i - 1), coeff(b, 0))
       end
 
       if lenc > lena
          for i = 2:min(lenb, lenc - lena + 1)
-            mul!(c.coeffs[lena + i - 1], coeff(a, lena - 1), coeff(b, i - 1))
+            c.coeffs[lena + i - 1] = mul!(c.coeffs[lena + i - 1], coeff(a, lena - 1), coeff(b, i - 1))
          end
       end
 
       for i = 1:lena - 1
          if lenc > i
             for j = 2:min(lenb, lenc - i + 1)
-               mul!(t, coeff(a, i - 1), coeff(b, j - 1))
-               addeq!(c.coeffs[i + j - 1], t)
+               t = mul!(t, coeff(a, i - 1), coeff(b, j - 1))
+               c.coeffs[i + j - 1] = addeq!(c.coeffs[i + j - 1], t)
             end
          end
       end
@@ -916,7 +916,7 @@ function addeq!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T})
    len = max(lenc, lena)
    fit!(c, len)
    for i = 1:lena
-      addeq!(c.coeffs[i], coeff(a, i - 1))
+      c.coeffs[i] = addeq!(c.coeffs[i], coeff(a, i - 1))
    end
    c.length = normalise(c, len)
    c.prec = prec

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -845,7 +845,7 @@ function fit!{T <: RingElem}(c::GenAbsSeries{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
-   return c
+   return nothing
 end
 
 function setcoeff!{T <: RingElem}(c::GenAbsSeries{T}, n::Int, a::T)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -845,6 +845,7 @@ function fit!{T <: RingElem}(c::GenAbsSeries{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
+   return c
 end
 
 function setcoeff!{T <: RingElem}(c::GenAbsSeries{T}, n::Int, a::T)
@@ -854,6 +855,7 @@ function setcoeff!{T <: RingElem}(c::GenAbsSeries{T}, n::Int, a::T)
       c.length = max(length(c), n + 1)
       # don't normalise
    end
+   return c
 end
 
 function mul!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T}, b::GenAbsSeries{T})
@@ -899,6 +901,7 @@ function mul!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T}, b::GenAbsSe
       c.length = normalise(c, lenc)
    end
    c.prec = prec
+   return c
 end
 
 function addeq!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T})
@@ -917,6 +920,7 @@ function addeq!{T <: RingElem}(c::GenAbsSeries{T}, a::GenAbsSeries{T})
    end
    c.length = normalise(c, len)
    c.prec = prec
+   return c
 end
 
 ###############################################################################

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -708,7 +708,7 @@ function zero!{T <: RingElem}(c::FracElem{T})
    if !isone(c.den)
       c.den = one(parent(c))
    end
-   nothing
+   return c
 end
 
 function mul!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
@@ -716,7 +716,7 @@ function mul!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
    g2 = gcd(num(b), den(a))
    c.num = divexact(num(a), g1)*divexact(num(b), g2)
    c.den = divexact(den(a), g2)*divexact(den(b), g1)
-   nothing
+   return c
 end
 
 function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T})
@@ -725,7 +725,7 @@ function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T})
    g = gcd(n, d)
    c.num = divexact(n, g)
    c.den = divexact(c.den, g)
-   nothing
+   return c
 end
 
 function add!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
@@ -734,7 +734,7 @@ function add!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
    g = gcd(n, d)
    c.num = divexact(n, g)
    c.den = divexact(d, g)
-   nothing
+   return c
 end
 
 function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
@@ -743,7 +743,7 @@ function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
    g = gcd(n, d)
    c.num = divexact(n, g)
    c.den = divexact(c.den, g)
-   nothing
+   return c
 end
 
 

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -704,7 +704,7 @@ end
 ###############################################################################
 
 function zero!{T <: RingElem}(c::FracElem{T})
-   zero!(c.num)
+   c.num = zero!(c.num)
    if !isone(c.den)
       c.den = one(parent(c))
    end
@@ -721,7 +721,7 @@ end
 
 function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T})
    n = c.num*den(a) + num(a)*c.den
-   mul!(c.den, c.den, den(a))
+   c.den = mul!(c.den, c.den, den(a))
    g = gcd(n, d)
    c.num = divexact(n, g)
    c.den = divexact(c.den, g)
@@ -739,7 +739,7 @@ end
 
 function addeq!{T <: RingElem}(c::FracElem{T}, a::FracElem{T}, b::FracElem{T})
    n = num(b)*den(a) + num(a)*den(b)
-   mul!(c.den, den(b), den(a))
+   c.den = mul!(c.den, den(b), den(a))
    g = gcd(n, d)
    c.num = divexact(n, g)
    c.den = divexact(c.den, g)

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -40,15 +40,17 @@ parent(a::NewInt) = zz
 
 function mul!(a::NewInt, b::NewInt, c::NewInt)
    a.d = b.d*c.d
+   return a
 end
 
 function addeq!(a::NewInt, b::NewInt)
    a.d += b.d
-   return
+   return a
 end
 
 function addmul!(a::NewInt, b::NewInt, c::NewInt, d::NewInt)
    NewInt(a.d + b.d*c.d)
+   return a
 end
 
 function (a::NewIntParent)()
@@ -2532,7 +2534,7 @@ function mul!{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, c::GenMPoly{T})
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function addeq!{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T})
@@ -2540,7 +2542,7 @@ function addeq!{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T})
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function fit!{T <: RingElem}(a::GenMPoly{T}, n::Int)
@@ -2551,10 +2553,12 @@ function fit!{T <: RingElem}(a::GenMPoly{T}, n::Int)
       resize!(A, n*N) 
       a.exps = reshape(A, N, n)
    end
+   return a
 end
 
 function zero!{T <: RingElem}(a::GenMPoly{T})
    a.length = 0
+   return a
 end
 
 ###############################################################################

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -517,7 +517,7 @@ function do_merge{T <: RingElem}(Ac::Array{T, 1}, Bc::Array{T, 1},
          monomial_set!(Be, r + k, Ae, s1 + i, N)
          i += 1
       elseif cmpexp == 0
-         addeq!(Ac[s1 + i], Ac[s2 + j])
+         Ac[s1 + i] = addeq!(Ac[s1 + i], Ac[s2 + j])
          if Ac[s1 + i] != 0
             Bc[r + k] = Ac[s1 + i]
             monomial_set!(Be, r + k, Ae, s1 + i, N)
@@ -903,14 +903,14 @@ function mul_johnson{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T})
             monomial_set!(Re, k, Exps, exp, N)
             first = false
          else
-            addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
+            Rc[k] = addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
          end
          if v.j < n || v.j == 1
             push!(Q, x.n)
          end
          while (xn = v.next) != 0
             v = I[xn]
-            addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
+            Rc[k] = addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
             if v.j < n || v.j == 1
                push!(Q, xn)
             end
@@ -1277,19 +1277,19 @@ function pow_fps{T <: RingElem}(f::GenMPoly{T}, k::Int)
          Re = reshape(Re, N, r_alloc)
       end
       first = true
-      zero!(C) 
-      zero!(SS)
+      C = zero!(C)
+      SS = zero!(SS)
       while !isempty(H) && monomial_isequal(Exps, H[1].exp, exp, N)
          x = H[1]
          viewc += 1
          Viewn[viewc] = heappop!(H, Exps, N)
          v = I[x.n]
          largest[v.i] |= topbit
-         mul!(t1, f.coeffs[v.i], gc[v.j])
-         addeq!(SS, t1)
+         t1 = mul!(t1, f.coeffs[v.i], gc[v.j])
+         SS = addeq!(SS, t1)
          if !monomial_isless(final_exp, 1, Exps, exp, N)
-            add!(temp2, fik[v.i], gi[v.j])
-            addmul!(C, temp2, t1, temp)
+            temp2 = add!(temp2, fik[v.i], gi[v.j])
+            C = addmul!(C, temp2, t1, temp)
          end
          if first
             monomial_sub!(ge, gnext, Exps, exp, f.exps, 1, N)
@@ -1299,11 +1299,11 @@ function pow_fps{T <: RingElem}(f::GenMPoly{T}, k::Int)
          while (xn = v.next) != 0
             v = I[xn]
             largest[v.i] |= topbit
-            mul!(t1, f.coeffs[v.i], gc[v.j])
-            addeq!(SS, t1)
+            t1 = mul!(t1, f.coeffs[v.i], gc[v.j])
+            SS = addeq!(SS, t1)
             if !monomial_isless(final_exp, 1, Exps, exp, N)
-               add!(temp2, fik[v.i], gi[v.j])
-               addmul!(C, temp2, t1, temp)
+               temp2 = add!(temp2, fik[v.i], gi[v.j])
+               C = addmul!(C, temp2, t1, temp)
             end
             push!(Q, xn)
          end
@@ -1345,7 +1345,7 @@ function pow_fps{T <: RingElem}(f::GenMPoly{T}, k::Int)
       end
       if C != 0
          temp = divexact(C, from_exp(R, exp_copy, 1, N) - kp1f1)
-         addeq!(SS, temp)
+         SS = addeq!(SS, temp)
          gc[gnext] = divexact(temp, f.coeffs[1])
          push!(gi, -from_exp(R, ge, gnext, N))
          if (largest[2] & topbit) != 0
@@ -1487,9 +1487,9 @@ function divides_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, b
             first = false
          end
          if v.i == 0
-            addmul!(qc, a.coeffs[v.j], m1, c)
+            qc = addmul!(qc, a.coeffs[v.j], m1, c)
          else
-            addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
+            qc = addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -1499,9 +1499,9 @@ function divides_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, b
          while (xn = v.next) != 0
             v = I[xn]
             if v.i == 0
-               addmul!(qc, a.coeffs[v.j], m1, c)
+               qc = addmul!(qc, a.coeffs[v.j], m1, c)
             else
-               addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
+               qc = addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -1559,7 +1559,7 @@ function divides_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, b
          end
          s = 1
       end
-      zero!(qc)
+      qc = zero!(qc)
    end
    resize!(Qc, k)
    Qe = reshape(Qe, N*size(Qe, 2))
@@ -1687,9 +1687,9 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, bi
          Viewn[viewc] = heappop!(H, Exps, N)
          v = I[x.n]
          if v.i == 0
-            addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+            qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
          else
-            addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
+            qc = addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -1699,9 +1699,9 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, bi
          while (xn = v.next) != 0
             v = I[xn]
             if v.i == 0
-               addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+               qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
             else
-               addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
+               qc = addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -1793,7 +1793,7 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::GenMPoly{T}, bi
             end
          end
       end
-      zero!(qc)
+      qc = zero!(qc)
    end
    resize!(Qc, k)
    Qe = reshape(Qe, N*size(Qe, 2))
@@ -1913,9 +1913,9 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::Array{GenMPoly{
          Viewn[viewc] = heappop!(H, Exps, N)
          v = I[x.n]
          if v.i == 0
-            addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+            qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
          else
-            addmul!(qc, b[v.p].coeffs[n[v.p] + 1 - v.i], Qc[v.p][v.j], c)
+            qc = addmul!(qc, b[v.p].coeffs[n[v.p] + 1 - v.i], Qc[v.p][v.j], c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -1925,9 +1925,9 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::Array{GenMPoly{
          while (xn = v.next) != 0
             v = I[xn]
             if v.i == 0
-               addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+               qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
             else
-               addmul!(qc, b[v.p].coeffs[n[v.p] + 1 - v.i], Qc[v.p][v.j], c)
+               qc = addmul!(qc, b[v.p].coeffs[n[v.p] + 1 - v.i], Qc[v.p][v.j], c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -2016,7 +2016,7 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::Array{GenMPoly{
             monomial_sub!(Re, l, maxn, 1, exp_copy, 1, N)
          end
       end
-      zero!(qc)
+      qc = zero!(qc)
    end
    for i = 1:len
       resize!(Qc[i], k[i])

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2553,7 +2553,7 @@ function fit!{T <: RingElem}(a::GenMPoly{T}, n::Int)
       resize!(A, n*N) 
       a.exps = reshape(A, N, n)
    end
-   return a
+   return nothing
 end
 
 function zero!{T <: RingElem}(a::GenMPoly{T})

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2733,21 +2733,21 @@ function hnf_cohen!{T <: RingElem}(H::GenMat{T}, U::GenMat{T})
          b = -divexact(H[j,i], d)
          for c = i:n
             t = deepcopy(H[j,c])
-            mul!(t1, a, H[j,c])
-            mul!(t2, b, H[k,c])
-            add!(H[j,c], t1, t2)
-            mul!(t1, u, H[k,c])
-            mul!(t2, v, t)
-            add!(H[k,c], t1, t2)
+            t1 = mul!(t1, a, H[j,c])
+            t2 = mul!(t2, b, H[k,c])
+            H[j,c] = add!(H[j,c], t1, t2)
+            t1 = mul!(t1, u, H[k,c])
+            t2 = mul!(t2, v, t)
+            H[k,c] = add!(H[k,c], t1, t2)
          end
          for c = 1:m
             t = deepcopy(U[j,c])
-            mul!(t1, a, U[j,c])
-            mul!(t2, b, U[k,c])
-            add!(U[j,c], t1, t2)
-            mul!(t1, u, U[k,c])
-            mul!(t2, v, t)
-            add!(U[k,c], t1, t2)
+            t1 = mul!(t1, a, U[j,c])
+            t2 = mul!(t2, b, U[k,c])
+            U[j,c] = add!(U[j,c], t1, t2)
+            t1 = mul!(t1, u, U[k,c])
+            t2 = mul!(t2, v, t)
+            U[k,c] = add!(U[k,c], t1, t2)
          end
       end
       if H[k,i] == 0
@@ -2765,12 +2765,12 @@ function hnf_cohen!{T <: RingElem}(H::GenMat{T}, U::GenMat{T})
       for j = 1:k-1
          q = -div(H[j,i], H[k, i])
          for c = i:n
-            mul!(t, q, H[k,c])
-            addeq!(H[j,c], t)
+            t = mul!(t, q, H[k,c])
+            H[j,c] = addeq!(H[j,c], t)
          end
          for c = 1:m
-            mul!(t, q, U[k,c])
-            addeq!(U[j,c], t)
+            t = mul!(t, q, U[k,c])
+            U[j,c] = addeq!(U[j,c], t)
          end
       end
       k += 1
@@ -2821,13 +2821,13 @@ function kb_reduce_row!{T <: RingElem}(H::GenMat{T}, U::GenMat{T}, pivot::Array{
       end
       q = -div(H[r,i], H[p,i])
       for j = i:cols(H)
-         mul!(t, q, H[p,j])
-         addeq!(H[r,j], t)
+         t = mul!(t, q, H[p,j])
+         H[r,j] = addeq!(H[r,j], t)
       end
       if with_trafo
          for j = 1:cols(U)
-            mul!(t, q, U[p,j])
-            addeq!(U[r,j], t)
+            t = mul!(t, q, U[p,j])
+            U[r,j] = addeq!(U[r,j], t)
          end
       end
    end
@@ -2844,13 +2844,13 @@ function kb_reduce_column!{T <: RingElem}(H::GenMat{T}, U::GenMat{T}, pivot::Arr
       end
       q = -div(H[p,c],H[r,c])
       for j = c:cols(H)
-         mul!(t, q, H[r,j])
-         addeq!(H[p,j], t)
+         t = mul!(t, q, H[r,j])
+         H[p,j] = addeq!(H[p,j], t)
       end
       if with_trafo
          for j = 1:cols(U)
-            mul!(t, q, U[r,j])
-            addeq!(U[p,j], t)
+            t = mul!(t, q, U[r,j])
+            U[p,j] = addeq!(U[p,j], t)
          end
       end
    end
@@ -2940,22 +2940,22 @@ function hnf_kb!{T <: RingElem}(H::GenMat{T}, U::GenMat{T}, with_trafo::Bool = f
             b = -divexact(H[i+1,j],d)
             for c = j:n
                t = deepcopy(H[i+1,c])
-               mul!(t1, a, H[i+1,c])
-               mul!(t2, b, H[p,c])
-               add!(H[i+1,c], t1, t2)
-               mul!(t1, u, H[p,c])
-               mul!(t2, v, t)
-               add!(H[p,c], t1, t2)
+               t1 = mul!(t1, a, H[i+1,c])
+               t2 = mul!(t2, b, H[p,c])
+               H[i+1,c] = add!(H[i+1,c], t1, t2)
+               t1 = mul!(t1, u, H[p,c])
+               t2 = mul!(t2, v, t)
+               H[p,c] = add!(H[p,c], t1, t2)
             end
             if with_trafo
                for c = 1:m
                   t = deepcopy(U[i+1,c])
-                  mul!(t1, a, U[i+1,c])
-                  mul!(t2, b, U[p,c])
-                  add!(U[i+1,c], t1, t2)
-                  mul!(t1, u, U[p,c])
-                  mul!(t2, v, t)
-                  add!(U[p,c], t1, t2)
+                  t1 = mul!(t1, a, U[i+1,c])
+                  t2 = mul!(t2, b, U[p,c])
+                  U[i+1,c] = add!(U[i+1,c], t1, t2)
+                  t1 = mul!(t1, u, U[p,c])
+                  t2 = mul!(t2, v, t)
+                  U[p,c] = add!(U[p,c], t1, t2)
                end
             end
          end
@@ -3044,22 +3044,22 @@ function kb_clear_row!{T <: RingElem}(S::GenMat{T}, K::GenMat{T}, i::Int, with_t
       b = -divexact(S[i,j], d)
       for r = i:m
          t = deepcopy(S[r,j])
-         mul!(t1, a, S[r,j])
-         mul!(t2, b, S[r,i])
-         add!(S[r,j], t1, t2)
-         mul!(t1, u, S[r,i])
-         mul!(t2, v, t)
-         add!(S[r,i], t1, t2)
+         t1 = mul!(t1, a, S[r,j])
+         t2 = mul!(t2, b, S[r,i])
+         S[r,j] = add!(S[r,j], t1, t2)
+         t1 = mul!(t1, u, S[r,i])
+         t2 = mul!(t2, v, t)
+         S[r,i] = add!(S[r,i], t1, t2)
       end
       if with_trafo
          for r = 1:n
             t = deepcopy(K[r,j])
-            mul!(t1, a, K[r,j])
-            mul!(t2, b, K[r,i])
-            add!(K[r,j], t1, t2)
-            mul!(t1, u, K[r,i])
-            mul!(t2, v, t)
-            add!(K[r,i], t1, t2)
+            t1 = mul!(t1, a, K[r,j])
+            t2 = mul!(t2, b, K[r,i])
+            K[r,j] = add!(K[r,j], t1, t2)
+            t1 = mul!(t1, u, K[r,i])
+            t2 = mul!(t2, v, t)
+            K[r,i] = add!(K[r,i], t1, t2)
          end
       end
    end
@@ -3093,25 +3093,25 @@ function snf_kb!{T <: RingElem}(S::GenMat{T}, U::GenMat{T}, K::GenMat{T}, with_t
       d, u, v = gcdx(S[i,i], S[i+1,i+1])
       if with_trafo
          q = -divexact(S[i+1,i+1], d)
-         mul!(t1, q, v)
+         t1 = mul!(t1, q, v)
          for c = 1:m
             t = deepcopy(U[i,c])
-            addeq!(U[i,c], U[i+1,c])
-            mul!(t2, t1, U[i+1,c])
-            addeq!(U[i+1,c], t2)
-            mul!(t2, t1, t)
-            addeq!(U[i+1,c], t2)
+            U[i,c] = addeq!(U[i,c], U[i+1,c])
+            t2 = mul!(t2, t1, U[i+1,c])
+            U[i+1,c] = addeq!(U[i+1,c], t2)
+            t2 = mul!(t2, t1, t)
+            U[i+1,c] = addeq!(U[i+1,c], t2)
          end
          q1 = -divexact(S[i+1,i+1], d)
          q2 = divexact(S[i,i], d)
          for r = 1:n
             t = deepcopy(K[r,i])
-            mul!(t1, K[r,i], u)
-            mul!(t2, K[r,i+1], v)
-            add!(K[r,i], t1, t2)
-            mul!(t1, t, q1)
-            mul!(t2, K[r,i+1], q2)
-            add!(K[r,i+1], t1, t2)
+            t1 = mul!(t1, K[r,i], u)
+            t2 = mul!(t2, K[r,i+1], v)
+            K[r,i] = add!(K[r,i], t1, t2)
+            t1 = mul!(t1, t, q1)
+            t2 = mul!(t2, K[r,i+1], q2)
+            K[r,i+1] = add!(K[r,i+1], t1, t2)
          end
       end
       S[i+1,i+1] = divexact(S[i,i]*S[i+1,i+1],d)
@@ -3264,18 +3264,18 @@ function weak_popov_with_pivots!{T <: PolyElem}(P::GenMat{T}, W::GenMat{T}, U::G
             end
             q = -div(P[pivots[i][j],i],P[pivot,i])
             for c = 1:n
-               mul!(t, q, P[pivot,c])
-               addeq!(P[pivots[i][j],c], t)
+               t = mul!(t, q, P[pivot,c])
+               P[pivots[i][j],c] = addeq!(P[pivots[i][j],c], t)
             end
             if with_trafo
                for c = 1:cols(U)
-                  mul!(t, q, U[pivot,c])
-                  addeq!(U[pivots[i][j],c], t)
+                  t = mul!(t, q, U[pivot,c])
+                  U[pivots[i][j],c] = addeq!(U[pivots[i][j],c], t)
                end
             end
             if extended
-               mul!(t, q, W[pivot,1])
-               addeq!(W[pivots[i][j],1], t)
+               t = mul!(t, q, W[pivot,1])
+               W[pivots[i][j],1] = addeq!(W[pivots[i][j],1], t)
             end
          end
          old_pivots = pivots[i]
@@ -3367,8 +3367,8 @@ function det_popov{T <: PolyElem}(A::GenMat{T})
          end
          q = -div(B[r1,c],B[r2,c])
          for j = 1:i+1
-            mul!(t, q, B[r2,j])
-            addeq!(B[r1,j], t)
+            t = mul!(t, q, B[r2,j])
+            B[r1,j] = addeq!(B[r1,j], t)
          end
          c = find_pivot_popov(B, r1, i)
       end
@@ -3376,9 +3376,9 @@ function det_popov{T <: PolyElem}(A::GenMat{T})
          return R(0)
       end
       diag_elems[i+1] = r1
-      mul!(det, det, B[r1,i+1])
+      det = mul!(det, det, B[r1,i+1])
    end
-   mul!(det, det, B[pivots[1],1])
+   det = mul!(det, det, B[pivots[1],1])
    diag_elems[1] = pivots[1]
    number_of_swaps = 0
    # Adjust the sign of det by sorting the diagonal elements.
@@ -3391,7 +3391,7 @@ function det_popov{T <: PolyElem}(A::GenMat{T})
       end
    end
    if number_of_swaps%2 == 1
-      mul!(det, det, R(-1))
+      det = mul!(det, det, R(-1))
    end
    return det
 end
@@ -3482,13 +3482,13 @@ function popov!{T <: PolyElem}(P::GenMat{T}, U::GenMat{T}, with_trafo::Bool = fa
          end
          q = -div(P[r,i],P[pivot,i])
          for c = 1:n
-            mul!(t, q, P[pivot,c])
-            addeq!(P[r,c], t)
+            t = mul!(t, q, P[pivot,c])
+            P[r,c] = addeq!(P[r,c], t)
          end
          if with_trafo
             for c = 1:cols(U)
-               mul!(t, q, U[pivot,c])
-               addeq!(U[r,c], t)
+               t = mul!(t, q, U[pivot,c])
+               U[r,c] = addeq!(U[r,c], t)
             end
          end
       end
@@ -3545,13 +3545,13 @@ function hnf_via_popov_reduce_row!{T <: PolyElem}(H::GenMat{T}, U::GenMat{T}, pi
       pivot = pivots_hermite[c]
       q = -div(H[r,c],H[pivot,c])
       for j = c:n
-         mul!(t, q, H[pivot,j])
-         addeq!(H[r,j], t)
+         t = mul!(t, q, H[pivot,j])
+         H[r,j] = addeq!(H[r,j], t)
       end
       if with_trafo
          for j = 1:cols(U)
-            mul!(t, q, U[pivot,j])
-            addeq!(U[r,j], t)
+            t = mul!(t, q, U[pivot,j])
+            U[r,j] = addeq!(U[r,j], t)
          end
       end
    end
@@ -3572,13 +3572,13 @@ function hnf_via_popov_reduce_column!{T <: PolyElem}(H::GenMat{T}, U::GenMat{T},
       end
       q = -div(H[i,c],H[r,c])
       for j = 1:n
-         mul!(t, q, H[r,j])
-         addeq!(H[i,j], t)
+         t = mul!(t, q, H[r,j])
+         H[i,j] = addeq!(H[i,j], t)
       end
       if with_trafo
          for j = 1:cols(U)
-            mul!(t, q, U[r,j])
-            addeq!(U[i,j], t)
+            t = mul!(t, q, U[r,j])
+            U[i,j] = addeq!(U[i,j], t)
          end
       end
    end
@@ -3621,13 +3621,13 @@ function hnf_via_popov!{T <: PolyElem}(H::GenMat{T}, U::GenMat{T}, with_trafo::B
          end
          q = -div(H[r1,c],H[r2,c])
          for j = 1:n
-            mul!(t, q, H[r2,j])
-            addeq!(H[r1,j], t)
+            t = mul!(t, q, H[r2,j])
+            H[r1,j] = addeq!(H[r1,j], t)
          end
          if with_trafo
             for j = 1:cols(U)
-               mul!(t, q, U[r2,j])
-               addeq!(U[r1,j], t)
+               t = mul!(t, q, U[r2,j])
+               U[r1,j] = addeq!(U[r1,j], t)
             end
          end
          hnf_via_popov_reduce_row!(H, U, pivots_hermite, r1, with_trafo)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -2234,7 +2234,7 @@ function charpoly_danilevsky_ff!{T <: RingElem}(S::Ring, A::MatElem{T})
          end
          if k == n - i
             b = S()
-            b = fit!(b, i + 1)
+            fit!(b, i + 1)
             b = setcoeff!(b, i, R(1))
             for k = 1:i
                b = setcoeff!(b, k - 1, -A[n - i + 1, n - k + 1]*d)
@@ -2315,7 +2315,7 @@ function charpoly_danilevsky_ff!{T <: RingElem}(S::Ring, A::MatElem{T})
       i += 1
    end
    b = S()
-   b = fit!(b, n + 1)
+   fit!(b, n + 1)
    b = setcoeff!(b, n, R(1))
    for i = 1:n
       b = setcoeff!(b, i - 1, -A[1, n - i + 1]*d)
@@ -2348,7 +2348,7 @@ function charpoly_danilevsky!{T <: RingElem}(S::Ring, A::MatElem{T})
          end
          if k == n - i
             b = S()
-            b = fit!(b, i + 1)
+            fit!(b, i + 1)
             b = setcoeff!(b, i, R(1))
             for k = 1:i
                b = setcoeff!(b, k - 1, -A[n - i + 1, n - k + 1])
@@ -2413,7 +2413,7 @@ function charpoly_danilevsky!{T <: RingElem}(S::Ring, A::MatElem{T})
       i += 1
    end
    b = S()
-   b = fit!(b, n + 1)
+   fit!(b, n + 1)
    b = setcoeff!(b, n, R(1))
    for i = 1:n
       b = setcoeff!(b, i - 1, -A[1, n - i + 1])
@@ -2577,7 +2577,7 @@ function minpoly{T <: FieldElem}(S::Ring, M::MatElem{T}, charpoly_only = false)
       end
       c2 = c
       b = S()
-      b = fit!(b, r1)
+      fit!(b, r1)
       h = inv(A[r1, n + r1])
       for i = 1:r1
          b = setcoeff!(b, i - 1, A[r1, n + i]*h)
@@ -2673,7 +2673,7 @@ function minpoly{T <: RingElem}(S::Ring, M::MatElem{T}, charpoly_only = false)
       end
       c2 = c
       b = S()
-      b = fit!(b, r1)
+      fit!(b, r1)
       for i = 1:r1
          b = setcoeff!(b, i - 1, A[r1, n + i])
       end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2185,7 +2185,7 @@ function fit!{T <: RingElem}(c::GenPoly{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
-   return c
+   return nothing
 end
 
 function zero!{T <: RingElem}(c::GenPoly{T})

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -298,7 +298,7 @@ function -(a::PolyElem)
    z = parent(a)()
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, -coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, -coeff(a, i - 1))
    end
    set_length!(z, len)
    return z
@@ -323,15 +323,15 @@ function +{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T})
    fit!(z, lenz)
    i = 1
    while i <= min(lena, lenb)
-      setcoeff!(z, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
       i += 1
    end
    while i <= lena
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(z, i - 1, coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(b, i - 1))
       i += 1
    end
    set_length!(z, normalise(z, i - 1))
@@ -351,15 +351,15 @@ function -{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T})
    fit!(z, lenz)
    i = 1
    while i <= min(lena, lenb)
-      setcoeff!(z, i - 1, coeff(a, i - 1) - coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1) - coeff(b, i - 1))
       i += 1
    end
    while i <= lena
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(z, i - 1, -coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, -coeff(b, i - 1))
       i += 1
    end
    set_length!(z, normalise(z, i - 1))
@@ -399,16 +399,16 @@ function mul_karatsuba{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T})
    r = parent(a)()
    fit!(r, lena + lenb - 1)
    for i = 1:length(z0)
-      setcoeff!(r, i - 1, coeff(z0, i - 1))
+      r = setcoeff!(r, i - 1, coeff(z0, i - 1))
    end
    for i = length(z0) + 1:2m
-      setcoeff!(r, i - 1, base_ring(a)())
+      r = setcoeff!(r, i - 1, base_ring(a)())
    end
    for i = 1:length(z2)
-      setcoeff!(r, 2m + i - 1, coeff(z2, i - 1))
+      r = setcoeff!(r, 2m + i - 1, coeff(z2, i - 1))
    end
    for i = 1:length(z1)
-      addeq!(r.coeffs[i + m], coeff(z1, i - 1))
+      r.coeffs[i + m] = addeq!(r.coeffs[i + m], coeff(z1, i - 1))
    end
    return r
 end
@@ -476,7 +476,7 @@ function mul_ks{T <: PolyElem}(a::PolyElem{T}, b::PolyElem{T})
    for i = 1:lenr
       fit!(r.coeffs[i], m)
       for j = 1:m
-         setcoeff!(r.coeffs[i], j - 1, coeff(p, (i - 1)*m + j - 1))
+         r.coeffs[i] = setcoeff!(r.coeffs[i], j - 1, coeff(p, (i - 1)*m + j - 1))
       end
    end
    set_length!(r, normalise(r, lenr))
@@ -500,8 +500,8 @@ function mul_classical{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T})
    end
    for i = 1:lena - 1
       for j = 2:lenb
-         mul!(t, coeff(a, i - 1), b.coeffs[j])
-         addeq!(d[i + j - 1], t)
+         t = mul!(t, coeff(a, i - 1), b.coeffs[j])
+         d[i + j - 1] = addeq!(d[i + j - 1], t)
       end
    end
    z = parent(a)(d)
@@ -533,7 +533,7 @@ function *{T <: RingElem}(a::T, b::PolyElem{T})
    z = parent(b)()
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -548,7 +548,7 @@ function *(a::Integer, b::PolyElem)
    z = parent(b)()
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -563,7 +563,7 @@ function *(a::fmpz, b::PolyElem)
    z = parent(b)()
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, a*coeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*coeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    return z
@@ -681,9 +681,9 @@ function pow_multinomial{T <: RingElem}(a::PolyElem{T}, e::Int)
       for i = 1 : min(k, lena - 1)
          t = coeff(a, i) * res[(k - i) + 1]
          u += e + 1
-         addeq!(res[k + 1], t * u)
+         res[k + 1] = addeq!(res[k + 1], t * u)
       end
-      addeq!(d, first)
+      d = addeq!(d, first)
       res[k + 1] = divexact(res[k + 1], d)
    end
    z = parent(a)(res)
@@ -701,9 +701,9 @@ function ^{T <: RingElem}(a::PolyElem{T}, b::Int)
    if isgen(a)
       z = parent(a)()
       fit!(z, b + 1)
-      setcoeff!(z, b, coeff(a, 1))
+      z = setcoeff!(z, b, coeff(a, 1))
       for i = 1:b
-         setcoeff!(z, i - 1, coeff(a, 0))
+         z = setcoeff!(z, i - 1, coeff(a, 0))
       end
       set_length!(z, b + 1)
       return z
@@ -854,7 +854,7 @@ function truncate(a::PolyElem, n::Int)
    z = parent(a)()
    fit!(a, lenz)
    for i = 1:lenz
-      setcoeff!(z, i - 1, coeff(a, i - 1))
+      z = setcoeff!(z, i - 1, coeff(a, i - 1))
    end
    set_length!(z, normalise(z, lenz))
    return z
@@ -888,8 +888,8 @@ function mullow{T <: RingElem}(a::PolyElem{T}, b::PolyElem{T}, n::Int)
    for i = 1:lena - 1
       if lenz > i
          for j = 2:min(lenb, lenz - i + 1)
-            mul!(t, coeff(a, i - 1), b.coeffs[j])
-            addeq!(d[i + j - 1], t)
+            t = mul!(t, coeff(a, i - 1), b.coeffs[j])
+            d[i + j - 1] = addeq!(d[i + j - 1], t)
          end
       end
    end  
@@ -917,7 +917,7 @@ function reverse(x::PolyElem, len::Int)
    r = parent(x)()
    fit!(r, len)
    for i = 1:len
-      setcoeff!(r, i - 1, coeff(x, len - i))
+      z = setcoeff!(r, i - 1, coeff(x, len - i))
    end
    set_length!(r, normalise(r, len))
    return r
@@ -953,10 +953,10 @@ function shift_left(f::PolyElem, n::Int)
    r = parent(f)()
    fit!(r, flen + n)
    for i = 1:n
-      setcoeff!(r, i - 1, zero(base_ring(f)))
+      r = setcoeff!(r, i - 1, zero(base_ring(f)))
    end
    for i = 1:flen
-      setcoeff!(r, i + n - 1, coeff(f, i - 1))
+      r = setcoeff!(r, i + n - 1, coeff(f, i - 1))
    end
    return r
 end
@@ -978,7 +978,7 @@ function shift_right(f::PolyElem, n::Int)
    r = parent(f)()
    fit!(r, flen - n)
    for i = 1:flen - n
-      setcoeff!(r, i - 1, coeff(f, i + n - 1))
+      r = setcoeff!(r, i - 1, coeff(f, i + n - 1))
    end
    return r
 end
@@ -1094,7 +1094,7 @@ function divexact{T <: RingElem}(a::PolyElem{T}, b::T)
    z = parent(a)()
    fit!(z, length(a))
    for i = 1:length(a)
-      setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
+      z = setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
    end
    set_length!(z, length(a))
    return z
@@ -1109,7 +1109,7 @@ function divexact(a::PolyElem, b::Integer)
    z = parent(a)()
    fit!(z, length(a))
    for i = 1:length(a)
-      setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
+      z = setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
    end
    set_length!(z, length(a))
    return z
@@ -1124,7 +1124,7 @@ function divexact(a::PolyElem, b::fmpz)
    z = parent(a)()
    fit!(z, length(a))
    for i = 1:length(a)
-      setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
+      z = setcoeff!(z, i - 1, divexact(coeff(a, i - 1), b))
    end
    set_length!(z, length(a))
    return z
@@ -1154,10 +1154,10 @@ function mod{T <: Union{ResElem, FieldElem}}(f::PolyElem{T}, g::PolyElem{T})
       while length(f) >= length(g)
          l = -lead(f)
          for i = 1:length(g)
-            mul!(c, coeff(g, i - 1), l)
+            c = mul!(c, coeff(g, i - 1), l)
             u = coeff(f, i + length(f) - length(g) - 1)
-            addeq!(u, c)
-            setcoeff!(f, i + length(f) - length(g) - 1, u)
+            u = addeq!(u, c)
+            f = setcoeff!(f, i + length(f) - length(g) - 1, u)
          end
          set_length!(f, normalise(f, length(f)))
       end
@@ -1189,12 +1189,12 @@ function divrem{T <: Union{ResElem, FieldElem}}(f::PolyElem{T}, g::PolyElem{T})
    while length(f) >= length(g)
       q1 = lead(f)
       l = -q1
-      setcoeff!(q, length(f) - length(g), q1*binv)
+      q = setcoeff!(q, length(f) - length(g), q1*binv)
       for i = 1:length(g)
-         mul!(c, coeff(g, i - 1), l)
+         c = mul!(c, coeff(g, i - 1), l)
          u = coeff(f, i + length(f) - length(g) - 1)
-         addeq!(u, c)
-         setcoeff!(f, i + length(f) - length(g) - 1, u)
+         u = addeq!(u, c)
+         f = setcoeff!(f, i + length(f) - length(g) - 1, u)
       end
       set_length!(f, normalise(f, length(f)))
    end
@@ -1244,9 +1244,9 @@ function pseudodivrem{T <: RingElem}(f::PolyElem{T}, g::PolyElem{T})
    x = gen(parent(f))
    while length(f) >= length(g)
       for i = length(f) - length(g) + 2:lenq
-         setcoeff!(q, i - 1, coeff(q, i - 1) * b)
+         q = setcoeff!(q, i - 1, coeff(q, i - 1) * b)
       end
-      setcoeff!(q, length(f) - length(g), coeff(f, length(f) - 1))
+      q = setcoeff!(q, length(f) - length(g), coeff(f, length(f) - 1))
       f = f*b - shift_left(coeff(f, length(f) - 1)*g, length(f) - length(g))
       k -= 1
    end
@@ -1331,13 +1331,13 @@ function divides{T <: RingElem}(f::PolyElem{T}, g::PolyElem{T})
       if !flag
          return false, parent(f)()
       end
-      setcoeff!(q, length(f) - length(g), d)
+      q = setcoeff!(q, length(f) - length(g), d)
       d = -d
       for i = 1:length(g)
-         mul!(c, coeff(g, i - 1), d)
+         c = mul!(c, coeff(g, i - 1), d)
          u = coeff(f, i + length(f) - length(g) - 1)
-         addeq!(u, c)
-         setcoeff!(f, i + length(f) - length(g) - 1, u)
+         u = addeq!(u, c)
+         f = setcoeff!(f, i + length(f) - length(g) - 1, u)
       end
       set_length!(f, normalise(f, length(f)))
    end
@@ -1360,7 +1360,7 @@ function divides{T <: RingElem}(z::PolyElem{T}, x::T)
       if !flag
          break
       end
-      setcoeff!(q, i - 1, c)
+      q = setcoeff!(q, i - 1, c)
    end
    set_length!(q, length(z))
    return flag, q
@@ -1610,7 +1610,7 @@ function derivative(a::PolyElem)
    z = parent(a)()
    fit!(z, len - 1)
    for i = 1:len - 1
-      setcoeff!(z, i - 1, i*coeff(a, i))
+      z = setcoeff!(z, i - 1, i*coeff(a, i))
    end
    set_length!(z, normalise(z, len - 1))
    return z
@@ -1630,9 +1630,9 @@ function integral{T <: Union{ResElem, FieldElem}}(x::PolyElem{T})
    len = length(x)
    p = parent(x)()
    fit!(p, len + 1)
-   setcoeff!(p, 0, zero(base_ring(x)))
+   p = setcoeff!(p, 0, zero(base_ring(x)))
    for i = 1:len
-      setcoeff!(p, i, divexact(coeff(x, i - 1), base_ring(x)(i)))
+      p = setcoeff!(p, i, divexact(coeff(x, i - 1), base_ring(x)(i)))
    end
    len += 1
    while len > 0 && coeff(p, len - 1) == 0 # FIXME: cannot use normalise here
@@ -2007,8 +2007,8 @@ function monomial_to_newton!{T <: RingElem}(P::Array{T, 1}, roots::Array{T, 1})
       t = R()
       for i = 1:n - 1
          for j = n - 1:-1:i
-            mul!(t, P[j + 1], roots[i])
-            addeq!(P[j], t)
+            t = mul!(t, P[j + 1], roots[i])
+            P[j] = addeq!(P[j], t)
          end
       end
    end
@@ -2032,8 +2032,8 @@ function newton_to_monomial!{T <: RingElem}(P::Array{T, 1}, roots::Array{T, 1})
       for i = n - 1:-1:1
          d = -roots[i]
          for j = i:n - 1
-            mul!(t, P[j + 1], d)
-            addeq!(P[j], t)
+            t = mul!(t, P[j + 1], d)
+            P[j] = addeq!(P[j], t)
          end
       end
    end
@@ -2223,17 +2223,17 @@ function mul!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
       fit!(c, lenc)
 
       for i = 1:lena
-         mul!(c.coeffs[i], coeff(a, i - 1), coeff(b, 0))
+         c.coeffs[i] = mul!(c.coeffs[i], coeff(a, i - 1), coeff(b, 0))
       end
 
       for i = 2:lenb
-         mul!(c.coeffs[lena + i - 1], a.coeffs[lena], coeff(b, i - 1))
+         c.coeffs[lena + i - 1] = mul!(c.coeffs[lena + i - 1], a.coeffs[lena], coeff(b, i - 1))
       end
 
       for i = 1:lena - 1
          for j = 2:lenb
-            mul!(t, coeff(a, i - 1), b.coeffs[j])
-            addeq!(c.coeffs[i + j - 1], t)
+            t = mul!(t, coeff(a, i - 1), b.coeffs[j])
+            c.coeffs[i + j - 1] = addeq!(c.coeffs[i + j - 1], t)
          end
       end
         
@@ -2248,7 +2248,7 @@ function addeq!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T})
    len = max(lenc, lena)
    fit!(c, len)
    for i = 1:lena
-      addeq!(c.coeffs[i], coeff(a, i - 1))
+      c.coeffs[i] = addeq!(c.coeffs[i], coeff(a, i - 1))
    end
    c.length = normalise(c, len)
    return c
@@ -2261,14 +2261,14 @@ function add!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
    fit!(c, len)
    i = 1
    while i <= 1:min(lena, lenb)
-      add!(c.coeffs[i], coeff(a, i - 1), coeff(b, i - 1))
+      c.coeffs[i] = add!(c.coeffs[i], coeff(a, i - 1), coeff(b, i - 1))
    end
    while i <= lena
-      setcoeff!(c, i - 1, coeff(a, i - 1))
+      c = setcoeff!(c, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(c, i - 1, coeff(b, i - 1))
+      c = setcoeff!(c, i - 1, coeff(b, i - 1))
       i += 1
    end
    c.length = normalise(c, len)

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -2185,12 +2185,12 @@ function fit!{T <: RingElem}(c::GenPoly{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
-   nothing
+   return c
 end
 
 function zero!{T <: RingElem}(c::GenPoly{T})
    c.length = 0
-   nothing
+   return c
 end
 
 function setcoeff!{T <: RingElem}(c::GenPoly{T}, n::Int, a::T)
@@ -2200,7 +2200,7 @@ function setcoeff!{T <: RingElem}(c::GenPoly{T}, n::Int, a::T)
       c.length = max(length(c), n + 1)
       # don't normalise
    end
-   nothing
+   return c
 end
 
 function mul!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
@@ -2239,7 +2239,7 @@ function mul!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
         
       c.length = normalise(c, lenc)
    end
-   nothing
+   return c
 end
 
 function addeq!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T})
@@ -2251,7 +2251,7 @@ function addeq!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T})
       addeq!(c.coeffs[i], coeff(a, i - 1))
    end
    c.length = normalise(c, len)
-   nothing
+   return c
 end
 
 function add!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
@@ -2272,7 +2272,7 @@ function add!{T <: RingElem}(c::PolyElem{T}, a::PolyElem{T}, b::PolyElem{T})
       i += 1
    end
    c.length = normalise(c, len)
-   nothing
+   return c
 end
 
 ###############################################################################

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1044,7 +1044,7 @@ function fit!{T <: RingElem}(c::GenRelSeries{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
-   return c
+   return nothing
 end
 
 function setcoeff!{T <: RingElem}(c::GenRelSeries{T}, n::Int, a::T)

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -210,7 +210,7 @@ function renormalize!(z::RelSeriesElem)
    else
       set_val!(z, zval + i)
       for j = 1:zlen - i
-         setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
+         z = setcoeff!(z, j - 1, polcoeff(z, j + i - 1))
       end
       set_length!(z, zlen - i)
    end
@@ -295,7 +295,7 @@ function -{T <: RingElem}(a::RelSeriesElem{T})
    set_val!(z, valuation(a))
    fit!(z, len)
    for i = 1:len
-      setcoeff!(z, i - 1, -polcoeff(a, i - 1))
+      z = setcoeff!(z, i - 1, -polcoeff(a, i - 1))
    end
    return z
 end
@@ -328,35 +328,35 @@ function +{T <: RingElem}(a::RelSeriesElem{T}, b::RelSeriesElem{T})
    set_val!(z, valz)
    if vala >= valb
       for i = 1:min(lenb, vala - valb)
-         setcoeff!(z, i - 1, polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(b, i - 1))
       end
       for i = lenb + 1:vala - valb
-         setcoeff!(z, i - 1, R())
+         z = setcoeff!(z, i - 1, R())
       end
       for i = vala - valb + 1:lenb
-         setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1) + polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1) + polcoeff(b, i - 1))
       end
       for i = max(lenb, vala - valb) + 1:lena + vala - valb
-         setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1))
       end
       for i = lena + vala - valb + 1:lenb
-         setcoeff!(z, i - 1, polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(b, i - 1))
       end
    else
       for i = 1:min(lena, valb - vala)
-         setcoeff!(z, i - 1, polcoeff(a, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
       for i = lena + 1:valb - vala
-         setcoeff!(z, i - 1, R())
+         z = setcoeff!(z, i - 1, R())
       end
       for i = valb - vala + 1:lena
-         setcoeff!(z, i - 1, polcoeff(a, i - 1) + polcoeff(b, i - valb + vala - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1) + polcoeff(b, i - valb + vala - 1))
       end
       for i = max(lena, valb - vala) + 1:lenb + valb - vala
-         setcoeff!(z, i - 1, polcoeff(b, i - valb + vala - 1))
+         z = setcoeff!(z, i - 1, polcoeff(b, i - valb + vala - 1))
       end
       for i = lenb + valb - vala + 1:lena
-         setcoeff!(z, i - 1, polcoeff(a, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
    end
    set_length!(z, normalise(z, lenz))
@@ -386,35 +386,35 @@ function -{T <: RingElem}(a::RelSeriesElem{T}, b::RelSeriesElem{T})
    set_val!(z, valz)
    if vala >= valb
       for i = 1:min(lenb, vala - valb)
-         setcoeff!(z, i - 1, -polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, -polcoeff(b, i - 1))
       end
       for i = lenb + 1:vala - valb
-         setcoeff!(z, i - 1, R())
+         z = setcoeff!(z, i - 1, R())
       end
       for i = vala - valb + 1:lenb
-         setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1) - polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1) - polcoeff(b, i - 1))
       end
       for i = max(lenb, vala - valb) + 1:lena + vala - valb
-         setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - vala + valb - 1))
       end
       for i = lena + vala - valb + 1:lenb
-         setcoeff!(z, i - 1, -polcoeff(b, i - 1))
+         z = setcoeff!(z, i - 1, -polcoeff(b, i - 1))
       end
    else
       for i = 1:min(lena, valb - vala)
-         setcoeff!(z, i - 1, polcoeff(a, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
       for i = lena + 1:valb - vala
-         setcoeff!(z, i - 1, R())
+         z = setcoeff!(z, i - 1, R())
       end
       for i = valb - vala + 1:lena
-         setcoeff!(z, i - 1, polcoeff(a, i - 1) - polcoeff(b, i - valb + vala - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1) - polcoeff(b, i - valb + vala - 1))
       end
       for i = max(lena, valb - vala) + 1:lenb + valb - vala
-         setcoeff!(z, i - 1, -polcoeff(b, i - valb + vala - 1))
+         z = setcoeff!(z, i - 1, -polcoeff(b, i - valb + vala - 1))
       end
       for i = lenb + valb - vala + 1:lena
-         setcoeff!(z, i - 1, polcoeff(a, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
    end
    set_length!(z, normalise(z, lenz))
@@ -453,8 +453,8 @@ function *{T <: RingElem}(a::RelSeriesElem{T}, b::RelSeriesElem{T})
    for i = 1:lena - 1
       if lenz > i
          for j = 2:min(lenb, lenz - i + 1)
-            mul!(t, polcoeff(a, i - 1), polcoeff(b, j - 1))
-            addeq!(d[i + j - 1], t)
+            t = mul!(t, polcoeff(a, i - 1), polcoeff(b, j - 1))
+            d[i + j - 1] = addeq!(d[i + j - 1], t)
          end
       end
    end        
@@ -481,7 +481,7 @@ function *{T <: RingElem}(a::T, b::RelSeriesElem{T})
    set_prec!(z, precision(b))
    set_val!(z, valuation(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    renormalize!(z)
@@ -499,7 +499,7 @@ function *{T <: RingElem}(a::Integer, b::RelSeriesElem{T})
    set_prec!(z, precision(b))
    set_val!(z, valuation(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    renormalize!(z)
@@ -517,7 +517,7 @@ function *{T <: RingElem}(a::fmpz, b::RelSeriesElem{T})
    set_prec!(z, precision(b))
    set_val!(z, valuation(b))
    for i = 1:len
-      setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
+      z = setcoeff!(z, i - 1, a*polcoeff(b, i - 1))
    end
    set_length!(z, normalise(z, len))
    renormalize!(z)
@@ -639,7 +639,7 @@ function shift_left{T <: RingElem}(x::RelSeriesElem{T}, len::Int)
    set_prec!(z, precision(x) + len)
    set_val!(z, valuation(x) + len)
    for i = 1:xlen
-      setcoeff!(z, i - 1, polcoeff(x, i - 1))
+      z = setcoeff!(z, i - 1, polcoeff(x, i - 1))
    end
    return z
 end
@@ -664,7 +664,7 @@ function shift_right{T <: RingElem}(x::RelSeriesElem{T}, len::Int)
       set_prec!(z, max(0, xprec - len))
       set_val!(z, max(0, xval - len))
       for i = 1:zlen
-         setcoeff!(z, i - 1, polcoeff(x, i + xlen  - zlen - 1))
+         z = setcoeff!(z, i - 1, polcoeff(x, i + xlen  - zlen - 1))
       end
       renormalize!(z)
    end
@@ -697,7 +697,7 @@ function truncate{T <: RingElem}(a::RelSeriesElem{T}, prec::Int)
    else
       fit!(z, prec - aval)
       for i = 1:min(prec - aval, alen)
-         setcoeff!(z, i - 1, polcoeff(a, i - 1))
+         z = setcoeff!(z, i - 1, polcoeff(a, i - 1))
       end
       set_length!(z, normalise(z, prec - aval))
       set_val!(z, aval)
@@ -722,7 +722,7 @@ function ^{T <: RingElem}(a::RelSeriesElem{T}, b::Int)
       z = parent(a)()
       fit!(z, 1)
       set_prec!(z, b + precision(a) - 1)
-      setcoeff!(z, 0, polcoeff(a, 0))
+      z = setcoeff!(z, 0, polcoeff(a, 0))
       set_val!(z, b)
       set_length!(z, 1)
       return z
@@ -909,7 +909,7 @@ function divexact{T <: RingElem}(x::RelSeriesElem{T}, y::Integer)
    set_prec!(z, precision(x))
    set_val!(z, valuation(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
    return z
 end
@@ -926,7 +926,7 @@ function divexact{T <: RingElem}(x::RelSeriesElem{T}, y::fmpz)
    set_prec!(z, precision(x))
    set_val!(z, valuation(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
    return z
 end
@@ -943,7 +943,7 @@ function divexact{T <: RingElem}(x::RelSeriesElem{T}, y::T)
    set_prec!(z, precision(x))
    set_val!(z, valuation(x))
    for i = 1:lenx
-      setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
+      z = setcoeff!(z, i - 1, divexact(polcoeff(x, i - 1), y))
    end
    return z
 end
@@ -966,7 +966,7 @@ function inv(a::RelSeriesElem)
    fit!(ainv, precision(a))
    set_prec!(ainv, precision(a))
    if precision(a) != 0
-      setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
+      ainv = setcoeff!(ainv, 0, divexact(one(base_ring(a)), a1))
    end
    a1 = -a1
    for n = 2:precision(a)
@@ -974,7 +974,7 @@ function inv(a::RelSeriesElem)
       for i = 2:min(n, pol_length(a)) - 1
          s += polcoeff(a, i)*polcoeff(ainv, n - i - 1)
       end
-      setcoeff!(ainv, n - 1, divexact(s, a1))
+      ainv = setcoeff!(ainv, n - 1, divexact(s, a1))
    end
    set_length!(ainv, normalise(ainv, precision(a)))
    set_val!(ainv, 0)
@@ -1005,7 +1005,7 @@ function exp(a::RelSeriesElem)
    fit!(z, preca)
    set_prec!(z, preca)
    c = vala == 0 ? polcoeff(a, 0) : R()
-   setcoeff!(z, 0, exp(c))
+   z = setcoeff!(z, 0, exp(c))
    len = pol_length(a) + vala
    for k = 1 : preca - 1
       s = R()
@@ -1014,7 +1014,7 @@ function exp(a::RelSeriesElem)
          s += j * c * polcoeff(z, k - j)
       end
       !isunit(R(k)) && error("Unable to divide in exp")
-      setcoeff!(z, k, divexact(s, k))
+      z = setcoeff!(z, k, divexact(s, k))
    end
    set_length!(z, normalise(z, preca))
    set_val!(z, 0)
@@ -1072,18 +1072,18 @@ function mul!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T}, b::GenRelSe
       lenc = min(lena + lenb - 1, prec)
       fit!(c, lenc)
       for i = 1:min(lena, lenc)
-         mul!(c.coeffs[i], polcoeff(a, i - 1), polcoeff(b, 0))
+         c.coeffs[i] = mul!(c.coeffs[i], polcoeff(a, i - 1), polcoeff(b, 0))
       end
       if lenc > lena
          for i = 2:min(lenb, lenc - lena + 1)
-            mul!(c.coeffs[lena + i - 1], polcoeff(a, lena - 1), polcoeff(b, i - 1))
+            c.coeffs[lena + i - 1] = mul!(c.coeffs[lena + i - 1], polcoeff(a, lena - 1), polcoeff(b, i - 1))
          end
       end
       for i = 1:lena - 1
          if lenc > i
             for j = 2:min(lenb, lenc - i + 1)
-               mul!(t, polcoeff(a, i - 1), polcoeff(b, j - 1))
-               addeq!(c.coeffs[i + j - 1], t)
+               t = mul!(t, polcoeff(a, i - 1), polcoeff(b, j - 1))
+               c.coeffs[i + j - 1] = addeq!(c.coeffs[i + j - 1], t)
             end
          end
       end        
@@ -1122,14 +1122,14 @@ function addeq!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T})
          c.coeffs[i] = R()
       end
       for i = valc + 1:min(lena, lenc + valc - vala)
-         addeq!(c.coeffs[i], a.coeffs[i])
+         c.coeffs[i] = addeq!(c.coeffs[i], a.coeffs[i])
       end
       for i = lenc + valc - vala + 1:lena
          c.coeffs[i] = a.coeffs[i]
       end
    else
       for i = 1:min(lena, lenc - vala + valc)
-         addeq!(c.coeffs[i + vala - valc], a.coeffs[i])
+         c.coeffs[i + vala - valc] = addeq!(c.coeffs[i + vala - valc], a.coeffs[i])
       end
       for i = lenc + 1:lena + vala - valc
          c.coeffs[i] = a.coeffs[i - vala + valc]
@@ -1153,15 +1153,15 @@ function add!{T <: RingElem}(c::SeriesElem{T}, a::SeriesElem{T}, b::SeriesElem{T
    set_prec!(c, prec)
    i = 1
    while i <= min(lena, lenb)
-      setcoeff!(c, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
+      c = setcoeff!(c, i - 1, coeff(a, i - 1) + coeff(b, i - 1))
       i += 1
    end
    while i <= lena
-      setcoeff!(c, i - 1, coeff(a, i - 1))
+      c = setcoeff!(c, i - 1, coeff(a, i - 1))
       i += 1
    end
    while i <= lenb
-      setcoeff!(c, i - 1, coeff(b, i - 1))
+      c = setcoeff!(c, i - 1, coeff(b, i - 1))
       i += 1
    end
    set_length!(c, normalise(c, i - 1))

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -1030,6 +1030,7 @@ end
 function zero!{T <: RingElem}(a::GenRelSeries{T})
    a.length = 0
    a.prec = parent(a).prec_max
+   return a
 end
 
 function fit!{T <: RingElem}(c::GenRelSeries{T}, n::Int)
@@ -1043,6 +1044,7 @@ function fit!{T <: RingElem}(c::GenRelSeries{T}, n::Int)
          c.coeffs[i] = zero(base_ring(c))
       end
    end
+   return c
 end
 
 function setcoeff!{T <: RingElem}(c::GenRelSeries{T}, n::Int, a::T)
@@ -1052,6 +1054,7 @@ function setcoeff!{T <: RingElem}(c::GenRelSeries{T}, n::Int, a::T)
       c.length = max(pol_length(c), n + 1)
       # don't normalise
    end
+   return c
 end
 
 function mul!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T}, b::GenRelSeries{T})
@@ -1089,7 +1092,7 @@ function mul!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T}, b::GenRelSe
    c.val = a.val + b.val
    c.prec = prec + c.val
    renormalize!(z)
-   return nothing
+   return c
 end
 
 function addeq!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T})
@@ -1136,6 +1139,7 @@ function addeq!{T <: RingElem}(c::GenRelSeries{T}, a::GenRelSeries{T})
    c.prec = prec
    c.val = valr
    renormalise!(c)
+   return c
 end
 
 function add!{T <: RingElem}(c::SeriesElem{T}, a::SeriesElem{T}, b::SeriesElem{T})
@@ -1161,7 +1165,7 @@ function add!{T <: RingElem}(c::SeriesElem{T}, a::SeriesElem{T}, b::SeriesElem{T
       i += 1
    end
    set_length!(c, normalise(c, i - 1))
-   nothing
+   return c
 end
 ###############################################################################
 #

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -481,7 +481,7 @@ end
 ###############################################################################
 
 function zero!{T <: RingElem}(a::ResElem{T})
-   zero!(a.data)
+   a.data = zero!(a.data)
    return a
 end
 

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -482,22 +482,22 @@ end
 
 function zero!{T <: RingElem}(a::ResElem{T})
    zero!(a.data)
-   nothing
+   return a
 end
 
 function mul!{T <: RingElem}(c::ResElem{T}, a::ResElem{T}, b::ResElem{T})
    c.data = mod(data(a)*data(b), modulus(a))
-   nothing
+   return c
 end
 
 function addeq!{T <: RingElem}(c::ResElem{T}, a::ResElem{T})
    c.data = mod(c.data + data(a), modulus(a))
-   nothing
+   return c
 end
 
 function add!{T <: RingElem}(c::ResElem{T}, a::ResElem{T}, b::ResElem{T})
    c.data = mod(data(a) + data(b), modulus(a))
-   nothing
+   return c
 end
 
 ###############################################################################

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -1697,7 +1697,7 @@ function fit!{T <: RingElem}(a::GenSparsePoly{T}, n::Int)
       resize!(a.coeffs, n)
       resize!(a.exps, n)
    end
-   return a
+   return nothing
 end
 
 function addmul!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSparsePoly{T}, d::GenSparsePoly{T})

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -1697,7 +1697,7 @@ function fit!{T <: RingElem}(a::GenSparsePoly{T}, n::Int)
       resize!(a.coeffs, n)
       resize!(a.exps, n)
    end
-   return
+   return a
 end
 
 function addmul!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSparsePoly{T}, d::GenSparsePoly{T})
@@ -1706,7 +1706,7 @@ function addmul!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::Gen
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function mul!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSparsePoly{T})
@@ -1714,7 +1714,7 @@ function mul!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSpa
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function addeq!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
@@ -1722,7 +1722,7 @@ function addeq!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function add!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSparsePoly{T})
@@ -1730,19 +1730,19 @@ function add!{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, c::GenSpa
    a.coeffs = t.coeffs
    a.exps = t.exps
    a.length = t.length
-   return
+   return a
 end
 
 function zero!{T <: RingElem}(a::GenSparsePoly{T})
    a.length = 0
-   return
+   return a
 end
 
 function shift_left!{T <: RingElem}(a::GenSparsePoly{T}, n::UInt)
    for i = 1:length(a)
       a.exps[i] += n
    end
-   return
+   return a
 end
 
 ###############################################################################

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -343,14 +343,14 @@ function mul_johnson{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
             Re[k] = exp
             first = false
          else
-            addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
+            Rc[k] = addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
          end
          if v.j < n || v.j == 1
             push!(Q, x.n)
          end
          while (xn = v.next) != 0
             v = I[xn]
-            addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
+            Rc[k] = addmul!(Rc[k], a.coeffs[v.i], b.coeffs[v.j], c)
             if v.j < n || v.j == 1
                push!(Q, xn)
             end
@@ -387,10 +387,10 @@ function *{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
       return b*a
    end
    r = a*b.coeffs[1]
-   shift_left!(r, b.exps[1])
+   r = shift_left!(r, b.exps[1])
    for i = 2:n
       s = a*b.coeffs[i]
-      shift_left!(s, b.exps[i])
+      s = shift_left!(s, b.exps[i])
       r += s
    end
    return r
@@ -445,9 +445,9 @@ function divrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
          heappop!(H)
          v = I[x.n]
          if v.i == 0
-            addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+            qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
          else
-            addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
+            qc = addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -457,9 +457,9 @@ function divrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
          while (xn = v.next) != 0
             v = I[xn]
             if v.i == 0
-               addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
+               qc = addmul!(qc, a.coeffs[m + 1 - v.j], m1, c)
             else
-               addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
+               qc = addmul!(qc, b.coeffs[n + 1 - v.i], Qc[v.j], c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -528,7 +528,7 @@ function divrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
             end
          end
       end
-      zero!(qc)
+      qc = zero!(qc)
    end
    resize!(Qc, k)
    resize!(Qe, k)
@@ -729,18 +729,18 @@ function pow_fps{T <: RingElem}(f::GenSparsePoly{T}, k::Int)
          resize!(Re, r_alloc)
       end
       first = true
-      zero!(C) 
-      zero!(SS)
+      C = zero!(C)
+      SS = zero!(SS)
       while !isempty(H) && H[1].exp == exp
          x = H[1]
          heappop!(H)
          v = I[x.n]
          largest[v.i] |= topbit
-         mul!(t1, f.coeffs[v.i], gc[v.j])
-         addeq!(SS, t1)
+         t1 = mul!(t1, f.coeffs[v.i], gc[v.j])
+         SS = addeq!(SS, t1)
          if exp <= finalexp
-            add!(temp2, fik[v.i], gi[v.j])
-            addmul!(C, temp2, t1, temp)
+            temp2 = add!(temp2, fik[v.i], gi[v.j])
+            C = addmul!(C, temp2, t1, temp)
          end
          if first
             ge[gnext] = exp - f.exps[1]
@@ -750,11 +750,11 @@ function pow_fps{T <: RingElem}(f::GenSparsePoly{T}, k::Int)
          while (xn = v.next) != 0
             v = I[xn]
             largest[v.i] |= topbit
-            mul!(t1, f.coeffs[v.i], gc[v.j])
-            addeq!(SS, t1)
+            t1 = mul!(t1, f.coeffs[v.i], gc[v.j])
+            SS = addeq!(SS, t1)
             if exp <= finalexp
-               add!(temp2, fik[v.i], gi[v.j])
-               addmul!(C, temp2, t1, temp)
+               temp2 = add!(temp2, fik[v.i], gi[v.j])
+               C = addmul!(C, temp2, t1, temp)
             end
             push!(Q, xn)
          end
@@ -784,7 +784,7 @@ function pow_fps{T <: RingElem}(f::GenSparsePoly{T}, k::Int)
       end
       if C != 0
          temp = divexact(C, from_exp(R, exp) - kp1f1)
-         addeq!(SS, temp)
+         SS = addeq!(SS, temp)
          gc[gnext] = divexact(temp, f.coeffs[1])
          push!(gi, -from_exp(R, ge[gnext]))
          if (largest[2] & topbit) != 0
@@ -882,9 +882,9 @@ function divides_monagan_pearce{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparse
             first = false
          end
          if v.i == 0
-            addmul!(qc, a.coeffs[v.j], m1, c)
+            qc = addmul!(qc, a.coeffs[v.j], m1, c)
          else
-            addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
+            qc = addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -894,9 +894,9 @@ function divides_monagan_pearce{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparse
          while (xn = v.next) != 0
             v = I[xn]
             if v.i == 0
-               addmul!(qc, a.coeffs[v.j], m1, c)
+               qc = addmul!(qc, a.coeffs[v.j], m1, c)
             else
-               addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
+               qc = addmul!(qc, b.coeffs[v.i], Qc[v.j], c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -938,7 +938,7 @@ function divides_monagan_pearce{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparse
          end
          s = 1
       end
-      zero!(qc)
+      qc = zero!(qc)
    end
    resize!(Qc, k)
    resize!(Qe, k)
@@ -974,7 +974,7 @@ function divides{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
       end
       Qe[k] = d
       Qc[k] = c
-      shift_left!(s, d)
+      s = shift_left!(s, d)
       r -= s
    end
    resize!(Qe, k)
@@ -1084,14 +1084,14 @@ function pseudodivrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
             else
                tc = -a.coeffs[m + 1 - v.j]
             end
-            addeq!(qc, tc)
+            qc = addeq!(qc, tc)
          else
             if p - Qpow[v.j] - 1 > 0
                tc = Qc[v.j]*Pc[p - Qpow[v.j] - 1]
             else
                tc = Qc[v.j]
             end
-            addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
+            qc = addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -1106,14 +1106,14 @@ function pseudodivrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
                else
                   tc = -a.coeffs[m + 1 - v.j]
                end
-               addeq!(qc, tc)
+               qc = addeq!(qc, tc)
             else
                if p - Qpow[v.j] - 1 > 0
                   tc = Qc[v.j]*Pc[p - Qpow[v.j] - 1]
                else
                   tc = Qc[v.j]
                end
-               addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
+               qc = addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -1175,7 +1175,7 @@ function pseudodivrem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
    resize!(Qe, k)
    for i = 1:k
       if p > Qpow[i]
-         mul!(Qc[i], Qc[i], Pc[p - Qpow[i]])
+         Qc[i] = mul!(Qc[i], Qc[i], Pc[p - Qpow[i]])
       else
          Qc[i] = Qc[i]
       end
@@ -1260,14 +1260,14 @@ function pseudorem_monagan_pearce{T <: RingElem}(a::GenSparsePoly{T}, b::GenSpar
             else
                tc = -a.coeffs[m + 1 - v.j]
             end
-            addeq!(qc, tc)
+            qc = addeq!(qc, tc)
          else
             if p - Qpow[v.j] - 1 > 0
                tc = Qc[v.j]*Pc[p - Qpow[v.j] - 1]
             else
                tc = Qc[v.j]
             end
-            addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
+            qc = addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
          end
          if v.i != 0 || v.j < m
             push!(Q, x.n)
@@ -1282,14 +1282,14 @@ function pseudorem_monagan_pearce{T <: RingElem}(a::GenSparsePoly{T}, b::GenSpar
                else
                   tc = -a.coeffs[m + 1 - v.j]
                end
-               addeq!(qc, tc)
+               qc = addeq!(qc, tc)
             else
                if p - Qpow[v.j] - 1 > 0
                   tc = Qc[v.j]*Pc[p - Qpow[v.j] - 1]
                else
                   tc = Qc[v.j]
                end
-               addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
+               qc = addmul!(qc, b.coeffs[n + 1 - v.i], tc, c)
             end
             if v.i != 0 || v.j < m
                push!(Q, xn)
@@ -1373,7 +1373,7 @@ function pseudorem{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T})
    l = lead(b)
    while a.length > 0 && a.exps[a.length] >= b.exps[b.length]
       s = lead(a)*b
-      shift_left!(s, a.exps[a.length] - b.exps[b.length])
+      s = shift_left!(s, a.exps[a.length] - b.exps[b.length])
       a = a*l - s
       k -= 1
    end
@@ -1552,10 +1552,10 @@ function gcd{T <: RingElem}(a::GenSparsePoly{T}, b::GenSparsePoly{T}, ignore_con
       fit!(f, reinterpret(Int, a.exps[a.length] + 1))
       fit!(g, reinterpret(Int, b.exps[b.length] + 1))
       for i = 1:a.length
-         setcoeff!(f, reinterpret(Int, a.exps[i]), a.coeffs[i].coeffs[1])
+         f = setcoeff!(f, reinterpret(Int, a.exps[i]), a.coeffs[i].coeffs[1])
       end
       for i = 1:b.length
-         setcoeff!(g, reinterpret(Int, b.exps[i]), b.coeffs[i].coeffs[1])
+         g = setcoeff!(g, reinterpret(Int, b.exps[i]), b.coeffs[i].coeffs[1])
       end
       # take gcd of univariate dense polys
       h = gcd(f, g)


### PR DESCRIPTION
Most of the "unsafe functions" now return the changed variable. I already edited Matrix.jl so that this is used.
This doesn't change the performance to the worse, as one might expect. These are the results for some of the benchmark-tests on my hardware (of course I only timed the computation not the whole script):

For det_field.jl:
_On branch master:_
BenchmarkTools.Trial:
  memory estimate:  39.29 MiB
  allocs estimate:  874184
  minimum time:     2.862 s (0.05% GC)
  median time:      2.873 s (0.09% GC)
  mean time:        2.873 s (0.09% GC)
  maximum time:     2.885 s (0.13% GC)
  samples:          2
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

_On branch fixunsafe:_
BenchmarkTools.Trial:
  memory estimate:  41.55 MiB
  allocs estimate:  877341
  minimum time:     2.813 s (0.13% GC)
  median time:      2.822 s (0.10% GC)
  mean time:        2.822 s (0.10% GC)
  maximum time:     2.830 s (0.06% GC)
  samples:          2
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

For minpoly_gcd_domain.jl:
_On branch  master:_
BenchmarkTools.Trial:
  memory estimate:  69.21 MiB
  allocs estimate:  663282
  minimum time:     1.565 s (0.20% GC)
  median time:      1.598 s (0.21% GC)
  mean time:        1.593 s (0.21% GC)
  maximum time:     1.608 s (0.22% GC)
  samples:          4
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

_On branch fixunsafe:_
BenchmarkTools.Trial:
  memory estimate:  69.24 MiB
  allocs estimate:  662169
  minimum time:     1.573 s (0.23% GC)
  median time:      1.599 s (0.22% GC)
  mean time:        1.596 s (0.22% GC)
  maximum time:     1.613 s (0.23% GC)
  samples:          4
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

For minpoly_finite_field.jl:
_On branch master:_
BenchmarkTools.Trial:
  memory estimate:  9.40 MiB
  allocs estimate:  136072
  minimum time:     143.206 ms (0.00% GC)
  median time:      150.720 ms (0.00% GC)
  mean time:        168.821 ms (4.52% GC)
  maximum time:     209.373 ms (9.32% GC)
  samples:          30
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

_On branch fixunsafe:_
BenchmarkTools.Trial:
  memory estimate:  9.40 MiB
  allocs estimate:  136072
  minimum time:     139.830 ms (0.00% GC)
  median time:      148.454 ms (0.00% GC)
  mean time:        163.969 ms (4.84% GC)
  maximum time:     196.983 ms (10.36% GC)
  samples:          31
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%