### PR TITLE
Fix #248.

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1026,6 +1026,10 @@ function solve_rational(a::fmpz_mat, b::fmpz_mat)
    return z, d
 end
 
+function Generic.solve_with_det(a::fmpz_mat, b::fmpz_mat)
+   return solve_rational(a, b)
+end
+
 doc"""
     solve_dixon(a::fmpz_mat, b::fmpz_mat)
 > Return a tuple $(x, m)$ consisting of a column vector $x$ such that $ax = b

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1536,7 +1536,7 @@ function solve_fflu(A::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
 end
 
 function solve_fflu_precomp(p::Generic.perm, FFLU::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
-   x = inv(p) * b 
+   x = p * b 
    n = rows(x)
    m = cols(x)
    R = base_ring(FFLU)

--- a/src/generic/Matrix.jl
+++ b/src/generic/Matrix.jl
@@ -1004,6 +1004,7 @@ function fflu!(P::Generic.perm, A::Nemo.MatElem{T}) where {T <: FieldElement}
       r += 1
       c += 1
    end
+   inv!(P)
    return rank, d2
 end
 
@@ -1523,6 +1524,121 @@ end
 #
 ###############################################################################
 
+function solve_fflu(A::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
+   base_ring(A) != base_ring(b) && error("Base rings don't match in solve_fflu")
+   rows(A) != cols(A) && error("Non-square matrix in solve_fflu")
+   rows(A) != rows(b) && error("Dimensions don't match in solve_fflu")
+   FFLU = deepcopy(A)
+   p = PermGroup(rows(A))()
+   r, d = fflu!(p, FFLU)
+   r < rows(A) && error("Singular matrix in solve_fflu")
+   return solve_fflu_precomp(p, FFLU, b), d
+end
+
+function solve_fflu_precomp(p::Generic.perm, FFLU::MatElem{T}, b::MatElem{T}) where {T <: RingElement}
+   x = inv(p) * b 
+   n = rows(x)
+   m = cols(x)
+   R = base_ring(FFLU)
+
+   t = base_ring(b)()
+   s = base_ring(b)()
+   minus_one = R(-1)
+
+   for k in 1:m
+      for i in 1:(n - 1)
+         t = mul!(t, x[i, k], minus_one)
+         for j in (i + 1):n
+            if i == 1
+              x[j, k] = x[j, k] * FFLU[i, i]
+            else
+              x[j, k] = mul!(x[j, k], x[j, k], FFLU[i, i])
+            end
+            s = mul!(s, FFLU[j, i], t)
+            x[j, k] = addeq!(x[j, k], s)
+            if i > 1
+                x[j, k] = divexact(x[j, k], FFLU[i - 1, i - 1])
+            end
+         end
+      end
+
+      for i in (n - 1):-1:1
+         if i > 1
+            x[i, k] = mul!(x[i, k], x[i, k], FFLU[n, n])
+         else
+            x[i, k] = x[i, k] * FFLU[n, n]
+         end
+         for j in (i + 1):n
+            t = mul!(t, x[j, k], FFLU[i, j])
+            t = mul!(t, t, minus_one)
+            x[i, k] = addeq!(x[i, k], t)
+         end
+         x[i, k] = divexact(x[i, k], FFLU[i, i])
+      end
+   end
+   return x
+end
+
+function solve_lu(A::MatElem{T}, b::MatElem{T}) where {T <: FieldElement}
+   base_ring(A) != base_ring(b) && error("Base rings don't match in solve_lu")
+   rows(A) != cols(A) && error("Non-square matrix in solve_lu")
+   rows(A) != rows(b) && error("Dimensions don't match in solve_lu")
+   
+   if rows(A) == 0 || cols(A) == 0
+      return b
+   end
+
+   LU = deepcopy(A)
+   p = PermGroup(rows(A))()
+   r = lufact!(p, LU)
+   r < rows(A) && error("Singular matrix in solve_lu")
+   return solve_lu_precomp(p, LU, b)
+end
+
+function solve_lu_precomp(p::Generic.perm, LU::MatElem{T}, b::MatElem{T}) where {T <: FieldElement}
+   x = p * b 
+   n = rows(x)
+   m = cols(x)
+   R = base_ring(LU)
+
+   t = base_ring(b)()
+   s = base_ring(b)()
+   minus_one = R(-1)
+
+   for k in 1:m
+      x[1, k] = deepcopy(x[1, k])
+      for i in 2:n
+         for j in 1:(i - 1)
+            # x[i, k] = x[i, k] - LU[i, j] * x[j, k]
+            t = mul!(t, LU[i, j], x[j, k])
+            t = mul!(t, t, minus_one)
+            if j == 1
+               x[i, k] = x[i, k] + t #LU[i, j] * x[j, k]
+            else
+               x[i, k] = addeq!(x[i, k], t)
+            end
+         end
+      end
+
+      # Now every entry of x is a proper copy, so we can change the entries
+      # as much as we want.
+
+      x[n, k] = divexact(x[n, k], LU[n, n])
+
+      for i in (n - 1):-1:1
+         for j in (i + 1):n
+            #x[i, k] = x[i, k] - x[j, k] * LU[i, j]
+            t = mul!(t, x[j, k], LU[i, j])
+            t = mul!(t, t, minus_one)
+            x[i, k] = addeq!(x[i, k], t)
+         end
+         x[i, k] = divexact(x[i, k], LU[i, i])
+      end
+   end
+   return x
+end
+
+
 function backsolve!(A::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: FieldElement}
    m = rows(A)
    h = cols(b)
@@ -1541,180 +1657,49 @@ function backsolve!(A::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: FieldEle
    end
 end
 
-function solve!(A::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: FieldElement}
-   m = rows(A)
-   n = cols(A)
-   h = cols(b)
-   r = 1
-   c = 1
-   R = base_ring(A)
-   d = R(1)
-   if m == 0 || n == 0
-      return
-   end
-   t = R()
-   while r <= m && c <= n
-      if A[r, c] == 0
-         i = r + 1
-         while i <= m
-            if !iszero(A[i, c])
-               for j = 1:n
-                  A[i, j], A[r, j] = A[r, j], A[i, j]
-               end
-               for j = 1:h
-                  b[i, j], b[r, j] = b[r, j], b[i, j]
-               end
-               break
-            end
-            i += 1
-         end
-         i > m && error("Matrix is singular in solve")
-      end
-      q = -A[r, c]
-      for i = r + 1:m
-         for j = 1:h
-            t = mul!(t, A[i, c], b[r, j])
-            b[i, j] = mul!(b[i, j], b[i, j], A[r, c])
-            b[i, j] = addeq!(b[i, j], -t)
-         end
-         for j = c + 1:n
-            A[i, j] = mul!(A[i, j], A[i, j], q)
-            t = mul!(t, A[i, c], A[r, j])
-            A[i, j] = addeq!(A[i, j], t)
-            if r > 1
-               A[i, j] = mul!(A[i, j], A[i, j], d)
-            else
-               A[i, j] = -A[i, j]
-            end
-         end
-         if r > 1
-            for j = 1:h
-               b[i, j] = mul!(b[i, j], b[i, j], -d)
-            end
-         end
-      end
-      d = -inv(A[r, c])
-      r += 1
-      c += 1
-   end
-   backsolve!(A, b)
-end
-
 function solve_ff(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: FieldElement}
    base_ring(M) != base_ring(b) && error("Base rings don't match in solve")
    rows(M) != cols(M) && error("Non-square matrix in solve")
    rows(M) != rows(b) && error("Dimensions don't match in solve")
    m = rows(M)
-   A = deepcopy(M)
-   x = deepcopy(b)
-   solve!(A, x)
+   x, d = solve_fflu(M, b)
+   for i in 1:rows(x)
+      for j in 1:cols(x)
+         x[i, j] = divexact(x[i, j], d)
+      end
+   end
    return x
 end
 
-function solve_with_det(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: FieldElement}
-   m = rows(M)
-   h = cols(b)
-   A = deepcopy(M)
-   x = deepcopy(b)
-   solve!(A, x)
-   d = A[m, m]
-   for i = 1:m
-      for j = 1:h
-         x[i, j] = mul!(x[i, j], x[i, j], d)
+function solve_with_det(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElement}
+   # We cannot use solve_fflu directly, since it forgot about the (parity of
+   # the) permutation.
+   rows(M) != cols(M) && error("Non-square matrix")
+   R = base_ring(M)
+   FFLU = deepcopy(M)
+   p = PermGroup(rows(M))()
+   r, d = fflu!(p, FFLU)
+   if r < rows(M)
+      error("Non-singular matrix in solve_with_det")
+   end
+   x = solve_fflu_precomp(p, FFLU, b)
+   # Now M*x = d*b, but d is only sign(P) * det(M)
+   if parity(p) != 0
+      minus_one = R(-1)
+      for k in 1:cols(x)
+         for i in 1:rows(x)
+            # We are allowed to modify x in-place.
+            x[i, k] = mul!(x[i, k], x[i, k], minus_one)
+         end
       end
-   end   
+      d = mul!(d, d, minus_one)
+   end
    return x, d
 end
 
-function solve_with_det(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElement}
-   return solve_rational(M, b)
-end
-
-function backsolve!(A::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElement}
-   m = rows(A)
-   h = cols(b)
-   R = base_ring(A)
-   t = R()
-   d = A[m, m]
-   for k = 1:h
-      b[m, k] = -b[m, k]
-   end
-   for i = m - 1:-1:1
-      q = -A[i, i]
-      for k = 1:h
-         b[i, k] = mul!(b[i, k], b[i, k], d)
-         for j = i + 1:m
-            t = mul!(t, A[i, j], b[j, k])
-            b[i, k] = addeq!(b[i, k], t)
-         end
-         b[i, k] = divexact(b[i, k], q)
-      end 
-   end
-   for i = 1:m
-      for k = 1:h
-         b[i, k] = -b[i, k]
-      end
-   end
-   return d
-end
-
-function solve!(A::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElement}
-   m = rows(A)
-   n = cols(A)
-   h = cols(b)
-   r = 1
-   c = 1
-   R = base_ring(A)
-   d = R(1)
-   if m == 0 || n == 0
-      return
-   end
-   t = R()
-   while r <= m && c <= n
-      if A[r, c] == 0
-         i = r + 1
-         while i <= m
-            if !iszero(A[i, c])
-               for j = 1:n
-                  A[i, j], A[r, j] = A[r, j], A[i, j]
-               end
-               for j = 1:h
-                  b[i, j], b[r, j] = b[r, j], b[i, j]
-               end
-               break
-            end
-            i += 1
-         end
-         i > m && error("Matrix is singular in solve")
-      end
-      q = -A[r, c]
-      for i = r + 1:m
-         for j = 1:h
-            t = mul!(t, A[i, c], b[r, j])
-            b[i, j] = mul!(b[i, j], b[i, j], A[r, c])
-            b[i, j] = addeq!(b[i, j], -t)
-         end 
-         for j = c + 1:n
-            A[i, j] = mul!(A[i, j], A[i, j], q)
-            t = mul!(t, A[i, c], A[r, j])
-            A[i, j] = addeq!(A[i, j], t)
-            if r > 1
-               A[i, j] = divexact(A[i, j], d)
-            else
-               A[i, j] = -A[i, j]
-            end
-         end
-         if r > 1
-            for j = 1:h
-               b[i, j] = divexact(b[i, j], -d)
-            end
-         end
-      end
-      d = -A[r, c]
-      r += 1
-      c += 1
-   end
-   return backsolve!(A, b)
+function solve_with_det(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: PolyElem}
+   x, d = solve_interpolation(M, b)
+   return x, d
 end
 
 function solve_ff(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElement}
@@ -1723,10 +1708,7 @@ function solve_ff(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: RingElemen
    if m == 0 || n == 0
       return b, base_ring(M)()
    end
-   A = deepcopy(M)
-   x = deepcopy(b)
-   d = solve!(A, x)
-   return x, d
+   return solve_fflu(M, b)
 end
 
 function solve_interpolation(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <: PolyElem}
@@ -1761,18 +1743,28 @@ function solve_interpolation(M::Nemo.MatElem{T}, b::Nemo.MatElem{T}) where {T <:
    x = similar(b)
    b2 = div(bound, 2)
    pt1 = base_ring(R)(1 - b2)
-   for i = 1:bound
-      y[i] = base_ring(R)(i - b2)
-      (y[i] == pt1 && i != 1) && error("Not enough interpolation points in ring")
+   l = 1
+   i = 1
+   while l <= bound
+      y[l] = base_ring(R)(i - b2)
+      (y[l] == pt1 && i != 1) && error("Not enough interpolation points in ring")
       for j = 1:m
          for k = 1:m
-            X[j, k] = evaluate(M[j, k], y[i])
+            X[j, k] = evaluate(M[j, k], y[l])
          end
          for k = 1:h
-            Y[j, k] = evaluate(b[j, k], y[i])
+            Y[j, k] = evaluate(b[j, k], y[l])
          end
       end
-      V[i], d[i] = solve_with_det(X, Y)
+      try
+         V[l], d[l] = solve_with_det(X, Y)
+         l = l + 1
+      catch e
+         if !(e isa ErrorException)
+            rethrow(e)
+         end
+      end
+      i = i + 1
    end
    for k = 1:h
       for i = 1:m
@@ -1898,7 +1890,7 @@ function inv(M::Nemo.MatElem{T}) where {T <: RingElement}
    n = cols(M)
    X = eye(M)
    A = deepcopy(M)
-   d = solve!(A, X)
+   X, d = solve_fflu(A, X)
    return X, d
 end
 
@@ -1912,9 +1904,8 @@ function inv(M::Nemo.MatElem{T}) where {T <: FieldElement}
    cols(M) != rows(M) && error("Matrix not square in invert")
    n = cols(M)
    X = eye(M)
-   A = deepcopy(M)
-   solve!(A, X)
-   return X
+   A = solve_lu(M, X)
+   return A
 end
 
 ###############################################################################

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -87,6 +87,10 @@ function randelem(R::Generic.ResRing{BigInt}, n)
    return rand(R, -n:n)
 end
 
+function randelem(R::Nemo.Rationals{BigInt}, n)
+   return BigInt(rand(-n:n))//BigInt(rand(-n:n))
+end
+
 function randelem(R::Nemo.NmodRing, n)
    return rand(R, -n:n)
 end
@@ -128,7 +132,7 @@ function randmat(R::Generic.MatSpace{T}, d::Int, c::Int) where {T <: RingElem}
    return r
 end
 
-function randmat(S::Generic.MatSpace{T}) where {T <: RingElem}
+function randmat(S::Generic.MatSpace{T}) where {T <: Nemo.RingElement}
    M = S()
    m = rows(M)
    n = cols(M)
@@ -140,7 +144,7 @@ function randmat(S::Generic.MatSpace{T}) where {T <: RingElem}
    return M
 end
 
-function randmat(S::Generic.MatSpace{T}, c::Int) where {T <: RingElem}
+function randmat(S::Generic.MatSpace{T}, c::Int) where {T <: Nemo.RingElement}
    M = S()
    m = rows(M)
    n = cols(M)
@@ -188,7 +192,7 @@ function randmat_triu(S::Generic.MatSpace{T}, c::Int) where {T <: RingElem}
    return M
 end
 
-function randmat_with_rank(R::Generic.MatSpace{T}, d::Int, c::Int, rank::Int) where {T <: RingElem}
+function randmat_with_rank(R::Generic.MatSpace{T}, d::Int, c::Int, rank::Int) where {T <: Nemo.RingElement}
    m = R.rows
    n = R.cols
    r = R()
@@ -223,7 +227,7 @@ function randmat_with_rank(R::Generic.MatSpace{T}, d::Int, c::Int, rank::Int) wh
    return r
 end
 
-function randmat_with_rank(S::Generic.MatSpace{T}, c::Int, rank::Int) where {T <: RingElem}
+function randmat_with_rank(S::Generic.MatSpace{T}, c::Int, rank::Int) where {T <: Nemo.RingElement}
    M = S()
    m = rows(M)
    n = cols(M)
@@ -703,6 +707,17 @@ function test_gen_mat_fflu()
    @test r == 2
    @test P*A == L*D*U
 
+   A = matrix(JuliaQQ, 3, 3, [0, 0, 1, 12, 1, 11, 1, 0, 1])
+
+   r, d, P, L, U, = fflu(A)
+
+   D = zero_matrix(JuliaQQ, 3, 3)
+   D[1, 1] = inv(U[1, 1])
+   D[2, 2] = inv(U[1, 1]*U[2, 2])
+   D[3, 3] = inv(U[2, 2])
+   @test r == 3
+   @test P*A == L*D*U
+
    println("PASS")
 end
 
@@ -822,6 +837,44 @@ function test_gen_mat_rank()
    end
 
    println("PASS")   
+end
+
+function test_gen_mat_solve_lu()
+   print("Generic.Mat.solve_lu...")
+
+   S = JuliaQQ
+
+   for dim = 0:5
+      R = MatrixSpace(S, dim, dim)
+      U = MatrixSpace(S, dim, rand(1:5))
+
+      M = randmat_with_rank(R, 100, dim);
+      b = randmat(U, 100);
+
+      x = Generic.solve_lu(M, b)
+
+      @test M*x == b
+   end
+
+   S, y = PolynomialRing(JuliaZZ, "y")
+   K = FractionField(S)
+
+   for dim = 0:5
+      R = MatrixSpace(S, dim, dim)
+      U = MatrixSpace(S, dim, rand(1:5))
+
+      M = randmat_with_rank(R, 5, 100, dim);
+      b = randmat(U, 5, 100);
+
+      MK = matrix(K, elem_type(K)[ K(M[i, j]) for i in 1:rows(M), j in 1:cols(M) ])
+      bK = matrix(K, elem_type(K)[ K(b[i, j]) for i in 1:rows(b), j in 1:cols(b) ])
+
+      x = Generic.solve_lu(MK, bK)
+
+      @test MK*x == bK
+   end
+
+   println("PASS")
 end
 
 function test_gen_mat_solve_rational()
@@ -1632,6 +1685,7 @@ function test_gen_mat()
    test_gen_mat_fflu()
    test_gen_mat_det()
    test_gen_mat_rank()
+   test_gen_mat_solve_lu()
    test_gen_mat_solve_rational()
    test_gen_mat_solve_triu()
    test_gen_mat_rref()

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -88,7 +88,11 @@ function randelem(R::Generic.ResRing{BigInt}, n)
 end
 
 function randelem(R::Nemo.Rationals{BigInt}, n)
-   return BigInt(rand(-n:n))//BigInt(rand(-n:n))
+   z = BigInt(rand(-n:n))
+   while iszero(z)
+      z = BigInt(rand(-n:n))
+   end
+   return BigInt(rand(-n:n))//z
 end
 
 function randelem(R::Nemo.NmodRing, n)


### PR DESCRIPTION
Fix #248. This was quite a rabbit hole. Here is what is contained:

There were some undocumented solve! and backsolve! which did solving
and (ff)lu factorization at the same time. I removed them and replaced
them by solve_fflu, solve_fflu_precomp, solve_lu, solve_lu_precomp.
This has two advantages:
- It does the same as flint.
- One can solve multiple times with the same left side.
- I can get the determinant.

Also the solve_interpolation used interpolated solutions, where the
interpolated determinant was zero. This is not quite correct if
solve_with_det is allowed to return any solution together with the determinant.

The generic solve_with_det called solve_rational, which is confusing
since there is no reason solve_rational has to return the determinant
as the denominator (it is only a coincidence that it is the same for
fmpz_mat).

The timings of the benchmarks are not effected.