### PR TITLE
Reexport ZZ, QQ, RealField, PadicField, etc.

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -30,6 +30,9 @@ export PolyRing, SeriesRing, AbsSeriesRing, ResRing, FracField, MatSpace, FinFie
 
 export JuliaZZ, JuliaQQ, zz, qq
 
+export PermutationGroup, ZZ, QQ, PadicField, FiniteField, RealField, ComplexField,
+       CyclotomicField, MaximalRealSubfield
+
 export create_accessors, get_handle, package_handle, zeros,
        Array, sig_exists
 


### PR DESCRIPTION
This was more difficult to support in Singular.jl than I thought, since ZZ cannot be created there until the module initialisation is called, because Singular needs to be initialised before trying to retrieve a pointer to n_Z. But injecting ZZ into the Singular module from the module initialisation caused a conflict with Nemo when ZZ was exported. But I have now worked around this by separating the creation of Singular's ZZ and QQ into two parts, one part creating the actual objects and the other part putting the Singular pointers inside the objects at module initialisation time. 