### PR TITLE
MPoly fixes

### DIFF
--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -1861,7 +1861,7 @@ function divrem_monagan_pearce{T <: RingElem}(a::GenMPoly{T}, b::Array{GenMPoly{
       n[i] == 0 && error("Division by zero in divrem_monagan_pearce")
    end
    if m == 0
-      return [par() for i in 1:len], [par() for i in 1:len]
+      return [par() for i in 1:len], par()
    end
    mask1 = UInt(1) << (bits - 1)
    mask = UInt(0)
@@ -2607,7 +2607,7 @@ function (a::GenMPolyRing{T}){T <: RingElem}(b::PolyElem{T})
 end
 
 function (a::GenMPolyRing{T}){T <: RingElem}(b::Array{T, 1}, m::Array{UInt, 2})
-   if length(b) > 0
+   if length(b) > 0 && isdefined(b, 1)
       parent(b[1]) != base_ring(a) && error("Unable to coerce to polynomial")
    end
    z = GenMPoly{T}(a, b, m)


### PR DESCRIPTION
Please double check. Fixes for the following bugs:
```julia
julia> Qx, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"]);

julia> Qx()*(x-x)
ERROR: UndefRefError: access to undefined reference
 in (::Nemo.GenMPolyRing{Nemo.fmpq})(::Array{Nemo.fmpq,1}, ::Array{UInt64,2}) at /home/thofmann/.julia/v0.5/Nemo/src/generic/MPoly.jl:2611
 in *(::Nemo.GenMPoly{Nemo.fmpq}, ::Nemo.GenMPoly{Nemo.fmpq}) at /home/thofmann/.julia/v0.5/Nemo/src/generic/MPoly.jl:1016

julia> divrem(x-x, [x, y])
ERROR: type Array has no field exps
 in divrem(::Nemo.GenMPoly{Nemo.fmpq}, ::Array{Nemo.GenMPoly{Nemo.fmpq},1}) at /home/thofmann/.julia/v0.5/Nemo/src/generic/MPoly.jl:2082
```
