### PR TITLE
Add elem_type(::Type{T})

### DIFF
--- a/src/Groups.jl
+++ b/src/Groups.jl
@@ -7,3 +7,11 @@
 include("generic/PermGroups.jl")
 
 include("Rings.jl")
+
+################################################################################
+#
+#  Element types for instances of rings
+#
+################################################################################
+
+elem_type{T <: Group}(::T) = elem_type(T)

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -19,6 +19,8 @@ import Base: floor, ceil, hypot, sqrt, log, log1p, exp, expm1, sin, cos, sinpi,
              cospi, tan, cot, sinh, cosh, tanh, coth, atan, asin, acos, atanh,
              asinh, acosh, gamma, lgamma, digamma, zeta, sinpi, cospi, atan2
 
+export elem_type, parent_type
+
 export SetElem, GroupElem, RingElem, FieldElem, AccessorNotSetError
 
 export PolyElem, SeriesElem, AbsSeriesElem, RelSeriesElem, ResElem, FracElem,

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -21,7 +21,7 @@ doc"""
 """
 parent(a::nf_elem) = a.parent
 
-elem_type(::AnticNumberField) = nf_elem
+elem_type(::Type{AnticNumberField}) = nf_elem
 
 doc"""
     base_ring(a::AnticNumberField)

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -31,7 +31,7 @@ export sqrt, rsqrt, log, log1p, exp, exppii, sin, cos, tan, cot,
 #
 ###############################################################################
 
-elem_type(::AcbField) = acb
+elem_type(::Type{AcbField}) = acb
 
 parent_type(::Type{acb}) = AcbField
 

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -35,10 +35,10 @@ end
 
 parent_type(::Type{acb_mat}) = AcbMatSpace
 
+elem_type(::Type{AcbMatSpace}) = acb_mat
+
 parent(x::acb_mat, cached::Bool = true) =
       MatrixSpace(base_ring(x), rows(x), cols(x))
-
-elem_type(x::AcbMatSpace) = acb_mat
 
 prec(x::AcbMatSpace) = prec(x.base_ring)
 

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -16,6 +16,8 @@ export AcbPolyRing, acb_poly, isreal, derivative, integral, evaluate,
 ###############################################################################    
 
 parent_type(::Type{acb_poly}) = AcbPolyRing
+
+elem_type(::Type{AcbPolyRing}) = acb_poly
   
 length(x::acb_poly) = ccall((:acb_poly_length, :libarb), Int, 
                                    (Ptr{acb_poly},), &x)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -32,7 +32,7 @@ export ball, radius, midpoint, contains, contains_zero,
 #
 ###############################################################################
 
-elem_type(::ArbField) = arb
+elem_type(::Type{ArbField}) = arb
 
 parent_type(::Type{arb}) = ArbField
 

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -35,14 +35,14 @@ end
 
 parent_type(::Type{arb_mat}) = ArbMatSpace
 
+elem_type(::Type{ArbMatSpace}) = arb_mat
+
 base_ring(a::ArbMatSpace) = a.base_ring
 
 base_ring(a::arb_mat) = a.base_ring
 
 parent(x::arb_mat, cached::Bool = true) =
       MatrixSpace(base_ring(x), rows(x), cols(x))
-
-elem_type(x::ArbMatSpace) = arb_mat
 
 prec(x::ArbMatSpace) = prec(x.base_ring)
 

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -17,6 +17,8 @@ export ArbPolyRing, arb_poly, derivative, integral, evaluate, evaluate2,
   
 parent_type(::Type{arb_poly}) = ArbPolyRing
 
+elem_type(::Type{ArbPolyRing}) = arb_poly
+
 length(x::arb_poly) = ccall((:arb_poly_length, :libarb), Int, 
                                    (Ptr{arb_poly},), &x)
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -37,7 +37,7 @@ parent(a::fmpq) = FlintQQ
 
 parent_type(::Type{fmpq}) = FlintRationalField
 
-elem_type(::FlintRationalField) = fmpq
+elem_type(::Type{FlintRationalField}) = fmpq
 
 base_ring(a::FlintRationalField) = FlintZZ
 

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -22,7 +22,7 @@ function O(a::fmpq_abs_series)
    return z
 end
 
-elem_type(::FmpqAbsSeriesRing) = fmpq_abs_series
+elem_type(::Type{FmpqAbsSeriesRing}) = fmpq_abs_series
 
 parent_type(::Type{fmpq_abs_series}) = FmpqAbsSeriesRing
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -12,7 +12,7 @@ export fmpq_mat, FmpqMatSpace, gso, hilbert
 #
 ###############################################################################
 
-elem_type(::FmpqMatSpace) = fmpq_mat
+elem_type(::Type{FmpqMatSpace}) = fmpq_mat
 
 parent_type(::Type{fmpq_mat}) = FmpqMatSpace
 

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -14,7 +14,7 @@ export FmpqPolyRing, fmpq_poly
 
 parent_type(::Type{fmpq_poly}) = FmpqPolyRing
 
-elem_type(::FmpqPolyRing) = fmpq_poly
+elem_type(::Type{FmpqPolyRing}) = fmpq_poly
 
 base_ring(a::FmpqPolyRing) = a.base_ring
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -20,7 +20,7 @@ function O(a::fmpq_rel_series)
    return z
 end
 
-elem_type(::FmpqRelSeriesRing) = fmpq_rel_series
+elem_type(::Type{FmpqRelSeriesRing}) = fmpq_rel_series
 
 parent_type(::Type{fmpq_rel_series}) = FmpqRelSeriesRing
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -57,7 +57,7 @@ doc"""
 """
 parent(a::fmpz) = FlintZZ
 
-elem_type(::FlintIntegerRing) = fmpz
+elem_type(::Type{FlintIntegerRing}) = fmpz
 
 doc"""
     base_ring(a::FlintIntegerRing)

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -23,7 +23,7 @@ function O(a::fmpz_abs_series)
    return z
 end
 
-elem_type(::FmpzAbsSeriesRing) = fmpz_abs_series
+elem_type(::Type{FmpzAbsSeriesRing}) = fmpz_abs_series
 
 parent_type(::Type{fmpz_abs_series}) = FmpzAbsSeriesRing
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -20,7 +20,7 @@ export fmpz_mat, FmpzMatSpace, getindex, getindex!, setindex!, rows, cols,
 #
 ###############################################################################
 
-elem_type(::FmpzMatSpace) = fmpz_mat
+elem_type(::Type{FmpzMatSpace}) = fmpz_mat
 
 parent_type(::Type{fmpz_mat}) = FmpzMatSpace
 

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -23,7 +23,7 @@ function O(a::fmpz_mod_abs_series)
    return z
 end
 
-elem_type(::FmpzModAbsSeriesRing) = fmpz_mod_abs_series
+elem_type(::Type{FmpzModAbsSeriesRing}) = fmpz_mod_abs_series
 
 parent_type(::Type{fmpz_mod_abs_series}) = FmpzModAbsSeriesRing
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -18,9 +18,9 @@ base_ring(R::FmpzModPolyRing) = R.base_ring
 
 base_ring(a::fmpz_mod_poly) = base_ring(parent(a))
 
-elem_type(::fmpz_mod_poly) = fmpz_mod_poly
+elem_type(::Type{fmpz_mod_poly}) = fmpz_mod_poly
 
-elem_type(::FmpzModPolyRing) = fmpz_mod_poly
+elem_type(::Type{FmpzModPolyRing}) = fmpz_mod_poly
 
 parent_type(::Type{fmpz_mod_poly}) = FmpzModPolyRing
 

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -20,7 +20,7 @@ function O(a::fmpz_mod_rel_series)
    return z
 end
 
-elem_type(::FmpzModRelSeriesRing) = fmpz_mod_rel_series
+elem_type(::Type{FmpzModRelSeriesRing}) = fmpz_mod_rel_series
 
 parent_type(::Type{fmpz_mod_rel_series}) = FmpzModRelSeriesRing
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -15,7 +15,7 @@ export FmpzPolyRing, fmpz_poly, cyclotomic, theta_qexp, eta_qexp, cos_minpoly,
 
 parent_type(::Type{fmpz_poly}) = FmpzPolyRing
 
-elem_type(::FmpzPolyRing) = fmpz_poly
+elem_type(::Type{FmpzPolyRing}) = fmpz_poly
 
 base_ring(a::FmpzPolyRing) = a.base_ring
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -20,7 +20,7 @@ function O(a::fmpz_rel_series)
    return z
 end
 
-elem_type(::FmpzRelSeriesRing) = fmpz_rel_series
+elem_type(::Type{FmpzRelSeriesRing}) = fmpz_rel_series
 
 parent_type(::Type{fmpz_rel_series}) = FmpzRelSeriesRing
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -15,7 +15,7 @@ export FlintFiniteField, characteristic, order, fq, FqFiniteField, frobenius,
 
 parent_type(::Type{fq}) = FqFiniteField
 
-elem_type(::FqFiniteField) = fq
+elem_type(::Type{FqFiniteField}) = fq
 
 doc"""
     base_ring(a::FqFiniteField)

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -23,7 +23,7 @@ function O(a::fq_abs_series)
    return z
 end
 
-elem_type(::FqAbsSeriesRing) = fq_abs_series
+elem_type(::Type{FqAbsSeriesRing}) = fq_abs_series
 
 parent_type(::Type{fq_abs_series}) = FqAbsSeriesRing
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -14,7 +14,7 @@ export fq_nmod, FqNmodFiniteField
 
 parent_type(::Type{fq_nmod}) = FqNmodFiniteField
 
-elem_type(::FqNmodFiniteField) = fq_nmod
+elem_type(::Type{FqNmodFiniteField}) = fq_nmod
 
 base_ring(a::FqNmodFiniteField) = Union{}
 

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -23,7 +23,7 @@ function O(a::fq_nmod_abs_series)
    return z
 end
 
-elem_type(::FqNmodAbsSeriesRing) = fq_nmod_abs_series
+elem_type(::Type{FqNmodAbsSeriesRing}) = fq_nmod_abs_series
 
 parent_type(::Type{fq_nmod_abs_series}) = FqNmodAbsSeriesRing
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -14,7 +14,7 @@ export fq_nmod_poly, FqNmodPolyRing
 
 parent_type(::Type{fq_nmod_poly}) = FqNmodPolyRing
 
-elem_type(::FqNmodPolyRing) = fq_nmod_poly
+elem_type(::Type{FqNmodPolyRing}) = fq_nmod_poly
 
 base_ring(a::FqNmodPolyRing) = a.base_ring
 

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -20,7 +20,7 @@ function O(a::fq_nmod_rel_series)
    return z
 end
 
-elem_type(::FqNmodRelSeriesRing) = fq_nmod_rel_series
+elem_type(::Type{FqNmodRelSeriesRing}) = fq_nmod_rel_series
 
 parent_type(::Type{fq_nmod_rel_series}) = FqNmodRelSeriesRing
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -14,7 +14,7 @@ export fq_poly, FqPolyRing
 
 parent_type(::Type{fq_poly}) = FqPolyRing
 
-elem_type(::FqPolyRing) = fq_poly
+elem_type(::Type{FqPolyRing}) = fq_poly
 
 base_ring(a::FqPolyRing) = a.base_ring
 

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -20,7 +20,7 @@ function O(a::fq_rel_series)
    return z
 end
 
-elem_type(::FqRelSeriesRing) = fq_rel_series
+elem_type(::Type{FqRelSeriesRing}) = fq_rel_series
 
 parent_type(::Type{fq_rel_series}) = FqRelSeriesRing
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -18,7 +18,7 @@ export nmod_mat, NmodMatSpace, getindex, setindex!, set_entry!, deepcopy, rows,
 
 parent_type(::Type{nmod_mat}) = NmodMatSpace
 
-elem_type(::NmodMatSpace) = nmod_mat
+elem_type(::Type{NmodMatSpace}) = nmod_mat
 
 function _checkbounds(I::Int, J::Int)
    J >= 1 && J <= I

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -27,9 +27,9 @@ base_ring(a::nmod_poly) = base_ring(parent(a))
 
 parent_type(::Type{nmod_poly}) = NmodPolyRing
 
-elem_type(::nmod_poly) = nmod_poly
+elem_type(::Type{nmod_poly}) = nmod_poly
 
-elem_type(::NmodPolyRing) = nmod_poly
+elem_type(::Type{NmodPolyRing}) = nmod_poly
 
 function check_parent(x::nmod_poly, y::nmod_poly)
   parent(x) != parent(y) && error("Parents must coincide")

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -64,7 +64,7 @@ doc"""
 """
 O(R::FlintPadicField, m::Integer) = O(R, fmpz(m))
 
-elem_type(::FlintPadicField) = padic
+elem_type(::Type{FlintPadicField}) = padic
 
 doc"""
     base_ring(a::FlintPadicField)

--- a/src/generic/AbsSeries.jl
+++ b/src/generic/AbsSeries.jl
@@ -28,9 +28,9 @@ function O{T}(a::AbsSeriesElem{T})
    return parent(a)(Array{T}(0), 0, prec)
 end
 
-parent_type{T}(::Type{GenAbsSeries{T}}) = GenAbsSeriesRing{T}
+parent_type{T <: RingElem}(::Type{GenAbsSeries{T}}) = GenAbsSeriesRing{T}
 
-elem_type{T <: RingElem}(::GenAbsSeriesRing{T}) = GenAbsSeries{T}
+elem_type{T <: RingElem}(::Type{GenAbsSeriesRing{T}}) = GenAbsSeries{T}
 
 ###############################################################################
 #

--- a/src/generic/Fraction.jl
+++ b/src/generic/Fraction.jl
@@ -14,7 +14,7 @@ export FractionField, GenFrac, GenFracField, num, den
 
 parent_type{T}(::Type{GenFrac{T}}) = GenFracField{T}
 
-elem_type{T <: RingElem}(::GenFracField{T}) = GenFrac{T}
+elem_type{T <: RingElem}(::Type{GenFracField{T}}) = GenFrac{T}
 
 doc"""
     base_ring{T}(S::FracField{T})

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -61,7 +61,7 @@ function (a::NewIntParent)(b::Int)
    return NewInt(b)
 end
 
-elem_type(::Nemo.NewIntParent) = NewInt
+elem_type(::Type{Nemo.NewIntParent}) = NewInt
  
 parent_type(::Type{Nemo.NewInt}) = NewIntParent
 
@@ -91,7 +91,7 @@ isnegative(a::Nemo.NewInt) = a.d < 0
 
 parent_type{T}(::Type{GenMPoly{T}}) = GenMPolyRing{T}
 
-elem_type{T <: RingElem}(::GenMPolyRing{T}) = GenMPoly{T}
+elem_type{T <: RingElem}(::Type{GenMPolyRing{T}}) = GenMPoly{T}
 
 vars(a::GenMPolyRing) = a.S
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -72,7 +72,7 @@ end
 
 parent_type{T}(::Type{GenMat{T}}) = GenMatSpace{T}
 
-elem_type{T <: RingElem}(::GenMatSpace{T}) = GenMat{T}
+elem_type{T <: RingElem}(::Type{GenMatSpace{T}}) = GenMat{T}
 
 doc"""
     base_ring{T <: RingElem}(S::MatSpace{T})

--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -46,7 +46,7 @@ export PermGroup, perm, parity, elements, cycles
 
 parent_type(::Type{perm}) = PermGroup
 
-elem_type(::PermGroup) = perm
+elem_type(::Type{PermGroup}) = perm
 
 ###############################################################################
 #

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -22,7 +22,7 @@ export GenPoly, GenPolyRing, PolynomialRing, hash, coeff, isgen, lead,
 
 parent_type{T}(::Type{GenPoly{T}}) = GenPolyRing{T}
 
-elem_type{T <: RingElem}(::GenPolyRing{T}) = GenPoly{T}
+elem_type{T <: RingElem}(::Type{GenPolyRing{T}}) = GenPoly{T}
 
 doc"""
     base_ring(R::PolyRing)

--- a/src/generic/RelSeries.jl
+++ b/src/generic/RelSeries.jl
@@ -33,7 +33,7 @@ doc"""
 """
 parent(a::SeriesElem) = a.parent
 
-elem_type{T <: RingElem}(::GenRelSeriesRing{T}) = GenRelSeries{T}
+elem_type{T <: RingElem}(::Type{GenRelSeriesRing{T}}) = GenRelSeries{T}
 
 doc"""
     base_ring(R::SeriesRing)

--- a/src/generic/Residue.jl
+++ b/src/generic/Residue.jl
@@ -14,7 +14,7 @@ export ResidueRing, GenRes, GenResRing, inv, modulus, data
 
 parent_type{T}(::Type{GenRes{T}}) = GenResRing{T}
 
-elem_type{T <: RingElem}(::GenResRing{T}) = GenRes{T}
+elem_type{T <: RingElem}(::Type{GenResRing{T}}) = GenRes{T}
 
 doc"""
     base_ring{T <: RingElem}(S::ResRing{T})

--- a/src/generic/SparsePoly.jl
+++ b/src/generic/SparsePoly.jl
@@ -14,7 +14,7 @@ export GenSparsePoly, GenSparsePolyRing, SparsePolynomialRing
 
 parent_type{T <: RingElem}(::Type{GenSparsePoly{T}}) = GenSparsePolyRing{T}
 
-elem_type{T <: RingElem}(::GenSparsePolyRing{T}) = GenSparsePoly{T}
+elem_type{T <: RingElem}(::Type{GenSparsePolyRing{T}}) = GenSparsePoly{T}
 
 var(a::GenSparsePolyRing) = a.S
 

--- a/test/antic/nf_elem-test.jl
+++ b/test/antic/nf_elem-test.jl
@@ -14,9 +14,13 @@ end
 
 function test_nf_elem_constructors()
    print("nf_elem.constructors...")
- 
+
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")
+
+   @test elem_type(K) == nf_elem
+   @test elem_type(AnticNumberField) == nf_elem
+   @test parent_type(nf_elem) == AnticNumberField
 
    @test isa(K, AnticNumberField)
 

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -2,7 +2,7 @@ RR = ArbField(64)
 CC = AcbField(64)
 
 function test_acb_constructors()
-   print("acb.constructors()...")
+   print("acb.constructors...")
 
    @test isa(CC, AcbField)
    @test isa(CC(2), FieldElem)
@@ -10,11 +10,14 @@ function test_acb_constructors()
    @test elem_type(CC) == acb
    @test base_ring(CC) == Union{} 
 
+   @test elem_type(AcbField) == acb
+   @test parent_type(acb) == AcbField
+
    println("PASS")
 end
 
 function test_acb_printing()
-   print("acb.printing()...")
+   print("acb.printing...")
 
    a = CC(1) + onei(CC)
 
@@ -24,7 +27,7 @@ function test_acb_printing()
 end
 
 function test_acb_basic_ops()
-   print("acb.basic_ops()...")
+   print("acb.basic_ops...")
 
    @test one(CC) == 1
    @test zero(CC) == 0
@@ -54,7 +57,7 @@ function test_acb_basic_ops()
 end
 
 function test_acb_comparison()
-   print("acb.comparison()...")
+   print("acb.comparison...")
 
    exact3 = CC(3)
    exact4 = CC(4)
@@ -92,7 +95,7 @@ end
 
 
 function test_acb_predicates()
-   print("acb.predicates()...")
+   print("acb.predicates...")
 
    @test iszero(CC(0))
    @test !iszero(CC(1))
@@ -121,7 +124,7 @@ function test_acb_predicates()
 end
 
 function test_acb_unary_ops()
-   print("acb.unary_ops()...")
+   print("acb.unary_ops...")
 
    @test -CC(3) == CC(-3)
    @test abs(-CC(3)) == 3
@@ -132,7 +135,7 @@ function test_acb_unary_ops()
 end
 
 function test_acb_binary_ops()
-   print("acb.binary_ops()...")
+   print("acb.binary_ops...")
 
    x = CC(2)
    y = CC(4)
@@ -194,7 +197,7 @@ function test_acb_binary_ops()
 end
 
 function test_acb_misc_ops()
-   print("acb.misc_ops()...")
+   print("acb.misc_ops...")
 
    @test ldexp(CC(3), 2) == 12
    @test ldexp(CC(3), ZZ(2)) == 12
@@ -218,7 +221,7 @@ function test_acb_misc_ops()
 end
 
 function test_acb_unsafe_ops()
-   print("acb.unsafe_ops()...")
+   print("acb.unsafe_ops...")
 
    z = CC(1)
    x = CC(2)
@@ -240,7 +243,7 @@ function test_acb_unsafe_ops()
 end
 
 function test_acb_constants()
-   print("acb.constants()...")
+   print("acb.constants...")
 
    @test overlaps(const_pi(CC), CC("3.141592653589793238462643 +/- 4.03e-25"))
 
@@ -248,7 +251,7 @@ function test_acb_constants()
 end
 
 function test_acb_functions()
-   print("acb.functions()...")
+   print("acb.functions...")
 
    z = CC("0.2", "0.3")
    a = CC("0.3", "0.4")

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -7,6 +7,10 @@ function test_acb_mat_constructors()
    S = MatrixSpace(CC, 3, 3)
    R = MatrixSpace(ZZ, 3, 3)
 
+   @test elem_type(S) == acb_mat
+   @test elem_type(AcbMatSpace) == acb_mat
+   @test parent_type(acb_mat) == AcbMatSpace
+
    @test isa(S, AcbMatSpace)
 
    f = S(fmpz(3))

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -6,6 +6,10 @@ function test_acb_poly_constructors()
 
    R, x = PolynomialRing(CC, "x")
 
+   @test elem_type(R) == acb_poly
+   @test elem_type(AcbPolyRing) == acb_poly
+   @test parent_type(acb_poly) == AcbPolyRing
+
    @test typeof(R) <: AcbPolyRing
 
    @test isa(x, PolyElem)

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -1,19 +1,21 @@
 RR = ArbField(64)
 
 function test_arb_constructors()
-   print("arb.constructors()...")
+   print("arb.constructors...")
 
    @test isa(RR, ArbField)
    @test isa(RR(2), FieldElem)
 
    @test elem_type(RR) == arb
+   @test elem_type(ArbField) == arb
+   @test parent_type(arb) == ArbField
    @test base_ring(RR) == Union{} 
 
    println("PASS")
 end
 
 function test_arb_printing()
-   print("arb.printing()...")
+   print("arb.printing...")
 
    a = RR(2)
 
@@ -23,7 +25,7 @@ function test_arb_printing()
 end
 
 function test_arb_basic_ops()
-   print("arb.basic_ops()...")
+   print("arb.basic_ops...")
 
    @test one(RR) == 1
    @test zero(RR) == 0
@@ -49,7 +51,7 @@ function test_arb_basic_ops()
 end
 
 function test_arb_comparison()
-   print("arb.comparison()...")
+   print("arb.comparison...")
 
    exact3 = RR(3)
    exact4 = RR(4)
@@ -114,7 +116,7 @@ function test_arb_comparison()
 end
 
 function test_arb_adhoc_comparison()
-   print("arb.adhoc_comparison()...")
+   print("arb.adhoc_comparison...")
 
    a = RR(3)
 
@@ -212,7 +214,7 @@ function test_arb_adhoc_comparison()
 end
 
 function test_arb_predicates()
-   print("arb.predicates()...")
+   print("arb.predicates...")
 
    @test iszero(RR(0))
    @test !iszero(RR(1))
@@ -251,7 +253,7 @@ function test_arb_predicates()
 end
 
 function test_arb_parts()
-   print("arb.parts()...")
+   print("arb.parts...")
 
    @test midpoint(RR(3)) == 3
    @test radius(RR(3)) == 0
@@ -262,7 +264,7 @@ function test_arb_parts()
 end
 
 function test_arb_unary_ops()
-   print("arb.unary_ops()...")
+   print("arb.unary_ops...")
 
    @test -RR(3) == RR(-3)
    @test abs(-RR(3)) == 3
@@ -273,7 +275,7 @@ function test_arb_unary_ops()
 end
 
 function test_arb_binary_ops()
-   print("arb.binary_ops()...")
+   print("arb.binary_ops...")
 
    x = RR(2)
    y = RR(4)
@@ -320,7 +322,7 @@ function test_arb_binary_ops()
 end
 
 function test_arb_misc_ops()
-   print("arb.misc_ops()...")
+   print("arb.misc_ops...")
 
    @test ldexp(RR(3), 2) == 12
    @test ldexp(RR(3), ZZ(2)) == 12
@@ -344,7 +346,7 @@ function test_arb_misc_ops()
 end
 
 function test_arb_unsafe_ops()
-   print("arb.unsafe_ops()...")
+   print("arb.unsafe_ops...")
 
    z = RR(1)
    x = RR(2)
@@ -366,7 +368,7 @@ function test_arb_unsafe_ops()
 end
 
 function test_arb_constants()
-   print("arb.constants()...")
+   print("arb.constants...")
 
    @test overlaps(const_pi(RR), RR("3.141592653589793238462643 +/- 4.03e-25"))
    @test overlaps(const_e(RR), RR("2.718281828459045235360287 +/- 4.96e-25"))
@@ -381,7 +383,7 @@ function test_arb_constants()
 end
 
 function test_arb_functions()
-   print("arb.functions()...")
+   print("arb.functions...")
 
    @test floor(RR(2.5)) == 2
    @test ceil(RR(2.5)) == 3
@@ -521,7 +523,7 @@ function test_arb_functions()
 end
 
 function test_fmpq_arb_special_functions()
-   print("fmpq.arb_special_functions()...")
+   print("fmpq.arb_special_functions...")
 
    @test bernoulli(10) == fmpz(5)//66
 

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -6,6 +6,10 @@ function test_arb_mat_constructors()
    S = MatrixSpace(RR, 3, 3)
    R = MatrixSpace(ZZ, 3, 3)
 
+   @test elem_type(S) == arb_mat
+   @test elem_type(ArbMatSpace) == arb_mat
+   @test parent_type(arb_mat) == ArbMatSpace
+
    @test isa(S, ArbMatSpace)
 
    f = S(fmpz(3))

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -5,6 +5,10 @@ function test_arb_poly_constructors()
 
    R, x = PolynomialRing(RR, "x")
 
+   @test elem_type(R) == arb_poly
+   @test elem_type(ArbPolyRing) == arb_poly
+   @test parent_type(arb_poly) == ArbPolyRing
+
    @test typeof(R) <: ArbPolyRing
 
    @test isa(x, PolyElem)

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -1,7 +1,11 @@
 function test_fmpq_constructors()
-   print("fmpq.constructors()...")
+   print("fmpq.constructors...")
 
    R = FractionField(ZZ)
+
+   @test elem_type(R) == fmpq
+   @test elem_type(FlintRationalField) == fmpq
+   @test parent_type(fmpq) == FlintRationalField
 
    @test isa(R, FlintRationalField)
 
@@ -41,7 +45,7 @@ function test_fmpq_constructors()
 end
 
 function test_fmpq_printing()
-   print("fmpq.constructors()...")
+   print("fmpq.constructors...")
 
    a = FlintQQ(1, 2)
 
@@ -51,7 +55,7 @@ function test_fmpq_printing()
 end
 
 function test_fmpq_conversions()
-   print("fmpq.conversions()...")
+   print("fmpq.conversions...")
 
    @test Rational(fmpz(12)) == 12
 
@@ -61,7 +65,7 @@ function test_fmpq_conversions()
 end
 
 function test_fmpq_manipulation()
-   print("fmpq.manipulation()...")
+   print("fmpq.manipulation...")
 
    R = FractionField(ZZ)
 
@@ -92,7 +96,7 @@ function test_fmpq_manipulation()
 end
 
 function test_fmpq_unary_ops()
-   print("fmpq.unary_ops()...")
+   print("fmpq.unary_ops...")
 
    a = fmpq(-2, 3)
 
@@ -102,7 +106,7 @@ function test_fmpq_unary_ops()
 end
 
 function test_fmpq_binary_ops()
-   print("fmpq.binary_ops()...")
+   print("fmpq.binary_ops...")
 
    a = fmpq(-2, 3)
    b = fmpz(5)//7
@@ -117,7 +121,7 @@ function test_fmpq_binary_ops()
 end
 
 function test_fmpq_adhoc_binary()
-   print("fmpq.adhoc_binary()...")
+   print("fmpq.adhoc_binary...")
 
    a = fmpq(-2, 3)
    
@@ -177,7 +181,7 @@ function test_fmpq_adhoc_binary()
 end
 
 function test_fmpq_comparison()
-   print("fmpq.comparison()...")
+   print("fmpq.comparison...")
 
    a = fmpq(-2, 3)
    b = fmpz(1)//2
@@ -198,7 +202,7 @@ function test_fmpq_comparison()
 end
 
 function test_fmpq_adhoc_comparison()
-   print("fmpq.adhoc_comparison()...")
+   print("fmpq.adhoc_comparison...")
 
    a = -fmpz(2)//3
    
@@ -260,7 +264,7 @@ function test_fmpq_adhoc_comparison()
 end
 
 function test_fmpq_shifting()
-   print("fmpq.shifting()...")
+   print("fmpq.shifting...")
 
    a = -fmpz(2)//3
    b = fmpq(1, 2)
@@ -273,7 +277,7 @@ function test_fmpq_shifting()
 end
 
 function test_fmpq_powering()
-   print("fmpq.powering()...")
+   print("fmpq.powering...")
 
    a = -fmpz(2)//3
    
@@ -283,7 +287,7 @@ function test_fmpq_powering()
 end
 
 function test_fmpq_inversion()
-   print("fmpq.inversion()...")
+   print("fmpq.inversion...")
 
    a = -fmpz(2)//3
    
@@ -293,7 +297,7 @@ function test_fmpq_inversion()
 end
 
 function test_fmpq_exact_division()
-   print("fmpq.exact_division()...")
+   print("fmpq.exact_division...")
 
    a = -fmpz(2)//3
    b = fmpz(1)//2
@@ -304,7 +308,7 @@ function test_fmpq_exact_division()
 end
 
 function test_fmpq_adhoc_exact_division()
-   print("fmpq.adhoc_exact_division()...")
+   print("fmpq.adhoc_exact_division...")
 
    a = -fmpz(2)//3
 
@@ -328,7 +332,7 @@ function test_fmpq_adhoc_exact_division()
 end
 
 function test_fmpq_modular_arithmetic()
-   print("fmpq.modular_arithmetic()...")
+   print("fmpq.modular_arithmetic...")
 
    a = -fmpz(2)//3
    b = fmpz(1)//2
@@ -341,7 +345,7 @@ function test_fmpq_modular_arithmetic()
 end
 
 function test_fmpq_gcd()
-   print("fmpq.gcd()...")
+   print("fmpq.gcd...")
 
    a = -fmpz(2)//3
    b = fmpz(1)//2
@@ -352,7 +356,7 @@ function test_fmpq_gcd()
 end
 
 function test_fmpq_rational_reconstruction()
-   print("fmpq.rational_reconstruction()...")
+   print("fmpq.rational_reconstruction...")
 
    @test reconstruct(7, 13) == fmpz(1)//2
    
@@ -366,7 +370,7 @@ function test_fmpq_rational_reconstruction()
 end
 
 function test_fmpq_rational_enumeration()
-   print("fmpq.rational_enumeration()...")
+   print("fmpq.rational_enumeration...")
 
    @test next_minimal(fmpz(2)//3) == fmpz(3)//2
 
@@ -380,7 +384,7 @@ function test_fmpq_rational_enumeration()
 end
 
 function test_fmpq_special_functions()
-   print("fmpq.special_functions()...")
+   print("fmpq.special_functions...")
 
    @test harmonic(12) == fmpz(86021)//27720
    
@@ -396,7 +400,7 @@ function test_fmpq_special_functions()
 end
 
 function test_fmpq_adhoc_remove_valuation()
-   print("fmpq.adhoc_remove_valuation()...")
+   print("fmpq.adhoc_remove_valuation...")
 
    a = fmpq(2, 3)
 

--- a/test/flint/fmpq_abs_series-test.jl
+++ b/test/flint/fmpq_abs_series-test.jl
@@ -3,6 +3,10 @@ function test_fmpq_abs_series_constructors()
 
    R, x = PowerSeriesRing(QQ, 30, "x", model=:capped_absolute)
 
+   @test elem_type(R) == fmpq_abs_series
+   @test elem_type(FmpqAbsSeriesRing) == fmpq_abs_series
+   @test parent_type(fmpq_abs_series) == FmpqAbsSeriesRing
+
    @test isa(R, FmpqAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -3,6 +3,10 @@ function test_fmpq_mat_constructors()
  
    S = MatrixSpace(QQ, 3, 3)
 
+   @test elem_type(S) == fmpq_mat
+   @test elem_type(FmpqMatSpace) == fmpq_mat
+   @test parent_type(fmpq_mat) == FmpqMatSpace
+
    @test isa(S, FmpqMatSpace)
 
    f = S(fmpq(3))

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -2,6 +2,10 @@ function test_fmpq_poly_constructors()
    print("fmpq_poly.constructors...")
  
    S, y = PolynomialRing(QQ, "y")
+ 
+   @test elem_type(S) == fmpq_poly
+   @test elem_type(FmpqPolyRing) == fmpq_poly
+   @test parent_type(fmpq_poly) == FmpqPolyRing
 
    @test isa(S, FmpqPolyRing)
 
@@ -568,7 +572,7 @@ function test_fmpq_poly_Polynomials()
 end
 
 function test_fmpq_poly_remove_valuation()
-   print("fmpq_poly.remove_valuation()...")
+   print("fmpq_poly.remove_valuation...")
 
    S, y = PolynomialRing(FlintQQ, "y")
 

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -3,6 +3,10 @@ function test_fmpq_rel_series_constructors()
 
    R, x = PowerSeriesRing(QQ, 30, "x")
 
+   @test elem_type(R) == fmpq_rel_series
+   @test elem_type(FmpqRelSeriesRing) == fmpq_rel_series
+   @test parent_type(fmpq_rel_series) == FmpqRelSeriesRing
+
    @test isa(R, FmpqRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -5,6 +5,10 @@ function test_fmpz_abstract_types()
 
    @test FlintIntegerRing <: Nemo.Ring
 
+   @test elem_type(FlintIntegerRing()) == fmpz
+   @test elem_type(FlintIntegerRing) == fmpz
+   @test parent_type(fmpz) == FlintIntegerRing
+
    println("PASS")
 end
 

--- a/test/flint/fmpz_abs_series-test.jl
+++ b/test/flint/fmpz_abs_series-test.jl
@@ -3,6 +3,10 @@ function test_fmpz_abs_series_constructors()
 
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
 
+   @test elem_type(R) == fmpz_abs_series
+   @test elem_type(FmpzAbsSeriesRing) == fmpz_abs_series
+   @test parent_type(fmpz_abs_series) == FmpzAbsSeriesRing
+
    @test isa(R, FmpzAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -3,6 +3,10 @@ function test_fmpz_mat_constructors()
  
    S = MatrixSpace(ZZ, 3, 3)
 
+   @test elem_type(S) == fmpz_mat
+   @test elem_type(FmpzMatSpace) == fmpz_mat
+   @test parent_type(fmpz_mat) == FmpzMatSpace
+
    @test isa(S, FmpzMatSpace)
 
    f = S(fmpz(3))

--- a/test/flint/fmpz_mod_abs_series-test.jl
+++ b/test/flint/fmpz_mod_abs_series-test.jl
@@ -4,6 +4,10 @@ function test_fmpz_mod_abs_series_constructors()
    S = ResidueRing(ZZ, 123456789012345678949)
    R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
 
+   @test elem_type(R) == fmpz_mod_abs_series
+   @test elem_type(FmpzModAbsSeriesRing) == fmpz_mod_abs_series
+   @test parent_type(fmpz_mod_abs_series) == FmpzModAbsSeriesRing
+
    @test isa(R, FmpzModAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -4,6 +4,10 @@ function test_fmpz_mod_poly_constructors()
    R = ResidueRing(ZZ, 123456789012345678949)
    S, x = PolynomialRing(R, "x")
 
+   @test elem_type(S) == fmpz_mod_poly
+   @test elem_type(FmpzModPolyRing) == fmpz_mod_poly
+   @test parent_type(fmpz_mod_poly) == FmpzModPolyRing
+
    @test typeof(S) <: FmpzModPolyRing
 
    @test isa(x, PolyElem)
@@ -541,7 +545,7 @@ function test_fmpz_mod_poly_factor()
 end
 
 function test_fmpz_mod_poly_remove_valuation()
-   print("fmpz_mod_poly.remove_valuation()...")
+   print("fmpz_mod_poly.remove_valuation...")
 
    R = ResidueRing(ZZ, 123456789012345678949)
    S, y = PolynomialRing(R, "y")

--- a/test/flint/fmpz_mod_rel_series-test.jl
+++ b/test/flint/fmpz_mod_rel_series-test.jl
@@ -4,6 +4,10 @@ function test_fmpz_mod_rel_series_constructors()
    R = ResidueRing(ZZ, 123456789012345678949)
    S, x = PowerSeriesRing(R, 30, "x")
 
+   @test elem_type(S) == fmpz_mod_rel_series
+   @test elem_type(FmpzModRelSeriesRing) == fmpz_mod_rel_series
+   @test parent_type(fmpz_mod_rel_series) == FmpzModRelSeriesRing
+
    @test isa(S, FmpzModRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -3,6 +3,10 @@ function test_fmpz_poly_constructors()
  
    R, x = PolynomialRing(ZZ, "x")
 
+   @test elem_type(R) == fmpz_poly
+   @test elem_type(FmpzPolyRing) == fmpz_poly
+   @test parent_type(fmpz_poly) == FmpzPolyRing
+
    @test typeof(R) <: FmpzPolyRing
 
    @test isa(x, PolyElem)

--- a/test/flint/fmpz_rel_series-test.jl
+++ b/test/flint/fmpz_rel_series-test.jl
@@ -3,6 +3,10 @@ function test_fmpz_rel_series_constructors()
 
    R, x = PowerSeriesRing(ZZ, 30, "x")
 
+   @test elem_type(R) == fmpz_rel_series
+   @test elem_type(FmpzRelSeriesRing) == fmpz_rel_series
+   @test parent_type(fmpz_rel_series) == FmpzRelSeriesRing
+
    @test isa(R, FmpzRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -1,7 +1,11 @@
 function test_fq_constructors()
-   print("fq.constructors()...")
+   print("fq.constructors...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
+
+   @test elem_type(R) == fq
+   @test elem_type(FqFiniteField) == fq
+   @test parent_type(fq) == FqFiniteField
    
    Sy, y = PolynomialRing(ResidueRing(FlintZZ, 36893488147419103363), "y")
 
@@ -32,7 +36,7 @@ function test_fq_constructors()
 end
 
 function test_fq_printing()
-   print("fq.printing()...")
+   print("fq.printing...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -44,7 +48,7 @@ function test_fq_printing()
 end
 
 function test_fq_manipulation()
-   print("fq.manipulation()...")
+   print("fq.manipulation...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -70,7 +74,7 @@ function test_fq_manipulation()
 end
 
 function test_fq_unary_ops()
-   print("fq.unary_ops()...")
+   print("fq.unary_ops...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -82,7 +86,7 @@ function test_fq_unary_ops()
 end
 
 function test_fq_binary_ops()
-   print("fq.binary_ops()...")
+   print("fq.binary_ops...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -99,7 +103,7 @@ function test_fq_binary_ops()
 end
 
 function test_fq_adhoc_binary()
-   print("fq.adhoc_binary()...")
+   print("fq.adhoc_binary...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -121,7 +125,7 @@ function test_fq_adhoc_binary()
 end
 
 function test_fq_powering()
-   print("fq.powering()...")
+   print("fq.powering...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -135,7 +139,7 @@ function test_fq_powering()
 end
 
 function test_fq_comparison()
-   print("fq.comparison()...")
+   print("fq.comparison...")
   
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -150,7 +154,7 @@ function test_fq_comparison()
 end
 
 function test_fq_inversion()
-   print("fq.inversion()...")
+   print("fq.inversion...")
   
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -166,7 +170,7 @@ function test_fq_inversion()
 end
 
 function test_fq_exact_division()
-   print("fq.exact_division()...")
+   print("fq.exact_division...")
   
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -181,7 +185,7 @@ function test_fq_exact_division()
 end
 
 function test_fq_gcd()
-   print("fq.gcd()...")
+   print("fq.gcd...")
 
    R, x = FiniteField(fmpz(7), 5, "x")
 
@@ -196,7 +200,7 @@ function test_fq_gcd()
 end
 
 function test_fq_special_functions()
-   print("fq.special_functions()...")
+   print("fq.special_functions...")
   
    R, x = FiniteField(fmpz(7), 5, "x")
 

--- a/test/flint/fq_abs_series-test.jl
+++ b/test/flint/fq_abs_series-test.jl
@@ -4,6 +4,10 @@ function test_fq_abs_series_constructors()
    S, t = FiniteField(fmpz(23), 5, "t")
    R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
 
+   @test elem_type(R) == fq_abs_series
+   @test elem_type(FqAbsSeriesRing) == fq_abs_series
+   @test parent_type(fq_abs_series) == FqAbsSeriesRing
+
    @test isa(R, FqAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -1,7 +1,11 @@
 function test_fq_nmod_constructors()
-   print("fq_nmod.constructors()...")
+   print("fq_nmod.constructors...")
 
    R, x = FiniteField(7, 5, "x")
+
+   @test elem_type(R) == fq_nmod
+   @test elem_type(FqNmodFiniteField) == fq_nmod
+   @test parent_type(fq_nmod) == FqNmodFiniteField
 
    Sy, y = PolynomialRing(ResidueRing(FlintZZ, 3), "y")
 
@@ -32,7 +36,7 @@ function test_fq_nmod_constructors()
 end
 
 function test_fq_nmod_printing()
-   print("fq_nmod.printing()...")
+   print("fq_nmod.printing...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -44,7 +48,7 @@ function test_fq_nmod_printing()
 end
 
 function test_fq_nmod_manipulation()
-   print("fq_nmod.manipulation()...")
+   print("fq_nmod.manipulation...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -70,7 +74,7 @@ function test_fq_nmod_manipulation()
 end
 
 function test_fq_nmod_unary_ops()
-   print("fq_nmod.unary_ops()...")
+   print("fq_nmod.unary_ops...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -82,7 +86,7 @@ function test_fq_nmod_unary_ops()
 end
 
 function test_fq_nmod_binary_ops()
-   print("fq_nmod.binary_ops()...")
+   print("fq_nmod.binary_ops...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -99,7 +103,7 @@ function test_fq_nmod_binary_ops()
 end
 
 function test_fq_nmod_adhoc_binary()
-   print("fq_nmod.adhoc_binary()...")
+   print("fq_nmod.adhoc_binary...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -121,7 +125,7 @@ function test_fq_nmod_adhoc_binary()
 end
 
 function test_fq_nmod_powering()
-   print("fq_nmod.powering()...")
+   print("fq_nmod.powering...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -135,7 +139,7 @@ function test_fq_nmod_powering()
 end
 
 function test_fq_nmod_comparison()
-   print("fq_nmod.comparison()...")
+   print("fq_nmod.comparison...")
   
    R, x = FiniteField(7, 5, "x")
 
@@ -150,7 +154,7 @@ function test_fq_nmod_comparison()
 end
 
 function test_fq_nmod_inversion()
-   print("fq_nmod.inversion()...")
+   print("fq_nmod.inversion...")
   
    R, x = FiniteField(7, 5, "x")
 
@@ -166,7 +170,7 @@ function test_fq_nmod_inversion()
 end
 
 function test_fq_nmod_exact_division()
-   print("fq_nmod.exact_division()...")
+   print("fq_nmod.exact_division...")
   
    R, x = FiniteField(7, 5, "x")
 
@@ -181,7 +185,7 @@ function test_fq_nmod_exact_division()
 end
 
 function test_fq_nmod_gcd()
-   print("fq_nmod.gcd()...")
+   print("fq_nmod.gcd...")
 
    R, x = FiniteField(7, 5, "x")
 
@@ -196,7 +200,7 @@ function test_fq_nmod_gcd()
 end
 
 function test_fq_nmod_special_functions()
-   print("fq_nmod.special_functions()...")
+   print("fq_nmod.special_functions...")
   
    R, x = FiniteField(7, 5, "x")
 

--- a/test/flint/fq_nmod_abs_series-test.jl
+++ b/test/flint/fq_nmod_abs_series-test.jl
@@ -4,6 +4,10 @@ function test_fq_nmod_abs_series_constructors()
    S, t = FiniteField(23, 5, "t")
    R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
 
+   @test elem_type(R) == fq_nmod_abs_series
+   @test elem_type(FqNmodAbsSeriesRing) == fq_nmod_abs_series
+   @test parent_type(fq_nmod_abs_series) == FqNmodAbsSeriesRing
+
    @test isa(R, FqNmodAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -4,6 +4,10 @@ function test_fq_nmod_poly_constructors()
    R, x = FiniteField(23, 5, "x")
    S, y = PolynomialRing(R, "y")
 
+   @test elem_type(S) == fq_nmod_poly
+   @test elem_type(FqNmodPolyRing) == fq_nmod_poly
+   @test parent_type(fq_nmod_poly) == FqNmodPolyRing
+
    @test typeof(S) <: FqNmodPolyRing
 
    @test isa(y, PolyElem)

--- a/test/flint/fq_nmod_rel_series-test.jl
+++ b/test/flint/fq_nmod_rel_series-test.jl
@@ -4,6 +4,10 @@ function test_fq_nmod_rel_series_constructors()
    R, t = FiniteField(23, 5, "t")
    S, x = PowerSeriesRing(R, 30, "x")
 
+   @test elem_type(S) == fq_nmod_rel_series
+   @test elem_type(FqNmodRelSeriesRing) == fq_nmod_rel_series
+   @test parent_type(fq_nmod_rel_series) == FqNmodRelSeriesRing
+
    @test isa(S, FqNmodRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -4,6 +4,10 @@ function test_fq_poly_constructors()
    R, x = FiniteField(fmpz(23), 5, "x")
    S, y = PolynomialRing(R, "y")
 
+   @test elem_type(S) == fq_poly
+   @test elem_type(FqPolyRing) == fq_poly
+   @test parent_type(fq_poly) == FqPolyRing
+
    @test typeof(S) <: FqPolyRing
 
    @test isa(y, PolyElem)
@@ -485,7 +489,7 @@ function test_fq_poly_special()
 end
 
 function test_fq_poly_inflation_deflation()
-   print("fq_poly.inflation_deflation()...")
+   print("fq_poly.inflation_deflation...")
 
    R, x = FiniteField(fmpz(23), 5, "x")
    S, y = PolynomialRing(R, "y")
@@ -530,7 +534,7 @@ function test_fq_poly_issquarefree()
 end
 
 function test_fq_poly_factor()
-   print("fq_poly.factor()...")
+   print("fq_poly.factor...")
 
    R, x = FiniteField(fmpz(23), 5, "x")
    S, y = PolynomialRing(R, "y")
@@ -564,7 +568,7 @@ function test_fq_poly_factor()
 end
 
 function test_fq_poly_remove_valuation()
-   print("fq_poly.remove_valuation()...")
+   print("fq_poly.remove_valuation...")
 
    R, x = FiniteField(23, 5, "x")
    S, y = PolynomialRing(R, "y")

--- a/test/flint/fq_rel_series-test.jl
+++ b/test/flint/fq_rel_series-test.jl
@@ -4,6 +4,10 @@ function test_fq_rel_series_constructors()
    R, t = FiniteField(fmpz(23), 5, "t")
    S, x = PowerSeriesRing(R, 30, "x")
 
+   @test elem_type(S) == fq_rel_series
+   @test elem_type(FqRelSeriesRing) == fq_rel_series
+   @test parent_type(fq_rel_series) == FqRelSeriesRing
+
    @test isa(S, FqRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -18,6 +18,10 @@ function test_nmod_mat_constructors()
   
   R = NmodMatSpace(Z2, 2, 2)
 
+  @test elem_type(R) == nmod_mat
+  @test elem_type(NmodMatSpace) == nmod_mat
+  @test parent_type(nmod_mat) == NmodMatSpace
+
   @test isa(R, NmodMatSpace)
 
   @test base_ring(R) == Z2

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -4,6 +4,10 @@ function test_nmod_poly_constructors()
   R = ResidueRing(ZZ, 17)
   Rx, x = PolynomialRing(R, "x")
 
+  @test elem_type(Rx) == nmod_poly
+  @test elem_type(NmodPolyRing) == nmod_poly
+  @test parent_type(nmod_poly) == NmodPolyRing
+
   S = ResidueRing(ZZ, 19)
   Sy, y = PolynomialRing(R, "y")
 

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -1,7 +1,11 @@
 function test_padic_constructors()
-   print("padic.constructors()...")  
+   print("padic.constructors...")  
 
    R = PadicField(7, 30)
+
+   @test elem_type(R) == padic
+   @test elem_type(FlintPadicField) == padic
+   @test parent_type(padic) == FlintPadicField
    
    @test isa(R, FlintPadicField)
 
@@ -27,7 +31,7 @@ function test_padic_constructors()
 end
 
 function test_padic_printing()
-   print("padic.constructors()...")  
+   print("padic.constructors...")  
 
    R = PadicField(7, 30)
    
@@ -39,7 +43,7 @@ function test_padic_printing()
 end
 
 function test_padic_manipulation()
-   print("padic.manipulation()...")  
+   print("padic.manipulation...")  
 
    R = PadicField(7, 30)
 
@@ -65,7 +69,7 @@ function test_padic_manipulation()
 end
 
 function test_padic_unary_ops()
-   print("padic.unary_ops()...")  
+   print("padic.unary_ops...")  
 
    R = PadicField(7, 30)
 
@@ -80,7 +84,7 @@ function test_padic_unary_ops()
 end
 
 function test_padic_binary_ops()
-   print("padic.binary_ops()...")  
+   print("padic.binary_ops...")  
 
    R = PadicField(7, 30)
 
@@ -103,7 +107,7 @@ function test_padic_binary_ops()
 end
 
 function test_padic_adhoc_binary()
-   print("padic.adhoc_binary()...")  
+   print("padic.adhoc_binary...")  
 
    R = PadicField(7, 30)
 
@@ -136,7 +140,7 @@ function test_padic_adhoc_binary()
 end
 
 function test_padic_comparison()
-   print("padic.comparison()...")  
+   print("padic.comparison...")  
 
    R = PadicField(7, 30)
 
@@ -157,7 +161,7 @@ function test_padic_comparison()
 end
 
 function test_padic_adhoc_comparison()
-   print("padic.adhoc_comparison()...")  
+   print("padic.adhoc_comparison...")  
 
    R = PadicField(7, 30)
 
@@ -179,7 +183,7 @@ function test_padic_adhoc_comparison()
 end
 
 function test_padic_powering()
-   print("padic.powering()...")  
+   print("padic.powering...")  
 
    R = PadicField(7, 30)
 
@@ -197,7 +201,7 @@ function test_padic_powering()
 end
 
 function test_padic_inversion()
-   print("padic.inversion()...")  
+   print("padic.inversion...")  
 
    R = PadicField(7, 30)
 
@@ -220,7 +224,7 @@ function test_padic_inversion()
 end
 
 function test_padic_exact_division()
-   print("padic.exact_division()...")  
+   print("padic.exact_division...")  
 
    R = PadicField(7, 30)
 
@@ -241,7 +245,7 @@ function test_padic_exact_division()
 end
 
 function test_padic_adhoc_exact_division()
-   print("padic.adhoc_exact_division()...")  
+   print("padic.adhoc_exact_division...")  
 
    R = PadicField(7, 30)
 
@@ -266,7 +270,7 @@ function test_padic_adhoc_exact_division()
 end
 
 function test_padic_divides()
-   print("padic.divides()...")  
+   print("padic.divides...")  
 
    R = PadicField(7, 30)
 
@@ -282,7 +286,7 @@ function test_padic_divides()
 end
 
 function test_padic_gcd()
-   print("padic.adhoc_gcd()...")  
+   print("padic.adhoc_gcd...")  
 
    R = PadicField(7, 30)
 
@@ -297,7 +301,7 @@ function test_padic_gcd()
 end
 
 function test_padic_square_root()
-   print("padic.square_root()...")  
+   print("padic.square_root...")  
 
    R = PadicField(7, 30)
 
@@ -317,7 +321,7 @@ function test_padic_square_root()
 end
 
 function test_padic_special_functions()
-   print("padic.special_functions()...")  
+   print("padic.special_functions...")  
 
    R = PadicField(7, 30)
 

--- a/test/generic/AbsSeries-test.jl
+++ b/test/generic/AbsSeries-test.jl
@@ -4,6 +4,10 @@ function test_abs_series_constructors()
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x", model=:capped_absolute)
 
+   @test elem_type(S) == GenAbsSeries{elem_type(R)}
+   @test elem_type(GenAbsSeriesRing{elem_type(R)}) == GenAbsSeries{elem_type(R)}
+   @test parent_type(GenAbsSeries{elem_type(R)}) == GenAbsSeriesRing{elem_type(R)}
+
    @test isa(S, GenAbsSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -4,6 +4,10 @@ function test_gen_frac_constructors()
    S, x = PolynomialRing(ZZ, "x")
    T = FractionField(S)
 
+   @test elem_type(T) == GenFrac{elem_type(S)}
+   @test elem_type(GenFracField{elem_type(S)}) == GenFrac{elem_type(S)}
+   @test parent_type(GenFrac{elem_type(S)}) == GenFracField{elem_type(S)}
+
    @test isa(T, GenFracField)
 
    @test isa(T(3), GenFrac)

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -308,6 +308,10 @@ function test_gen_mat_constructors()
    R, t = PolynomialRing(QQ, "t")
    S = MatrixSpace(R, 3, 3)
 
+   @test elem_type(S) == GenMat{elem_type(R)}
+   @test elem_type(GenMatSpace{elem_type(R)}) == GenMat{elem_type(R)}
+   @test parent_type(GenMat{elem_type(R)}) == GenMatSpace{elem_type(R)}
+
    @test typeof(S) <: GenMatSpace
 
    f = S(t^2 + 1)

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -4,6 +4,10 @@ function test_gen_poly_constructors()
    R, x = ZZ["x"]
    S, y = R["y"]
 
+   @test elem_type(S) == GenPoly{elem_type(R)}
+   @test elem_type(GenPolyRing{elem_type(R)}) == GenPoly{elem_type(R)}
+   @test parent_type(GenPoly{elem_type(R)}) == GenPolyRing{elem_type(R)}
+
    @test typeof(R) <: Nemo.Ring
    @test typeof(S) <: GenPolyRing
 

--- a/test/generic/RelSeries-test.jl
+++ b/test/generic/RelSeries-test.jl
@@ -4,6 +4,10 @@ function test_rel_series_constructors()
    R, t = PolynomialRing(QQ, "t")
    S, x = PowerSeriesRing(R, 30, "x")
 
+   @test elem_type(S) == GenRelSeries{elem_type(R)}
+   @test elem_type(GenRelSeriesRing{elem_type(R)}) == GenRelSeries{elem_type(R)}
+   @test parent_type(GenRelSeries{elem_type(R)}) == GenRelSeriesRing{elem_type(R)}
+
    @test isa(S, GenRelSeriesRing)
 
    a = x^3 + 2x + 1

--- a/test/generic/Residue-test.jl
+++ b/test/generic/Residue-test.jl
@@ -1,7 +1,13 @@
 function test_gen_res_constructors()
    print("GenRes.constructors...")
  
-   R = ResidueRing(ZZ, 16453889)
+   B = FlintZZ
+
+   R = ResidueRing(B, 16453889)
+
+   @test elem_type(R) == GenRes{elem_type(B)}
+   @test elem_type(GenResRing{elem_type(B)}) == GenRes{elem_type(B)}
+   @test parent_type(GenRes{elem_type(B)}) == GenResRing{elem_type(B)}
 
    @test isa(R, GenResRing)
 

--- a/test/generic/perm-test.jl
+++ b/test/generic/perm-test.jl
@@ -13,6 +13,10 @@ function test_perm_constructors()
 
    R = PermutationGroup(10)
 
+   @test elem_type(R) == perm
+   @test elem_type(PermGroup) == perm
+   @test parent_type(perm) == PermGroup
+
    a = R()
    b = R([2, 3, 5, 4, 6, 7, 1, 9, 10, 8])
    c = R(a)


### PR DESCRIPTION
I changed `elem_type` to work on the type of the ring and not the ring itself. The old behavior is recovered by defining
```
elem_type{T <: Group}(::T) = elem_type(T)
```
in Groups.jl. Now it holds that
```
elem_type(parent_type(T)) == T
parent_type(elem_type(T)) == T
```
which is useful.

I have also added tests for `elem_type` and `parent_type` and added some missing methods (for arb types).