### PR TITLE
Fix permutation in lufact!(::nmod_mat)

### DIFF
--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -483,6 +483,11 @@ end
 function lufact!(P::perm, x::nmod_mat)
   rank = ccall((:nmod_mat_lu, :libflint), Cint, (Ptr{Int}, Ptr{nmod_mat}, Cint),
            P.d, &x, 0)
+
+  for i in 1:length(P.d)
+    P.d[i] += 1
+  end
+
   return rank
 end
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -908,7 +908,7 @@ doc"""
 > Apply the pemutation $P$ to the rows of the matrix $x$ and return the result.
 """
 function *(P::perm, x::MatElem)
-  z = similar(x)
+   z = similar(x)
    m = rows(x)
    n = cols(x)
    for i = 1:m

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -564,11 +564,13 @@ function test_nmod_mat_lu()
 
   r, P, l, u = lufact(a)
 
-  @test l*u == a
+  @test l*u == P*a
 
   r, P, l, u = lufact(b)
 
   @test l*u == S([ 2 1 0 1; 0 1 2 0; 0 0 0 0])
+
+  @test l*u == P*b
 
   println("PASS")
 end


### PR DESCRIPTION
flint lets the permutation act on [0,1,2,...,n-1], so we need to shift the entries by 1 when passing to Nemo. Somehow we missed this in the permutation makeover and the test did not check for it.
