### PR TITLE
First stab at wrapping root bounds

### DIFF
--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -933,6 +933,13 @@ xs = arb[inv(RR(i)) for i=1:5]
 f = from_roots(R, xs)
 ```
 
+## Bounding absolute values of roots
+
+```@docs
+roots_upper_bound(::arb_poly)
+roots_upper_bound(::acb_poly)
+```
+
 ## Lifting
 
 When working over a residue ring it is useful to be able to lift to the base

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -16,6 +16,14 @@ export AcbMatSpace, acb_mat
 
 arb_check_prec(p::Int) = (p >= 2 && p < (typemax(Int) >> 4)) || throw(ArgumentError("invalid precision"))
 
+# Rounding modes
+
+const ARB_RND_DOWN = Cint(0)   # towards zero
+const ARB_RND_UP = Cint(1)     # away from zero
+const ARB_RND_FLOOR = Cint(2)  # towards -infinity
+const ARB_RND_CEIL = Cint(3)   # towards +infinity
+const ARB_RND_NEAR = Cint(4)   # to nearest
+
 ################################################################################
 #
 #  Types and memory management for ArbField

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -710,6 +710,31 @@ end
 
 ###############################################################################
 #
+#   Root bounds
+#
+###############################################################################
+
+doc"""
+    roots_upper_bound(f::acb_poly) -> arb
+
+> Returns an upper bound for the absolute value of all complex roots of $f$.
+"""
+function roots_upper_bound(x::acb_poly)
+   z = ArbField(prec(base_ring(x)))()
+   p = prec(base_ring(x))
+   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), &z)
+   ccall((:acb_poly_root_bound_fujiwara, :libarb), Void,
+         (Ptr{mag_struct}, Ptr{acb_poly}), t, &x)
+   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), &z)
+   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+   ccall((:arf_set_round, :libarb), Void,
+         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+   ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
+   return z
+end
+
+###############################################################################
+#
 #   Unsafe functions
 #
 ###############################################################################

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -7,7 +7,7 @@
 export ArbPolyRing, arb_poly, derivative, integral, evaluate, evaluate2,
        compose, from_roots, evaluate_iter, evaluate_fast, evaluate,
        interpolate, interpolate_newton, interpolate_barycentric,
-       interpolate_fast
+       interpolate_fast, roots_upper_bound
 
 ###############################################################################
 #
@@ -606,6 +606,31 @@ end
 # todo: cutoffs for fast algorithm
 function evaluate(x::arb_poly, b::Array{arb, 1})
    return evaluate_iter(x, b)
+end
+
+###############################################################################
+#
+#   Root bounds
+#
+###############################################################################
+
+doc"""
+    roots_upper_bound(f::arb_poly) -> arb
+
+> Returns an upper bound for the absolute value of all complex roots of $f$.
+"""
+function roots_upper_bound(x::arb_poly)
+   z = base_ring(x)()
+   p = prec(base_ring(x))
+   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), &z)
+   ccall((:arb_poly_root_bound_fujiwara, :libarb), Void,
+         (Ptr{mag_struct}, Ptr{arb_poly}), t, &x)
+   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), &z)
+   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+   ccall((:arf_set_round, :libarb), Void,
+         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+   ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
+   return z
 end
 
 ###############################################################################

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -429,6 +429,22 @@ function test_acb_poly_evaluation_interpolation()
    println("PASS")
 end
 
+function test_acb_poly_root_bound()
+   print("acb_poly.root_bound...")
+
+   Rx, x = PolynomialRing(CC, "x")
+
+   for i in 1:2
+      r = rand(1:10)
+      z = map(CC, rand(-BigInt(2)^60:BigInt(2)^60, r))
+      f = prod([ x - (z[i]  + onei(CC)) for i in 1:r])
+      b = roots_upper_bound(f)
+      @test all([ abs(z[i] + onei(CC)) <= b for i in 1:r])
+   end
+
+   println("PASS")
+end
+
 function test_acb_poly()
    test_acb_poly_constructors()
    test_acb_poly_printing()
@@ -449,6 +465,7 @@ function test_acb_poly()
    test_acb_poly_composition()
    test_acb_poly_derivative_integral()
    test_acb_poly_evaluation_interpolation()
+   test_acb_poly_root_bound()
 
    println("")
 end

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -406,6 +406,22 @@ function test_arb_poly_evaluation_interpolation()
    println("PASS")
 end
 
+function test_arb_poly_root_bound()
+   print("arb_poly.root_bound...")
+
+   Rx, x = PolynomialRing(RR, "x")
+
+   for i in 1:2
+      r = rand(1:10)
+      z = map(RR, rand(-BigInt(2)^60:BigInt(2)^60, r))
+      f = prod([ x - z[i] for i in 1:r])
+      b = roots_upper_bound(f)
+      @test all([ abs(z[i]) <= b for i in 1:r])
+   end
+
+   println("PASS")
+end
+
 function test_arb_poly()
    test_arb_poly_constructors()
    test_arb_poly_printing()
@@ -425,6 +441,7 @@ function test_arb_poly()
    test_arb_poly_composition()
    test_arb_poly_derivative_integral()
    test_arb_poly_evaluation_interpolation()
+   test_arb_poly_root_bound()
 
    println("")
 end


### PR DESCRIPTION
Could you have a look at this @fredrik-johansson? If you like it, I will wrap the rest and add docs and tests.

I think the rounding would also have to be done at https://github.com/Nemocas/Nemo.jl/blob/master/src/arb/arb_mat.jl#L612-L623?
When converting to an element of `base_ring(x)`, it could produce a ball which contains elements smaller then the actual bound, right?