### PR TITLE
WIP: Clean up matrix constructors and remove remaining calls to MatrixSpace

### DIFF
--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -814,6 +814,57 @@ end
 
 ###############################################################################
 #
+#   Matrix constructor
+#
+###############################################################################
+
+function matrix(R::AcbField, arr::Array{T, 2}) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb, AbstractString}}
+   z = acb_mat(size(arr, 1), size(arr, 2), arr, prec(R))
+   z.base_ring = R
+   return z
+end
+
+function matrix(R::AcbField, r::Int, c::Int, arr::Array{T, 1}) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, acb, AbstractString}}
+   _check_dim(r, c, arr)
+   z = acb_mat(r, c, arr, prec(R))
+   z.base_ring = R
+   return z
+end
+
+function matrix(R::AcbField, arr::Array{<: Integer, 2})
+   arr_fmpz = map(fmpz, arr)
+   return matrix(R, arr_fmpz)
+end
+
+function matrix(R::AcbField, r::Int, c::Int, arr::Array{<: Integer, 1})
+   arr_fmpz = map(fmpz, arr)
+   return matrix(R, r, c, arr_fmpz)
+end
+
+function matrix(R::AcbField, arr::Array{Rational{T}, 2}) where {T <: Integer}
+   arr_fmpz = map(fmpq, arr)
+   return matrix(R, arr_fmpz)
+end
+
+function matrix(R::AcbField, r::Int, c::Int, arr::Array{Rational{T}, 1}) where {T <: Integer}
+   arr_fmpz = map(fmpq, arr)
+   return matrix(R, r, c, arr_fmpz)
+end
+
+###############################################################################
+#
+#  Zero matrix
+#
+###############################################################################
+
+function zero_matrix(R::AcbField, r::Int, c::Int)
+   z = acb_mat(r, c)
+   z.base_ring = R
+   return z
+end
+
+###############################################################################
+#
 #   Promotions
 #
 ###############################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -696,6 +696,57 @@ end
 
 ###############################################################################
 #
+#   Matrix constructor
+#
+###############################################################################
+
+function matrix(R::ArbField, arr::Array{T, 2}) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
+   z = arb_mat(size(arr, 1), size(arr, 2), arr, prec(R))
+   z.base_ring = R
+   return z
+end
+
+function matrix(R::ArbField, r::Int, c::Int, arr::Array{T, 1}) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
+   _check_dim(r, c, arr)
+   z = arb_mat(r, c, arr, prec(R))
+   z.base_ring = R
+   return z
+end
+
+function matrix(R::ArbField, arr::Array{<: Integer, 2})
+   arr_fmpz = map(fmpz, arr)
+   return matrix(R, arr_fmpz)
+end
+
+function matrix(R::ArbField, r::Int, c::Int, arr::Array{<: Integer, 1})
+   arr_fmpz = map(fmpz, arr)
+   return matrix(R, r, c, arr_fmpz)
+end
+
+function matrix(R::ArbField, arr::Array{Rational{T}, 2}) where {T <: Integer}
+   arr_fmpz = map(fmpq, arr)
+   return matrix(R, arr_fmpz)
+end
+
+function matrix(R::ArbField, r::Int, c::Int, arr::Array{Rational{T}, 1}) where {T <: Integer}
+   arr_fmpz = map(fmpq, arr)
+   return matrix(R, r, c, arr_fmpz)
+end
+
+###############################################################################
+#
+#  Zero matrix
+#
+###############################################################################
+
+function zero_matrix(R::ArbField, r::Int, c::Int)
+   z = arb_mat(r, c)
+   z.base_ring = R
+   return z
+end
+
+###############################################################################
+#
 #   Promotions
 #
 ###############################################################################

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,0 +1,46 @@
+###############################################################################
+#
+#   Error objects
+#
+###############################################################################
+
+mutable struct ErrorConstrDimMismatch <: Exception
+  expect_r::Int
+  expect_c::Int
+  get_r::Int
+  get_c::Int
+  get_l::Int
+
+  function ErrorConstrDimMismatch(er::Int, ec::Int, gr::Int, gc::Int)
+    e = new(er, ec, gr, gc, -1)
+    return e
+  end
+
+  function ErrorConstrDimMismatch(er::Int, ec::Int, gl::Int)
+    e = new(er, ec, -1, -1, gl)
+    return e
+  end
+
+  function ErrorConstrDimMismatch(er::Int, ec::Int, a::Array{T, 2}) where {T}
+    gr, gc = size(a)
+    return ErrorConstrDimMismatch(er, ec, gr, gc)
+  end
+
+  function ErrorConstrDimMismatch(er::Int, ec::Int, a::Array{T, 1}) where {T}
+    gl = length(a)
+    return ErrorConstrDimMismatch(er, ec, gl)
+  end
+end
+
+function Base.showerror(io::IO, e::ErrorConstrDimMismatch)
+  if e.get_l == -1
+    print(io, "Expected dimension $(e.expect_r) x $(e.expect_c), ")
+    print(io, "got $(e.get_r) x $(e.get_c)")
+  else
+    print(io, "Expected an array of length $(e.expect_r * e.expect_c), ")
+    print(io, "got $(e.get_l)")
+  end
+end
+
+const error_dim_negative = ErrorException("Dimensions must be non-negative")
+

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2198,7 +2198,6 @@ mutable struct nmod_mat <: MatElem{nmod}
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{UInt, 2}, transpose::Bool = false)
-    _check_dim(r, c, arr, transpose)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
@@ -2211,14 +2210,13 @@ mutable struct nmod_mat <: MatElem{nmod}
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i,j])
+        se(z, i, j, arr[i, j])
       end
     end
     return z
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{UInt, 1}, transpose::Bool = false)
-    _check_dim(r, c, arr, transpose)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
@@ -2231,7 +2229,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i-1)*c+j])
+        se(z, i, j, arr[(i - 1) * c + j])
       end
     end
     return z
@@ -2250,7 +2248,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i,j])
+        se(z, i, j, arr[i, j])
       end
     end
     return z
@@ -2269,20 +2267,20 @@ mutable struct nmod_mat <: MatElem{nmod}
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i-1)*c+j])
+        se(z, i, j, arr[(i - 1) * c + j])
       end
     end
     return z
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{T, 2}, transpose::Bool = false) where {T <: Integer}
-    arr = map(fmpz, arr)
-    return nmod_mat(r, c, n, arr, transpose)
+    arr_fmpz = map(fmpz, arr)
+    return nmod_mat(r, c, n, arr_fmpz, transpose)
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{T, 1}, transpose::Bool = false) where {T <: Integer}
-    arr = map(fmpz, arr)
-    return nmod_mat(r, c, n, arr, transpose)
+    arr_fmpz = map(fmpz, arr)
+    return nmod_mat(r, c, n, arr_fmpz, transpose)
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{nmod, 2}, transpose::Bool = false)
@@ -2298,7 +2296,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i,j])
+        se(z, i, j, arr[i, j])
       end
     end
     return z
@@ -2311,13 +2309,13 @@ mutable struct nmod_mat <: MatElem{nmod}
     finalizer(z, _nmod_mat_clear_fn)
     if transpose 
       se = set_entry_t!
-      r,c = c,r
+      r, c = c, r
     else
       se = set_entry!
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i-1)*c+j])
+        se(z, i, j, arr[(i - 1) * c + j])
       end
     end
     return z
@@ -2341,7 +2339,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(n::fmpz, b::fmpz_mat)
     (n < 0) && error("Modulus must be positive")
     (n > typemax(UInt)) &&
-          error("Exponent must be smaller than ", fmpz(typemax(UInt)))
+          error("Modulus must be smaller than ", fmpz(typemax(UInt)))
     return nmod_mat(UInt(n), b) 
   end
 end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -761,6 +761,63 @@ promote_rule(::Type{fmpq_mat}, ::Type{Rational{T}}) where T <: Union{Int, BigInt
 
 ###############################################################################
 #
+#   Matrix constructor
+#
+###############################################################################
+
+function matrix(R::FlintRationalField, arr::Array{fmpq, 2})
+   z = fmpq_mat(size(arr, 1), size(arr, 2), arr)
+   z.base_ring = FlintQQ
+   return z
+end
+
+function matrix(R::FlintRationalField, arr::Array{<: Union{fmpz, Int, BigInt}, 2})
+   z = fmpq_mat(size(arr, 1), size(arr, 2), arr)
+   z.base_ring = FlintQQ
+   return z
+end
+
+function matrix(R::FlintRationalField, arr::Array{Rational{T}, 2}) where {T <: Integer}
+   z = fmpq_mat(size(arr, 1), size(arr, 2), map(fmpq, arr))
+   z.base_ring = FlintQQ
+   return z
+end
+
+function matrix(R::FlintRationalField, r::Int, c::Int, arr::Array{fmpq, 1})
+   _check_dim(r, c, arr)
+   z = fmpq_mat(r, c, arr)
+   z.base_ring = FlintQQ
+   return z
+end
+
+function matrix(R::FlintRationalField, r::Int, c::Int, arr::Array{<: Union{fmpz, Int, BigInt}, 1})
+   _check_dim(r, c, arr)
+   z = fmpq_mat(r, c, arr)
+   z.base_ring = FlintQQ
+   return z
+end
+
+function matrix(R::FlintRationalField, r::Int, c::Int, arr::Array{Rational{T}, 1}) where {T <: Union{fmpz, Int, BigInt}}
+   _check_dim(r, c, arr)
+   z = fmpq_mat(r, c, map(fmpq, arr))
+   z.base_ring = FlintQQ
+   return z
+end
+
+###############################################################################
+#
+#  Zero matrix
+#
+###############################################################################
+
+function zero_matrix(R::FlintRationalField, r::Int, c::Int)
+   z = fmpq_mat(r, c)
+   z.base_ring = FlintQQ
+   return z
+end
+
+###############################################################################
+#
 #   MatrixSpace constructor
 #
 ###############################################################################

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1227,6 +1227,50 @@ end
 
 ###############################################################################
 #
+#   Matrix constructor
+#
+###############################################################################
+
+function matrix(R::FlintIntegerRing, arr::Array{fmpz, 2})
+   z = fmpz_mat(size(arr, 1), size(arr, 2), arr)
+   z.base_ring = FlintZZ
+   return z
+end
+
+function matrix(R::FlintIntegerRing, arr::Array{<: Integer, 2})
+   z = fmpz_mat(size(arr, 1), size(arr, 2), arr)
+   z.base_ring = FlintZZ
+   return z
+end
+
+function matrix(R::FlintIntegerRing, r::Int, c::Int, arr::Array{fmpz, 1})
+   _check_dim(r, c, arr)
+   z = fmpz_mat(r, c, arr)
+   z.base_ring = FlintZZ
+   return z
+end
+
+function matrix(R::FlintIntegerRing, r::Int, c::Int, arr::Array{<: Integer, 1})
+   _check_dim(r, c, arr)
+   z = fmpz_mat(r, c, arr)
+   z.base_ring = FlintZZ
+   return z
+end
+
+###############################################################################
+#
+#  Zero matrix
+#
+###############################################################################
+
+function zero_matrix(R::FlintIntegerRing, r::Int, c::Int)
+   z = fmpz_mat(r, c)
+   z.base_ring = FlintZZ
+   return z
+end
+
+###############################################################################
+#
 #   MatrixSpace constructor
 #
 ###############################################################################

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -762,6 +762,37 @@ function (a::NmodMatSpace)(b::fmpz_mat)
   return z
 end
 
+###############################################################################
+#
+#   Matrix constructor
+#
+###############################################################################
+
+function matrix(R::NmodRing, arr::Array{<: Union{nmod, fmpz, Integer}, 2})
+   z = nmod_mat(size(arr, 1), size(arr, 2), R.n, arr)
+   z.base_ring = R
+   return z
+end
+
+function matrix(R::NmodRing, r::Int, c::Int, arr::Array{<: Union{nmod, fmpz, Integer}, 1})
+   _check_dim(r, c, arr)
+   z = nmod_mat(r, c, R.n, arr)
+   z.base_ring = R
+   return z
+end
+
+###############################################################################
+#
+#  Zero matrix
+#
+###############################################################################
+
+function zero_matrix(R::NmodRing, r::Int, c::Int)
+   z = nmod_mat(r, c, R.n)
+   z.base_ring = R
+   return z
+end
+
 ################################################################################
 #
 #  Matrix space constructor

--- a/src/generic/GenericTypes.jl
+++ b/src/generic/GenericTypes.jl
@@ -442,4 +442,14 @@ mutable struct Mat{T <: RingElement} <: Nemo.MatElem{T}
    function Mat{T}(A::Array{T, 2}) where T <: RingElement
       return new{T}(A)
    end
+
+   function Mat{T}(r::Int, c::Int, A::Array{T, 1}) where T <: RingElement
+      t = Array{T}(r, c)
+      for i = 1:r
+         for j = 1:c
+            t[i, j] = A[(i - 1) * c + j]
+         end
+      end
+      return new{T}(t)
+   end
 end

--- a/src/generic/Poly.jl
+++ b/src/generic/Poly.jl
@@ -1817,11 +1817,11 @@ function sylvester_matrix(p::Nemo.PolyElem{T}, q::Nemo.PolyElem{T}) where T <: R
    check_parent(p, q)
    R = base_ring(p)
    if length(p) == 0 || length(q) == 0
-      return Nemo.MatrixSpace(R, 0, 0)()
+      return zero_matrix(R, 0, 0)
    end
    m = degree(p)
    n = degree(q)
-   M = Nemo.MatrixSpace(R, m + n, m + n)()
+   M = zero_matrix(R, m + n, m + n)
    for i = 1:n
       for j = m:-1:0
          M[i, m - j + i] = coeff(p, j)

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -56,6 +56,30 @@ function test_acb_mat_constructors()
    @test_throws ErrorConstrDimMismatch S([(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7),
                                           (8,8), (9,9), (10,10)])
 
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [fmpz, fmpq, Int, BigInt, Float64, BigFloat, RR, CC, string, Rational{Int}, Rational{BigInt}]
+      M = matrix(CC, map(T, arr))
+      @test isa(M, acb_mat)
+      @test M.base_ring == CC
+      @test rows(M) == 2
+      @test cols(M) == 2
+
+      M2 = matrix(CC, 2, 3, map(T, arr2))
+      @test isa(M2, acb_mat)
+      @test M2.base_ring == CC
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(CC, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(CC, 2, 4, map(T, arr2))
+   end
+
+   M3 = zero_matrix(CC, 2, 3)
+
+   @test isa(M3, acb_mat)
+   @test M3.base_ring == CC
+
    println("PASS")
 end
 

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -289,7 +289,7 @@ function test_acb_poly_exact_division()
 end
 
 function test_acb_poly_scalar_division()
-   print("acb_poly_scalar_division...")
+   print("acb_poly.scalar_division...")
 
    R, x = PolynomialRing(CC, "x")
 

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -53,6 +53,30 @@ function test_arb_mat_constructors()
    @test_throws ErrorConstrDimMismatch S([1 2 3; 4 5 6; 7 8 9; 10 11 12])
    @test_throws ErrorConstrDimMismatch S([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [fmpz, fmpq, Int, BigInt, Float64, BigFloat, RR, string, Rational{Int}, Rational{BigInt}]
+      M = matrix(RR, map(T, arr))
+      @test isa(M, arb_mat)
+      @test M.base_ring == RR
+      @test rows(M) == 2
+      @test cols(M) == 2
+
+      M2 = matrix(RR, 2, 3, map(T, arr2))
+      @test isa(M2, arb_mat)
+      @test M2.base_ring == RR
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(RR, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(RR, 2, 4, map(T, arr2))
+   end
+
+   M3 = zero_matrix(RR, 2, 3)
+
+   @test isa(M3, arb_mat)
+   @test M3.base_ring == RR
+
    println("PASS")
 end
 

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -78,6 +78,28 @@ function test_fmpq_mat_constructors()
    @test_throws ErrorConstrDimMismatch (S([fmpq(1) 2 3 4; 5 6 7 8; 1 2 3 4]))
    @test_throws ErrorConstrDimMismatch (S([fmpq(1), 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4]))
 
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [fmpz, Int, BigInt, Rational{Int}, Rational{BigInt}]
+      M = matrix(FlintQQ, map(T, arr))
+      @test isa(M, fmpq_mat)
+      @test M.base_ring == FlintQQ
+
+      M2 = matrix(FlintQQ, 2, 3, map(T, arr2))
+      @test isa(M2, fmpq_mat)
+      @test M2.base_ring == FlintQQ
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(FlintQQ, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(FlintQQ, 2, 4, map(T, arr2))
+   end
+   
+   M3 = zero_matrix(FlintQQ, 2, 3)
+
+   @test isa(M3, fmpq_mat)
+   @test M3.base_ring == FlintQQ
+
    println("PASS")
 end
 

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -1,7 +1,7 @@
 function test_fmpz_mat_constructors()
    print("fmpz_mat.constructors...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    @test elem_type(S) == fmpz_mat
    @test elem_type(FmpzMatSpace) == fmpz_mat
@@ -34,13 +34,35 @@ function test_fmpz_mat_constructors()
    @test_throws ErrorConstrDimMismatch (S([fmpz(1) 2 3 4; 5 6 7 8; 1 2 3 4]))
    @test_throws ErrorConstrDimMismatch (S([fmpz(1), 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4]))
 
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [fmpz, Int, BigInt]
+      M = matrix(FlintZZ, map(T, arr))
+      @test isa(M, fmpz_mat)
+      @test M.base_ring == FlintZZ
+
+      M2 = matrix(FlintZZ, 2, 3, map(T, arr2))
+      @test isa(M2, fmpz_mat)
+      @test M2.base_ring == FlintZZ
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(FlintZZ, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(FlintZZ, 2, 4, map(T, arr2))
+   end
+
+   M3 = zero_matrix(FlintZZ, 2, 3)
+
+   @test isa(M3, fmpz_mat)
+   @test M3.base_ring == FlintZZ
+
    println("PASS")
 end
 
 function test_fmpz_mat_printing()
    print("fmpz_mat.printing...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
    f = S(fmpz(3))
 
    @test string(f) == "[3 0 0]\n[0 3 0]\n[0 0 3]"
@@ -54,7 +76,7 @@ function test_fmpz_mat_convert()
    # Basic tests.
    A = [[1 2 3]; [4 5 6]]
    Abig = BigInt[[1 2 3]; [4 5 6]]
-   S = MatrixSpace(ZZ, 2, 3)
+   S = MatrixSpace(FlintZZ, 2, 3)
    B = S(A)
 
    @test Matrix{Int}(B) == A
@@ -70,7 +92,7 @@ end
 function test_fmpz_mat_manipulation()
    print("fmpz_mat.manipulation...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
    B = S([fmpz(1) 4 7; 9 6 7; 4 3 3])
 
@@ -92,14 +114,14 @@ end
 function test_fmpz_mat_view()
    print("fmpz_mat.view...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([1 2 3; 4 5 6; 7 8 9])
 
    B = @inferred view(A, 1, 1, 2, 2)
 
    @test typeof(B) == fmpz_mat
-   @test B == MatrixSpace(ZZ, 2, 2)([1 2; 4 5])
+   @test B == MatrixSpace(FlintZZ, 2, 2)([1 2; 4 5])
 
    B[1, 1] = 10
    @test A[1, 1] == 10
@@ -107,7 +129,7 @@ function test_fmpz_mat_view()
    C = @inferred view(B, 1:2, 1:2)
 
    @test typeof(C) == fmpz_mat
-   @test C == MatrixSpace(ZZ, 2, 2)([10 2; 4 5])
+   @test C == MatrixSpace(FlintZZ, 2, 2)([10 2; 4 5])
 
    C[1, 1] = 20
    @test B[1, 1] == 20
@@ -119,7 +141,7 @@ end
 function test_fmpz_mat_unary_ops()
    print("fmpz_mat.unary_ops...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
    B = S([fmpz(-2) (-3) (-5); (-1) (-4) (-7); (-9) (-6) (-3)])
@@ -132,7 +154,7 @@ end
 function test_fmpz_mat_binary_ops()
    print("fmpz_mat.binary_ops...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
    B = S([fmpz(1) 4 7; 9 6 7; 4 3 3])
@@ -149,7 +171,7 @@ end
 function test_fmpz_mat_adhoc_binary()
    print("fmpz_mat.adhoc_binary...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -166,7 +188,7 @@ end
 function test_fmpz_mat_comparison()
    print("fmpz_mat.comparison...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
    B = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
@@ -181,7 +203,7 @@ end
 function test_fmpz_mat_adhoc_comparison()
    print("fmpz_mat.adhoc_comparison...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -198,7 +220,7 @@ end
 function test_fmpz_mat_powering()
    print("fmpz_mat.powering...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -212,7 +234,7 @@ end
 function test_fmpz_mat_adhoc_exact_division()
    print("fmpz_mat.adhoc_exact_division...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -225,7 +247,7 @@ end
 function test_fmpz_mat_gram()
    print("fmpz_mat.gram...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -237,7 +259,7 @@ end
 function test_fmpz_mat_trace()
    print("fmpz_mat.trace...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -249,7 +271,7 @@ end
 function test_fmpz_mat_content()
    print("fmpz_mat.content...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -260,7 +282,7 @@ end
 function test_fmpz_mat_transpose()
    print("fmpz_mat.transpose...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -278,7 +300,7 @@ end
 function test_fmpz_mat_scaling()
    print("fmpz_mat.scaling...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
 
@@ -290,7 +312,7 @@ end
 function test_fmpz_mat_inversion()
    print("fmpz_mat.inversion...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 2 2])
    B = S([-6 4 1; 61 (-41) (-9); -34 23 5])
@@ -307,7 +329,7 @@ end
 function test_fmpz_mat_pseudo_inversion()
    print("fmpz_mat.pseudo_inversion...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([1 2 3; 1 2 3; 1 2 3])
    B = S([1 0 1; 2 3 1; 5 6 7])
@@ -323,7 +345,7 @@ end
 function test_fmpz_mat_exact_division()
    print("fmpz_mat.exact_division...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 2 2])
    B = S([2 3 4; 7 9 1; 5 4 5])
@@ -336,7 +358,7 @@ end
 function test_fmpz_mat_modular_reduction()
    print("fmpz_mat.modular_reduction...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 2 2])
    B = S([2 0 2; 1 1 1; 0 2 2])
@@ -351,7 +373,7 @@ end
 function test_fmpz_mat_det()
    print("fmpz_mat.det...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 19 3 7])
 
@@ -369,7 +391,7 @@ end
 function test_fmpz_mat_hadamard()
    print("fmpz_mat.hadamard...")
 
-   S = MatrixSpace(ZZ, 4, 4)
+   S = MatrixSpace(FlintZZ, 4, 4)
 
    @test ishadamard(hadamard(S))
 
@@ -379,7 +401,7 @@ end
 function test_fmpz_mat_hnf()
    print("fmpz_mat.hnf...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 19 3 7])
 
@@ -406,7 +428,7 @@ end
 function test_fmpz_mat_lll()
    print("fmpz_mat.lll...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 19 3 7])
 
@@ -434,8 +456,8 @@ end
 function test_fmpz_mat_nullspace()
    print("fmpz_mat.nullspace...")
 
-   S = MatrixSpace(ZZ, 3, 3)
-   T = MatrixSpace(ZZ, 3, 1)
+   S = MatrixSpace(FlintZZ, 3, 3)
+   T = MatrixSpace(FlintZZ, 3, 1)
 
    A = S([fmpz(2) 3 5; 1 4 7; 4 1 1])
 
@@ -451,7 +473,7 @@ end
 function test_fmpz_mat_rank()
    print("fmpz_mat.rank...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 4 1 1])
 
@@ -463,7 +485,7 @@ end
 function test_fmpz_mat_rref()
    print("fmpz_mat.rref...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 4 1 1])
 
@@ -475,7 +497,7 @@ end
 function test_fmpz_mat_snf()
    print("fmpz_mat.snf...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 19 3 7])
 
@@ -493,11 +515,11 @@ end
 function test_fmpz_mat_solve_rational()
    print("fmpz_mat.solve_rational...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 2 2])
 
-   T = MatrixSpace(ZZ, 3, 1)
+   T = MatrixSpace(FlintZZ, 3, 1)
 
    B = T([fmpz(4), 5, 7])
 
@@ -519,11 +541,11 @@ end
 function test_fmpz_mat_solve()
    print("fmpz_mat.solve...")
 
-   S = MatrixSpace(ZZ, 3, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 2 2])
 
-   T = MatrixSpace(ZZ, 3, 1)
+   T = MatrixSpace(FlintZZ, 3, 1)
 
    B = T([fmpz(4), 5, 7])
 
@@ -539,9 +561,9 @@ end
 function test_fmpz_mat_concat()
    print("fmpz_mat.concat...")
 
-   S = MatrixSpace(ZZ, 3, 3)
-   T = MatrixSpace(ZZ, 3, 6)
-   U = MatrixSpace(ZZ, 6, 3)
+   S = MatrixSpace(FlintZZ, 3, 3)
+   T = MatrixSpace(FlintZZ, 3, 6)
+   U = MatrixSpace(FlintZZ, 6, 3)
 
    A = S([fmpz(2) 3 5; 1 4 7; 9 6 3])
    B = S([fmpz(1) 4 7; 9 6 7; 4 3 3])

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -114,7 +114,6 @@ function test_nmod_mat_constructors()
   @test_throws ErrorConstrDimMismatch R([Z2(1), Z2(1), Z2(1)])
   @test_throws ErrorConstrDimMismatch R([Z2(1), Z2(1), Z2(1), Z2(1), Z2(1)])
 
-
   @test isa(S(1), nmod_mat)
   
   @test isa(S(fmpz(1)), nmod_mat)
@@ -128,7 +127,29 @@ function test_nmod_mat_constructors()
   @test d == e
   @test e == f
   @test g == e
-  
+
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [Z3, fmpz, Int, BigInt]
+      M = matrix(Z3, map(T, arr))
+      @test isa(M, nmod_mat)
+      @test M.base_ring == Z3
+
+      M2 = matrix(Z3, 2, 3, map(T, arr2))
+      @test isa(M2, nmod_mat)
+      @test M2.base_ring == Z3
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(Z3, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(Z3, 2, 4, map(T, arr2))
+   end
+
+   M3 = zero_matrix(Z3, 2, 3)
+
+   @test isa(M3, nmod_mat)
+   @test M3.base_ring == Z3
+
   println("PASS")
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -360,6 +360,31 @@ function test_gen_mat_constructors()
    @test_throws ErrorConstrDimMismatch S([t t^2 t^3 ; t^4 t^5 t^6 ; t^7 t^8 t^9 ; t t^2 t^3])
    @test_throws ErrorConstrDimMismatch S([t, t^2])
    @test_throws ErrorConstrDimMismatch S([t, t^2, t^3, t^4, t^5, t^6, t^7, t^8, t^9, t^10]) 
+
+   arr = [1 2; 3 4]
+   arr2 = [1, 2, 3, 4, 5, 6]
+
+   for T in [R, Int, BigInt, Rational{Int}, Rational{BigInt}]
+      M = matrix(R, map(T, arr))
+      @test isa(M, Generic.Mat{elem_type(R)})
+      @test M.base_ring == R
+      @test rows(M) == 2
+      @test cols(M) == 2
+
+      M2 = matrix(R, 2, 3, map(T, arr2))
+      @test isa(M2, Generic.Mat{elem_type(R)})
+      @test M2.base_ring == R
+      @test rows(M2) == 2
+      @test cols(M2) == 3
+      @test_throws ErrorConstrDimMismatch matrix(R, 2, 2, map(T, arr2))
+      @test_throws ErrorConstrDimMismatch matrix(R, 2, 4, map(T, arr2))
+   end
+
+   M3 = zero_matrix(R, 2, 3)
+
+   @test isa(M3, Generic.Mat{elem_type(R)})
+   @test M3.base_ring == R
+
    println("PASS")
 end
 
@@ -531,6 +556,23 @@ function test_gen_mat_adhoc_exact_division()
    @test divexact((1 + t)*A, 1 + t) == A
 
    println("PASS")
+end
+
+function test_gen_mat_transpose()
+   print("Generic.Mat.transpose...")
+
+   R, t = PolynomialRing(JuliaQQ, "t")
+   arr = [t + 1 t R(1); t^2 t t]
+   A = matrix(R, arr)
+   B = matrix(R, permutedims(arr, [2, 1]))
+   @test transpose(A) == B
+
+   arr = [t + 1 t; t^2 t]
+   A = matrix(R, arr)
+   B = matrix(R, permutedims(arr, [2, 1]))
+   @test transpose(A) == B
+
+   println("PASS")   
 end
 
 function test_gen_mat_gram()
@@ -1244,7 +1286,7 @@ function test_gen_row_swapping()
    println("PASS")
 end
 
-function test_gen_concat()
+function test_gen_mat_concat()
    print("Generic.Mat.concat...")
 
    R, x = PolynomialRing(JuliaZZ, "x")
@@ -1455,7 +1497,7 @@ function test_gen_mat_weak_popov()
 
    R, x = PolynomialRing(JuliaQQ, "x")
 
-   A = Matrix(R, 3, 4, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]))
+   A = matrix(R, map(R, Any[1 2 3 x; x 2*x 3*x x^2; x x^2+1 x^3+x^2 x^4+x^2+1]))
    r = rank(A)
 
    P = weak_popov(A)
@@ -1470,7 +1512,7 @@ function test_gen_mat_weak_popov()
    
    S, y = PolynomialRing(F, "y")
 
-   B = Matrix(S, 3, 3, map(S, Any[ 4*y^2+3*y+5 4*y^2+3*y+4 6*y^2+1; 3*y+6 3*y+5 y+3; 6*y^2+4*y+2 6*y^2 2*y^2+y]))
+   B = matrix(S, map(S, Any[ 4*y^2+3*y+5 4*y^2+3*y+4 6*y^2+1; 3*y+6 3*y+5 y+3; 6*y^2+4*y+2 6*y^2 2*y^2+y]))
    s = rank(B)
 
    P = weak_popov(B)
@@ -1530,6 +1572,7 @@ function test_gen_mat()
    test_gen_mat_adhoc_comparison()
    test_gen_mat_powering()
    test_gen_mat_adhoc_exact_division()
+   test_gen_mat_transpose()
    test_gen_mat_gram()
    test_gen_mat_trace()
    test_gen_mat_content()
@@ -1546,7 +1589,7 @@ function test_gen_mat()
    test_gen_mat_charpoly()
    test_gen_mat_minpoly()
    test_gen_row_swapping()
-   test_gen_concat()
+   test_gen_mat_concat()
    test_gen_mat_hnf_kb()
    test_gen_mat_hnf_cohen()
    test_gen_mat_hnf()


### PR DESCRIPTION
@wbhart I think in one of our previous discussions this came up. Here is the aim
- Rename the function `Matrix` to `matrix` and implement it in every matrix module.
- Provide `zero_matrix` to remove the remaining `MatrixSpace` calls. It is also super handy if you want to first create a matrix which you want to fill.
- Make `R[0, 0; 0 1]` call the `matrix` function.
- The generic matrices will provide the fallback version. So `matrix(R::{T <: Ring}, ...)` will construct generic matrices in case it is not explicitely provided  for `T`.

So far I did it only for `fmpz_mat`. If you think this is a good idea, I will finish it.

