### PR TITLE
Big switcheroo for generic matrices

### DIFF
--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -828,6 +828,113 @@ function transpose(x::MatElem)
    return par(x.entries)
 end
 
+doc"""
+    transpose!(x::MatElem)
+> Transpose the given matrix in-place.
+"""
+function transpose!(x::MatElem)
+   _transpose!(x.entries)
+   if rows(x) != cols(x)
+      x.entries = reshape(x.entries, rows(x), cols(x))
+      x.parent = MatrixSpace(base_ring(x), cols(x), rows(x))
+   end
+   return nothing
+end
+
+doc"""
+    _transpose!{T}(A::Array{T,2})
+> Transpose a given $m\times n$ array $A$ by rearranging it's elements in-place.
+> An $m\cdot n$ BitArray is used to determine wether an element has already been
+> moved. Note that $A$ will stay an $m\times n$ array. Use A = reshape(A, n, m)
+> to obtain the right dimensions.
+"""
+#=
+   We use an algorithm due to S. Laflin and M. A. Brebner.
+   "In-situ transposition of a rectangular matrix."
+=#
+function _transpose!{T}(A::Array{T,2})
+   m = size(A,1)
+   n = size(A,2)
+
+   if m<2 || n<2
+      return nothing
+   end
+
+   # If A is square, we just swap A[i,j] and A[j,i]
+   if m == n
+      for i = 1:m
+         for j = 1:i-1
+            t = A[i,j]
+            A[i,j] = A[j,i]
+            A[j,i] = t
+         end
+      end
+      return nothing
+   end
+
+   ncount = 2 # number of elements which are in the right position
+   m1 = m - 1
+   n1 = n - 1
+   m2 = m - 2
+   mn = m*n
+   moved = falses(mn)
+
+   # Check for "single points" which don't need to be moved.
+   for ia = 1:m2
+      ib, r = divrem(ia*n1, m1)
+      r != 0 ? continue : nothing
+      ncount += 1
+      i = ia*n + ib
+      @inbounds moved[i] = true
+   end
+
+   k = mn - 1
+   kmi = k - 1
+   max = mn
+   for i = 1:mn
+      # At least one loop must be rearranged.
+      if i != 1
+         # search for the next loop
+         kmi = k - i
+         max = kmi + 1
+         @inbounds moved[i] ? continue : nothing
+         i1 = i
+         i2 = m*i1 - k*div(i1, n)
+         i1 == i2 ? continue : nothing
+         while i2 > i && i2 < max
+            i1 = i2
+            i2 = m*i1 - k*div(i1, n)
+         end
+         i2 != i ? continue : nothing
+      end
+
+      # rearrange the elements
+      i1 = i
+      t = A[i1 + 1]
+      while true
+         i2 = m*i1 - k*div(i1, n)
+         @inbounds moved[i1] = true
+         ncount += 1
+         if i2 == i || i2 >= kmi
+            if max == kmi || i2 == i
+               A[i1 + 1] = t
+               if ncount >= mn
+                  return nothing
+               end
+               i2 == max || max == kmi ? break : nothing
+               max = kmi
+               i1 = max
+               t = A[i1 + 1]
+               continue
+            end
+            max = kmi
+         end
+         A[i1 + 1] = A[i2 + 1]
+         i1 = i2
+      end
+   end
+end
+
 ###############################################################################
 #
 #   Gram matrix
@@ -3902,7 +4009,11 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 2})
       parent(b[1, 1]) != base_ring(a) && error("Unable to coerce to matrix")
    end
    _check_dim(a.rows, a.cols, b)
-   z = GenMat{T}(b')
+   _transpose!(b)
+   if a.cols != a.rows
+      b = reshape(b, a.cols, a.rows)
+   end
+   z = GenMat{T}(b)
    z.parent = a
    return z
 end

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -30,7 +30,7 @@ function similar{T}(x::GenMat{T})
 end
 
 function similar{T}(x::GenMat{T}, r::Int, c::Int)
-   z = GenMat{T}(similar(x.entries, r, c))
+   z = GenMat{T}(similar(x.entries, c, r))
    for i in 1:rows(z)
       for j in 1:cols(z)
          z[i, j] = zero(base_ring(x))
@@ -92,7 +92,7 @@ doc"""
 > Return the parent object of the given matrix.
 """
 parent{T}(a::MatElem{T}, cached::Bool = true) =
-    GenMatSpace{T}(a.base_ring, size(a.entries)..., cached)
+         GenMatSpace{T}(a.base_ring, rows(a), cols(a), cached)
 
 function check_parent(a::MatElem, b::MatElem)
   (base_ring(a) != base_ring(b) || rows(a) != rows(b) || cols(a) != cols(b)) && 
@@ -120,13 +120,13 @@ doc"""
     rows(a::MatElem)
 > Return the number of rows of the given matrix.
 """
-rows(a::MatElem) = size(a.entries, 1)
+rows(a::MatElem) = size(a.entries, 2)
 
 doc"""
     cols(a::MatElem)
 > Return the number of columns of the given matrix.
 """
-cols(a::MatElem) = size(a.entries, 2)
+cols(a::MatElem) = size(a.entries, 1)
 
 function getindex{T <: RingElem}(a::MatElem{T}, r::Int, c::Int)
    return a.entries[c, r]
@@ -833,7 +833,6 @@ function transpose!(x::MatElem)
    _transpose!(x.entries)
    if rows(x) != cols(x)
       x.entries = reshape(x.entries, rows(x), cols(x))
-      x.parent = MatrixSpace(base_ring(x), cols(x), rows(x))
    end
    return nothing
 end
@@ -4076,7 +4075,7 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 2})
       b = reshape(b, a.cols, a.rows)
    end
    z = GenMat{T}(b)
-   z.parent = a
+   z.base_ring = parent(b[1, 1])
    return z
 end
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -845,11 +845,68 @@ doc"""
 > moved. Note that $A$ will stay an $m\times n$ array. Use A = reshape(A, n, m)
 > to obtain the right dimensions.
 """
+function _transpose!{T}(A::Array{T,2})
+   m = size(A,1)
+   n = size(A,2)
+
+   if m<2 || n<2
+      return nothing
+   end
+
+   # If A is square, we just swap A[i,j] and A[j,i]
+   if m == n
+      for i = 1:m
+         for j = 1:i-1
+            t = A[i,j]
+            A[i,j] = A[j,i]
+            A[j,i] = t
+         end
+      end
+      return nothing
+   end
+
+   ncount = 2 # number of elements which are in the right position
+   mn = m*n
+   moved = falses(mn)
+   k = mn - 1
+
+   # We don't need to move the first and the last element
+   for i = 2:k
+      @inbounds if moved[i]
+         continue
+      end
+      i1 = i
+      t = A[i1]
+      i2 = m*(i1 - 1) - k*div(i1 - 1, n) + 1
+      while i2 != i
+         A[i1] = A[i2]
+         @inbounds moved[i1] = true
+         ncount += 1
+         i1 = i2
+         i2 = m*(i1 - 1) - k*div(i1 - 1, n) + 1
+      end
+      A[i1] = t
+      @inbounds moved[i1] = true
+      ncount += 1
+      if ncount >= mn
+         break
+      end
+   end
+   return nothing
+end
+
+doc"""
+    _less_memory_transpose!{T}(A::Array{T,2})
+> Transpose a given $m\times n$ array $A$ by rearranging it's elements in-place.
+> A BitArray of length $(m + n)/2$ is used to determine wether an element has
+> already been moved. Note that $A$ will stay an $m\times n$ array. Use
+> A = reshape(A, n, m) to obtain the right dimensions.
+"""
 #=
    We use an algorithm due to S. Laflin and M. A. Brebner.
    "In-situ transposition of a rectangular matrix."
 =#
-function _transpose!{T}(A::Array{T,2})
+function _less_memory_transpose!{T}(A::Array{T,2})
    m = size(A,1)
    n = size(A,2)
 
@@ -874,7 +931,8 @@ function _transpose!{T}(A::Array{T,2})
    n1 = n - 1
    m2 = m - 2
    mn = m*n
-   moved = falses(mn)
+   iwrk = cld(m + n, 2)
+   moved = falses(iwrk)
 
    # Check for "single points" which don't need to be moved.
    for ia = 1:m2
@@ -882,7 +940,9 @@ function _transpose!{T}(A::Array{T,2})
       r != 0 ? continue : nothing
       ncount += 1
       i = ia*n + ib
-      @inbounds moved[i] = true
+      if i <= iwrk
+         @inbounds moved[i] = true
+      end
    end
 
    k = mn - 1
@@ -894,15 +954,18 @@ function _transpose!{T}(A::Array{T,2})
          # search for the next loop
          kmi = k - i
          max = kmi + 1
-         @inbounds moved[i] ? continue : nothing
-         i1 = i
-         i2 = m*i1 - k*div(i1, n)
-         i1 == i2 ? continue : nothing
-         while i2 > i && i2 < max
-            i1 = i2
+         if i <= iwrk
+            @inbounds moved[i] ? continue : nothing
+         else
+            i1 = i
             i2 = m*i1 - k*div(i1, n)
+            i1 == i2 ? continue : nothing
+            while i2 > i && i2 < max
+               i1 = i2
+               i2 = m*i1 - k*div(i1, n)
+            end
+            i2 != i ? continue : nothing
          end
-         i2 != i ? continue : nothing
       end
 
       # rearrange the elements
@@ -910,7 +973,9 @@ function _transpose!{T}(A::Array{T,2})
       t = A[i1 + 1]
       while true
          i2 = m*i1 - k*div(i1, n)
-         @inbounds moved[i1] = true
+         if i1 <= iwrk
+            @inbounds moved[i1] = true
+         end
          ncount += 1
          if i2 == i || i2 >= kmi
             if max == kmi || i2 == i

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -820,12 +820,9 @@ doc"""
 > Return the transpose of the given matrix.
 """
 function transpose(x::MatElem)
-   if rows(x) == cols(x)
-      par = parent(x)
-   else
-      par = MatrixSpace(base_ring(x), cols(x), rows(x))
-   end
-   return par(x.entries)
+   y = deepcopy(x)
+   transpose!(y)
+   return y
 end
 
 doc"""

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -129,11 +129,11 @@ doc"""
 cols(a::MatElem) = size(a.entries, 2)
 
 function getindex{T <: RingElem}(a::MatElem{T}, r::Int, c::Int)
-   return a.entries[r, c]
+   return a.entries[c, r]
 end
  
 function setindex!{T <: RingElem}(a::MatElem{T}, d::T, r::Int, c::Int)
-   a.entries[r, c] = d
+   a.entries[c, r] = d
 end
 
 setindex_t!{T <: RingElem}(a::MatElem{T}, d::T, r::Int, c::Int) = setindex!(a, d, c, r)
@@ -825,7 +825,7 @@ function transpose(x::MatElem)
    else
       par = MatrixSpace(base_ring(x), cols(x), rows(x))
    end
-   return par(permutedims(x.entries, [2, 1]))
+   return par(x.entries)
 end
 
 ###############################################################################
@@ -3832,10 +3832,10 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::RingElem)
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}()
-   entries = Array{T}(a.rows, a.cols)
+   entries = Array{T}(a.cols, a.rows)
    for i = 1:a.rows
       for j = 1:a.cols
-         entries[i, j] = zero(base_ring(a))
+         entries[j, i] = zero(base_ring(a))
       end
    end
    z = GenMat{T}(entries)
@@ -3844,13 +3844,13 @@ function (a::GenMatSpace{T}){T <: RingElem}()
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
-   entries = Array{T}(a.rows, a.cols)
+   entries = Array{T}(a.cols, a.rows)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
-            entries[i, j] = zero(base_ring(a))
+            entries[j, i] = zero(base_ring(a))
          else
-            entries[i, j] = base_ring(a)(b)
+            entries[j, i] = base_ring(a)(b)
          end
       end
    end
@@ -3860,13 +3860,13 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Integer)
 end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::fmpz)
-   entries = Array{T}(a.rows, a.cols)
+   entries = Array{T}(a.cols, a.rows)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
-            entries[i, j] = zero(base_ring(a))
+            entries[j, i] = zero(base_ring(a))
          else
-            entries[i, j] = base_ring(a)(b)
+            entries[j, i] = base_ring(a)(b)
          end
       end
    end
@@ -3877,13 +3877,13 @@ end
 
 function (a::GenMatSpace{T}){T <: RingElem}(b::T)
    parent(b) != base_ring(a) && error("Unable to coerce to matrix")
-   entries = Array{T}(a.rows, a.cols)
+   entries = Array{T}(a.cols, a.rows)
    for i = 1:a.rows
       for j = 1:a.cols
          if i != j
-            entries[i, j] = zero(base_ring(a))
+            entries[j, i] = zero(base_ring(a))
          else
-            entries[i, j] = deepcopy(b)
+            entries[j, i] = deepcopy(b)
          end
       end
    end
@@ -3902,8 +3902,8 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 2})
       parent(b[1, 1]) != base_ring(a) && error("Unable to coerce to matrix")
    end
    _check_dim(a.rows, a.cols, b)
-   z = GenMat{T}(b)
-   z.base_ring = a.base_ring
+   z = GenMat{T}(b')
+   z.parent = a
    return z
 end
 
@@ -3912,7 +3912,7 @@ function (a::GenMatSpace{T}){T <: RingElem}(b::Array{T, 1})
       parent(b[1]) != base_ring(a) && error("Unable to coerce to matrix")
    end
    _check_dim(a.rows, a.cols, b)
-   b = reshape(b, a.cols, a.rows)'
+   b = reshape(b, a.cols, a.rows)
    z = GenMat{T}(b)
    z.base_ring = a.base_ring
    return z

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1487,6 +1487,7 @@ function test_gen_mat_weak_popov()
          @test isunit(det(U))
       end
    end
+   println("PASS")
 end
 
 function test_gen_mat_transpose()

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1487,6 +1487,31 @@ function test_gen_mat_weak_popov()
          @test isunit(det(U))
       end
    end
+end
+
+function test_gen_mat_transpose()
+   print("GenMat.transpose...")
+
+   R, x = PolynomialRing(ZZ, "x")
+
+   A = Matrix(R, 3, 3, map(R, Any[1 2 3; x x^2 x^3; x 2*x 3*x]))
+   B = Matrix(R, 3, 3, map(R, Any[1 x x; 2 x^2 2*x; 3 x^3 3*x]))
+
+   @test transpose(A) == B
+
+   transpose!(A)
+
+   @test A == B
+
+   A = Matrix(R, 2, 4, map(R, Any[1 2 3 4; x x^2 x^3 x^4]))
+   B = Matrix(R, 4, 2, map(R, Any[1 x; 2 x^2; 3 x^3; 4 x^4]))
+
+   @test transpose(A) == B
+
+   transpose!(A)
+
+   @test A == B
+
    println("PASS")
 end
 
@@ -1524,6 +1549,7 @@ function test_gen_mat()
    test_gen_mat_snf_kb()
    test_gen_mat_snf()
    test_gen_mat_weak_popov()
+   test_gen_mat_transpose()
 
    println("")
 end


### PR DESCRIPTION
Save the entries of a generic matrix transposed, so that row operations are cache friendly. Do we still want this?

Did not see any regression in the benchmarks.