### PR TITLE
AllPerms minor fixes

### DIFF
--- a/src/generic/PermGroups.jl
+++ b/src/generic/PermGroups.jl
@@ -308,8 +308,8 @@ end
 Base.start(A::AllPerms) = (collect(1:A.n), 1, 1, ones(Int, A.n))
 Base.next(A::AllPerms, state) = all_perms(state...)
 Base.done(A::AllPerms, state) = state[2] > A.all
-Base.eltype(::AllPerms) = Vector{Int}
-Base.length(A::AllPerms) = factorial(A.n)
+Base.eltype(::Type{AllPerms}) = Vector{Int}
+Base.length(A::AllPerms) = A.all
 
 function all_perms(elts, counter, i, c)
    if counter == 1


### PR DESCRIPTION
There is a problem with type of generator: currently `eltype(elements(PermutationGroup(n))` is inferred as `Any`; note that `eltype(collect(elements(PermutationGroup(n)))` is inferred correctly;

this is an issue with type inference of generators in julia