### PR TITLE
Add MPolyElem and MPolyRing abstract types.

### DIFF
--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -41,6 +41,8 @@ abstract type ModuleElem{T <: RingElem} <: GroupElem end
 
 abstract type PolyRing{T} <: Ring end
 
+abstract type MPolyRing{T} <: Ring end
+
 abstract type SeriesRing{T} <: Ring end
 
 abstract type ResRing{T} <: Ring end
@@ -58,6 +60,8 @@ abstract type MatSpace{T} <: Ring end
 # implementation is meaningful over that base ring
 
 abstract type PolyElem{T} <: RingElem end
+
+abstract type MPolyElem{T} <: RingElem end
 
 abstract type ResElem{T} <: RingElem end
 

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -24,9 +24,10 @@ export elem_type, parent_type
 export SetElem, GroupElem, RingElem, FieldElem, AccessorNotSetError
 
 export PolyElem, SeriesElem, AbsSeriesElem, RelSeriesElem, ResElem, FracElem,
-       MatElem, FinFieldElem
+       MatElem, FinFieldElem, MPolyElem
 
-export PolyRing, SeriesRing, AbsSeriesRing, ResRing, FracField, MatSpace, FinField
+export PolyRing, SeriesRing, AbsSeriesRing, ResRing, FracField, MatSpace,
+       FinField, MPolyRing
 
 export JuliaZZ, JuliaQQ, zz, qq
 

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -110,7 +110,7 @@ end
 # T is an Int which is the number of variables
 # (plus one if ordered by total degree)
 
-mutable struct GenMPolyRing{T <: RingElement} <: PolyRing{T}
+mutable struct GenMPolyRing{T <: RingElement} <: MPolyRing{T}
    base_ring::Ring
    S::Array{Symbol, 1}
    ord::Symbol
@@ -133,7 +133,7 @@ end
 
 const GenMPolyID = Dict{Tuple{Ring, Array{Symbol, 1}, Symbol, Int}, Ring}()
 
-mutable struct GenMPoly{T <: RingElement} <: PolyElem{T}
+mutable struct GenMPoly{T <: RingElement} <: MPolyElem{T}
    coeffs::Array{T, 1}
    exps::Array{UInt, 2}
    length::Int

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -15,9 +15,15 @@ export GenMPoly, GenMPolyRing, max_degrees, gens, divides,
 #
 ###############################################################################
 
+parent(a::GenMPoly{T}) where T <: RingElement = a.parent
+
 parent_type(::Type{GenMPoly{T}}) where T <: RingElement = GenMPolyRing{T}
 
-elem_type(::Type{GenMPolyRing{T}}) where {T <: RingElement} = GenMPoly{T}
+elem_type(::Type{GenMPolyRing{T}}) where T <: RingElement = GenMPoly{T}
+
+base_ring(R::GenMPolyRing{T}) where T <: RingElement = R.base_ring
+
+base_ring(a::GenMPoly{T}) where T <: RingElement = base_ring(parent(a))
 
 doc"""
     vars(a::GenMPolyRing)
@@ -58,6 +64,11 @@ doc"""
 """
 function ordering(a::GenMPolyRing{T}) where {T <: RingElement}
    return a.ord
+end
+
+function check_parent(a::GenMPoly{T}, b::GenMPoly{T}) where T <: RingElement
+   parent(a) != parent(b) && 
+      error("Incompatible polynomial rings in polynomial operation")
 end
 
 ###############################################################################
@@ -329,9 +340,15 @@ doc"""
 """
 nvars(x::GenMPoly) = parent(x).num_vars
 
+one(R::GenMPolyRing) = R(1)
+
+zero(R::GenMPolyRing) = R(0)
+
 isone(x::GenMPoly) = x.length == 1 && monomial_iszero(x.exps, 1, size(x.exps, 1)) && x.coeffs[1] == 1
 
 iszero(x::GenMPoly) = x.length == 0
+
+isunit(x::GenMPoly) = x.length == 1 && monomial_iszero(x.exps, 1, size(x.exps, 1)) && isunit(x.coeffs[1])
 
 doc"""
     isconstant(x::GenMPoly)
@@ -2929,7 +2946,7 @@ function (a::GenMPolyRing{T})(b::T) where {T <: RingElement}
    return z
 end
 
-function (a::GenMPolyRing{T})(b::PolyElem{T}) where {T <: RingElement}
+function (a::GenMPolyRing{T})(b::GenMPoly{T}) where {T <: RingElement}
    parent(b) != a && error("Unable to coerce polynomial")
    return b
 end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -18,26 +18,26 @@ function test_gen_mpoly_constructors()
       isa(vars(S), Array{Symbol, 1})
 
       for j = 1:num_vars
-         @test isa(varlist[j], PolyElem)
-         @test isa(gens(S)[j], PolyElem)
+         @test isa(varlist[j], MPolyElem)
+         @test isa(gens(S)[j], MPolyElem)
       end
 
       f =  rand(S, 0:5, 0:100, 0:0, -100:100)
 
-      @test isa(f, PolyElem)
+      @test isa(f, MPolyElem)
 
-      @test isa(S(2), PolyElem)
+      @test isa(S(2), MPolyElem)
 
-      @test isa(S(R(2)), PolyElem)
+      @test isa(S(R(2)), MPolyElem)
 
-      @test isa(S(f), PolyElem)
+      @test isa(S(f), MPolyElem)
 
       V = [R(rand(-100:100)) for i in 1:5]
 
       W0 = UInt[rand(0:100) for i in 1:5*num_vars]
       W = reshape(W0, num_vars, 5)
 
-      @test isa(S(V, W), PolyElem)
+      @test isa(S(V, W), MPolyElem)
    end
 
    println("PASS")


### PR DESCRIPTION
This adds MPolyElem and MPolyRing abstract types so that Poly.jl functionality is not available for multivariate polynomials. In almost all cases it is broken for them and shouldn't be defined for them (e.g. the order of terms is reversed and they are sparse rather than dense, etc.)