### PR TITLE
Remove remaining parent() calls

### DIFF
--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -593,7 +593,8 @@ doc"""
 > entries of the returned matrix are those of $a$ lifted to $\mathbb{Z}$.
 """
 function lift(a::nmod_mat)
-  z = MatrixSpace(FlintZZ, rows(a), cols(a))()
+  z = fmpz_mat(rows(a), cols(a))
+  z.base_ring = FlintIntegerRing()
   ccall((:fmpz_mat_set_nmod_mat, :libflint), Void,
           (Ptr{fmpz_mat}, Ptr{nmod_mat}), &z, &a)
   return z 


### PR DESCRIPTION
There were some tricky ones, like
```
one(MatrixSpace(base_ring(A), rows(A), rows(A)))
```
One way to replace the call to `MatrixSpace` is to use
```
one(parent(similar(A, rows(A), rows(A)))
```
But then you have a call to `parent`, which is equally bad. Thus I wrote this helper function called `_one`. I don't know if this will be the final solution, but it works for the time being.

If this here is merged, I can finally start separating `GenMat` and `MatElem`.