### PR TITLE
Revamp the checkbounds calls in Nemo matrices

### DIFF
--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -174,7 +174,7 @@ function den(a::nf_elem)
 end
 
 function elem_from_mat_row(a::AnticNumberField, b::fmpz_mat, i::Int, d::fmpz)
-   _checkbounds(rows(b), i) || throw(BoundsError())
+   Generic._checkbounds(rows(b), i) || throw(BoundsError())
    cols(b) == degree(a) || error("Wrong number of columns")
    z = a()
    ccall((:nf_elem_set_fmpz_mat_row, :libflint), Void,

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -53,10 +53,8 @@ end
 ###############################################################################
 
 function Base.view(x::fmpq_mat, r1::Int, c1::Int, r2::Int, c2::Int)
-  _checkbounds(x.r, r1) || throw(BoundsError())
-  _checkbounds(x.r, r2) || throw(BoundsError())
-  _checkbounds(x.c, c1) || throw(BoundsError())
-  _checkbounds(x.c, c2) || throw(BoundsError())
+  Generic._checkbounds(x, r1, c1)
+  Generic._checkbounds(x, r2, c2)
   (r1 > r2 || c1 > c2) && error("Invalid parameters")
   b = fmpq_mat()
   b.base_ring = x.base_ring
@@ -91,9 +89,8 @@ function getindex!(v::fmpq, a::fmpq_mat, r::Int, c::Int)
    ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &v, z)
 end
 
-function getindex(a::fmpq_mat, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function getindex(a::fmpq_mat, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    v = fmpq()
    z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
@@ -101,9 +98,8 @@ function getindex(a::fmpq_mat, r::Int, c::Int)
    return v
 end
 
-function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    z = ccall((:fmpq_mat_entry_num, :libflint), Ptr{fmpz},
              (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
    ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), z, &d)
@@ -112,25 +108,27 @@ function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
    ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, 1)
 end
 
-function setindex!(a::fmpq_mat, d::fmpq, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function setindex!(a::fmpq_mat, d::fmpq, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
    ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), z, &d)
 end
 
-setindex!(a::fmpq_mat, d::Integer, r::Int, c::Int) = setindex!(a, fmpq(d), r, c)
+Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
+                                 r::Int, c::Int) =
+         setindex!(a, fmpq(d), r, c)
 
-function setindex!(a::fmpq_mat, d::Int, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function setindex!(a::fmpq_mat, d::Int, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
    ccall((:fmpq_set_si, :libflint), Void, (Ptr{fmpq}, Int, Int), z, d, 1)
 end
 
-setindex!(a::fmpq_mat, d::Rational, r::Int, c::Int) = setindex!(a, fmpq(d), r, c)
+Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Rational,
+                                 r::Int, c::Int) =
+         setindex!(a, fmpq(d), r, c)
 
 rows(a::fmpq_mat) = a.r
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -58,16 +58,14 @@ end
 ###############################################################################
 
 function Base.view(x::fmpz_mat, r1::Int, c1::Int, r2::Int, c2::Int)
-  _checkbounds(x.r, r1) || throw(BoundsError())
-  _checkbounds(x.r, r2) || throw(BoundsError())
-  _checkbounds(x.c, c1) || throw(BoundsError())
-  _checkbounds(x.c, c2) || throw(BoundsError())
+  Generic._checkbounds(x, r1, c1)
+  Generic._checkbounds(x, r2, c2)
   (r1 > r2 || c1 > c2) && error("Invalid parameters")
   b = fmpz_mat()
   b.base_ring = FlintZZ
   ccall((:fmpz_mat_window_init, :libflint), Void,
         (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int, Int, Int, Int),
-            &b, &x, r1-1, c1-1, r2, c2)
+            &b, &x, r1 - 1, c1 - 1, r2, c2)
   finalizer(b, _fmpz_mat_window_clear_fn)
   return b
 end
@@ -96,9 +94,8 @@ function getindex!(v::fmpz, a::fmpz_mat, r::Int, c::Int)
    ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &v, z)
 end
 
-function getindex(a::fmpz_mat, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function getindex(a::fmpz_mat, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    v = fmpz()
    z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
@@ -106,27 +103,25 @@ function getindex(a::fmpz_mat, r::Int, c::Int)
    return v
 end
 
-function setindex!(a::fmpz_mat, d::fmpz, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function setindex!(a::fmpz_mat, d::fmpz, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
    ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), z, &d)
 end
 
-setindex!(a::fmpz_mat, d::Integer, r::Int, c::Int) = setindex!(a, fmpz(d), r, c)
+@inline setindex!(a::fmpz_mat, d::Integer, r::Int, c::Int) = setindex!(a, fmpz(d), r, c)
 
-function setindex!(a::fmpz_mat, d::Int, r::Int, c::Int)
-   _checkbounds(rows(a), r) || throw(BoundsError())
-   _checkbounds(cols(a), c) || throw(BoundsError())
+@inline function setindex!(a::fmpz_mat, d::Int, r::Int, c::Int)
+   @boundscheck Generic._checkbounds(a, r, c)
    z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
    ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, d)
 end
 
-rows(a::fmpz_mat) = a.r
+@inline rows(a::fmpz_mat) = a.r
 
-cols(a::fmpz_mat) = a.c
+@inline cols(a::fmpz_mat) = a.c
 
 zero(a::FmpzMatSpace) = a()
 

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -122,6 +122,15 @@ function _check_dim(r::Int, c::Int, arr::Array{T, 1}) where {T}
   return nothing
 end
 
+function _checkbounds(i::Int, j::Int)
+   j >= 1 && j <= i
+end
+
+function _checkbounds(A, i::Int, j::Int)
+  (_checkbounds(rows(A), i) && _checkbounds(cols(A), j)) ||
+            Base.throw_boundserror(A, (i, j))
+end
+
 ###############################################################################
 #
 #   Basic manipulation
@@ -151,11 +160,12 @@ doc"""
 """
 cols(a::Nemo.MatElem) = size(a.entries, 2)
 
-function getindex(a::Nemo.MatElem, r::Int, c::Int)
+Base.@propagate_inbounds function getindex(a::Nemo.MatElem, r::Int, c::Int)
    return a.entries[r, c]
 end
  
-function setindex!(a::Nemo.MatElem, d::T, r::Int, c::Int) where T <: RingElement
+Base.@propagate_inbounds function setindex!(a::Nemo.MatElem, d::T, r::Int,
+                                            c::Int) where T <: RingElement
     a.entries[r, c] = base_ring(a)(d)
 end
 


### PR DESCRIPTION
  - The _checkindex function went from nmod_mat.jl to generic/Matrix.jl.
    Eventually it should land in the file which contains the stuff for
    abstract matrices.
  - In getindex and setindex! the bounds check can now be eliminated using
    the `@inbounds` macro (similar to ordinary julia arrays). So you can do `@inbounds z = z + M[i, j]` 
    where `M` is a Nemo matrix.
  - Not inlining the throw(ErrorBounds()) makes it slightly faster.

Closes #271