### PR TITLE
Changes for the new ccall syntax

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -36,7 +36,7 @@ mutable struct AnticNumberField <: Field
          nf = new()
          nf.pol = pol
          ccall((:nf_init, :libflint), Void, 
-            (Ptr{AnticNumberField}, Ptr{fmpq_poly}), &nf, &pol)
+            (Ref{AnticNumberField}, Ref{fmpq_poly}), nf, pol)
          finalizer(nf, _AnticNumberField_clear_fn)
          nf.S = s
          nf.auxilliary_data = Array{Any}(5)
@@ -48,7 +48,7 @@ mutable struct AnticNumberField <: Field
             nf = new()
             nf.pol = pol
             ccall((:nf_init, :libflint), Void, 
-               (Ptr{AnticNumberField}, Ptr{fmpq_poly}), &nf, &pol)
+               (Ref{AnticNumberField}, Ref{fmpq_poly}), nf, pol)
             finalizer(nf, _AnticNumberField_clear_fn)
             nf.S = s
             nf.auxilliary_data = Array{Any}(5)
@@ -62,7 +62,7 @@ mutable struct AnticNumberField <: Field
 end
 
 function _AnticNumberField_clear_fn(a::AnticNumberField)
-   ccall((:nf_clear, :libflint), Void, (Ptr{AnticNumberField},), &a)
+   ccall((:nf_clear, :libflint), Void, (Ref{AnticNumberField},), a)
 end
 
 mutable struct nf_elem <: FieldElem
@@ -75,7 +75,7 @@ mutable struct nf_elem <: FieldElem
    function nf_elem(p::AnticNumberField)
       r = new()
       ccall((:nf_elem_init, :libflint), Void, 
-            (Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &p)
+            (Ref{nf_elem}, Ref{AnticNumberField}), r, p)
       r.parent = p
       finalizer(r, _nf_elem_clear_fn)
       return r
@@ -84,9 +84,9 @@ mutable struct nf_elem <: FieldElem
    function nf_elem(p::AnticNumberField, a::nf_elem)
       r = new()
       ccall((:nf_elem_init, :libflint), Void, 
-            (Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &p)
+            (Ref{nf_elem}, Ref{AnticNumberField}), r, p)
       ccall((:nf_elem_set, :libflint), Void,
-            (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &a, &p)
+            (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}), r, a, p)
       r.parent = p
       finalizer(r, _nf_elem_clear_fn)
       return r
@@ -95,5 +95,5 @@ end
 
 function _nf_elem_clear_fn(a::nf_elem)
    ccall((:nf_elem_clear, :libflint), Void, 
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &a.parent)
+         (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -81,14 +81,14 @@ function coeff(x::nf_elem, n::Int)
    n < 0 && throw(DomainError())
    z = fmpq()
    ccall((:nf_elem_get_coeff_fmpq, :libflint), Void,
-     (Ptr{fmpq}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, &x, n, &parent(x))
+     (Ref{fmpq}, Ref{nf_elem}, Int, Ref{AnticNumberField}), z, x, n, parent(x))
    return z
 end
 
 function num_coeff!(z::fmpz, x::nf_elem, n::Int)
    n < 0 && throw(DomainError())
    ccall((:nf_elem_get_coeff_fmpz, :libflint), Void,
-     (Ptr{fmpz}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, &x, n, &parent(x))
+     (Ref{fmpz}, Ref{nf_elem}, Int, Ref{AnticNumberField}), z, x, n, parent(x))
    return z
 end
 
@@ -99,7 +99,7 @@ doc"""
 function gen(a::AnticNumberField)
    r = nf_elem(a)
    ccall((:nf_elem_gen, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &a)
+         (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
 
@@ -110,7 +110,7 @@ doc"""
 function one(a::AnticNumberField)
    r = nf_elem(a)
    ccall((:nf_elem_one, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &a)
+         (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
 
@@ -121,7 +121,7 @@ doc"""
 function zero(a::AnticNumberField)
    r = nf_elem(a)
    ccall((:nf_elem_zero, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &a)
+         (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
 
@@ -132,7 +132,7 @@ doc"""
 """
 function isgen(a::nf_elem)
    return ccall((:nf_elem_is_gen, :libflint), Bool,
-                (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &a.parent)
+                (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
 doc"""
@@ -142,7 +142,7 @@ doc"""
 """
 function isone(a::nf_elem)
    return ccall((:nf_elem_is_one, :libflint), Bool,
-                (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &a.parent)
+                (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
 doc"""
@@ -152,7 +152,7 @@ doc"""
 """
 function iszero(a::nf_elem)
    return ccall((:nf_elem_is_zero, :libflint), Bool,
-                (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &a.parent)
+                (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
 doc"""
@@ -170,8 +170,8 @@ doc"""
 function denominator(a::nf_elem)
    z = fmpz()
    ccall((:nf_elem_get_den, :libflint), Void,
-         (Ptr{fmpz}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &z, &a, &a.parent)
+         (Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
+         z, a, a.parent)
    return z
 end
 
@@ -180,15 +180,15 @@ function elem_from_mat_row(a::AnticNumberField, b::fmpz_mat, i::Int, d::fmpz)
    cols(b) == degree(a) || error("Wrong number of columns")
    z = a()
    ccall((:nf_elem_set_fmpz_mat_row, :libflint), Void,
-        (Ptr{nf_elem}, Ptr{fmpz_mat}, Int, Ptr{fmpz}, Ptr{AnticNumberField}),
-        &z, &b, i - 1, &d, &a)
+        (Ref{nf_elem}, Ref{fmpz_mat}, Int, Ref{fmpz}, Ref{AnticNumberField}),
+        z, b, i - 1, d, a)
    return z
 end
 
 function elem_to_mat_row!(a::fmpz_mat, i::Int, d::fmpz, b::nf_elem)
    ccall((:nf_elem_get_fmpz_mat_row, :libflint), Void,
-         (Ptr{fmpz_mat}, Int, Ptr{fmpz}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &a, i - 1, &d, &b, &b.parent)
+         (Ref{fmpz_mat}, Int, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
+         a, i - 1, d, b, b.parent)
    nothing
  end
 
@@ -225,8 +225,8 @@ end
 
 function show(io::IO, x::nf_elem)
    cstr = ccall((:nf_elem_get_str_pretty, :libflint), Ptr{UInt8},
-                (Ptr{nf_elem}, Ptr{UInt8}, Ptr{AnticNumberField}),
-                 &x, string(var(parent(x))), &parent(x))
+                (Ref{nf_elem}, Ptr{UInt8}, Ref{AnticNumberField}),
+                 x, string(var(parent(x))), parent(x))
    s = unsafe_string(cstr)
    ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 
@@ -249,8 +249,8 @@ isnegative(::nf_elem) = false
 function -(a::nf_elem)
    r = a.parent()
    ccall((:nf_elem_neg, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, a.parent)
    return r
 end
 
@@ -264,8 +264,8 @@ function +(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
    ccall((:nf_elem_add, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -273,8 +273,8 @@ function -(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
    ccall((:nf_elem_sub, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -282,8 +282,8 @@ function *(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
    ccall((:nf_elem_mul, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -296,72 +296,72 @@ end
 function +(a::nf_elem, b::Int)
    r = a.parent()
    ccall((:nf_elem_add_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &r, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function +(a::nf_elem, b::fmpz)
    r = a.parent()
    ccall((:nf_elem_add_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function +(a::nf_elem, b::fmpq)
    r = a.parent()
    ccall((:nf_elem_add_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function -(a::nf_elem, b::Int)
    r = a.parent()
    ccall((:nf_elem_sub_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &r, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function -(a::nf_elem, b::fmpz)
    r = a.parent()
    ccall((:nf_elem_sub_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function -(a::nf_elem, b::fmpq)
    r = a.parent()
    ccall((:nf_elem_sub_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function -(a::Int, b::nf_elem)
    r = b.parent()
    ccall((:nf_elem_si_sub, :libflint), Void,
-         (Ptr{nf_elem}, Int, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, a, &b, &b.parent)
+         (Ref{nf_elem}, Int, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, b.parent)
    return r
 end
 
 function -(a::fmpz, b::nf_elem)
    r = b.parent()
    ccall((:nf_elem_fmpz_sub, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpz}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &b.parent)
+         (Ref{nf_elem}, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, b.parent)
    return r
 end
 
 function -(a::fmpq, b::nf_elem)
    r = b.parent()
    ccall((:nf_elem_fmpq_sub, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpq}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &b.parent)
+         (Ref{nf_elem}, Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, b.parent)
    return r
 end
 
@@ -386,24 +386,24 @@ end
 function *(a::nf_elem, b::Int)
    r = a.parent()
    ccall((:nf_elem_scalar_mul_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &r, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function *(a::nf_elem, b::fmpz)
    r = a.parent()
    ccall((:nf_elem_scalar_mul_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
 function *(a::nf_elem, b::fmpq)
    r = a.parent()
    ccall((:nf_elem_scalar_mul_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -446,8 +446,8 @@ end
 function ^(a::nf_elem, n::Int)
    r = a.parent()
    ccall((:nf_elem_pow, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &r, &a, abs(n), &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         r, a, abs(n), a.parent)
    if n < 0
       r = inv(r)
    end
@@ -463,7 +463,7 @@ end
 function ==(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    return ccall((:nf_elem_equal, :libflint), Bool,
-           (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &b, &a.parent)
+           (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}), a, b, a.parent)
 end
 
 ###############################################################################
@@ -498,8 +498,8 @@ function inv(a::nf_elem)
    iszero(a) && throw(DivideError())
    r = a.parent()
    ccall((:nf_elem_inv, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, a.parent)
    return r
 end
 
@@ -514,8 +514,8 @@ function divexact(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
    ccall((:nf_elem_div, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -529,8 +529,8 @@ function divexact(a::nf_elem, b::Int)
    b == 0 && throw(DivideError())
    r = a.parent()
    ccall((:nf_elem_scalar_div_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &r, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -538,8 +538,8 @@ function divexact(a::nf_elem, b::fmpz)
    iszero(b) && throw(DivideError())
    r = a.parent()
    ccall((:nf_elem_scalar_div_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -549,8 +549,8 @@ function divexact(a::nf_elem, b::fmpq)
    iszero(b) && throw(DivideError())
    r = a.parent()
    ccall((:nf_elem_scalar_div_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &r, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         r, a, b, a.parent)
    return r
 end
 
@@ -590,8 +590,8 @@ doc"""
 function norm(a::nf_elem)
    z = fmpq()
    ccall((:nf_elem_norm, :libflint), Void,
-         (Ptr{fmpq}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &z, &a, &a.parent)
+         (Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
+         z, a, a.parent)
    return z
 end
 
@@ -602,8 +602,8 @@ doc"""
 function trace(a::nf_elem)
    z = fmpq()
    ccall((:nf_elem_trace, :libflint), Void,
-         (Ptr{fmpq}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &z, &a, &a.parent)
+         (Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
+         z, a, a.parent)
    return z
 end
 
@@ -615,41 +615,41 @@ end
 
 function zero!(a::nf_elem)
    ccall((:nf_elem_zero, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &a, &parent(a))
+         (Ref{nf_elem}, Ref{AnticNumberField}), a, parent(a))
    return a
 end
 
 function mul!(z::nf_elem, x::nf_elem, y::nf_elem)
    ccall((:nf_elem_mul, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-                                                  &z, &x, &y, &parent(x))
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+                                                  z, x, y, parent(x))
    return z
 end
 
 function mul_red!(z::nf_elem, x::nf_elem, y::nf_elem, red::Bool)
    ccall((:nf_elem_mul_red, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}, Cint),
-                                                &z, &x, &y, &parent(x), red)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}, Cint),
+                                                z, x, y, parent(x), red)
    return z
 end
 
 function addeq!(z::nf_elem, x::nf_elem)
    ccall((:nf_elem_add, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-                                                  &z, &z, &x, &parent(x))
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+                                                  z, z, x, parent(x))
    return z
 end
 
 function add!(a::nf_elem, b::nf_elem, c::nf_elem)
    ccall((:nf_elem_add, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &a, &b, &c, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
+         a, b, c, a.parent)
   return a
 end
 
 function reduce!(x::nf_elem)
    ccall((:nf_elem_reduce, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{AnticNumberField}), &x, &parent(x))
+         (Ref{nf_elem}, Ref{AnticNumberField}), x, parent(x))
    return x
 end
 
@@ -661,22 +661,22 @@ end
 
 function add!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_add_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_add_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_add_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &c, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
@@ -684,22 +684,22 @@ add!(c::nf_elem, a::nf_elem, b::Integer) = add!(c, a, fmpz(b))
 
 function sub!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_sub_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_sub_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_sub_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &c, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
@@ -707,22 +707,22 @@ sub!(c::nf_elem, a::nf_elem, b::Integer) = sub!(c, a, fmpz(b))
 
 function sub!(c::nf_elem, a::fmpq, b::nf_elem)
    ccall((:nf_elem_fmpq_sub, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpq}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::fmpz, b::nf_elem)
    ccall((:nf_elem_fmpz_sub, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpz}, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::Int, b::nf_elem)
    ccall((:nf_elem_si_sub, :libflint), Void,
-         (Ptr{nf_elem}, Int, Ptr{nf_elem}, Ptr{AnticNumberField}),
-         &c, a, &b, &b.parent)
+         (Ref{nf_elem}, Int, Ref{nf_elem}, Ref{AnticNumberField}),
+         c, a, b, b.parent)
    return c
 end
 
@@ -730,22 +730,22 @@ sub!(c::nf_elem, a::Integer, b::nf_elem) = sub!(c, fmpz(a), b)
 
 function mul!(c::nf_elem, a::nf_elem, b::fmpq)
    ccall((:nf_elem_scalar_mul_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::fmpz)
    ccall((:nf_elem_scalar_mul_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}),
-         &c, &a, &b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::Int)
    ccall((:nf_elem_scalar_mul_si, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{nf_elem}, Int, Ptr{AnticNumberField}),
-         &c, &a, b, &a.parent)
+         (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
+         c, a, b, a.parent)
    return c
 end
 
@@ -903,14 +903,14 @@ promote_rule(::Type{nf_elem}, ::Type{fmpq_poly}) = nf_elem
 function (a::AnticNumberField)()
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
-         (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, 0, &a)
+         (Ref{nf_elem}, Int, Ref{AnticNumberField}), z, 0, a)
    return z
 end
 
 function (a::AnticNumberField)(c::Int)
    z = nf_elem(a)
    ccall((:nf_elem_set_si, :libflint), Void,
-         (Ptr{nf_elem}, Int, Ptr{AnticNumberField}), &z, c, &a)
+         (Ref{nf_elem}, Int, Ref{AnticNumberField}), z, c, a)
    return z
 end
 
@@ -919,14 +919,14 @@ end
 function (a::AnticNumberField)(c::fmpz)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpz, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpz}, Ptr{AnticNumberField}), &z, &c, &a)
+         (Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}), z, c, a)
    return z
 end
 
 function (a::AnticNumberField)(c::fmpq)
    z = nf_elem(a)
    ccall((:nf_elem_set_fmpq, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpq}, Ptr{AnticNumberField}), &z, &c, &a)
+         (Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}), z, c, a)
    return z
 end
 
@@ -942,7 +942,7 @@ function (a::AnticNumberField)(pol::fmpq_poly)
       pol = mod(pol, a.pol)
    end
    ccall((:nf_elem_set_fmpq_poly, :libflint), Void,
-         (Ptr{nf_elem}, Ptr{fmpq_poly}, Ptr{AnticNumberField}), &z, &pol, &a)
+         (Ref{nf_elem}, Ref{fmpq_poly}, Ref{AnticNumberField}), z, pol, a)
    return z
 end
 
@@ -950,7 +950,7 @@ function (a::FmpqPolyRing)(b::nf_elem)
    parent(parent(b).pol) != a && error("Cannot coerce from number field to polynomial ring")
    r = a()
    ccall((:nf_elem_get_fmpq_poly, :libflint), Void,
-         (Ptr{fmpq_poly}, Ptr{nf_elem}, Ptr{AnticNumberField}), &r, &b, &parent(b))
+         (Ref{fmpq_poly}, Ref{nf_elem}, Ref{AnticNumberField}), r, b, parent(b))
    return r
 end
 

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -99,7 +99,7 @@ mutable struct arb <: FieldElem
 
   function arb()
     z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
+    ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     finalizer(z, _arb_clear_fn)
     return z
   end
@@ -107,7 +107,7 @@ mutable struct arb <: FieldElem
   function arb(x::Union{Int, UInt, Float64, fmpz, fmpq,
                         BigFloat, AbstractString, arb}, p::Int)
     z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
+    ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     _arb_set(z, x, p)
     finalizer(z, _arb_clear_fn)
     return z
@@ -115,7 +115,7 @@ mutable struct arb <: FieldElem
 
   function arb(x::Union{Int, UInt, Float64, fmpz, BigFloat, arb})
     z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
+    ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     _arb_set(z, x)
     finalizer(z, _arb_clear_fn)
     return z
@@ -123,24 +123,24 @@ mutable struct arb <: FieldElem
 
   function arb(mid::arb, rad::arb)
     z = new()
-    ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-    ccall((:arb_set, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &mid)
-    ccall((:arb_add_error, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &rad)
+    ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
+    ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), z, mid)
+    ccall((:arb_add_error, :libarb), Void, (Ref{arb}, Ref{arb}), z, rad)
     finalizer(z, _arb_clear_fn)
     return z
   end
 
   #function arb(x::arf)
   #  z = new()
-  #  ccall((:arb_init, :libarb), Void, (Ptr{arb}, ), &z)
-  #  ccall((:arb_set_arf, :libarb), Void, (Ptr{arb}, Ptr{arf}), &z, &x)
+  #  ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
+  #  ccall((:arb_set_arf, :libarb), Void, (Ref{arb}, Ref{arf}), z, x)
   #  finalizer(z, _arb_clear_fn)
   #  return z
   #end
 end
 
 function _arb_clear_fn(x::arb)
-  ccall((:arb_clear, :libarb), Void, (Ptr{arb}, ), &x)
+  ccall((:arb_clear, :libarb), Void, (Ref{arb}, ), x)
 end
 
 ################################################################################
@@ -187,14 +187,14 @@ mutable struct acb <: FieldElem
 
   function acb()
     z = new()
-    ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+    ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     finalizer(z, _acb_clear_fn)
     return z
   end
 
   function acb(x::Union{Int, UInt, Float64, fmpz, BigFloat, arb, acb})
     z = new()
-    ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+    ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x)
     finalizer(z, _acb_clear_fn)
     return z
@@ -203,7 +203,7 @@ mutable struct acb <: FieldElem
   function acb(x::Union{Int, UInt, Float64, fmpz, fmpq,
                         BigFloat, arb, acb, AbstractString}, p::Int)
     z = new()
-    ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+    ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x, p)
     finalizer(z, _acb_clear_fn)
     return z
@@ -211,7 +211,7 @@ mutable struct acb <: FieldElem
 
   #function acb{T <: Union{Int, UInt, Float64, fmpz, BigFloat, arb}}(x::T, y::T)
   #  z = new()
-  #  ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+  #  ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
   #  _acb_set(z, x, y)
   #  finalizer(z, _acb_clear_fn)
   #  return z
@@ -219,7 +219,7 @@ mutable struct acb <: FieldElem
 
   function acb(x::T, y::T, p::Int) where {T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString, arb}}
     z = new()
-    ccall((:acb_init, :libarb), Void, (Ptr{acb}, ), &z)
+    ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x, y, p)
     finalizer(z, _acb_clear_fn)
     return z
@@ -227,7 +227,7 @@ mutable struct acb <: FieldElem
 end
 
 function _acb_clear_fn(x::acb)
-  ccall((:acb_clear, :libarb), Void, (Ptr{acb}, ), &x)
+  ccall((:acb_clear, :libarb), Void, (Ref{acb}, ), x)
 end
 
 
@@ -264,26 +264,26 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly()
     z = new()
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
   function arb_poly(x::arb, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_coeff_arb, :libarb), Void,
-                (Ptr{arb_poly}, Int, Ptr{arb}), &z, 0, &x)
+                (Ref{arb_poly}, Int, Ref{arb}), z, 0, x)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
   function arb_poly(x::Array{arb, 1}, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     for i = 1:length(x)
         ccall((:arb_poly_set_coeff_arb, :libarb), Void,
-                (Ptr{arb_poly}, Int, Ptr{arb}), &z, i - 1, &x[i])
+                (Ref{arb_poly}, Int, Ref{arb}), z, i - 1, x[i])
     end
     finalizer(z, _arb_poly_clear_fn)
     return z
@@ -291,42 +291,42 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly(x::arb_poly)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
-    ccall((:arb_poly_set, :libarb), Void, (Ptr{arb_poly}, Ptr{arb_poly}), &z, &x)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set, :libarb), Void, (Ref{arb_poly}, Ref{arb_poly}), z, x)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
   function arb_poly(x::arb_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_round, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, p)
+                (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, p)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
   function arb_poly(x::fmpz_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_fmpz_poly, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{fmpz_poly}, Int), &z, &x, p)
+                (Ref{arb_poly}, Ref{fmpz_poly}, Int), z, x, p)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
   function arb_poly(x::fmpq_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Void, (Ptr{arb_poly}, ), &z)
+    ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_fmpq_poly, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{fmpq_poly}, Int), &z, &x, p)
+                (Ref{arb_poly}, Ref{fmpq_poly}, Int), z, x, p)
     finalizer(z, _arb_poly_clear_fn)
     return z
   end
 end
 
 function _arb_poly_clear_fn(x::arb_poly)
-  ccall((:arb_poly_clear, :libarb), Void, (Ptr{arb_poly}, ), &x)
+  ccall((:arb_poly_clear, :libarb), Void, (Ref{arb_poly}, ), x)
 end
 
 parent(x::arb_poly) = x.parent
@@ -372,26 +372,26 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly()
     z = new()
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::acb, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_coeff_acb, :libarb), Void,
-                (Ptr{acb_poly}, Int, Ptr{acb}), &z, 0, &x)
+                (Ref{acb_poly}, Int, Ref{acb}), z, 0, x)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::Array{acb, 1}, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     for i = 1:length(x)
         ccall((:acb_poly_set_coeff_acb, :libarb), Void,
-                (Ptr{acb_poly}, Int, Ptr{acb}), &z, i - 1, &x[i])
+                (Ref{acb_poly}, Int, Ref{acb}), z, i - 1, x[i])
     end
     finalizer(z, _acb_poly_clear_fn)
     return z
@@ -399,53 +399,53 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::acb_poly)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
-    ccall((:acb_poly_set, :libarb), Void, (Ptr{acb_poly}, Ptr{acb_poly}), &z, &x)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set, :libarb), Void, (Ref{acb_poly}, Ref{acb_poly}), z, x)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::arb_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_arb_poly, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{arb_poly}, Int), &z, &x, p)
+                (Ref{acb_poly}, Ref{arb_poly}, Int), z, x, p)
     ccall((:acb_poly_set_round, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &z, p)
+                (Ref{acb_poly}, Ref{acb_poly}, Int), z, z, p)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::acb_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_round, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, p)
+                (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, p)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::fmpz_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_fmpz_poly, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{fmpz_poly}, Int), &z, &x, p)
+                (Ref{acb_poly}, Ref{fmpz_poly}, Int), z, x, p)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
   function acb_poly(x::fmpq_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Void, (Ptr{acb_poly}, ), &z)
+    ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_fmpq_poly, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{fmpq_poly}, Int), &z, &x, p)
+                (Ref{acb_poly}, Ref{fmpq_poly}, Int), z, x, p)
     finalizer(z, _acb_poly_clear_fn)
     return z
   end
 end
 
 function _acb_poly_clear_fn(x::acb_poly)
-  ccall((:acb_poly_clear, :libarb), Void, (Ptr{acb_poly}, ), &x)
+  ccall((:acb_poly_clear, :libarb), Void, (Ref{acb_poly}, ), x)
 end
 
 parent(x::acb_poly) = x.parent
@@ -493,7 +493,7 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(r::Int, c::Int)
     z = new()
-    ccall((:arb_mat_init, :libarb), Void, (Ptr{arb_mat}, Int, Int), &z, r, c)
+    ccall((:arb_mat_init, :libarb), Void, (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(z, _arb_mat_clear_fn)
     return z
   end
@@ -501,9 +501,9 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(a::fmpz_mat)
     z = new()
     ccall((:arb_mat_init, :libarb), Void,
-                (Ptr{arb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_fmpz_mat, :libarb), Void,
-                (Ptr{arb_mat}, Ptr{fmpz_mat}), &z, &a)
+                (Ref{arb_mat}, Ref{fmpz_mat}), z, a)
     finalizer(z, _arb_mat_clear_fn)
     return z
   end
@@ -511,9 +511,9 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(a::fmpz_mat, prec::Int)
     z = new()
     ccall((:arb_mat_init, :libarb), Void,
-                (Ptr{arb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_round_fmpz_mat, :libarb), Void,
-                (Ptr{arb_mat}, Ptr{fmpz_mat}, Int), &z, &a, prec)
+                (Ref{arb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
     finalizer(z, _arb_mat_clear_fn)
     return z
   end
@@ -521,12 +521,12 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(r::Int, c::Int, arr::Array{T, 2}) where {T <: Union{Int, UInt, fmpz, Float64, BigFloat, arb}}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
-                (Ptr{arb_mat}, Int, Int), &z, r, c)
+                (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
-                    (Ptr{arb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+                    (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[i, j])
       end
     end
@@ -536,12 +536,12 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(r::Int, c::Int, arr::Array{T, 1}) where {T <: Union{Int, UInt, fmpz, Float64, BigFloat, arb}}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
-                (Ptr{arb_mat}, Int, Int), &z, r, c)
+                (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
-                    (Ptr{arb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+                    (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[(i-1)*c+j])
       end
     end
@@ -551,12 +551,12 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(r::Int, c::Int, arr::Array{T, 2}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
-                (Ptr{arb_mat}, Int, Int), &z, r, c)
+                (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
-                    (Ptr{arb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+                    (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[i, j], prec)
       end
     end
@@ -566,12 +566,12 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(r::Int, c::Int, arr::Array{T, 1}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
-                (Ptr{arb_mat}, Int, Int), &z, r, c)
+                (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
-                    (Ptr{arb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+                    (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[(i-1)*c+j], prec)
       end
     end
@@ -581,16 +581,16 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(a::fmpq_mat, prec::Int)
     z = new()
     ccall((:arb_mat_init, :libarb), Void,
-                (Ptr{arb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_fmpq_mat, :libarb), Void,
-                (Ptr{arb_mat}, Ptr{fmpq_mat}, Int), &z, &a, prec)
+                (Ref{arb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
     finalizer(z, _arb_mat_clear_fn)
     return z
   end
 end
 
 function _arb_mat_clear_fn(x::arb_mat)
-  ccall((:arb_mat_clear, :libarb), Void, (Ptr{arb_mat}, ), &x)
+  ccall((:arb_mat_clear, :libarb), Void, (Ref{arb_mat}, ), x)
 end
 
 ################################################################################
@@ -628,7 +628,7 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int)
     z = new()
-    ccall((:acb_mat_init, :libarb), Void, (Ptr{acb_mat}, Int, Int), &z, r, c)
+    ccall((:acb_mat_init, :libarb), Void, (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
@@ -636,9 +636,9 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(a::fmpz_mat)
     z = new()
     ccall((:acb_mat_init, :libarb), Void,
-                (Ptr{acb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_fmpz_mat, :libarb), Void,
-                (Ptr{acb_mat}, Ptr{fmpz_mat}), &z, &a)
+                (Ref{acb_mat}, Ref{fmpz_mat}), z, a)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
@@ -646,9 +646,9 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(a::fmpz_mat, prec::Int)
     z = new()
     ccall((:acb_mat_init, :libarb), Void,
-                (Ptr{acb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_round_fmpz_mat, :libarb), Void,
-                (Ptr{acb_mat}, Ptr{fmpz_mat}, Int), &z, &a, prec)
+                (Ref{acb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
@@ -656,9 +656,9 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(a::arb_mat)
     z = new()
     ccall((:acb_mat_init, :libarb), Void,
-                (Ptr{acb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_arb_mat, :libarb), Void,
-                (Ptr{acb_mat}, Ptr{arb_mat}), &z, &a)
+                (Ref{acb_mat}, Ref{arb_mat}), z, a)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
@@ -666,9 +666,9 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(a::arb_mat, prec::Int)
     z = new()
     ccall((:acb_mat_init, :libarb), Void,
-                (Ptr{acb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_round_arb_mat, :libarb), Void,
-                (Ptr{acb_mat}, Ptr{arb_mat}, Int), &z, &a, prec)
+                (Ref{acb_mat}, Ref{arb_mat}, Int), z, a, prec)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
@@ -676,12 +676,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 2}) where {T <: Union{Int, UInt, Float64, fmpz}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
     end
@@ -691,12 +691,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 2}) where {T <: Union{BigFloat, acb, arb}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
     end
@@ -706,12 +706,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 1}) where {T <: Union{Int, UInt, Float64, fmpz}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
     end
@@ -721,12 +721,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 1}) where {T <: Union{BigFloat, acb, arb}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
     end
@@ -736,12 +736,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 2}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
     end
@@ -751,12 +751,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 2}, prec::Int) where {T <: Union{BigFloat, arb, AbstractString, acb}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
     end
@@ -766,12 +766,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 1}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
     end
@@ -781,12 +781,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::Array{T, 1}, prec::Int) where {T <: Union{BigFloat, arb, AbstractString, acb}}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
     end
@@ -797,12 +797,12 @@ mutable struct acb_mat <: MatElem{acb}
 
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
@@ -813,12 +813,12 @@ mutable struct acb_mat <: MatElem{acb}
 
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
@@ -829,12 +829,12 @@ mutable struct acb_mat <: MatElem{acb}
 
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
@@ -845,12 +845,12 @@ mutable struct acb_mat <: MatElem{acb}
 
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
-                (Ptr{acb_mat}, Int, Int), &z, r, c)
+                (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
-                    (Ptr{acb_mat}, Int, Int), &z, i - 1, j - 1)
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+                    (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
@@ -860,15 +860,15 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(a::fmpq_mat, prec::Int)
     z = new()
     ccall((:acb_mat_init, :libarb), Void,
-                (Ptr{acb_mat}, Int, Int), &z, a.r, a.c)
+                (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_fmpq_mat, :libarb), Void,
-                (Ptr{acb_mat}, Ptr{fmpq_mat}, Int), &z, &a, prec)
+                (Ref{acb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
     finalizer(z, _acb_mat_clear_fn)
     return z
   end
 end
 
 function _acb_mat_clear_fn(x::acb_mat)
-  ccall((:acb_mat_clear, :libarb), Void, (Ptr{acb_mat}, ), &x)
+  ccall((:acb_mat_clear, :libarb), Void, (Ref{acb_mat}, ), x)
 end
 

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -20,10 +20,10 @@ parent_type(::Type{acb_poly}) = AcbPolyRing
 elem_type(::Type{AcbPolyRing}) = acb_poly
 
 length(x::acb_poly) = ccall((:acb_poly_length, :libarb), Int, 
-                                   (Ptr{acb_poly},), &x)
+                                   (Ref{acb_poly},), x)
 
 set_length!(x::acb_poly, n::Int) = ccall((:_acb_poly_set_length, :libarb), Void,
-                                   (Ptr{acb_poly}, Int), &x, n)
+                                   (Ref{acb_poly}, Int), x, n)
 
 degree(x::acb_poly) = length(x) - 1
 
@@ -31,7 +31,7 @@ function coeff(a::acb_poly, n::Int)
   n < 0 && throw(DomainError())
   t = parent(a).base_ring()
   ccall((:acb_poly_get_coeff_acb, :libarb), Void,
-              (Ptr{acb}, Ptr{acb_poly}, Int), &t, &a, n)
+              (Ref{acb}, Ref{acb_poly}, Int), t, a, n)
   return t
 end
 
@@ -42,7 +42,7 @@ one(a::AcbPolyRing) = a(1)
 function gen(a::AcbPolyRing)
    z = acb_poly()
    ccall((:acb_poly_set_coeff_si, :libarb), Void,
-        (Ptr{acb_poly}, Int, Int), &z, 1, 1)
+        (Ref{acb_poly}, Int, Int), z, 1, 1)
    z.parent = a
    return z
 end
@@ -101,7 +101,7 @@ end
 
 function isequal(x::acb_poly, y::acb_poly)
    return ccall((:acb_poly_equal, :libarb), Bool,
-                                      (Ptr{acb_poly}, Ptr{acb_poly}), &x, &y)
+                                      (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
 doc"""
@@ -111,7 +111,7 @@ doc"""
 """
 function overlaps(x::acb_poly, y::acb_poly)
    return ccall((:acb_poly_overlaps, :libarb), Bool,
-                                      (Ptr{acb_poly}, Ptr{acb_poly}), &x, &y)
+                                      (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
 doc"""
@@ -121,7 +121,7 @@ doc"""
 """
 function contains(x::acb_poly, y::acb_poly)
    return ccall((:acb_poly_contains, :libarb), Bool,
-                                      (Ptr{acb_poly}, Ptr{acb_poly}), &x, &y)
+                                      (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
 doc"""
@@ -131,7 +131,7 @@ doc"""
 """
 function contains(x::acb_poly, y::fmpz_poly)
    return ccall((:acb_poly_contains_fmpz_poly, :libarb), Bool,
-                                      (Ptr{acb_poly}, Ptr{fmpz_poly}), &x, &y)
+                                      (Ref{acb_poly}, Ref{fmpz_poly}), x, y)
 end
 
 doc"""
@@ -141,7 +141,7 @@ doc"""
 """
 function contains(x::acb_poly, y::fmpq_poly)
    return ccall((:acb_poly_contains_fmpq_poly, :libarb), Bool,
-                                      (Ptr{acb_poly}, Ptr{fmpq_poly}), &x, &y)
+                                      (Ref{acb_poly}, Ref{fmpq_poly}), x, y)
 end
 
 function ==(x::acb_poly, y::acb_poly)
@@ -174,7 +174,7 @@ doc"""
 function unique_integer(x::acb_poly)
   z = FmpzPolyRing(var(parent(x)))()
   unique = ccall((:acb_poly_get_unique_fmpz_poly, :libarb), Int,
-    (Ptr{fmpz_poly}, Ptr{acb_poly}), &z, &x)
+    (Ref{fmpz_poly}, Ref{acb_poly}), z, x)
   return (unique != 0, z)
 end
 
@@ -184,7 +184,7 @@ doc"""
 > imaginary parts.
 """
 function isreal(x::acb_poly)
-  return ccall((:acb_poly_is_real, :libarb), Cint, (Ptr{acb_poly}, ), &x) != 0
+  return ccall((:acb_poly_is_real, :libarb), Cint, (Ref{acb_poly}, ), x) != 0
 end
 
 ###############################################################################
@@ -197,7 +197,7 @@ function shift_left(x::acb_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:acb_poly_shift_left, :libarb), Void,
-      (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, len)
+      (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
    return z
 end
 
@@ -205,7 +205,7 @@ function shift_right(x::acb_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:acb_poly_shift_right, :libarb), Void,
-       (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, len)
+       (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
    return z
 end
 
@@ -217,7 +217,7 @@ end
 
 function -(x::acb_poly)
   z = parent(x)()
-  ccall((:acb_poly_neg, :libarb), Void, (Ptr{acb_poly}, Ptr{acb_poly}), &z, &x)
+  ccall((:acb_poly_neg, :libarb), Void, (Ref{acb_poly}, Ref{acb_poly}), z, x)
   return z
 end
 
@@ -230,24 +230,24 @@ end
 function +(x::acb_poly, y::acb_poly)
   z = parent(x)()
   ccall((:acb_poly_add, :libarb), Void,
-              (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
 function *(x::acb_poly, y::acb_poly)
   z = parent(x)()
   ccall((:acb_poly_mul, :libarb), Void,
-              (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
 function -(x::acb_poly, y::acb_poly)
   z = parent(x)()
   ccall((:acb_poly_sub, :libarb), Void,
-              (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
@@ -255,8 +255,8 @@ function ^(x::acb_poly, y::Int)
   y < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:acb_poly_pow_ui, :libarb), Void,
-              (Ptr{acb_poly}, Ptr{acb_poly}, UInt, Int),
-              &z, &x, y, prec(parent(x)))
+              (Ref{acb_poly}, Ref{acb_poly}, UInt, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
@@ -323,8 +323,8 @@ function divrem(x::acb_poly, y::acb_poly)
    q = parent(x)()
    r = parent(x)()
    if (ccall((:acb_poly_divrem, :libarb), Int,
-         (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-               &q, &r, &x, &y, prec(parent(x))) == 1)
+         (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+               q, r, x, y, prec(parent(x))) == 1)
       return (q, r)
    else
       throw(DivideError())
@@ -353,7 +353,7 @@ function truncate(a::acb_poly, n::Int)
    # todo: implement set_trunc in arb
    z = deepcopy(a)
    ccall((:acb_poly_truncate, :libarb), Void,
-                (Ptr{acb_poly}, Int), &z, n)
+                (Ref{acb_poly}, Int), z, n)
    return z
 end
 
@@ -361,8 +361,8 @@ function mullow(x::acb_poly, y::acb_poly, n::Int)
    n < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:acb_poly_mullow, :libarb), Void,
-         (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int, Int),
-            &z, &x, &y, n, prec(parent(x)))
+         (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int, Int),
+            z, x, y, n, prec(parent(x)))
    return z
 end
 
@@ -376,7 +376,7 @@ end
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
 #   ccall((:acb_poly_reverse, :libarb), Void,
-#                (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, len)
+#                (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
 #   return z
 #end
 
@@ -389,8 +389,8 @@ end
 function evaluate(x::acb_poly, y::acb)
    z = parent(y)()
    ccall((:acb_poly_evaluate, :libarb), Void,
-                (Ptr{acb}, Ptr{acb_poly}, Ptr{acb}, Int),
-                &z, &x, &y, prec(parent(y)))
+                (Ref{acb}, Ref{acb_poly}, Ref{acb}, Int),
+                z, x, y, prec(parent(y)))
    return z
 end
 
@@ -403,8 +403,8 @@ function evaluate2(x::acb_poly, y::acb)
    z = parent(y)()
    w = parent(y)()
    ccall((:acb_poly_evaluate2, :libarb), Void,
-                (Ptr{acb}, Ptr{acb}, Ptr{acb_poly}, Ptr{acb}, Int),
-                &z, &w, &x, &y, prec(parent(y)))
+                (Ref{acb}, Ref{acb}, Ref{acb_poly}, Ref{acb}, Int),
+                z, w, x, y, prec(parent(y)))
    return z, w
 end
 
@@ -470,8 +470,8 @@ end
 function compose(x::acb_poly, y::acb_poly)
    z = parent(x)()
    ccall((:acb_poly_compose, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-                &z, &x, &y, prec(parent(x)))
+                (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+                z, x, y, prec(parent(x)))
    return z
 end
 
@@ -484,14 +484,14 @@ end
 function derivative(x::acb_poly)
    z = parent(x)()
    ccall((:acb_poly_derivative, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, prec(parent(x)))
+                (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
 function integral(x::acb_poly)
    z = parent(x)()
    ccall((:acb_poly_integral, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Int), &z, &x, prec(parent(x)))
+                (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
@@ -508,8 +508,8 @@ end
 function acb_vec(b::Array{acb, 1})
    v = ccall((:_acb_vec_init, :libarb), Ptr{acb_struct}, (Int,), length(b))
    for i=1:length(b)
-       ccall((:acb_set, :libarb), Void, (Ptr{acb_struct}, Ptr{acb}),
-           v + (i-1)*sizeof(acb_struct), &b[i])
+       ccall((:acb_set, :libarb), Void, (Ptr{acb_struct}, Ref{acb}),
+           v + (i-1)*sizeof(acb_struct), b[i])
    end
    return v
 end
@@ -518,8 +518,8 @@ function array(R::AcbField, v::Ptr{acb_struct}, n::Int)
    r = Array{acb}(n)
    for i=1:n
        r[i] = R()
-       ccall((:acb_set, :libarb), Void, (Ptr{acb}, Ptr{acb_struct}),
-           &r[i], v + (i-1)*sizeof(acb_struct))
+       ccall((:acb_set, :libarb), Void, (Ref{acb}, Ptr{acb_struct}),
+           r[i], v + (i-1)*sizeof(acb_struct))
    end
    return r
 end
@@ -536,7 +536,7 @@ function from_roots(R::AcbPolyRing, b::Array{acb, 1})
    z = R()
    tmp = acb_vec(b)
    ccall((:acb_poly_product_roots, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_struct}, Int, Int), &z, tmp, length(b), prec(R))
+                (Ref{acb_poly}, Ptr{acb_struct}, Int, Int), z, tmp, length(b), prec(R))
    acb_vec_clear(tmp, length(b))
    return z
 end
@@ -548,8 +548,8 @@ end
 function evaluate_fast(x::acb_poly, b::Array{acb, 1})
    tmp = acb_vec(b)
    ccall((:acb_poly_evaluate_vec_fast, :libarb), Void,
-                (Ptr{acb_struct}, Ptr{acb_poly}, Ptr{acb_struct}, Int, Int),
-            tmp, &x, tmp, length(b), prec(parent(x)))
+                (Ptr{acb_struct}, Ref{acb_poly}, Ptr{acb_struct}, Int, Int),
+            tmp, x, tmp, length(b), prec(parent(x)))
    res = array(base_ring(parent(x)), tmp, length(b))
    acb_vec_clear(tmp, length(b))
    return res
@@ -561,8 +561,8 @@ function interpolate_newton(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{acb, 1}
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
    ccall((:acb_poly_interpolate_newton, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
    acb_vec_clear(ysv, length(ys))
    return z
@@ -574,8 +574,8 @@ function interpolate_barycentric(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{ac
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
    ccall((:acb_poly_interpolate_barycentric, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
    acb_vec_clear(ysv, length(ys))
    return z
@@ -587,8 +587,8 @@ function interpolate_fast(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{acb, 1})
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
    ccall((:acb_poly_interpolate_fast, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
    acb_vec_clear(ysv, length(ys))
    return z
@@ -642,8 +642,8 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
         in_roots = (wp == initial_prec) ? C_NULL : roots
         step_max_iter = (max_iter >= 1) ? max_iter : min(max(deg, 32), wp)
         isolated = ccall((:acb_poly_find_roots, :libarb), Int,
-            (Ptr{acb_struct}, Ptr{acb_poly}, Ptr{acb_struct}, Int, Int),
-                roots, &x, in_roots, step_max_iter, wp)
+            (Ptr{acb_struct}, Ref{acb_poly}, Ptr{acb_struct}, Int, Int),
+                roots, x, in_roots, step_max_iter, wp)
 
         wp = wp * 2
 
@@ -655,8 +655,8 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
                     im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct},
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
-                    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), re)
-                    u = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), im)
+                    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), re)
+                    u = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), im)
                     ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
                         (Ptr{mag_struct}, Int), t, -target) <= 0)
                     ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
@@ -666,7 +666,7 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
 
             if isreal(x)
                 real_ok = ccall((:acb_poly_validate_real_roots, :libarb),
-                    Bool, (Ptr{acb_struct}, Ptr{acb_poly}, Int), roots, &x, wp)
+                    Bool, (Ptr{acb_struct}, Ref{acb_poly}, Int), roots, x, wp)
 
                 if isolate_real && !real_ok
                     ok = false
@@ -722,13 +722,13 @@ doc"""
 function roots_upper_bound(x::acb_poly)
    z = ArbField(prec(base_ring(x)))()
    p = prec(base_ring(x))
-   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), &z)
+   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
    ccall((:acb_poly_root_bound_fujiwara, :libarb), Void,
-         (Ptr{mag_struct}, Ptr{acb_poly}), t, &x)
-   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), &z)
-   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+         (Ptr{mag_struct}, Ref{acb_poly}), t, x)
+   s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
+   ccall((:arf_set_mag, :libarb), Void, (Ref{arf_struct}, Ptr{mag_struct}), s, t)
    ccall((:arf_set_round, :libarb), Void,
-         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+         (Ref{arf_struct}, Ref{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
    ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
    return z
 end
@@ -740,46 +740,46 @@ end
 ###############################################################################
 
 function zero!(z::acb_poly)
-   ccall((:acb_poly_zero, :libarb), Void, (Ptr{acb_poly},), &z)
+   ccall((:acb_poly_zero, :libarb), Void, (Ref{acb_poly},), z)
    return z
 end
 
 function fit!(z::acb_poly, n::Int)
    ccall((:acb_poly_fit_length, :libarb), Void,
-                    (Ptr{acb_poly}, Int), &z, n)
+                    (Ref{acb_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::fmpz)
    ccall((:acb_poly_set_coeff_fmpz, :libarb), Void,
-                    (Ptr{acb_poly}, Int, Ptr{fmpz}), &z, n, &x)
+                    (Ref{acb_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::acb)
    ccall((:acb_poly_set_coeff_acb, :libarb), Void,
-                    (Ptr{acb_poly}, Int, Ptr{acb}), &z, n, &x)
+                    (Ref{acb_poly}, Int, Ref{acb}), z, n, x)
    return z
 end
 
 function mul!(z::acb_poly, x::acb_poly, y::acb_poly)
    ccall((:acb_poly_mul, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-                    &z, &x, &y, prec(parent(z)))
+                (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+                    z, x, y, prec(parent(z)))
    return z
 end
 
 function addeq!(z::acb_poly, x::acb_poly)
    ccall((:acb_poly_add, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-                    &z, &z, &x, prec(parent(z)))
+                (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+                    z, z, x, prec(parent(z)))
    return z
 end
 
 function add!(z::acb_poly, x::acb_poly, y::acb_poly)
    ccall((:acb_poly_add, :libarb), Void,
-                (Ptr{acb_poly}, Ptr{acb_poly}, Ptr{acb_poly}, Int),
-                    &z, &x, &y, prec(parent(z)))
+                (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
+                    z, x, y, prec(parent(z)))
    return z
 end
 

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -79,12 +79,12 @@ doc"""
 > `typemax(Int)` and `-typemax(Int)`.
 """
 function accuracy_bits(x::arb)
-  return ccall((:arb_rel_accuracy_bits, :libarb), Int, (Ptr{arb},), &x)
+  return ccall((:arb_rel_accuracy_bits, :libarb), Int, (Ref{arb},), x)
 end
 
 function deepcopy_internal(a::arb, dict::ObjectIdDict)
   b = parent(a)()
-  ccall((:arb_set, :libarb), Void, (Ptr{arb}, Ptr{arb}), &b, &a)
+  ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), b, a)
   return b
 end
 
@@ -99,9 +99,9 @@ doc"""
 > Return the midpoint of $x$ rounded down to a machine double.
 """
 function convert(::Type{Float64}, x::arb)
-    t = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), &x)
+    t = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), x)
     # 4 == round to nearest
-    return ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
+    return ccall((:arf_get_d, :libarb), Float64, (Ref{arf_struct}, Int), t, 4)
 end
 
 ################################################################################
@@ -118,8 +118,8 @@ end
 
 function show(io::IO, x::arb)
   d = ceil(parent(x).prec * 0.30102999566398119521)
-  cstr = ccall((:arb_get_str, :libarb), Ptr{UInt8}, (Ptr{arb}, Int, UInt),
-                                                  &x, Int(d), UInt(0))
+  cstr = ccall((:arb_get_str, :libarb), Ptr{UInt8}, (Ref{arb}, Int, UInt),
+                                                  x, Int(d), UInt(0))
   print(io, unsafe_string(cstr))
   ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
 end
@@ -138,12 +138,12 @@ doc"""
 > otherwise return `false`.
 """
 function overlaps(x::arb, y::arb)
-  r = ccall((:arb_overlaps, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
+  r = ccall((:arb_overlaps, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
 #function contains(x::arb, y::arf)
-#  r = ccall((:arb_contains_arf, :libarb), Cint, (Ptr{arb}, Ptr{arf}), &x, &y)
+#  r = ccall((:arb_contains_arf, :libarb), Cint, (Ref{arb}, Ref{arf}), x, y)
 #  return Bool(r)
 #end
 
@@ -153,7 +153,7 @@ doc"""
 > return `false`.
 """
 function contains(x::arb, y::fmpq)
-  r = ccall((:arb_contains_fmpq, :libarb), Cint, (Ptr{arb}, Ptr{fmpq}), &x, &y)
+  r = ccall((:arb_contains_fmpq, :libarb), Cint, (Ref{arb}, Ref{fmpq}), x, y)
   return Bool(r)
 end
 
@@ -163,12 +163,12 @@ doc"""
 > return `false`.
 """
 function contains(x::arb, y::fmpz)
-  r = ccall((:arb_contains_fmpz, :libarb), Cint, (Ptr{arb}, Ptr{fmpz}), &x, &y)
+  r = ccall((:arb_contains_fmpz, :libarb), Cint, (Ref{arb}, Ref{fmpz}), x, y)
   return Bool(r)
 end
 
 function contains(x::arb, y::Int)
-  r = ccall((:arb_contains_si, :libarb), Cint, (Ptr{arb}, Int), &x, y)
+  r = ccall((:arb_contains_si, :libarb), Cint, (Ref{arb}, Int), x, y)
   return Bool(r)
 end
 
@@ -193,7 +193,7 @@ doc"""
 """
 function contains(x::arb, y::BigFloat)
   r = ccall((:arb_contains_mpfr, :libarb), Cint,
-              (Ptr{arb}, Ptr{BigFloat}), &x, &y)
+              (Ref{arb}, Ref{BigFloat}), x, y)
   return Bool(r)
 end
 
@@ -203,7 +203,7 @@ doc"""
 > `false`.
 """
 function contains(x::arb, y::arb)
-  r = ccall((:arb_contains, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
+  r = ccall((:arb_contains, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
@@ -212,7 +212,7 @@ doc"""
 > Returns `true` if the ball $x$ contains zero, otherwise return `false`.
 """
 function contains_zero(x::arb)
-   r = ccall((:arb_contains_zero, :libarb), Cint, (Ptr{arb}, ), &x)
+   r = ccall((:arb_contains_zero, :libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -222,7 +222,7 @@ doc"""
 > `false`.
 """
 function contains_negative(x::arb)
-   r = ccall((:arb_contains_negative, :libarb), Cint, (Ptr{arb}, ), &x)
+   r = ccall((:arb_contains_negative, :libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -232,7 +232,7 @@ doc"""
 > `false`.
 """
 function contains_positive(x::arb)
-   r = ccall((:arb_contains_positive, :libarb), Cint, (Ptr{arb}, ), &x)
+   r = ccall((:arb_contains_positive, :libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -242,7 +242,7 @@ doc"""
 > return `false`.
 """
 function contains_nonnegative(x::arb)
-   r = ccall((:arb_contains_nonnegative, :libarb), Cint, (Ptr{arb}, ), &x)
+   r = ccall((:arb_contains_nonnegative, :libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -252,7 +252,7 @@ doc"""
 > return `false`.
 """
 function contains_nonpositive(x::arb)
-   r = ccall((:arb_contains_nonpositive, :libarb), Cint, (Ptr{arb}, ), &x)
+   r = ccall((:arb_contains_nonpositive, :libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -268,32 +268,32 @@ doc"""
 > same midpoints and radii.
 """
 function isequal(x::arb, y::arb)
-  r = ccall((:arb_equal, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y)
+  r = ccall((:arb_equal, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
 function ==(x::arb, y::arb)
-    return Bool(ccall((:arb_eq, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_eq, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function !=(x::arb, y::arb)
-    return Bool(ccall((:arb_ne, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_ne, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function >(x::arb, y::arb)
-    return Bool(ccall((:arb_gt, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_gt, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function >=(x::arb, y::arb)
-    return Bool(ccall((:arb_ge, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_ge, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function <(x::arb, y::arb)
-    return Bool(ccall((:arb_lt, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_lt, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function <=(x::arb, y::arb)
-    return Bool(ccall((:arb_le, :libarb), Cint, (Ptr{arb}, Ptr{arb}), &x, &y))
+    return Bool(ccall((:arb_le, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 ==(x::arb, y::Int) = x == arb(y)
@@ -410,7 +410,7 @@ doc"""
 > Return `true` if $x$ is certainly zero, otherwise return `false`.
 """
 function iszero(x::arb)
-   return Bool(ccall((:arb_is_zero, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_zero, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -419,7 +419,7 @@ doc"""
 > `false`.
 """
 function isnonzero(x::arb)
-   return Bool(ccall((:arb_is_nonzero, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_nonzero, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -428,7 +428,7 @@ doc"""
 > `false`.
 """
 function isone(x::arb)
-   return Bool(ccall((:arb_is_one, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_one, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -437,7 +437,7 @@ doc"""
 > otherwise return `false`.
 """
 function isfinite(x::arb)
-   return Bool(ccall((:arb_is_finite, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_finite, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -446,7 +446,7 @@ doc"""
 > `false`.
 """
 function isexact(x::arb)
-   return Bool(ccall((:arb_is_exact, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_exact, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -454,7 +454,7 @@ doc"""
 > Return `true` if $x$ is an exact integer, otherwise return `false`.
 """
 function isint(x::arb)
-   return Bool(ccall((:arb_is_int, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_int, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -462,7 +462,7 @@ doc"""
 > Return `true` if $x$ is certainly positive, otherwise return `false`.
 """
 function ispositive(x::arb)
-   return Bool(ccall((:arb_is_positive, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_positive, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -470,7 +470,7 @@ doc"""
 > Return `true` if $x$ is certainly nonnegative, otherwise return `false`.
 """
 function isnonnegative(x::arb)
-   return Bool(ccall((:arb_is_nonnegative, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_nonnegative, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -478,7 +478,7 @@ doc"""
 > Return `true` if $x$ is certainly negative, otherwise return `false`.
 """
 function isnegative(x::arb)
-   return Bool(ccall((:arb_is_negative, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_negative, :libarb), Cint, (Ref{arb},), x))
 end
 
 doc"""
@@ -486,7 +486,7 @@ doc"""
 > Return `true` if $x$ is certainly nonpositive, otherwise return `false`.
 """
 function isnonpositive(x::arb)
-   return Bool(ccall((:arb_is_nonpositive, :libarb), Cint, (Ptr{arb},), &x))
+   return Bool(ccall((:arb_is_nonpositive, :libarb), Cint, (Ref{arb},), x))
 end
 
 ################################################################################
@@ -512,7 +512,7 @@ doc"""
 """
 function radius(x::arb)
   z = parent(x)()
-  ccall((:arb_get_rad_arb, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
+  ccall((:arb_get_rad_arb, :libarb), Void, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -522,7 +522,7 @@ doc"""
 """
 function midpoint(x::arb)
   z = parent(x)()
-  ccall((:arb_get_mid_arb, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
+  ccall((:arb_get_mid_arb, :libarb), Void, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -534,7 +534,7 @@ end
 
 function -(x::arb)
   z = parent(x)()
-  ccall((:arb_neg, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
+  ccall((:arb_neg, :libarb), Void, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -548,8 +548,8 @@ for (s,f) in ((:+,"arb_add"), (:*,"arb_mul"), (://, "arb_div"), (:-,"arb_sub"))
   @eval begin
     function ($s)(x::arb, y::arb)
       z = parent(x)()
-      ccall(($f, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
-                           &z, &x, &y, parent(x).prec)
+      ccall(($f, :libarb), Void, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+                           z, x, y, parent(x).prec)
       return z
     end
   end
@@ -560,8 +560,8 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
     #function ($f)(x::arb, y::arf)
     #  z = parent(x)()
     #  ccall(($("arb_"*s*"_arf"), :libarb), Void,
-    #              (Ptr{arb}, Ptr{arb}, Ptr{arf}, Int),
-    #              &z, &x, &y, parent(x).prec)
+    #              (Ref{arb}, Ref{arb}, Ref{arf}, Int),
+    #              z, x, y, parent(x).prec)
     #  return z
     #end
 
@@ -570,8 +570,8 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
     function ($f)(x::arb, y::UInt)
       z = parent(x)()
       ccall(($("arb_"*s*"_ui"), :libarb), Void,
-                  (Ptr{arb}, Ptr{arb}, UInt, Int),
-                  &z, &x, y, parent(x).prec)
+                  (Ref{arb}, Ref{arb}, UInt, Int),
+                  z, x, y, parent(x).prec)
       return z
     end
 
@@ -580,7 +580,7 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
     function ($f)(x::arb, y::Int)
       z = parent(x)()
       ccall(($("arb_"*s*"_si"), :libarb), Void,
-      (Ptr{arb}, Ptr{arb}, Int, Int), &z, &x, y, parent(x).prec)
+      (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
       return z
     end
 
@@ -589,8 +589,8 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
     function ($f)(x::arb, y::fmpz)
       z = parent(x)()
       ccall(($("arb_"*s*"_fmpz"), :libarb), Void,
-                  (Ptr{arb}, Ptr{arb}, Ptr{fmpz}, Int),
-                  &z, &x, &y, parent(x).prec)
+                  (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
+                  z, x, y, parent(x).prec)
       return z
     end
 
@@ -601,7 +601,7 @@ end
 #function -(x::arb, y::arf)
 #  z = parent(x)()
 #  ccall((:arb_sub_arf, :libarb), Void,
-#              (Ptr{arb}, Ptr{arb}, Ptr{arf}, Int), &z, &x, &y, parent(x).prec)
+#              (Ref{arb}, Ref{arb}, Ref{arf}, Int), z, x, y, parent(x).prec)
 #  return z
 #end
 
@@ -610,7 +610,7 @@ end
 function -(x::arb, y::UInt)
   z = parent(x)()
   ccall((:arb_sub_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
 
@@ -619,7 +619,7 @@ end
 function -(x::arb, y::Int)
   z = parent(x)()
   ccall((:arb_sub_si, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Int, Int), &z, &x, y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
   return z
 end
 
@@ -628,8 +628,8 @@ end
 function -(x::arb, y::fmpz)
   z = parent(x)()
   ccall((:arb_sub_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{fmpz}, Int),
-              &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
+              z, x, y, parent(x).prec)
   return z
 end
 
@@ -654,36 +654,36 @@ end
 #function //(x::arb, y::arf)
 #  z = parent(x)()
 #  ccall((:arb_div_arf, :libarb), Void,
-#              (Ptr{arb}, Ptr{arb}, Ptr{arf}, Int), &z, &x, &y, parent(x).prec)
+#              (Ref{arb}, Ref{arb}, Ref{arf}, Int), z, x, y, parent(x).prec)
 #  return z
 #end
 
 function //(x::arb, y::UInt)
   z = parent(x)()
   ccall((:arb_div_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function //(x::arb, y::Int)
   z = parent(x)()
   ccall((:arb_div_si, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Int, Int), &z, &x, y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function //(x::arb, y::fmpz)
   z = parent(x)()
   ccall((:arb_div_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{fmpz}, Int),
-              &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
+              z, x, y, parent(x).prec)
   return z
 end
 
 function //(x::UInt, y::arb)
   z = parent(y)()
   ccall((:arb_ui_div, :libarb), Void,
-              (Ptr{arb}, UInt, Ptr{arb}, Int), &z, x, &y, parent(y).prec)
+              (Ref{arb}, UInt, Ref{arb}, Int), z, x, y, parent(y).prec)
   return z
 end
 
@@ -691,7 +691,7 @@ function //(x::Int, y::arb)
   z = parent(y)()
   t = arb(x)
   ccall((:arb_div, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &t, &y, parent(y).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, t, y, parent(y).prec)
   return z
 end
 
@@ -699,22 +699,22 @@ function //(x::fmpz, y::arb)
   z = parent(y)()
   t = arb(x)
   ccall((:arb_div, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &t, &y, parent(y).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, t, y, parent(y).prec)
   return z
 end
 
 function ^(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_pow, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function ^(x::arb, y::fmpz)
   z = parent(x)()
   ccall((:arb_pow_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{fmpz}, Int),
-              &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
+              z, x, y, parent(x).prec)
   return z
 end
 
@@ -723,15 +723,15 @@ end
 function ^(x::arb, y::UInt)
   z = parent(x)()
   ccall((:arb_pow_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function ^(x::arb, y::fmpq)
   z = parent(x)()
   ccall((:arb_pow_fmpq, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{fmpq}, Int),
-              &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{fmpq}, Int),
+              z, x, y, parent(x).prec)
   return z
 end
 
@@ -814,7 +814,7 @@ doc"""
 """
 function abs(x::arb)
   z = parent(x)()
-  ccall((:arb_abs, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
+  ccall((:arb_abs, :libarb), Void, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -831,7 +831,7 @@ doc"""
 function inv(x::arb)
   z = parent(x)()
   ccall((:arb_inv, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
   return parent(x)(z)
 end
 
@@ -848,7 +848,7 @@ doc"""
 function ldexp(x::arb, y::Int)
   z = parent(x)()
   ccall((:arb_mul_2exp_si, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Int), &z, &x, y)
+              (Ref{arb}, Ref{arb}, Int), z, x, y)
   return z
 end
 
@@ -859,7 +859,7 @@ doc"""
 function ldexp(x::arb, y::fmpz)
   z = parent(x)()
   ccall((:arb_mul_2exp_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{fmpz}), &z, &x, &y)
+              (Ref{arb}, Ref{arb}, Ref{fmpz}), z, x, y)
   return z
 end
 
@@ -876,7 +876,7 @@ doc"""
 """
 function trim(x::arb)
   z = parent(x)()
-  ccall((:arb_trim, :libarb), Void, (Ptr{arb}, Ptr{arb}), &z, &x)
+  ccall((:arb_trim, :libarb), Void, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -890,7 +890,7 @@ doc"""
 function unique_integer(x::arb)
   z = fmpz()
   unique = ccall((:arb_get_unique_fmpz, :libarb), Int,
-    (Ptr{fmpz}, Ptr{arb}), &z, &x)
+    (Ref{fmpz}, Ref{arb}), z, x)
   return (unique != 0, z)
 end
 
@@ -902,7 +902,7 @@ doc"""
 function setunion(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_union, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
@@ -918,7 +918,7 @@ doc"""
 """
 function const_pi(r::ArbField)
   z = r()
-  ccall((:arb_const_pi, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_pi, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -928,7 +928,7 @@ doc"""
 """
 function const_e(r::ArbField)
   z = r()
-  ccall((:arb_const_e, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_e, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -938,7 +938,7 @@ doc"""
 """
 function const_log2(r::ArbField)
   z = r()
-  ccall((:arb_const_log2, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_log2, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -948,7 +948,7 @@ doc"""
 """
 function const_log10(r::ArbField)
   z = r()
-  ccall((:arb_const_log10, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_log10, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -958,7 +958,7 @@ doc"""
 """
 function const_euler(r::ArbField)
   z = r()
-  ccall((:arb_const_euler, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_euler, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -968,7 +968,7 @@ doc"""
 """
 function const_catalan(r::ArbField)
   z = r()
-  ccall((:arb_const_catalan, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_catalan, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -978,7 +978,7 @@ doc"""
 """
 function const_khinchin(r::ArbField)
   z = r()
-  ccall((:arb_const_khinchin, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_khinchin, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -988,7 +988,7 @@ doc"""
 """
 function const_glaisher(r::ArbField)
   z = r()
-  ccall((:arb_const_glaisher, :libarb), Void, (Ptr{arb}, Int), &z, prec(r))
+  ccall((:arb_const_glaisher, :libarb), Void, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1007,7 +1007,7 @@ doc"""
 """
 function floor(x::arb)
    z = parent(x)()
-   ccall((:arb_floor, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_floor, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1018,7 +1018,7 @@ doc"""
 """
 function ceil(x::arb)
    z = parent(x)()
-   ccall((:arb_ceil, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_ceil, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1028,7 +1028,7 @@ doc"""
 """
 function sqrt(x::arb)
    z = parent(x)()
-   ccall((:arb_sqrt, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_sqrt, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1038,7 +1038,7 @@ doc"""
 """
 function rsqrt(x::arb)
    z = parent(x)()
-   ccall((:arb_rsqrt, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_rsqrt, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1048,7 +1048,7 @@ doc"""
 """
 function sqrt1pm1(x::arb)
    z = parent(x)()
-   ccall((:arb_sqrt1pm1, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_sqrt1pm1, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1058,7 +1058,7 @@ doc"""
 """
 function log(x::arb)
    z = parent(x)()
-   ccall((:arb_log, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_log, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1068,7 +1068,7 @@ doc"""
 """
 function log1p(x::arb)
    z = parent(x)()
-   ccall((:arb_log1p, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_log1p, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1078,7 +1078,7 @@ doc"""
 """
 function Base.exp(x::arb)
    z = parent(x)()
-   ccall((:arb_exp, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_exp, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1088,7 +1088,7 @@ doc"""
 """
 function expm1(x::arb)
    z = parent(x)()
-   ccall((:arb_expm1, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_expm1, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1098,7 +1098,7 @@ doc"""
 """
 function sin(x::arb)
    z = parent(x)()
-   ccall((:arb_sin, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_sin, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1108,7 +1108,7 @@ doc"""
 """
 function cos(x::arb)
    z = parent(x)()
-   ccall((:arb_cos, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_cos, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1118,7 +1118,7 @@ doc"""
 """
 function sinpi(x::arb)
    z = parent(x)()
-   ccall((:arb_sin_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_sin_pi, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1128,7 +1128,7 @@ doc"""
 """
 function cospi(x::arb)
    z = parent(x)()
-   ccall((:arb_cos_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_cos_pi, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1138,7 +1138,7 @@ doc"""
 """
 function tan(x::arb)
    z = parent(x)()
-   ccall((:arb_tan, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_tan, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1148,7 +1148,7 @@ doc"""
 """
 function cot(x::arb)
    z = parent(x)()
-   ccall((:arb_cot, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_cot, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1158,7 +1158,7 @@ doc"""
 """
 function tanpi(x::arb)
    z = parent(x)()
-   ccall((:arb_tan_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_tan_pi, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1168,7 +1168,7 @@ doc"""
 """
 function cotpi(x::arb)
    z = parent(x)()
-   ccall((:arb_cot_pi, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_cot_pi, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1178,7 +1178,7 @@ doc"""
 """
 function sinh(x::arb)
    z = parent(x)()
-   ccall((:arb_sinh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_sinh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1188,7 +1188,7 @@ doc"""
 """
 function cosh(x::arb)
    z = parent(x)()
-   ccall((:arb_cosh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_cosh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1198,7 +1198,7 @@ doc"""
 """
 function tanh(x::arb)
    z = parent(x)()
-   ccall((:arb_tanh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_tanh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1208,7 +1208,7 @@ doc"""
 """
 function coth(x::arb)
    z = parent(x)()
-   ccall((:arb_coth, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_coth, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1218,7 +1218,7 @@ doc"""
 """
 function atan(x::arb)
    z = parent(x)()
-   ccall((:arb_atan, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_atan, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1228,7 +1228,7 @@ doc"""
 """
 function asin(x::arb)
    z = parent(x)()
-   ccall((:arb_asin, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_asin, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1238,7 +1238,7 @@ doc"""
 """
 function acos(x::arb)
    z = parent(x)()
-   ccall((:arb_acos, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_acos, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1248,7 +1248,7 @@ doc"""
 """
 function atanh(x::arb)
    z = parent(x)()
-   ccall((:arb_atanh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_atanh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1258,7 +1258,7 @@ doc"""
 """
 function asinh(x::arb)
    z = parent(x)()
-   ccall((:arb_asinh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_asinh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1268,7 +1268,7 @@ doc"""
 """
 function acosh(x::arb)
    z = parent(x)()
-   ccall((:arb_acosh, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_acosh, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1278,7 +1278,7 @@ doc"""
 """
 function gamma(x::arb)
    z = parent(x)()
-   ccall((:arb_gamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_gamma, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1288,7 +1288,7 @@ doc"""
 """
 function lgamma(x::arb)
    z = parent(x)()
-   ccall((:arb_lgamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_lgamma, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1298,7 +1298,7 @@ doc"""
 """
 function rgamma(x::arb)
    z = parent(x)()
-   ccall((:arb_rgamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_rgamma, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1309,7 +1309,7 @@ doc"""
 """
 function digamma(x::arb)
    z = parent(x)()
-   ccall((:arb_digamma, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_digamma, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1319,7 +1319,7 @@ doc"""
 """
 function zeta(x::arb)
    z = parent(x)()
-   ccall((:arb_zeta, :libarb), Void, (Ptr{arb}, Ptr{arb}, Int), &z, &x, parent(x).prec)
+   ccall((:arb_zeta, :libarb), Void, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1331,7 +1331,7 @@ function sincos(x::arb)
   s = parent(x)()
   c = parent(x)()
   ccall((:arb_sin_cos, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &s, &c, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
 
@@ -1343,7 +1343,7 @@ function sincospi(x::arb)
   s = parent(x)()
   c = parent(x)()
   ccall((:arb_sin_cos_pi, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &s, &c, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
 
@@ -1354,7 +1354,7 @@ doc"""
 function sinpi(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_sin_pi_fmpq, :libarb), Void,
-        (Ptr{arb}, Ptr{fmpq}, Int), &z, &x, prec(r))
+        (Ref{arb}, Ref{fmpq}, Int), z, x, prec(r))
   return z
 end
 
@@ -1365,7 +1365,7 @@ doc"""
 function cospi(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_cos_pi_fmpq, :libarb), Void,
-        (Ptr{arb}, Ptr{fmpq}, Int), &z, &x, prec(r))
+        (Ref{arb}, Ref{fmpq}, Int), z, x, prec(r))
   return z
 end
 
@@ -1378,7 +1378,7 @@ function sincospi(x::fmpq, r::ArbField)
   s = r()
   c = r()
   ccall((:arb_sin_cos_pi_fmpq, :libarb), Void,
-        (Ptr{arb}, Ptr{arb}, Ptr{fmpq}, Int), &s, &c, &x, prec(r))
+        (Ref{arb}, Ref{arb}, Ref{fmpq}, Int), s, c, x, prec(r))
   return (s, c)
 end
 
@@ -1390,7 +1390,7 @@ function sinhcosh(x::arb)
   s = parent(x)()
   c = parent(x)()
   ccall((:arb_sinh_cosh, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &s, &c, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
 
@@ -1401,7 +1401,7 @@ doc"""
 function atan2(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_atan2, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
@@ -1412,7 +1412,7 @@ doc"""
 function agm(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_agm, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
@@ -1423,7 +1423,7 @@ doc"""
 function zeta(s::arb, a::arb)
   z = parent(s)()
   ccall((:arb_hurwitz_zeta, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &s, &a, parent(s).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, s, a, parent(s).prec)
   return z
 end
 
@@ -1434,14 +1434,14 @@ doc"""
 function hypot(x::arb, y::arb)
   z = parent(x)()
   ccall((:arb_hypot, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &x, &y, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function root(x::arb, n::UInt)
   z = parent(x)()
   ccall((:arb_root, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, n, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
 
@@ -1459,7 +1459,7 @@ fac(x::arb) = gamma(x+1)
 
 function fac(n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_fac_ui, :libarb), Void, (Ptr{arb}, UInt, Int), &z, n, r.prec)
+  ccall((:arb_fac_ui, :libarb), Void, (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
 
@@ -1476,7 +1476,7 @@ doc"""
 function binom(x::arb, n::UInt)
   z = parent(x)()
   ccall((:arb_bin_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, n, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
 
@@ -1487,7 +1487,7 @@ doc"""
 function binom(n::UInt, k::UInt, r::ArbField)
   z = r()
   ccall((:arb_bin_uiui, :libarb), Void,
-              (Ptr{arb}, UInt, UInt, Int), &z, n, k, r.prec)
+              (Ref{arb}, UInt, UInt, Int), z, n, k, r.prec)
   return z
 end
 
@@ -1498,14 +1498,14 @@ doc"""
 function fib(n::fmpz, r::ArbField)
   z = r()
   ccall((:arb_fib_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpz}, Int), &z, &n, r.prec)
+              (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
 
 function fib(n::UInt, r::ArbField)
   z = r()
   ccall((:arb_fib_ui, :libarb), Void,
-              (Ptr{arb}, UInt, Int), &z, n, r.prec)
+              (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
 
@@ -1522,7 +1522,7 @@ doc"""
 function gamma(x::fmpz, r::ArbField)
   z = r()
   ccall((:arb_gamma_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpz}, Int), &z, &x, r.prec)
+              (Ref{arb}, Ref{fmpz}, Int), z, x, r.prec)
   return z
 end
 
@@ -1533,7 +1533,7 @@ doc"""
 function gamma(x::fmpq, r::ArbField)
   z = r()
   ccall((:arb_gamma_fmpq, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpq}, Int), &z, &x, r.prec)
+              (Ref{arb}, Ref{fmpq}, Int), z, x, r.prec)
   return z
 end
 
@@ -1541,7 +1541,7 @@ end
 function zeta(n::UInt, r::ArbField)
   z = r()
   ccall((:arb_zeta_ui, :libarb), Void,
-              (Ptr{arb}, UInt, Int), &z, n, r.prec)
+              (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
 
@@ -1555,7 +1555,7 @@ zeta(n::Int, r::ArbField) = n >= 0 ? zeta(UInt(n), r) : zeta(r(n))
 function bernoulli(n::UInt, r::ArbField)
   z = r()
   ccall((:arb_bernoulli_ui, :libarb), Void,
-              (Ptr{arb}, UInt, Int), &z, n, r.prec)
+              (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
 
@@ -1568,7 +1568,7 @@ bernoulli(n::Int, r::ArbField) = n >= 0 ? bernoulli(UInt(n), r) : throw(DomainEr
 function risingfac(x::arb, n::UInt)
   z = parent(x)()
   ccall((:arb_rising_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Int), &z, &x, n, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
 
@@ -1581,7 +1581,7 @@ risingfac(x::arb, n::Int) = n < 0 ? throw(DomainError()) : risingfac(x, UInt(n))
 function risingfac(x::fmpq, n::UInt, r::ArbField)
   z = r()
   ccall((:arb_rising_fmpq_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpq}, UInt, Int), &z, &x, n, r.prec)
+              (Ref{arb}, Ref{fmpq}, UInt, Int), z, x, n, r.prec)
   return z
 end
 
@@ -1596,7 +1596,7 @@ function risingfac2(x::arb, n::UInt)
   z = parent(x)()
   w = parent(x)()
   ccall((:arb_rising2_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, UInt, Int), &z, &w, &x, n, parent(x).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, UInt, Int), z, w, x, n, parent(x).prec)
   return (z, w)
 end
 
@@ -1614,7 +1614,7 @@ doc"""
 function polylog(s::arb, a::arb)
   z = parent(s)()
   ccall((:arb_polylog, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int), &z, &s, &a, parent(s).prec)
+              (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, s, a, parent(s).prec)
   return z
 end
 
@@ -1625,21 +1625,21 @@ doc"""
 function polylog(s::Int, a::arb)
   z = parent(a)()
   ccall((:arb_polylog_si, :libarb), Void,
-              (Ptr{arb}, Int, Ptr{arb}, Int), &z, s, &a, parent(a).prec)
+              (Ref{arb}, Int, Ref{arb}, Int), z, s, a, parent(a).prec)
   return z
 end
 
 function chebyshev_t(n::UInt, x::arb)
   z = parent(x)()
   ccall((:arb_chebyshev_t_ui, :libarb), Void,
-              (Ptr{arb}, UInt, Ptr{arb}, Int), &z, n, &x, parent(x).prec)
+              (Ref{arb}, UInt, Ref{arb}, Int), z, n, x, parent(x).prec)
   return z
 end
 
 function chebyshev_u(n::UInt, x::arb)
   z = parent(x)()
   ccall((:arb_chebyshev_u_ui, :libarb), Void,
-              (Ptr{arb}, UInt, Ptr{arb}, Int), &z, n, &x, parent(x).prec)
+              (Ref{arb}, UInt, Ref{arb}, Int), z, n, x, parent(x).prec)
   return z
 end
 
@@ -1647,7 +1647,7 @@ function chebyshev_t2(n::UInt, x::arb)
   z = parent(x)()
   w = parent(x)()
   ccall((:arb_chebyshev_t2_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Ptr{arb}, Int), &z, &w, n, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Ref{arb}, Int), z, w, n, x, parent(x).prec)
   return z, w
 end
 
@@ -1655,7 +1655,7 @@ function chebyshev_u2(n::UInt, x::arb)
   z = parent(x)()
   w = parent(x)()
   ccall((:arb_chebyshev_u2_ui, :libarb), Void,
-              (Ptr{arb}, Ptr{arb}, UInt, Ptr{arb}, Int), &z, &w, n, &x, parent(x).prec)
+              (Ref{arb}, Ref{arb}, UInt, Ref{arb}, Int), z, w, n, x, parent(x).prec)
   return z, w
 end
 
@@ -1690,7 +1690,7 @@ doc"""
 function bell(n::fmpz, r::ArbField)
   z = r()
   ccall((:arb_bell_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpz}, Int), &z, &n, r.prec)
+              (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
 
@@ -1707,7 +1707,7 @@ doc"""
 function numpart(n::fmpz, r::ArbField)
   z = r()
   ccall((:arb_partitions_fmpz, :libarb), Void,
-              (Ptr{arb}, Ptr{fmpz}, Int), &z, &n, r.prec)
+              (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
 
@@ -1724,7 +1724,7 @@ numpart(n::Int, r::ArbField) = numpart(fmpz(n), r)
 ################################################################################
 
 function zero!(z::arb)
-   ccall((:arb_zero, :libarb), Void, (Ptr{arb},), &z)
+   ccall((:arb_zero, :libarb), Void, (Ref{arb},), z)
    return z
 end
 
@@ -1732,16 +1732,16 @@ for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
               ("sub!","arb_sub"))
   @eval begin
     function ($(Symbol(s)))(z::arb, x::arb, y::arb)
-      ccall(($f, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
-                           &z, &x, &y, parent(x).prec)
+      ccall(($f, :libarb), Void, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+                           z, x, y, parent(x).prec)
       return z
     end
   end
 end
 
 function addeq!(z::arb, x::arb)
-    ccall((:arb_add, :libarb), Void, (Ptr{arb}, Ptr{arb}, Ptr{arb}, Int),
-                           &z, &z, &x, parent(x).prec)
+    ccall((:arb_add, :libarb), Void, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+                           z, z, x, parent(x).prec)
     return z
 end
 
@@ -1751,7 +1751,7 @@ end
 #
 ################################################################################
 
-for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
+for (typeofx, passtoc) in ((arb, Ref{arb}), (Ref{arb}, Ref{arb}))
   for (f,t) in (("arb_set_si", Int), ("arb_set_ui", UInt),
                 ("arb_set_d", Float64))
     @eval begin
@@ -1769,26 +1769,26 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
 
   @eval begin
     function _arb_set(x::($typeofx), y::fmpz)
-      ccall((:arb_set_fmpz, :libarb), Void, (($passtoc), Ptr{fmpz}), x, &y)
+      ccall((:arb_set_fmpz, :libarb), Void, (($passtoc), Ref{fmpz}), x, y)
     end
 
     function _arb_set(x::($typeofx), y::fmpz, p::Int)
       ccall((:arb_set_round_fmpz, :libarb), Void,
-                  (($passtoc), Ptr{fmpz}, Int), x, &y, p)
+                  (($passtoc), Ref{fmpz}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::fmpq, p::Int)
       ccall((:arb_set_fmpq, :libarb), Void,
-                  (($passtoc), Ptr{fmpq}, Int), x, &y, p)
+                  (($passtoc), Ref{fmpq}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::arb)
-      ccall((:arb_set, :libarb), Void, (($passtoc), Ptr{arb}), x, &y)
+      ccall((:arb_set, :libarb), Void, (($passtoc), Ref{arb}), x, y)
     end
 
     function _arb_set(x::($typeofx), y::arb, p::Int)
       ccall((:arb_set_round, :libarb), Void,
-                  (($passtoc), Ptr{arb}, Int), x, &y, p)
+                  (($passtoc), Ref{arb}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::AbstractString, p::Int)
@@ -1799,20 +1799,20 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
     end
 
     function _arb_set(x::($typeofx), y::BigFloat)
-      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct},
+      m = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct},
                   (($passtoc), ), x)
       r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct},
                   (($passtoc), ), x)
       ccall((:arf_set_mpfr, :libarb), Void,
-                  (Ptr{arf_struct}, Ptr{BigFloat}), m, &y)
+                  (Ref{arf_struct}, Ref{BigFloat}), m, y)
       ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
     end
 
     function _arb_set(x::($typeofx), y::BigFloat, p::Int)
-      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (($passtoc), ), x)
+      m = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (($passtoc), ), x)
       r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (($passtoc), ), x)
       ccall((:arf_set_mpfr, :libarb), Void,
-                  (Ptr{arf_struct}, Ptr{BigFloat}), m, &y)
+                  (Ref{arf_struct}, Ref{BigFloat}), m, y)
       ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
       ccall((:arb_set_round, :libarb), Void,
                   (($passtoc), ($passtoc), Int), x, x, p)

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -20,10 +20,10 @@ parent_type(::Type{arb_poly}) = ArbPolyRing
 elem_type(::Type{ArbPolyRing}) = arb_poly
 
 length(x::arb_poly) = ccall((:arb_poly_length, :libarb), Int, 
-                                   (Ptr{arb_poly},), &x)
+                                   (Ref{arb_poly},), x)
 
 set_length!(x::arb_poly, n::Int) = ccall((:_arb_poly_set_length, :libarb), Void,
-                                   (Ptr{arb_poly}, Int), &x, n)
+                                   (Ref{arb_poly}, Int), x, n)
 
 degree(x::arb_poly) = length(x) - 1
 
@@ -31,7 +31,7 @@ function coeff(a::arb_poly, n::Int)
   n < 0 && throw(DomainError())
   t = parent(a).base_ring()
   ccall((:arb_poly_get_coeff_arb, :libarb), Void,
-              (Ptr{arb}, Ptr{arb_poly}, Int), &t, &a, n)
+              (Ref{arb}, Ref{arb_poly}, Int), t, a, n)
   return t
 end
 
@@ -42,7 +42,7 @@ one(a::ArbPolyRing) = a(1)
 function gen(a::ArbPolyRing)
    z = arb_poly()
    ccall((:arb_poly_set_coeff_si, :libarb), Void,
-        (Ptr{arb_poly}, Int, Int), &z, 1, 1)
+        (Ref{arb_poly}, Int, Int), z, 1, 1)
    z.parent = a
    return z
 end
@@ -101,7 +101,7 @@ end
 
 function isequal(x::arb_poly, y::arb_poly)
    return ccall((:arb_poly_equal, :libarb), Bool,
-                                      (Ptr{arb_poly}, Ptr{arb_poly}), &x, &y)
+                                      (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
 doc"""
@@ -111,7 +111,7 @@ doc"""
 """
 function overlaps(x::arb_poly, y::arb_poly)
    return ccall((:arb_poly_overlaps, :libarb), Bool,
-                                      (Ptr{arb_poly}, Ptr{arb_poly}), &x, &y)
+                                      (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
 doc"""
@@ -121,7 +121,7 @@ doc"""
 """
 function contains(x::arb_poly, y::arb_poly)
    return ccall((:arb_poly_contains, :libarb), Bool,
-                                      (Ptr{arb_poly}, Ptr{arb_poly}), &x, &y)
+                                      (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
 doc"""
@@ -131,7 +131,7 @@ doc"""
 """
 function contains(x::arb_poly, y::fmpz_poly)
    return ccall((:arb_poly_contains_fmpz_poly, :libarb), Bool,
-                                      (Ptr{arb_poly}, Ptr{fmpz_poly}), &x, &y)
+                                      (Ref{arb_poly}, Ref{fmpz_poly}), x, y)
 end
 
 doc"""
@@ -141,7 +141,7 @@ doc"""
 """
 function contains(x::arb_poly, y::fmpq_poly)
    return ccall((:arb_poly_contains_fmpq_poly, :libarb), Bool,
-                                      (Ptr{arb_poly}, Ptr{fmpq_poly}), &x, &y)
+                                      (Ref{arb_poly}, Ref{fmpq_poly}), x, y)
 end
 
 function ==(x::arb_poly, y::arb_poly)
@@ -174,7 +174,7 @@ doc"""
 function unique_integer(x::arb_poly)
   z = FmpzPolyRing(var(parent(x)))()
   unique = ccall((:arb_poly_get_unique_fmpz_poly, :libarb), Int,
-    (Ptr{fmpz_poly}, Ptr{arb_poly}), &z, &x)
+    (Ref{fmpz_poly}, Ref{arb_poly}), z, x)
   return (unique != 0, z)
 end
 
@@ -188,7 +188,7 @@ function shift_left(x::arb_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:arb_poly_shift_left, :libarb), Void,
-      (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, len)
+      (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
    return z
 end
 
@@ -196,7 +196,7 @@ function shift_right(x::arb_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:arb_poly_shift_right, :libarb), Void,
-       (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, len)
+       (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
    return z
 end
 
@@ -208,7 +208,7 @@ end
 
 function -(x::arb_poly)
   z = parent(x)()
-  ccall((:arb_poly_neg, :libarb), Void, (Ptr{arb_poly}, Ptr{arb_poly}), &z, &x)
+  ccall((:arb_poly_neg, :libarb), Void, (Ref{arb_poly}, Ref{arb_poly}), z, x)
   return z
 end
 
@@ -221,24 +221,24 @@ end
 function +(x::arb_poly, y::arb_poly)
   z = parent(x)()
   ccall((:arb_poly_add, :libarb), Void,
-              (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
 function *(x::arb_poly, y::arb_poly)
   z = parent(x)()
   ccall((:arb_poly_mul, :libarb), Void,
-              (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
 function -(x::arb_poly, y::arb_poly)
   z = parent(x)()
   ccall((:arb_poly_sub, :libarb), Void,
-              (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-              &z, &x, &y, prec(parent(x)))
+              (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
@@ -246,8 +246,8 @@ function ^(x::arb_poly, y::Int)
   y < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:arb_poly_pow_ui, :libarb), Void,
-              (Ptr{arb_poly}, Ptr{arb_poly}, UInt, Int),
-              &z, &x, y, prec(parent(x)))
+              (Ref{arb_poly}, Ref{arb_poly}, UInt, Int),
+              z, x, y, prec(parent(x)))
   return z
 end
 
@@ -314,8 +314,8 @@ function divrem(x::arb_poly, y::arb_poly)
    q = parent(x)()
    r = parent(x)()
    if (ccall((:arb_poly_divrem, :libarb), Int,
-         (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-               &q, &r, &x, &y, prec(parent(x))) == 1)
+         (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+               q, r, x, y, prec(parent(x))) == 1)
       return (q, r)
    else
       throw(DivideError())
@@ -344,7 +344,7 @@ function truncate(a::arb_poly, n::Int)
    # todo: implement set_trunc in arb
    z = deepcopy(a)
    ccall((:arb_poly_truncate, :libarb), Void,
-                (Ptr{arb_poly}, Int), &z, n)
+                (Ref{arb_poly}, Int), z, n)
    return z
 end
 
@@ -352,8 +352,8 @@ function mullow(x::arb_poly, y::arb_poly, n::Int)
    n < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:arb_poly_mullow, :libarb), Void,
-         (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int, Int),
-            &z, &x, &y, n, prec(parent(x)))
+         (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int, Int),
+            z, x, y, n, prec(parent(x)))
    return z
 end
 
@@ -367,7 +367,7 @@ end
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
 #   ccall((:arb_poly_reverse, :libarb), Void,
-#                (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, len)
+#                (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
 #   return z
 #end
 
@@ -380,8 +380,8 @@ end
 function evaluate(x::arb_poly, y::arb)
    z = parent(y)()
    ccall((:arb_poly_evaluate, :libarb), Void,
-                (Ptr{arb}, Ptr{arb_poly}, Ptr{arb}, Int),
-                &z, &x, &y, prec(parent(y)))
+                (Ref{arb}, Ref{arb_poly}, Ref{arb}, Int),
+                z, x, y, prec(parent(y)))
    return z
 end
 
@@ -394,16 +394,16 @@ function evaluate2(x::arb_poly, y::arb)
    z = parent(y)()
    w = parent(y)()
    ccall((:arb_poly_evaluate2, :libarb), Void,
-                (Ptr{arb}, Ptr{arb}, Ptr{arb_poly}, Ptr{arb}, Int),
-                &z, &w, &x, &y, prec(parent(y)))
+                (Ref{arb}, Ref{arb}, Ref{arb_poly}, Ref{arb}, Int),
+                z, w, x, y, prec(parent(y)))
    return z, w
 end
 
 function evaluate(x::arb_poly, y::acb)
    z = parent(y)()
    ccall((:arb_poly_evaluate_acb, :libarb), Void,
-                (Ptr{acb}, Ptr{arb_poly}, Ptr{acb}, Int),
-                &z, &x, &y, prec(parent(y)))
+                (Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
+                z, x, y, prec(parent(y)))
    return z
 end
 
@@ -416,8 +416,8 @@ function evaluate2(x::arb_poly, y::acb)
    z = parent(y)()
    w = parent(y)()
    ccall((:arb_poly_evaluate2_acb, :libarb), Void,
-                (Ptr{acb}, Ptr{acb}, Ptr{arb_poly}, Ptr{acb}, Int),
-                &z, &w, &x, &y, prec(parent(y)))
+                (Ref{acb}, Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
+                z, w, x, y, prec(parent(y)))
    return z, w
 end
 
@@ -474,8 +474,8 @@ end
 function compose(x::arb_poly, y::arb_poly)
    z = parent(x)()
    ccall((:arb_poly_compose, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-                &z, &x, &y, prec(parent(x)))
+                (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+                z, x, y, prec(parent(x)))
    return z
 end
 
@@ -488,14 +488,14 @@ end
 function derivative(x::arb_poly)
    z = parent(x)()
    ccall((:arb_poly_derivative, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, prec(parent(x)))
+                (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
 function integral(x::arb_poly)
    z = parent(x)()
    ccall((:arb_poly_integral, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Int), &z, &x, prec(parent(x)))
+                (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
@@ -512,8 +512,8 @@ end
 function arb_vec(b::Array{arb, 1})
    v = ccall((:_arb_vec_init, :libarb), Ptr{arb_struct}, (Int,), length(b))
    for i=1:length(b)
-       ccall((:arb_set, :libarb), Void, (Ptr{arb_struct}, Ptr{arb}),
-           v + (i-1)*sizeof(arb_struct), &b[i])
+       ccall((:arb_set, :libarb), Void, (Ptr{arb_struct}, Ref{arb}),
+           v + (i-1)*sizeof(arb_struct), b[i])
    end
    return v
 end
@@ -522,8 +522,8 @@ function array(R::ArbField, v::Ptr{arb_struct}, n::Int)
    r = Array{arb}(n)
    for i=1:n
        r[i] = R()
-       ccall((:arb_set, :libarb), Void, (Ptr{arb}, Ptr{arb_struct}),
-           &r[i], v + (i-1)*sizeof(arb_struct))
+       ccall((:arb_set, :libarb), Void, (Ref{arb}, Ptr{arb_struct}),
+           r[i], v + (i-1)*sizeof(arb_struct))
    end
    return r
 end
@@ -540,7 +540,7 @@ function from_roots(R::ArbPolyRing, b::Array{arb, 1})
    z = R()
    tmp = arb_vec(b)
    ccall((:arb_poly_product_roots, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_struct}, Int, Int), &z, tmp, length(b), prec(R))
+                (Ref{arb_poly}, Ptr{arb_struct}, Int, Int), z, tmp, length(b), prec(R))
    arb_vec_clear(tmp, length(b))
    return z
 end
@@ -552,8 +552,8 @@ end
 function evaluate_fast(x::arb_poly, b::Array{arb, 1})
    tmp = arb_vec(b)
    ccall((:arb_poly_evaluate_vec_fast, :libarb), Void,
-                (Ptr{arb_struct}, Ptr{arb_poly}, Ptr{arb_struct}, Int, Int),
-            tmp, &x, tmp, length(b), prec(parent(x)))
+                (Ptr{arb_struct}, Ref{arb_poly}, Ptr{arb_struct}, Int, Int),
+            tmp, x, tmp, length(b), prec(parent(x)))
    res = array(base_ring(parent(x)), tmp, length(b))
    arb_vec_clear(tmp, length(b))
    return res
@@ -565,8 +565,8 @@ function interpolate_newton(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{arb, 1}
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
    ccall((:arb_poly_interpolate_newton, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
    arb_vec_clear(ysv, length(ys))
    return z
@@ -578,8 +578,8 @@ function interpolate_barycentric(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{ar
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
    ccall((:arb_poly_interpolate_barycentric, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
    arb_vec_clear(ysv, length(ys))
    return z
@@ -591,8 +591,8 @@ function interpolate_fast(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{arb, 1})
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
    ccall((:arb_poly_interpolate_fast, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
-            &z, xsv, ysv, length(xs), prec(R))
+                (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
+            z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
    arb_vec_clear(ysv, length(ys))
    return z
@@ -622,13 +622,13 @@ doc"""
 function roots_upper_bound(x::arb_poly)
    z = base_ring(x)()
    p = prec(base_ring(x))
-   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), &z)
+   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
    ccall((:arb_poly_root_bound_fujiwara, :libarb), Void,
-         (Ptr{mag_struct}, Ptr{arb_poly}), t, &x)
-   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), &z)
-   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+         (Ptr{mag_struct}, Ref{arb_poly}), t, x)
+   s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
+   ccall((:arf_set_mag, :libarb), Void, (Ref{arf_struct}, Ptr{mag_struct}), s, t)
    ccall((:arf_set_round, :libarb), Void,
-         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+         (Ref{arf_struct}, Ref{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
    ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
    return z
 end
@@ -641,46 +641,46 @@ end
 
 function zero!(z::arb_poly)
    ccall((:arb_poly_zero, :libarb), Void,
-                    (Ptr{arb_poly}, ), &z)
+                    (Ref{arb_poly}, ), z)
    return z
 end
 
 function fit!(z::arb_poly, n::Int)
    ccall((:arb_poly_fit_length, :libarb), Void,
-                    (Ptr{arb_poly}, Int), &z, n)
+                    (Ref{arb_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::fmpz)
    ccall((:arb_poly_set_coeff_fmpz, :libarb), Void,
-                    (Ptr{arb_poly}, Int, Ptr{fmpz}), &z, n, &x)
+                    (Ref{arb_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::arb)
    ccall((:arb_poly_set_coeff_arb, :libarb), Void,
-                    (Ptr{arb_poly}, Int, Ptr{arb}), &z, n, &x)
+                    (Ref{arb_poly}, Int, Ref{arb}), z, n, x)
    return z
 end
 
 function mul!(z::arb_poly, x::arb_poly, y::arb_poly)
    ccall((:arb_poly_mul, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-                    &z, &x, &y, prec(parent(z)))
+                (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+                    z, x, y, prec(parent(z)))
    return z
 end
 
 function addeq!(z::arb_poly, x::arb_poly)
    ccall((:arb_poly_add, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-                    &z, &z, &x, prec(parent(z)))
+                (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+                    z, z, x, prec(parent(z)))
    return z
 end
 
 function add!(z::arb_poly, x::arb_poly, y::arb_poly)
    ccall((:arb_poly_add, :libarb), Void,
-                (Ptr{arb_poly}, Ptr{arb_poly}, Ptr{arb_poly}, Int),
-                    &z, &x, &y, prec(parent(z)))
+                (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
+                    z, x, y, prec(parent(z)))
    return z
 end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -20,29 +20,29 @@ mutable struct fmpz <: RingElem
 
     function fmpz()
         z = new()
-        ccall((:fmpz_init, :libflint), Void, (Ptr{fmpz},), &z)
+        ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
         finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     function fmpz(x::Int)
         z = new()
-        ccall((:fmpz_init_set_si, :libflint), Void, (Ptr{fmpz}, Int), &z, x)
+        ccall((:fmpz_init_set_si, :libflint), Void, (Ref{fmpz}, Int), z, x)
         finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     function fmpz(x::UInt)
         z = new()
-        ccall((:fmpz_init_set_ui, :libflint), Void, (Ptr{fmpz}, UInt), &z, x)
+        ccall((:fmpz_init_set_ui, :libflint), Void, (Ref{fmpz}, UInt), z, x)
         finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     function fmpz(x::BigInt)
         z = new()
-        ccall((:fmpz_init, :libflint), Void, (Ptr{fmpz},), &z)
-        ccall((:fmpz_set_mpz, :libflint), Void, (Ptr{fmpz}, Ptr{BigInt}), &z, &x)
+        ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
+        ccall((:fmpz_set_mpz, :libflint), Void, (Ref{fmpz}, Ref{BigInt}), z, x)
         finalizer(z, _fmpz_clear_fn)
         return z
     end
@@ -50,8 +50,8 @@ mutable struct fmpz <: RingElem
     function fmpz(x::Float64)
         !isinteger(x) && throw(InexactError())
         z = new()
-        ccall((:fmpz_init, :libflint), Void, (Ptr{fmpz},), &z)
-        ccall((:fmpz_set_d, :libflint), Void, (Ptr{fmpz}, Cdouble), &z, x)
+        ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
+        ccall((:fmpz_set_d, :libflint), Void, (Ref{fmpz}, Cdouble), z, x)
         finalizer(z, _fmpz_clear_fn)
         return z
     end
@@ -60,7 +60,7 @@ mutable struct fmpz <: RingElem
 end
 
 function _fmpz_clear_fn(a::fmpz)
-   ccall((:fmpz_clear, :libflint), Void, (Ptr{fmpz},), &a)
+   ccall((:fmpz_clear, :libflint), Void, (Ref{fmpz},), a)
 end
 
 mutable struct fmpz_factor
@@ -72,7 +72,7 @@ mutable struct fmpz_factor
 
    function fmpz_factor()
       z = new()
-      ccall((:fmpz_factor_init, :libflint), Void, (Ptr{fmpz_factor}, ), &z)
+      ccall((:fmpz_factor_init, :libflint), Void, (Ref{fmpz_factor}, ), z)
       finalizer(z, _fmpz_factor_clear_fn)
       return z
    end
@@ -80,7 +80,7 @@ end
 
 function _fmpz_factor_clear_fn(a::fmpz_factor)
    ccall((:fmpz_factor_clear, :libflint), Void,
-         (Ptr{fmpz_factor}, ), &a)
+         (Ref{fmpz_factor}, ), a)
 end
 
 ###############################################################################
@@ -100,7 +100,7 @@ mutable struct fmpq <: FracElem{fmpz}
 
    function fmpq()
       z = new()
-      ccall((:fmpq_init, :libflint), Void, (Ptr{fmpq},), &z)
+      ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       finalizer(z, _fmpq_clear_fn)
       return z
    end
@@ -108,19 +108,19 @@ mutable struct fmpq <: FracElem{fmpz}
    function fmpq(a::fmpz, b::fmpz)
       iszero(b) && throw(DivideError())
       z = new()
-      ccall((:fmpq_init, :libflint), Void, (Ptr{fmpq},), &z)
+      ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-            (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), &z, &a, &b)
+            (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
       finalizer(z, _fmpq_clear_fn)
       return z
    end
 
    function fmpq(a::fmpz)
       z = new()
-      ccall((:fmpq_init, :libflint), Void, (Ptr{fmpq},), &z)
+      ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       b = fmpz(1)
       ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-            (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), &z, &a, &b)
+            (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
       finalizer(z, _fmpq_clear_fn)
       return z
    end
@@ -128,24 +128,24 @@ mutable struct fmpq <: FracElem{fmpz}
    function fmpq(a::Int, b::Int)
       b == 0 && throw(DivideError())
       z = new()
-      ccall((:fmpq_init, :libflint), Void, (Ptr{fmpq},), &z)
+      ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_si, :libflint), Void,
-            (Ptr{fmpq}, Int, Int), &z, a, b)
+            (Ref{fmpq}, Int, Int), z, a, b)
       finalizer(z, _fmpq_clear_fn)
       return z
    end
 
    function fmpq(a::Int)
       z = new()
-      ccall((:fmpq_init, :libflint), Void, (Ptr{fmpq},), &z)
+      ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_si, :libflint), Void,
-            (Ptr{fmpq}, Int, Int), &z, a, 1)
+            (Ref{fmpq}, Int, Int), z, a, 1)
       finalizer(z, _fmpq_clear_fn)
       return z
    end
 end
 
-_fmpq_clear_fn(a::fmpq) = ccall((:fmpq_clear, :libflint), Void, (Ptr{fmpq},), &a)
+_fmpq_clear_fn(a::fmpq) = ccall((:fmpq_clear, :libflint), Void, (Ref{fmpq},), a)
 
 ###############################################################################
 #
@@ -180,7 +180,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 
    function fmpz_poly()
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_poly},), &z)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
@@ -188,10 +188,10 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
    function fmpz_poly(a::Array{fmpz, 1})
       z = new()
       ccall((:fmpz_poly_init2, :libflint), Void,
-            (Ptr{fmpz_poly}, Int), &z, length(a))
+            (Ref{fmpz_poly}, Int), z, length(a))
       for i = 1:length(a)
          ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_poly}, Int, Ptr{fmpz}), &z, i - 1, &a[i])
+                     (Ref{fmpz_poly}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       finalizer(z, _fmpz_poly_clear_fn)
       return z
@@ -199,33 +199,33 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 
    function fmpz_poly(a::Int)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_poly},), &z)
-      ccall((:fmpz_poly_set_si, :libflint), Void, (Ptr{fmpz_poly}, Int), &z, a)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
+      ccall((:fmpz_poly_set_si, :libflint), Void, (Ref{fmpz_poly}, Int), z, a)
       finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
    function fmpz_poly(a::fmpz)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_poly},), &z)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       ccall((:fmpz_poly_set_fmpz, :libflint), Void,
-            (Ptr{fmpz_poly}, Ptr{fmpz}), &z, &a)
+            (Ref{fmpz_poly}, Ref{fmpz}), z, a)
       finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
    function fmpz_poly(a::fmpz_poly)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_poly},), &z)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       ccall((:fmpz_poly_set, :libflint), Void,
-            (Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &a)
+            (Ref{fmpz_poly}, Ref{fmpz_poly}), z, a)
       finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 end
 
 function _fmpz_poly_clear_fn(a::fmpz_poly)
-   ccall((:fmpz_poly_clear, :libflint), Void, (Ptr{fmpz_poly},), &a)
+   ccall((:fmpz_poly_clear, :libflint), Void, (Ref{fmpz_poly},), a)
 end
 
 mutable struct fmpz_poly_factor
@@ -238,7 +238,7 @@ mutable struct fmpz_poly_factor
   function fmpz_poly_factor()
     z = new()
     ccall((:fmpz_poly_factor_init, :libflint), Void,
-                (Ptr{fmpz_poly_factor}, ), &z)
+                (Ref{fmpz_poly_factor}, ), z)
     finalizer(z, _fmpz_poly_factor_clear_fn)
     return z
   end
@@ -246,7 +246,7 @@ end
 
 function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
   ccall((:fmpz_poly_factor_clear, :libflint), Void,
-            (Ptr{fmpz_poly_factor}, ), &f)
+            (Ref{fmpz_poly_factor}, ), f)
   nothing
 end
 
@@ -284,7 +284,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly()
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
@@ -292,10 +292,10 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
    function fmpq_poly(a::Array{fmpq, 1})
       z = new()
       ccall((:fmpq_poly_init2, :libflint), Void,
-            (Ptr{fmpq_poly}, Int), &z, length(a))
+            (Ref{fmpq_poly}, Int), z, length(a))
       for i = 1:length(a)
          ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
-                     (Ptr{fmpq_poly}, Int, Ptr{fmpq}), &z, i - 1, &a[i])
+                     (Ref{fmpq_poly}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       finalizer(z, _fmpq_poly_clear_fn)
       return z
@@ -303,51 +303,51 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly(a::Int)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
-      ccall((:fmpq_poly_set_si, :libflint), Void, (Ptr{fmpq_poly}, Int), &z, a)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set_si, :libflint), Void, (Ref{fmpq_poly}, Int), z, a)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
    function fmpq_poly(a::fmpz)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpz, :libflint), Void,
-            (Ptr{fmpq_poly}, Ptr{fmpz}), &z, &a)
+            (Ref{fmpq_poly}, Ref{fmpz}), z, a)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
    function fmpq_poly(a::fmpq)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpq, :libflint), Void,
-            (Ptr{fmpq_poly}, Ptr{fmpq}), &z, &a)
+            (Ref{fmpq_poly}, Ref{fmpq}), z, a)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
    function fmpq_poly(a::fmpz_poly)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpz_poly, :libflint), Void,
-            (Ptr{fmpq_poly}, Ptr{fmpz_poly}), &z, &a)
+            (Ref{fmpq_poly}, Ref{fmpz_poly}), z, a)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
    function fmpq_poly(a::fmpq_poly)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_poly},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set, :libflint), Void,
-            (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &a)
+            (Ref{fmpq_poly}, Ref{fmpq_poly}), z, a)
       finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 end
 
 function _fmpq_poly_clear_fn(a::fmpq_poly)
-   ccall((:fmpq_poly_clear, :libflint), Void, (Ptr{fmpq_poly},), &a)
+   ccall((:fmpq_poly_clear, :libflint), Void, (Ref{fmpq_poly},), a)
 end
 
 ###############################################################################
@@ -419,25 +419,25 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Void, (Ptr{nmod_poly}, UInt), &z, n)
+      ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
       finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
    function nmod_poly(n::UInt, a::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Void, (Ptr{nmod_poly}, UInt), &z, n)
+      ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
       ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{nmod_poly}, Int, UInt), &z, 0, a)
+              (Ref{nmod_poly}, Int, UInt), z, 0, a)
       finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
    function nmod_poly(n::UInt, a::Int)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Void, (Ptr{nmod_poly}, UInt), &z, n)
+      ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
       ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{nmod_poly}, Int, UInt), &z, 0, mod(a, n))
+              (Ref{nmod_poly}, Int, UInt), z, 0, mod(a, n))
       finalizer(z, _nmod_poly_clear_fn)
       return z
    end
@@ -445,11 +445,11 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt, arr::Array{fmpz, 1})
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_poly}, UInt, Int), &z, n, length(arr))
+            (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &arr[i], n)
+         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), arr[i], n)
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{nmod_poly}, Int, UInt), &z, i - 1, tt)
+              (Ref{nmod_poly}, Int, UInt), z, i - 1, tt)
       end
       finalizer(z, _nmod_poly_clear_fn)
       return z
@@ -458,10 +458,10 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt, arr::Array{UInt, 1})
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_poly}, UInt, Int), &z, n, length(arr))
+            (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{nmod_poly}, Int, UInt), &z, i - 1, arr[i])
+              (Ref{nmod_poly}, Int, UInt), z, i - 1, arr[i])
       end
       finalizer(z, _nmod_poly_clear_fn)
       return z
@@ -470,10 +470,10 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt, arr::Array{nmod, 1})
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_poly}, UInt, Int), &z, n, length(arr))
+            (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{nmod_poly}, Int, UInt), &z, i-1, arr[i].data)
+              (Ref{nmod_poly}, Int, UInt), z, i-1, arr[i].data)
       end
       finalizer(z, _nmod_poly_clear_fn)
       return z
@@ -482,9 +482,9 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt, f::fmpz_poly)
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_poly}, UInt, Int), &z, n, length(f))
+            (Ref{nmod_poly}, UInt, Int), z, n, length(f))
       ccall((:fmpz_poly_get_nmod_poly, :libflint), Void,
-            (Ptr{nmod_poly}, Ptr{fmpz_poly}), &z, &f)
+            (Ref{nmod_poly}, Ref{fmpz_poly}), z, f)
       finalizer(z, _nmod_poly_clear_fn)
       return z
    end
@@ -492,16 +492,16 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt, f::nmod_poly)
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_poly}, UInt, Int), &z, n, length(f))
+            (Ref{nmod_poly}, UInt, Int), z, n, length(f))
       ccall((:nmod_poly_set, :libflint), Void,
-            (Ptr{nmod_poly}, Ptr{nmod_poly}), &z, &f)
+            (Ref{nmod_poly}, Ref{nmod_poly}), z, f)
       finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 end
 
 function _nmod_poly_clear_fn(x::nmod_poly)
-  ccall((:nmod_poly_clear, :libflint), Void, (Ptr{nmod_poly}, ), &x)
+  ccall((:nmod_poly_clear, :libflint), Void, (Ref{nmod_poly}, ), x)
 end
 
 mutable struct nmod_poly_factor
@@ -514,7 +514,7 @@ mutable struct nmod_poly_factor
   function nmod_poly_factor(n::UInt)
     z = new()
     ccall((:nmod_poly_factor_init, :libflint), Void,
-            (Ptr{nmod_poly_factor}, ), &z)
+            (Ref{nmod_poly_factor}, ), z)
     z.n = n
     finalizer(z, _nmod_poly_factor_clear_fn)
     return z
@@ -523,7 +523,7 @@ end
 
 function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
   ccall((:nmod_poly_factor_clear, :libflint), Void,
-          (Ptr{nmod_poly_factor}, ), &a)
+          (Ref{nmod_poly_factor}, ), a)
 end
 
 ###############################################################################
@@ -563,7 +563,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz)
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &n)
+            (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
@@ -571,9 +571,9 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz, a::UInt)
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &n)
+            (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       ccall((:fmod_poly_set_coeff_ui, :libflint), Void,
-              (Ptr{fmpz_mod_poly}, Int, UInt), &z, 0, a)
+              (Ref{fmpz_mod_poly}, Int, UInt), z, 0, a)
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
@@ -581,9 +581,9 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz, a::fmpz)
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &n)
+            (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-              (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz}), &z, 0, &a)
+              (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, 0, a)
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
@@ -592,10 +592,10 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
       length(arr) == 0 && error("Array must have length > 0")
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}, Int), &z, &n, length(arr))
+            (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-              (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz}), &z, i - 1, &arr[i])
+              (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i])
       end
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
@@ -604,10 +604,10 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz, arr::Array{Generic.Res{fmpz}, 1})
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}, Int), &z, &n, length(arr))
+            (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-              (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz}), &z, i - 1, &(arr[i].data))
+              (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i].data)
       end
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
@@ -616,9 +616,9 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz, f::fmpz_poly)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}, Int), &z, &n, length(f))
+            (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
       ccall((:fmpz_mod_poly_set_fmpz_poly, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz_poly}), &z, &f)
+            (Ref{fmpz_mod_poly}, Ref{fmpz_poly}), z, f)
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
@@ -626,16 +626,16 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
    function fmpz_mod_poly(n::fmpz, f::fmpz_mod_poly)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz}, Int), &z, &n, length(f))
+            (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
       ccall((:fmpz_mod_poly_set, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &z, &f)
+            (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), z, f)
       finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 end
 
 function _fmpz_mod_poly_clear_fn(x::fmpz_mod_poly)
-  ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ptr{fmpz_mod_poly}, ), &x)
+  ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ref{fmpz_mod_poly}, ), x)
 end
 
 mutable struct fmpz_mod_poly_factor
@@ -648,7 +648,7 @@ mutable struct fmpz_mod_poly_factor
   function fmpz_mod_poly_factor(n::fmpz)
     z = new()
     ccall((:fmpz_mod_poly_factor_init, :libflint), Void,
-            (Ptr{fmpz_mod_poly_factor}, ), &z)
+            (Ref{fmpz_mod_poly_factor}, ), z)
     z.n = n
     finalizer(z, _fmpz_mod_poly_factor_clear_fn)
     return z
@@ -657,7 +657,7 @@ end
 
 function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
   ccall((:fmpz_mod_poly_factor_clear, :libflint), Void,
-          (Ptr{fmpz_mod_poly_factor}, ), &a)
+          (Ref{fmpz_mod_poly_factor}, ), a)
 end
 
 ###############################################################################
@@ -695,8 +695,8 @@ mutable struct FmpzMPolyRing{S, N} <: PolyRing{fmpz}
 
          z = new{S, N}()
          ccall((:fmpz_mpoly_ctx_init, :libflint), Void,
-               (Ptr{FmpzMPolyRing}, Int, Int),
-               &z, length(s), ord)
+               (Ref{FmpzMPolyRing}, Int, Int),
+               z, length(s), ord)
          z.base_ring = FlintZZ
          z.S = s
          z.num_vars = length(s)
@@ -722,7 +722,7 @@ mutable struct fmpz_mpoly{S, N} <: PolyElem{fmpz}
    function fmpz_mpoly(ctx::FmpzMPolyRing{S, N}) where {S, N}
       z = new{S, N}()
       ccall((:fmpz_mpoly_init, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing},), &z, &ctx)
+            (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
       finalizer(z, _fmpz_mpoly_clear_fn)
       return z
    end
@@ -730,7 +730,7 @@ mutable struct fmpz_mpoly{S, N} <: PolyElem{fmpz}
    function fmpz_mpoly(ctx::FmpzMPolyRing{S, N}, a::Array{fmpz, 1}, b::Array{NTuple{N, Int}, 1}) where {S, N}
       z = new{S, N}()
       ccall((:fmpz_mpoly_init, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing},), &z, &ctx)
+            (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
       m = 0
       for i = 1:length(b)
          for j = 1:N
@@ -745,20 +745,20 @@ mutable struct fmpz_mpoly{S, N} <: PolyElem{fmpz}
       end
       deg = ctx.ord == :deglex || ctx.ord == :degrevlex ? 1 : 0
       ccall((:fmpz_mpoly_fit_length, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, length(a), &ctx)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, length(a), ctx)
       ccall((:fmpz_mpoly_fit_bits, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, bits, &ctx)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, bits, ctx)
       for i = 1:length(a)
          ccall((:fmpz_mpoly_set_coeff_fmpz, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{fmpz}, Ptr{FmpzMPolyRing}),
-                                                        &z, i - 1, &a[i], &ctx)
+            (Ref{fmpz_mpoly}, Int, Ref{fmpz}, Ref{FmpzMPolyRing}),
+                                                        z, i - 1, a[i], ctx)
          A = [b[i][j + deg] for j = 1:N - deg]
          ccall((:fmpz_mpoly_set_monomial, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{Int}, Ptr{FmpzMPolyRing}),
-                                                            &z, i - 1, A, &ctx)
+            (Ref{fmpz_mpoly}, Int, Ptr{Int}, Ref{FmpzMPolyRing}),
+                                                            z, i - 1, A, ctx)
       end
       ccall((:_fmpz_mpoly_set_length, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, length(a), &ctx)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, length(a), ctx)
       finalizer(z, _fmpz_mpoly_clear_fn)
       return z
    end
@@ -766,9 +766,9 @@ mutable struct fmpz_mpoly{S, N} <: PolyElem{fmpz}
    function fmpz_mpoly(ctx::FmpzMPolyRing{S, N}, a::Int) where {S, N}
       z = new{S, N}()
       ccall((:fmpz_mpoly_init, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing},), &z, &ctx)
+            (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
       ccall((:fmpz_mpoly_set_si, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, a, &ctx)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, a, ctx)
       finalizer(z, _fmpz_mpoly_clear_fn)
       return z
    end
@@ -776,9 +776,9 @@ mutable struct fmpz_mpoly{S, N} <: PolyElem{fmpz}
    function fmpz_mpoly(ctx::FmpzMPolyRing{S, N}, a::fmpz) where {S, N}
       z = new{S, N}()
       ccall((:fmpz_mpoly_init, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing},), &z, &ctx)
+            (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
       ccall((:fmpz_mpoly_set_fmpz, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}), &z, &a, &ctx)
+            (Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), z, a, ctx)
       finalizer(z, _fmpz_mpoly_clear_fn)
       return z
    end
@@ -786,12 +786,12 @@ end
 
 function _fmpz_mpoly_clear_fn(a::fmpz_mpoly)
   ccall((:fmpz_mpoly_clear, :libflint), Void,
-          (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &a.parent)
+          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
 end
 
 function _fmpz_mpoly_ctx_clear_fn(a::FmpzMPolyRing)
   ccall((:fmpz_mpoly_ctx_clear, :libflint), Void,
-          (Ptr{FmpzMPolyRing},), &a)
+          (Ref{FmpzMPolyRing},), a)
 end
 
 ###############################################################################
@@ -829,8 +829,8 @@ mutable struct FqNmodFiniteField <: FinField
       else
          d = new()
          ccall((:fq_nmod_ctx_init, :libflint), Void,
-               (Ptr{FqNmodFiniteField}, Ptr{fmpz}, Int, Ptr{UInt8}),
-			    &d, &c, deg, string(s))
+               (Ref{FqNmodFiniteField}, Ref{fmpz}, Int, Ptr{UInt8}),
+			    d, c, deg, string(s))
          if cached
             FqNmodFiniteFieldID[c, deg, s] = d
          end
@@ -845,8 +845,8 @@ mutable struct FqNmodFiniteField <: FinField
       else
          z = new()
          ccall((:fq_nmod_ctx_init_modulus, :libflint), Void,
-            (Ptr{FqNmodFiniteField}, Ptr{nmod_poly}, Ptr{UInt8}),
-	      &z, &f, string(s))
+            (Ref{FqNmodFiniteField}, Ref{nmod_poly}, Ptr{UInt8}),
+	      z, f, string(s))
          if cached
             FqNmodFiniteFieldIDPol[parent(f), f, s] = z
          end
@@ -862,7 +862,7 @@ const FqNmodFiniteFieldIDPol = Dict{Tuple{NmodPolyRing, nmod_poly, Symbol},
                                     FqNmodFiniteField}()
 
 function _FqNmodFiniteField_clear_fn(a :: FqNmodFiniteField)
-   ccall((:fq_nmod_ctx_clear, :libflint), Void, (Ptr{FqNmodFiniteField},), &a)
+   ccall((:fq_nmod_ctx_clear, :libflint), Void, (Ref{FqNmodFiniteField},), a)
 end
 
 mutable struct fq_nmod <: FinFieldElem
@@ -877,7 +877,7 @@ mutable struct fq_nmod <: FinFieldElem
    function fq_nmod(ctx::FqNmodFiniteField)
       d = new()
       ccall((:fq_nmod_init2, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &ctx)
+            (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(d, _fq_nmod_clear_fn)
       return d
    end
@@ -885,37 +885,37 @@ mutable struct fq_nmod <: FinFieldElem
    function fq_nmod(ctx::FqNmodFiniteField, x::Int)
       d = new()
       ccall((:fq_nmod_init2, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &ctx)
+            (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(d, _fq_nmod_clear_fn)
       ccall((:fq_nmod_set_si, :libflint), Void,
-                (Ptr{fq_nmod}, Int, Ptr{FqNmodFiniteField}), &d, x, &ctx)
+                (Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 
    function fq_nmod(ctx::FqNmodFiniteField, x::fmpz)
       d = new()
       ccall((:fq_nmod_init2, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &ctx)
+            (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(d, _fq_nmod_clear_fn)
       ccall((:fq_nmod_set_fmpz, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fmpz}, Ptr{FqNmodFiniteField}), &d, &x, &ctx)
+            (Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 
       function fq_nmod(ctx::FqNmodFiniteField, x::fq_nmod)
       d = new()
       ccall((:fq_nmod_init2, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &ctx)
+            (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(d, _fq_nmod_clear_fn)
       ccall((:fq_nmod_set, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &x, &ctx)
+            (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 end
 
 function _fq_nmod_clear_fn(a::fq_nmod)
    ccall((:fq_nmod_clear, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &a, &a.parent)
+         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 end
 
 ###############################################################################
@@ -947,8 +947,8 @@ mutable struct FqFiniteField <: FinField
          d = new()
          finalizer(d, _FqFiniteField_clear_fn)
          ccall((:fq_ctx_init, :libflint), Void,
-               (Ptr{FqFiniteField}, Ptr{fmpz}, Int, Ptr{UInt8}),
-                  &d, &char, deg, string(s))
+               (Ref{FqFiniteField}, Ref{fmpz}, Int, Ptr{UInt8}),
+                  d, char, deg, string(s))
          if cached
             FqFiniteFieldID[char, deg, s] = d
          end
@@ -962,8 +962,8 @@ mutable struct FqFiniteField <: FinField
       else
          z = new()
          ccall((:fq_ctx_init_modulus, :libflint), Void,
-               (Ptr{FqFiniteField}, Ptr{fmpz_mod_poly}, Ptr{UInt8}),
-                  &z, &f, string(s))
+               (Ref{FqFiniteField}, Ref{fmpz_mod_poly}, Ptr{UInt8}),
+                  z, f, string(s))
          if cached
             FqFiniteFieldIDPol[f, s] = z
          end
@@ -978,7 +978,7 @@ const FqFiniteFieldID = Dict{Tuple{fmpz, Int, Symbol}, FqFiniteField}()
 const FqFiniteFieldIDPol = Dict{Tuple{fmpz_mod_poly, Symbol}, FqFiniteField}()
 
 function _FqFiniteField_clear_fn(a :: FqFiniteField)
-   ccall((:fq_ctx_clear, :libflint), Void, (Ptr{FqFiniteField},), &a)
+   ccall((:fq_ctx_clear, :libflint), Void, (Ref{FqFiniteField},), a)
 end
 
 mutable struct fq <: FinFieldElem
@@ -990,7 +990,7 @@ mutable struct fq <: FinFieldElem
    function fq(ctx::FqFiniteField)
       d = new()
       ccall((:fq_init2, :libflint), Void,
-            (Ptr{fq}, Ptr{FqFiniteField}), &d, &ctx)
+            (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(d, _fq_clear_fn)
       d.parent = ctx
       return d
@@ -999,10 +999,10 @@ mutable struct fq <: FinFieldElem
    function fq(ctx::FqFiniteField, x::Int)
       d = new()
       ccall((:fq_init2, :libflint), Void,
-            (Ptr{fq}, Ptr{FqFiniteField}), &d, &ctx)
+            (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(d, _fq_clear_fn)
       ccall((:fq_set_si, :libflint), Void,
-                (Ptr{fq}, Int, Ptr{FqFiniteField}), &d, x, &ctx)
+                (Ref{fq}, Int, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
    end
@@ -1010,10 +1010,10 @@ mutable struct fq <: FinFieldElem
    function fq(ctx::FqFiniteField, x::fmpz)
       d = new()
       ccall((:fq_init2, :libflint), Void,
-            (Ptr{fq}, Ptr{FqFiniteField}), &d, &ctx)
+            (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(d, _fq_clear_fn)
       ccall((:fq_set_fmpz, :libflint), Void,
-            (Ptr{fq}, Ptr{fmpz}, Ptr{FqFiniteField}), &d, &x, &ctx)
+            (Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
    end
@@ -1021,10 +1021,10 @@ mutable struct fq <: FinFieldElem
    function fq(ctx::FqFiniteField, x::fq)
       d = new()
       ccall((:fq_init2, :libflint), Void,
-            (Ptr{fq}, Ptr{FqFiniteField}), &d, &ctx)
+            (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(d, _fq_clear_fn)
       ccall((:fq_set, :libflint), Void,
-            (Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &d, &x, &ctx)
+            (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
    end
@@ -1032,7 +1032,7 @@ end
 
 function _fq_clear_fn(a::fq)
    ccall((:fq_clear, :libflint), Void,
-         (Ptr{fq}, Ptr{FqFiniteField}), &a, &a.parent)
+         (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 end
 
 ###############################################################################
@@ -1055,8 +1055,8 @@ mutable struct FlintPadicField <: Field
       !isprime(p) && error("Prime base required in FlintPadicField")
       d = new()
       ccall((:padic_ctx_init, :libflint), Void,
-           (Ptr{FlintPadicField}, Ptr{fmpz}, Int, Int, Cint),
-                                     &d, &p, 0, 0, 1)
+           (Ref{FlintPadicField}, Ref{fmpz}, Int, Int, Cint),
+                                     d, p, 0, 0, 1)
       finalizer(d, _padic_ctx_clear_fn)
       d.prec_max = prec
       return d
@@ -1066,7 +1066,7 @@ end
 const PadicBase = Dict{Tuple{fmpz, Int}, FlintPadicField}()
 
 function _padic_ctx_clear_fn(a::FlintPadicField)
-   ccall((:padic_ctx_clear, :libflint), Void, (Ptr{FlintPadicField},), &a)
+   ccall((:padic_ctx_clear, :libflint), Void, (Ref{FlintPadicField},), a)
 end
 
 mutable struct padic <: FieldElem
@@ -1077,14 +1077,14 @@ mutable struct padic <: FieldElem
 
    function padic(prec::Int)
       d = new()
-      ccall((:padic_init2, :libflint), Void, (Ptr{padic}, Int), &d, prec)
+      ccall((:padic_init2, :libflint), Void, (Ref{padic}, Int), d, prec)
       finalizer(d, _padic_clear_fn)
       return d
    end
 end
 
 function _padic_clear_fn(a::padic)
-   ccall((:padic_clear, :libflint), Void, (Ptr{padic},), &a)
+   ccall((:padic_clear, :libflint), Void, (Ref{padic},), a)
 end
 
 ###############################################################################
@@ -1124,7 +1124,7 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
    function fmpz_rel_series()
       z = new()
       ccall((:fmpz_poly_init, :libflint), Void,
-            (Ptr{fmpz_rel_series},), &z)
+            (Ref{fmpz_rel_series},), z)
       finalizer(z, _fmpz_rel_series_clear_fn)
       return z
    end
@@ -1132,10 +1132,10 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
    function fmpz_rel_series(a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fmpz_poly_init2, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Int), &z, len)
+            (Ref{fmpz_rel_series}, Int), z, len)
       for i = 1:len
          ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_rel_series}, Int, Ptr{fmpz}), &z, i - 1, &a[i])
+                     (Ref{fmpz_rel_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
       z.val = val
@@ -1145,16 +1145,16 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
 
    function fmpz_rel_series(a::fmpz_rel_series)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_rel_series},), &z)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_rel_series},), z)
       ccall((:fmpz_poly_set, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}), &z, &a)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}), z, a)
       finalizer(z, _fmpz_rel_series_clear_fn)
       return z
    end
 end
 
 function _fmpz_rel_series_clear_fn(a::fmpz_rel_series)
-   ccall((:fmpz_poly_clear, :libflint), Void, (Ptr{fmpz_rel_series},), &a)
+   ccall((:fmpz_poly_clear, :libflint), Void, (Ref{fmpz_rel_series},), a)
 end
 
 ###############################################################################
@@ -1193,7 +1193,7 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
    function fmpz_abs_series()
       z = new()
       ccall((:fmpz_poly_init, :libflint), Void,
-            (Ptr{fmpz_abs_series},), &z)
+            (Ref{fmpz_abs_series},), z)
       finalizer(z, _fmpz_abs_series_clear_fn)
       return z
    end
@@ -1201,10 +1201,10 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
    function fmpz_abs_series(a::Array{fmpz, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fmpz_poly_init2, :libflint), Void,
-            (Ptr{fmpz_abs_series}, Int), &z, len)
+            (Ref{fmpz_abs_series}, Int), z, len)
       for i = 1:len
          ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_abs_series}, Int, Ptr{fmpz}), &z, i - 1, &a[i])
+                     (Ref{fmpz_abs_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
       finalizer(z, _fmpz_abs_series_clear_fn)
@@ -1213,16 +1213,16 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
 
    function fmpz_abs_series(a::fmpz_abs_series)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Void, (Ptr{fmpz_abs_series},), &z)
+      ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_abs_series},), z)
       ccall((:fmpz_poly_set, :libflint), Void,
-            (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}), &z, &a)
+            (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}), z, a)
       finalizer(z, _fmpz_abs_series_clear_fn)
       return z
    end
 end
 
 function _fmpz_abs_series_clear_fn(a::fmpz_abs_series)
-   ccall((:fmpz_poly_clear, :libflint), Void, (Ptr{fmpz_abs_series},), &a)
+   ccall((:fmpz_poly_clear, :libflint), Void, (Ref{fmpz_abs_series},), a)
 end
 
 ###############################################################################
@@ -1263,7 +1263,7 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
    function fmpq_rel_series()
       z = new()
       ccall((:fmpq_poly_init, :libflint), Void,
-            (Ptr{fmpq_rel_series},), &z)
+            (Ref{fmpq_rel_series},), z)
       finalizer(z, _fmpq_rel_series_clear_fn)
       return z
    end
@@ -1271,10 +1271,10 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
    function fmpq_rel_series(a::Array{fmpq, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fmpq_poly_init2, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Int), &z, len)
+            (Ref{fmpq_rel_series}, Int), z, len)
       for i = 1:len
          ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
-                     (Ptr{fmpq_rel_series}, Int, Ptr{fmpq}), &z, i - 1, &a[i])
+                     (Ref{fmpq_rel_series}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       z.prec = prec
       z.val = val
@@ -1284,16 +1284,16 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
 
    function fmpq_rel_series(a::fmpq_rel_series)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_rel_series},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_rel_series},), z)
       ccall((:fmpq_poly_set, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}), &z, &a)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}), z, a)
       finalizer(z, _fmpq_rel_series_clear_fn)
       return z
    end
 end
 
 function _fmpq_rel_series_clear_fn(a::fmpq_rel_series)
-   ccall((:fmpq_poly_clear, :libflint), Void, (Ptr{fmpq_rel_series},), &a)
+   ccall((:fmpq_poly_clear, :libflint), Void, (Ref{fmpq_rel_series},), a)
 end
 
 ###############################################################################
@@ -1333,7 +1333,7 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
    function fmpq_abs_series()
       z = new()
       ccall((:fmpq_poly_init, :libflint), Void,
-            (Ptr{fmpq_abs_series},), &z)
+            (Ref{fmpq_abs_series},), z)
       finalizer(z, _fmpq_abs_series_clear_fn)
       return z
    end
@@ -1341,10 +1341,10 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
    function fmpq_abs_series(a::Array{fmpq, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fmpq_poly_init2, :libflint), Void,
-            (Ptr{fmpq_abs_series}, Int), &z, len)
+            (Ref{fmpq_abs_series}, Int), z, len)
       for i = 1:len
          ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
-                     (Ptr{fmpq_abs_series}, Int, Ptr{fmpq}), &z, i - 1, &a[i])
+                     (Ref{fmpq_abs_series}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       z.prec = prec
       finalizer(z, _fmpq_abs_series_clear_fn)
@@ -1353,16 +1353,16 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
 
    function fmpq_abs_series(a::fmpq_abs_series)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Void, (Ptr{fmpq_abs_series},), &z)
+      ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_abs_series},), z)
       ccall((:fmpq_poly_set, :libflint), Void,
-            (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}), &z, &a)
+            (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}), z, a)
       finalizer(z, _fmpq_abs_series_clear_fn)
       return z
    end
 end
 
 function _fmpq_abs_series_clear_fn(a::fmpq_abs_series)
-   ccall((:fmpq_poly_clear, :libflint), Void, (Ptr{fmpq_abs_series},), &a)
+   ccall((:fmpq_poly_clear, :libflint), Void, (Ref{fmpq_abs_series},), a)
 end
 
 ###############################################################################
@@ -1407,7 +1407,7 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
    function nmod_rel_series(p::UInt)
       z = new()
       ccall((:nmod_poly_init, :libflint), Void,
-            (Ptr{nmod_rel_series}, UInt), &z, p)
+            (Ref{nmod_rel_series}, UInt), z, p)
       finalizer(z, _nmod_rel_series_clear_fn)
       return z
    end
@@ -1415,11 +1415,11 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
    function nmod_rel_series(p::UInt, a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_rel_series}, UInt, Int), &z, p, len)
+            (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
-         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &a[i], p)
+         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), a[i], p)
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                     (Ptr{nmod_rel_series}, Int, UInt), &z, i - 1, tt)
+                     (Ref{nmod_rel_series}, Int, UInt), z, i - 1, tt)
       end
       z.prec = prec
       z.val = val
@@ -1430,10 +1430,10 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
    function nmod_rel_series(p::UInt, a::Array{UInt, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_rel_series}, UInt, Int), &z, p, len)
+            (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                     (Ptr{nmod_rel_series}, Int, UInt), &z, i - 1, a[i])
+                     (Ref{nmod_rel_series}, Int, UInt), z, i - 1, a[i])
       end
       z.prec = prec
       z.val = val
@@ -1444,10 +1444,10 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
    function nmod_rel_series(p::UInt, a::Array{nmod, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:nmod_poly_init2, :libflint), Void,
-            (Ptr{nmod_rel_series}, UInt, Int), &z, p, len)
+            (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                     (Ptr{nmod_rel_series}, Int, UInt), &z, i - 1, data(a[i]))
+                     (Ref{nmod_rel_series}, Int, UInt), z, i - 1, data(a[i]))
       end
       z.prec = prec
       z.val = val
@@ -1459,16 +1459,16 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
       z = new()
       p = modulus(base_ring(parent(a)))
       ccall((:nmod_poly_init, :libflint), Void,
-            (Ptr{nmod_rel_series}, UInt), &z, p)
+            (Ref{nmod_rel_series}, UInt), z, p)
       ccall((:nmod_poly_set, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}), &z, &a)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}), z, a)
       finalizer(z, _nmod_rel_series_clear_fn)
       return z
    end
 end
 
 function _nmod_rel_series_clear_fn(a::nmod_rel_series)
-   ccall((:nmod_poly_clear, :libflint), Void, (Ptr{nmod_rel_series},), &a)
+   ccall((:nmod_poly_clear, :libflint), Void, (Ref{nmod_rel_series},), a)
 end
 
 ###############################################################################
@@ -1511,7 +1511,7 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_rel_series(p::fmpz)
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz}), &z, &p)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz}), z, p)
       finalizer(z, _fmpz_mod_rel_series_clear_fn)
       return z
    end
@@ -1519,10 +1519,10 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_rel_series(p::fmpz, a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz}, Int), &z, &p, len)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}), &z, i - 1, &a[i])
+                     (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
       z.val = val
@@ -1533,10 +1533,10 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_rel_series(p::fmpz, a::Array{Generic.Res{fmpz}, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz}, Int), &z, &p, len)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}), &z, i - 1, &data(a[i]))
+                     (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}), z, i - 1, data(a[i]))
       end
       z.prec = prec
       z.val = val
@@ -1548,16 +1548,16 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{Generic.Res{fmpz}}
       z = new()
       p = modulus(base_ring(parent(a)))
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz}), &z, &p)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz}), z, p)
       ccall((:fmpz_mod_poly_set, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}), &z, &a)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}), z, a)
       finalizer(z, _fmpz_mod_rel_series_clear_fn)
       return z
    end
 end
 
 function _fmpz_mod_rel_series_clear_fn(a::fmpz_mod_rel_series)
-   ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ptr{fmpz_mod_rel_series},), &a)
+   ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ref{fmpz_mod_rel_series},), a)
 end
 
 ###############################################################################
@@ -1599,7 +1599,7 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_abs_series(p::fmpz)
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_abs_series}, Ptr{fmpz}), &z, &p)
+            (Ref{fmpz_mod_abs_series}, Ref{fmpz}), z, p)
       finalizer(z, _fmpz_mod_abs_series_clear_fn)
       return z
    end
@@ -1607,10 +1607,10 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_abs_series(p::fmpz, a::Array{fmpz, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_abs_series}, Ptr{fmpz}, Int), &z, &p, len)
+            (Ref{fmpz_mod_abs_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_mod_abs_series}, Int, Ptr{fmpz}), &z, i - 1, &a[i])
+                     (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
       finalizer(z, _fmpz_mod_abs_series_clear_fn)
@@ -1620,10 +1620,10 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{Generic.Res{fmpz}}
    function fmpz_mod_abs_series(p::fmpz, a::Array{Generic.Res{fmpz}, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fmpz_mod_poly_init2, :libflint), Void,
-            (Ptr{fmpz_mod_abs_series}, Ptr{fmpz}, Int), &z, &p, len)
+            (Ref{fmpz_mod_abs_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                     (Ptr{fmpz_mod_abs_series}, Int, Ptr{fmpz}), &z, i - 1, &data(a[i]))
+                     (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}), z, i - 1, data(a[i]))
       end
       z.prec = prec
       finalizer(z, _fmpz_mod_abs_series_clear_fn)
@@ -1634,16 +1634,16 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{Generic.Res{fmpz}}
       z = new()
       p = modulus(base_ring(parent(a)))
       ccall((:fmpz_mod_poly_init, :libflint), Void,
-            (Ptr{fmpz_mod_abs_series}, Ptr{fmpz}), &z, &p)
+            (Ref{fmpz_mod_abs_series}, Ref{fmpz}), z, p)
       ccall((:fmpz_mod_poly_set, :libflint), Void,
-            (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}), &z, &a)
+            (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}), z, a)
       finalizer(z, _fmpz_mod_abs_series_clear_fn)
       return z
    end
 end
 
 function _fmpz_mod_abs_series_clear_fn(a::fmpz_mod_abs_series)
-   ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ptr{fmpz_mod_abs_series},), &a)
+   ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ref{fmpz_mod_abs_series},), a)
 end
 
 ###############################################################################
@@ -1684,7 +1684,7 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
    function fq_rel_series(ctx::FqFiniteField)
       z = new()
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_rel_series}, Ref{FqFiniteField}), z, ctx)
       finalizer(z, _fq_rel_series_clear_fn)
       return z
    end
@@ -1692,11 +1692,11 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
    function fq_rel_series(ctx::FqFiniteField, a::Array{fq, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fq_poly_init2, :libflint), Void,
-            (Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}), &z, len, &ctx)
+            (Ref{fq_rel_series}, Int, Ref{FqFiniteField}), z, len, ctx)
       for i = 1:len
          ccall((:fq_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_rel_series}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-                                               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_rel_series}, Int, Ref{fq}, Ref{FqFiniteField}),
+                                               z, i - 1, a[i], ctx)
       end
       z.prec = prec
       z.val = val
@@ -1707,9 +1707,9 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
    function fq_rel_series(ctx::FqFiniteField, a::fq_rel_series)
       z = new()
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_rel_series}, Ref{FqFiniteField}), z, ctx)
       ccall((:fq_poly_set, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Ptr{FqFiniteField}), &z, &a, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}), z, a, ctx)
       finalizer(z, _fq_rel_series_clear_fn)
       return z
    end
@@ -1718,7 +1718,7 @@ end
 function _fq_rel_series_clear_fn(a::fq_rel_series)
    ctx = base_ring(a)
    ccall((:fq_poly_clear, :libflint), Void,
-         (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &a, &ctx)
+         (Ref{fq_rel_series}, Ref{FqFiniteField}), a, ctx)
 end
 
 ###############################################################################
@@ -1758,7 +1758,7 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
    function fq_abs_series(ctx::FqFiniteField)
       z = new()
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_abs_series}, Ref{FqFiniteField}), z, ctx)
       finalizer(z, _fq_abs_series_clear_fn)
       return z
    end
@@ -1766,11 +1766,11 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
    function fq_abs_series(ctx::FqFiniteField, a::Array{fq, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fq_poly_init2, :libflint), Void,
-            (Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}), &z, len, &ctx)
+            (Ref{fq_abs_series}, Int, Ref{FqFiniteField}), z, len, ctx)
       for i = 1:len
          ccall((:fq_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_abs_series}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-                                               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_abs_series}, Int, Ref{fq}, Ref{FqFiniteField}),
+                                               z, i - 1, a[i], ctx)
       end
       z.prec = prec
       finalizer(z, _fq_abs_series_clear_fn)
@@ -1780,9 +1780,9 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
    function fq_abs_series(ctx::FqFiniteField, a::fq_abs_series)
       z = new()
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_abs_series}, Ref{FqFiniteField}), z, ctx)
       ccall((:fq_poly_set, :libflint), Void,
-            (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Ptr{FqFiniteField}), &z, &a, &ctx)
+            (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{FqFiniteField}), z, a, ctx)
       finalizer(z, _fq_abs_series_clear_fn)
       return z
    end
@@ -1791,7 +1791,7 @@ end
 function _fq_abs_series_clear_fn(a::fq_abs_series)
    ctx = base_ring(a)
    ccall((:fq_poly_clear, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &a, &ctx)
+         (Ref{fq_abs_series}, Ref{FqFiniteField}), a, ctx)
 end
 
 ###############################################################################
@@ -1833,7 +1833,7 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
    function fq_nmod_rel_series(ctx::FqNmodFiniteField)
       z = new()
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, ctx)
       finalizer(z, _fq_nmod_rel_series_clear_fn)
       return z
    end
@@ -1841,11 +1841,11 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
    function fq_nmod_rel_series(ctx::FqNmodFiniteField, a::Array{fq_nmod, 1}, len::Int, prec::Int, val::Int)
       z = new()
       ccall((:fq_nmod_poly_init2, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}), &z, len, &ctx)
+            (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}), z, len, ctx)
       for i = 1:len
          ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_nmod_rel_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_nmod_rel_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                               z, i - 1, a[i], ctx)
       end
       z.prec = prec
       z.val = val
@@ -1856,9 +1856,9 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
    function fq_nmod_rel_series(ctx::FqNmodFiniteField, a::fq_nmod_rel_series)
       z = new()
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, ctx)
       ccall((:fq_nmod_poly_set, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &z, &a, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, a, ctx)
       finalizer(z, _fq_nmod_rel_series_clear_fn)
       return z
    end
@@ -1867,7 +1867,7 @@ end
 function _fq_nmod_rel_series_clear_fn(a::fq_nmod_rel_series)
    ctx = base_ring(a)
    ccall((:fq_nmod_poly_clear, :libflint), Void,
-         (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &a, &ctx)
+         (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), a, ctx)
 end
 
 ###############################################################################
@@ -1908,7 +1908,7 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
    function fq_nmod_abs_series(ctx::FqNmodFiniteField)
       z = new()
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, ctx)
       finalizer(z, _fq_nmod_abs_series_clear_fn)
       return z
    end
@@ -1916,11 +1916,11 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
    function fq_nmod_abs_series(ctx::FqNmodFiniteField, a::Array{fq_nmod, 1}, len::Int, prec::Int)
       z = new()
       ccall((:fq_nmod_poly_init2, :libflint), Void,
-            (Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}), &z, len, &ctx)
+            (Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}), z, len, ctx)
       for i = 1:len
          ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_nmod_abs_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_nmod_abs_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                               z, i - 1, a[i], ctx)
       end
       z.prec = prec
       finalizer(z, _fq_nmod_abs_series_clear_fn)
@@ -1930,9 +1930,9 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
    function fq_nmod_abs_series(ctx::FqNmodFiniteField, a::fq_nmod_abs_series)
       z = new()
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, ctx)
       ccall((:fq_nmod_poly_set, :libflint), Void,
-            (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &z, &a, &ctx)
+            (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, a, ctx)
       finalizer(z, _fq_nmod_abs_series_clear_fn)
       return z
    end
@@ -1941,7 +1941,7 @@ end
 function _fq_nmod_abs_series_clear_fn(a::fq_nmod_abs_series)
    ctx = base_ring(a)
    ccall((:fq_nmod_poly_clear, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &a, &ctx)
+         (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, ctx)
 end
 
 ###############################################################################
@@ -1986,7 +1986,7 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int)
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       return z
    end
@@ -1994,14 +1994,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{fmpq, 2})
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpq}), el, &arr[i, j])
+                  (Ref{fmpq}, Ref{fmpq}), el, arr[i, j])
          end
       end
       return z
@@ -2010,15 +2010,15 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{fmpz, 2})
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       b = fmpz(1)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), el, &arr[i, j], &b)
+                  (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[i, j], b)
          end
       end
       return z
@@ -2028,14 +2028,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{fmpq, 1})
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpq}), el, &arr[(i-1)*c+j])
+                  (Ref{fmpq}, Ref{fmpq}), el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -2044,15 +2044,15 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{fmpz, 1})
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       b = fmpz(1)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), el, &arr[(i-1)*c+j], &b)
+                  (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j], b)
          end
       end
       return z
@@ -2062,14 +2062,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{T, 2}) where {T <: Integer}
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpq}), el, &fmpq(arr[i, j]))
+                  (Ref{fmpq}, Ref{fmpq}), el, fmpq(arr[i, j]))
          end
       end
       return z
@@ -2078,14 +2078,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, arr::Array{T, 1}) where {T <: Integer}
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                       (Ptr{fmpq_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                       (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ptr{fmpq}, Ptr{fmpq}), el, &fmpq(arr[(i-1)*c+j]))
+                  (Ref{fmpq}, Ref{fmpq}), el, fmpq(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -2094,13 +2094,13 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(r::Int, c::Int, d::fmpq)
       z = new()
       ccall((:fmpq_mat_init, :libflint), Void,
-            (Ptr{fmpq_mat}, Int, Int), &z, r, c)
+            (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:min(r, c)
-         el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-                    (Ptr{fmpq_mat}, Int, Int), &z, i - 1, i - 1)
+         el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+                    (Ref{fmpq_mat}, Int, Int), z, i - 1, i - 1)
          ccall((:fmpq_set, :libflint), Void,
-               (Ptr{fmpq}, Ptr{fmpq}), el, &d)
+               (Ref{fmpq}, Ref{fmpq}), el, d)
       end
       return z
    end
@@ -2108,14 +2108,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
    function fmpq_mat(m::fmpq_mat)
       z = new()
       ccall((:fmpq_mat_init_set, :libflint), Void,
-            (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &m)
+            (Ref{fmpq_mat}, Ref{fmpq_mat}), z, m)
       finalizer(z, _fmpq_mat_clear_fn)
       return z
    end
 end
 
 function _fmpq_mat_clear_fn(a::fmpq_mat)
-   ccall((:fmpq_mat_clear, :libflint), Void, (Ptr{fmpq_mat},), &a)
+   ccall((:fmpq_mat_clear, :libflint), Void, (Ref{fmpq_mat},), a)
 end
 
 ###############################################################################
@@ -2160,7 +2160,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int)
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       return z
    end
@@ -2168,14 +2168,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int, arr::Array{fmpz, 2})
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-                       (Ptr{fmpz_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+                       (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}), el, &arr[i, j])
+                  (Ref{fmpz}, Ref{fmpz}), el, arr[i, j])
          end
       end
       return z
@@ -2184,14 +2184,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int, arr::Array{fmpz, 1})
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-                       (Ptr{fmpz_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+                       (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}), el, &arr[(i-1)*c+j])
+                  (Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -2200,14 +2200,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int, arr::Array{T, 2}) where {T <: Integer}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-                       (Ptr{fmpz_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+                       (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}), el, &fmpz(arr[i, j]))
+                  (Ref{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
          end
       end
       return z
@@ -2216,14 +2216,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int, arr::Array{T,1}) where {T <: Integer}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-                       (Ptr{fmpz_mat}, Int, Int), &z, i - 1, j - 1)
+            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+                       (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}), el, &fmpz(arr[(i-1)*c+j]))
+                  (Ref{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -2232,13 +2232,13 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(r::Int, c::Int, d::fmpz)
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
-            (Ptr{fmpz_mat}, Int, Int), &z, r, c)
+            (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:min(r, c)
-         el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-                    (Ptr{fmpz_mat}, Int, Int), &z, i - 1, i- 1)
+         el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+                    (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
          ccall((:fmpz_set, :libflint), Void,
-               (Ptr{fmpz}, Ptr{fmpz}), el, &d)
+               (Ref{fmpz}, Ref{fmpz}), el, d)
       end
       return z
    end
@@ -2246,14 +2246,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
    function fmpz_mat(m::fmpz_mat)
       z = new()
       ccall((:fmpz_mat_init_set, :libflint), Void,
-            (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &m)
+            (Ref{fmpz_mat}, Ref{fmpz_mat}), z, m)
       finalizer(z, _fmpz_mat_clear_fn)
       return z
    end
 end
 
 function _fmpz_mat_clear_fn(a::fmpz_mat)
-   ccall((:fmpz_mat_clear, :libflint), Void, (Ptr{fmpz_mat},), &a)
+   ccall((:fmpz_mat_clear, :libflint), Void, (Ref{fmpz_mat},), a)
 end
 
 ###############################################################################
@@ -2298,7 +2298,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     return z
   end
@@ -2306,7 +2306,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{UInt, 2}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2325,7 +2325,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{UInt, 1}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2344,7 +2344,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{fmpz, 2}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2363,7 +2363,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{fmpz, 1}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2392,7 +2392,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{nmod, 2}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2411,7 +2411,7 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(r::Int, c::Int, n::UInt, arr::Array{nmod, 1}, transpose::Bool = false)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, r, c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
@@ -2430,10 +2430,10 @@ mutable struct nmod_mat <: MatElem{nmod}
   function nmod_mat(n::UInt, b::fmpz_mat)
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
-            (Ptr{nmod_mat}, Int, Int, UInt), &z, b.r, b.c, n)
+            (Ref{nmod_mat}, Int, Int, UInt), z, b.r, b.c, n)
     finalizer(z, _nmod_mat_clear_fn)
     ccall((:fmpz_mat_get_nmod_mat, :libflint), Void,
-            (Ptr{nmod_mat}, Ptr{fmpz_mat}), &z, &b)
+            (Ref{nmod_mat}, Ref{fmpz_mat}), z, b)
     return z
   end
 
@@ -2451,7 +2451,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 end
 
 function _nmod_mat_clear_fn(mat::nmod_mat)
-  ccall((:nmod_mat_clear, :libflint), Void, (Ptr{nmod_mat}, ), &mat)
+  ccall((:nmod_mat_clear, :libflint), Void, (Ref{nmod_mat}, ), mat)
 end
 
 ###############################################################################
@@ -2487,7 +2487,7 @@ mutable struct fq_poly <: PolyElem{fq}
 
    function fq_poly()
       z = new()
-      ccall((:fq_poly_init, :libflint), Void, (Ptr{fq_poly},), &z)
+      ccall((:fq_poly_init, :libflint), Void, (Ref{fq_poly},), z)
       finalizer(z, _fq_poly_clear_fn)
       return z
    end
@@ -2496,10 +2496,10 @@ mutable struct fq_poly <: PolyElem{fq}
       z = new()
       ctx = base_ring(parent(a))
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_poly}, Ref{FqFiniteField}), z, ctx)
       ccall((:fq_poly_set, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-            &z, &a, &ctx)
+            (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+            z, a, ctx)
       finalizer(z, _fq_poly_clear_fn)
       return z
    end
@@ -2508,10 +2508,10 @@ mutable struct fq_poly <: PolyElem{fq}
       z = new()
       ctx = parent(a)
       ccall((:fq_poly_init, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{FqFiniteField}), &z, &ctx)
+            (Ref{fq_poly}, Ref{FqFiniteField}), z, ctx)
       ccall((:fq_poly_set_fq, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{fq}, Ptr{FqFiniteField}),
-            &z, &a, &ctx)
+            (Ref{fq_poly}, Ref{fq}, Ref{FqFiniteField}),
+            z, a, ctx)
       finalizer(z, _fq_poly_clear_fn)
       return z
    end
@@ -2520,12 +2520,12 @@ mutable struct fq_poly <: PolyElem{fq}
       z = new()
       ctx = parent(a[1])
       ccall((:fq_poly_init2, :libflint), Void,
-            (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_poly}, Int, Ref{FqFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          ccall((:fq_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_poly}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
+               z, i - 1, a[i], ctx)
       end
       finalizer(z, _fq_poly_clear_fn)
       return z
@@ -2535,13 +2535,13 @@ mutable struct fq_poly <: PolyElem{fq}
       z = new()
       temp = ctx()
       ccall((:fq_poly_init2, :libflint), Void,
-            (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_poly}, Int, Ref{FqFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(a[i])
          ccall((:fq_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_poly}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, i - 1, &temp, &ctx)
+               (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
+               z, i - 1, temp, ctx)
       end
       finalizer(z, _fq_poly_clear_fn)
       return z
@@ -2550,13 +2550,13 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly(a::fmpz_poly, ctx::FqFiniteField)
       z = new()
       ccall((:fq_poly_init2, :libflint), Void,
-            (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_poly}, Int, Ref{FqFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(coeff(a, i-1))
          ccall((:fq_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_poly}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, i - 1, &temp, &ctx)
+               (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
+               z, i - 1, temp, ctx)
       end
       finalizer(z, _fq_poly_clear_fn)
       return z
@@ -2564,7 +2564,7 @@ mutable struct fq_poly <: PolyElem{fq}
 end
 
 function _fq_poly_clear_fn(a::fq_poly)
-   ccall((:fq_poly_clear, :libflint), Void, (Ptr{fq_poly},), &a)
+   ccall((:fq_poly_clear, :libflint), Void, (Ref{fq_poly},), a)
 end
 
 mutable struct fq_poly_factor
@@ -2577,7 +2577,7 @@ mutable struct fq_poly_factor
   function fq_poly_factor(ctx::FqFiniteField)
     z = new()
     ccall((:fq_poly_factor_init, :libflint), Void,
-         (Ptr{fq_poly_factor}, Ptr{FqFiniteField}), &z, &ctx)
+         (Ref{fq_poly_factor}, Ref{FqFiniteField}), z, ctx)
     z.base_field = ctx
     finalizer(z, _fq_poly_factor_clear_fn)
     return z
@@ -2586,8 +2586,8 @@ end
 
 function _fq_poly_factor_clear_fn(a::fq_poly_factor)
    ccall((:fq_poly_factor_clear, :libflint), Void,
-         (Ptr{fq_poly_factor}, Ptr{FqFiniteField}),
-         &a, &(a.base_field))
+         (Ref{fq_poly_factor}, Ref{FqFiniteField}),
+         a, a.base_field)
 end
 
 ###############################################################################
@@ -2623,7 +2623,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
 
    function fq_nmod_poly()
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Void, (Ptr{fq_nmod_poly},), &z)
+      ccall((:fq_nmod_poly_init, :libflint), Void, (Ref{fq_nmod_poly},), z)
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
@@ -2632,10 +2632,10 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       z = new()
       ctx = base_ring(parent(a))
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), z, ctx)
       ccall((:fq_nmod_poly_set, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-            &z, &a, &ctx)
+            (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+            z, a, ctx)
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
@@ -2644,10 +2644,10 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       z = new()
       ctx = parent(a)
       ccall((:fq_nmod_poly_init, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}), &z, &ctx)
+            (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), z, ctx)
       ccall((:fq_nmod_poly_set_fq_nmod, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-            &z, &a, &ctx)
+            (Ref{fq_nmod_poly}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+            z, a, ctx)
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
@@ -2656,12 +2656,12 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       z = new()
       ctx = parent(a[1])
       ccall((:fq_nmod_poly_init2, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, i - 1, &a[i], &ctx)
+               (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, i - 1, a[i], ctx)
       end
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
@@ -2671,13 +2671,13 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       z = new()
       temp = ctx()
       ccall((:fq_nmod_poly_init2, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(a[i])
          ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, i - 1, &temp, &ctx)
+               (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, i - 1, temp, ctx)
       end
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
@@ -2686,13 +2686,13 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly(a::fmpz_poly, ctx::FqNmodFiniteField)
       z = new()
       ccall((:fq_nmod_poly_init2, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-            &z, length(a), &ctx)
+            (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+            z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(coeff(a,i-1))
          ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-               (Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, i - 1, &temp, &ctx)
+               (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, i - 1, temp, ctx)
       end
       finalizer(z, _fq_nmod_poly_clear_fn)
       return z
@@ -2700,7 +2700,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
 end
 
 function _fq_nmod_poly_clear_fn(a::fq_nmod_poly)
-   ccall((:fq_nmod_poly_clear, :libflint), Void, (Ptr{fq_nmod_poly},), &a)
+   ccall((:fq_nmod_poly_clear, :libflint), Void, (Ref{fq_nmod_poly},), a)
 end
 
 mutable struct fq_nmod_poly_factor
@@ -2713,7 +2713,7 @@ mutable struct fq_nmod_poly_factor
   function fq_nmod_poly_factor(ctx::FqNmodFiniteField)
     z = new()
     ccall((:fq_nmod_poly_factor_init, :libflint), Void,
-         (Ptr{fq_nmod_poly_factor}, Ptr{FqNmodFiniteField}), &z, &ctx)
+         (Ref{fq_nmod_poly_factor}, Ref{FqNmodFiniteField}), z, ctx)
     z.base_field = ctx
     finalizer(z, _fq_nmod_poly_factor_clear_fn)
     return z
@@ -2722,6 +2722,6 @@ end
 
 function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
    ccall((:fq_nmod_poly_factor_clear, :libflint), Void,
-         (Ptr{fq_nmod_poly_factor}, Ptr{FqNmodFiniteField}),
-         &a, &(a.base_field))
+         (Ref{fq_nmod_poly_factor}, Ref{FqNmodFiniteField}),
+         a, a.base_field)
 end

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -19,7 +19,7 @@ fmpq(a::Rational{BigInt}) = fmpq(fmpz(a.num), fmpz(a.den))
 
 function fmpq(a::Rational{Int})
   r = fmpq()
-  ccall((:fmpq_set_si, :libflint), Void, (Ptr{fmpq}, Int64, UInt64), &r, numerator(a), denominator(a))
+  ccall((:fmpq_set_si, :libflint), Void, (Ref{fmpq}, Int64, UInt64), r, numerator(a), denominator(a))
   return r
 end
 
@@ -79,13 +79,13 @@ end
 
 function numerator(a::fmpq)
    z = fmpz()
-   ccall((:fmpq_numerator, :libflint), Void, (Ptr{fmpz}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_numerator, :libflint), Void, (Ref{fmpz}, Ref{fmpq}), z, a)
    return z
 end
 
 function denominator(a::fmpq)
    z = fmpz()
-   ccall((:fmpq_denominator, :libflint), Void, (Ptr{fmpz}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_denominator, :libflint), Void, (Ref{fmpz}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -95,7 +95,7 @@ doc"""
 """
 function abs(a::fmpq)
    z = fmpq()
-   ccall((:fmpq_abs, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_abs, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -104,11 +104,11 @@ zero(a::FlintRationalField) = fmpq(0)
 one(a::FlintRationalField) = fmpq(1)
 
 function isone(a::fmpq)
-   return Bool(ccall((:fmpq_is_one, :libflint), Cint, (Ptr{fmpq}, ), &a))
+   return Bool(ccall((:fmpq_is_one, :libflint), Cint, (Ref{fmpq}, ), a))
 end
 
 function iszero(a::fmpq)
-   return Bool(ccall((:fmpq_is_zero, :libflint), Cint, (Ptr{fmpq}, ), &a))
+   return Bool(ccall((:fmpq_is_zero, :libflint), Cint, (Ref{fmpq}, ), a))
 end
 
 isunit(a::fmpq) = !iszero(a)
@@ -120,7 +120,7 @@ doc"""
 """
 function height(a::fmpq)
    temp = fmpz()
-   ccall((:fmpq_height, :libflint), Void, (Ptr{fmpz}, Ptr{fmpq}), &temp, &a)
+   ccall((:fmpq_height, :libflint), Void, (Ref{fmpz}, Ref{fmpq}), temp, a)
    return temp
 end
 
@@ -129,12 +129,12 @@ doc"""
 > Return the number of bits of the height of the fraction $a$.
 """
 function height_bits(a::fmpq)
-   return ccall((:fmpq_height_bits, :libflint), Int, (Ptr{fmpq},), &a)
+   return ccall((:fmpq_height_bits, :libflint), Int, (Ref{fmpq},), a)
 end
 
 function deepcopy_internal(a::fmpq, dict::ObjectIdDict)
    z = fmpq()
-   ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -177,7 +177,7 @@ show_minus_one(::Type{fmpq}) = false
 
 function -(a::fmpq)
    z = fmpq()
-   ccall((:fmpq_neg, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_neg, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -190,21 +190,21 @@ end
 function +(a::fmpq, b::fmpq)
    z = fmpq()
    ccall((:fmpq_add, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
 function -(a::fmpq, b::fmpq)
    z = fmpq()
    ccall((:fmpq_sub, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
 function *(a::fmpq, b::fmpq)
    z = fmpq()
    ccall((:fmpq_mul, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
@@ -217,14 +217,14 @@ end
 function +(a::fmpq, b::Int)
    z = fmpq()
    ccall((:fmpq_add_si, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &a, b)
+         (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
 function +(a::fmpq, b::fmpz)
    z = fmpq()
    ccall((:fmpq_add_fmpz, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpz}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
 
@@ -239,14 +239,14 @@ end
 function -(a::fmpq, b::Int)
    z = fmpq()
    ccall((:fmpq_sub_si, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &a, b)
+         (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
 function -(a::fmpq, b::fmpz)
    z = fmpq()
    ccall((:fmpq_sub_fmpz, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpz}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
 
@@ -257,7 +257,7 @@ end
 function *(a::fmpq, b::fmpz)
    z = fmpq()
    ccall((:fmpq_mul_fmpz, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpz}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
 
@@ -284,7 +284,7 @@ end
 
 function ==(a::fmpq, b::fmpq)
    return ccall((:fmpq_equal, :libflint), Bool,
-                (Ptr{fmpq}, Ptr{fmpq}), &a, &b)
+                (Ref{fmpq}, Ref{fmpq}), a, b)
 end
 
 doc"""
@@ -293,7 +293,7 @@ doc"""
 """
 function isless(a::fmpq, b::fmpq)
    return ccall((:fmpq_cmp, :libflint), Cint,
-                (Ptr{fmpq}, Ptr{fmpq}), &a, &b) < 0
+                (Ref{fmpq}, Ref{fmpq}), a, b) < 0
 end
 
 ###############################################################################
@@ -303,14 +303,14 @@ end
 ###############################################################################
 
 function ==(a::fmpq, b::Int)
-   return ccall((:fmpq_equal_si, :libflint), Bool, (Ptr{fmpq}, Int), &a, b)
+   return ccall((:fmpq_equal_si, :libflint), Bool, (Ref{fmpq}, Int), a, b)
 end
 
 ==(a::Int, b::fmpq) = b == a
 
 function ==(a::fmpq, b::fmpz)
    return ccall((:fmpq_equal_fmpz, :libflint), Bool,
-                (Ptr{fmpq}, Ptr{fmpz}), &a, &b)
+                (Ref{fmpq}, Ref{fmpz}), a, b)
 end
 
 ==(a::fmpz, b::fmpq) = b == a
@@ -326,7 +326,7 @@ doc"""
 function isless(a::fmpq, b::Integer)
    z = fmpq(b)
    return ccall((:fmpq_cmp, :libflint), Cint,
-                (Ptr{fmpq}, Ptr{fmpq}), &a, &z) < 0
+                (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
 doc"""
@@ -336,7 +336,7 @@ doc"""
 function isless(a::Integer, b::fmpq)
    z = fmpq(a)
    return ccall((:fmpq_cmp, :libflint), Cint,
-                (Ptr{fmpq}, Ptr{fmpq}), &z, &b) < 0
+                (Ref{fmpq}, Ref{fmpq}), z, b) < 0
 end
 
 doc"""
@@ -346,7 +346,7 @@ doc"""
 function isless(a::fmpq, b::fmpz)
    z = fmpq(b)
    return ccall((:fmpq_cmp, :libflint), Cint,
-                (Ptr{fmpq}, Ptr{fmpq}), &a, &z) < 0
+                (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
 doc"""
@@ -356,7 +356,7 @@ doc"""
 function isless(a::fmpz, b::fmpq)
    z = fmpq(a)
    return ccall((:fmpq_cmp, :libflint), Cint,
-                (Ptr{fmpq}, Ptr{fmpq}), &z, &b) < 0
+                (Ref{fmpq}, Ref{fmpq}), z, b) < 0
 end
 
 isless(a::Rational{T}, b::fmpq) where {T <: Integer} = isless(fmpq(a), b)
@@ -372,7 +372,7 @@ isless(a::fmpq, b::Rational{T}) where {T <: Integer} = isless(a, fmpq(b))
 function ^(a::fmpq, b::Int)
    temp = fmpq()
    ccall((:fmpq_pow_si, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Int), &temp, &a, b)
+         (Ref{fmpq}, Ref{fmpq}, Int), temp, a, b)
    return temp
 end
 
@@ -389,7 +389,7 @@ doc"""
 function >>(a::fmpq, b::Int)
    z = fmpq()
    ccall((:fmpq_div_2exp, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &a, b)
+         (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
@@ -400,7 +400,7 @@ doc"""
 function <<(a::fmpq, b::Int)
    z = fmpq()
    ccall((:fmpq_mul_2exp, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &a, b)
+         (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
@@ -412,7 +412,7 @@ end
 
 function inv(a::fmpq)
    z = fmpq()
-   ccall((:fmpq_inv, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &z, &a)
+   ccall((:fmpq_inv, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -425,7 +425,7 @@ end
 function divexact(a::fmpq, b::fmpq)
    z = fmpq()
    ccall((:fmpq_div, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
@@ -445,7 +445,7 @@ end
 function divexact(a::fmpq, b::fmpz)
    z = fmpq()
    ccall((:fmpq_div_fmpz, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpz}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
 
@@ -473,7 +473,7 @@ doc"""
 function mod(a::fmpq, b::fmpz)
    z = fmpz()
    ccall((:fmpq_mod_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpq}, Ptr{fmpz}), &z, &a, &b)
+         (Ref{fmpz}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
 
@@ -493,7 +493,7 @@ mod(a::fmpq, b::Integer) = mod(a, fmpz(b))
 function gcd(a::fmpq, b::fmpq)
    z = fmpq()
    ccall((:fmpq_gcd, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &z, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
@@ -523,7 +523,7 @@ doc"""
 function reconstruct(a::fmpz, b::fmpz)
    c = fmpq()
    if !Bool(ccall((:fmpq_reconstruct_fmpz, :libflint), Cint,
-                  (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), &c, &a, &b))
+                  (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), c, a, b))
       error("Impossible rational reconstruction")
    end
    return c
@@ -577,7 +577,7 @@ doc"""
 function next_minimal(a::fmpq)
    a < 0 && throw(DomainError())
    c = fmpq()
-   ccall((:fmpq_next_minimal, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &c, &a)
+   ccall((:fmpq_next_minimal, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
 
@@ -593,7 +593,7 @@ doc"""
 function next_signed_minimal(a::fmpq)
    c = fmpq()
    ccall((:fmpq_next_signed_minimal, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}), &c, &a)
+         (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
 
@@ -612,7 +612,7 @@ function next_calkin_wilf(a::fmpq)
    a < 0 && throw(DomainError())
    c = fmpq()
    ccall((:fmpq_next_calkin_wilf, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}), &c, &a)
+         (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
 
@@ -627,7 +627,7 @@ doc"""
 function next_signed_calkin_wilf(a::fmpq)
    c = fmpq()
    ccall((:fmpq_next_signed_calkin_wilf, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}), &c, &a)
+         (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
 
@@ -646,7 +646,7 @@ doc"""
 function harmonic(n::Int)
    n < 0 && throw(DomainError())
    c = fmpq()
-   ccall((:fmpq_harmonic_ui, :libflint), Void, (Ptr{fmpq}, Int), &c, n)
+   ccall((:fmpq_harmonic_ui, :libflint), Void, (Ref{fmpq}, Int), c, n)
    return c
 end
 
@@ -657,7 +657,7 @@ doc"""
 function bernoulli(n::Int)
    n < 0 && throw(DomainError())
    c = fmpq()
-   ccall((:bernoulli_fmpq_ui, :libarb), Void, (Ptr{fmpq}, Int), &c, n)
+   ccall((:bernoulli_fmpq_ui, :libarb), Void, (Ref{fmpq}, Int), c, n)
    return c
 end
 
@@ -680,7 +680,7 @@ doc"""
 function dedekind_sum(h::fmpz, k::fmpz)
    c = fmpq()
    ccall((:fmpq_dedekind_sum, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpz}, Ptr{fmpz}), &c, &h, &k)
+         (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), c, h, k)
    return c
 end
 
@@ -710,25 +710,25 @@ dedekind_sum(h::Integer, k::Integer) = dedekind_sum(fmpz(h), fmpz(k))
 
 function zero!(c::fmpq)
    ccall((:fmpq_zero, :libflint), Void,
-         (Ptr{fmpq},), &c)
+         (Ref{fmpq},), c)
    return c
 end
 
 function mul!(c::fmpq, a::fmpq, b::fmpq)
    ccall((:fmpq_mul, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
    return c
 end
 
 function addeq!(c::fmpq, a::fmpq)
    ccall((:fmpq_add, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &c, &a)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, c, a)
    return c
 end
 
 function add!(c::fmpq, a::fmpq, b::fmpq)
    ccall((:fmpq_add, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq}, Ptr{fmpq}), &c, &a, &b)
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
    return c
 end
 
@@ -741,7 +741,7 @@ end
 function Rational(z::fmpq)
    r = Rational{BigInt}(0)
    ccall((:fmpq_get_mpz_frac, :libflint), Void,
-         (Ptr{BigInt}, Ptr{BigInt}, Ptr{fmpq}), &r.num, &r.den, &z)
+         (Ref{BigInt}, Ref{BigInt}, Ref{fmpq}), r.num, r.den, z)
    return r
 end
 

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -42,13 +42,13 @@ function normalise(a::fmpq_abs_series, len::Int)
    if len > 0
       c = fmpq()
       ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq_abs_series}, Int), &c, &a, len - 1)
+         (Ref{fmpq}, Ref{fmpq_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-            (Ptr{fmpq}, Ptr{fmpq_abs_series}, Int), &c, &a, len - 1)
+            (Ref{fmpq}, Ref{fmpq_abs_series}, Int), c, a, len - 1)
       end
    end
 
@@ -61,12 +61,12 @@ function coeff(x::fmpq_abs_series, n::Int)
    end
    z = fmpq()
    ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq_abs_series}, Int), &z, &x, n)
+         (Ref{fmpq}, Ref{fmpq_abs_series}, Int), z, x, n)
    return z
 end
 
 function length(x::fmpq_abs_series)
-   return ccall((:fmpq_poly_length, :libflint), Int, (Ptr{fmpq_abs_series},), &x)
+   return ccall((:fmpq_poly_length, :libflint), Int, (Ref{fmpq_abs_series},), x)
 end
 
 precision(x::fmpq_abs_series) = x.prec
@@ -90,7 +90,7 @@ end
 
 function isgen(a::fmpq_abs_series)
    return precision(a) == 0 || ccall((:fmpq_poly_is_x, :libflint), Bool,
-                            (Ptr{fmpq_abs_series},), &a)
+                            (Ref{fmpq_abs_series},), a)
 end
 
 iszero(a::fmpq_abs_series) = length(a) == 0
@@ -99,7 +99,7 @@ isunit(a::fmpq_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpq_abs_series)
    return precision(a) == 0 || ccall((:fmpq_poly_is_one, :libflint), Bool,
-                                (Ptr{fmpq_abs_series},), &a)
+                                (Ref{fmpq_abs_series},), a)
 end
 
 # todo: write an fmpq_poly_valuation
@@ -134,8 +134,8 @@ show_minus_one(::Type{fmpq_abs_series}) = show_minus_one(fmpq)
 function -(x::fmpq_abs_series)
    z = parent(x)()
    ccall((:fmpq_poly_neg, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}),
-               &z, &x)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}),
+               z, x)
    z.prec = x.prec
    return z
 end
@@ -160,8 +160,8 @@ function +(a::fmpq_abs_series, b::fmpq_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -179,8 +179,8 @@ function -(a::fmpq_abs_series, b::fmpq_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpq_poly_sub_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -208,8 +208,8 @@ function *(a::fmpq_abs_series, b::fmpq_abs_series)
    lenz = min(lena + lenb - 1, prec)
 
    ccall((:fmpq_poly_mullow, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -224,8 +224,8 @@ function *(x::Int, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpq_poly_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &y, x)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, y, x)
    return z
 end
 
@@ -233,8 +233,8 @@ function *(x::fmpz, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpz}),
-               &z, &y, &x)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpz}),
+               z, y, x)
    return z
 end
 
@@ -242,8 +242,8 @@ function *(x::fmpq, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq}),
-               &z, &y, &x)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq}),
+               z, y, x)
    return z
 end
 
@@ -281,8 +281,8 @@ function shift_left(x::fmpq_abs_series, len::Int)
    z = parent(x)()
    z.prec = x.prec + len
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, x, len)
    return z
 end
 
@@ -295,8 +295,8 @@ function shift_right(x::fmpq_abs_series, len::Int)
    else
       z.prec = x.prec - len
       ccall((:fmpq_poly_shift_right, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, x, len)
    end
    return z
 end
@@ -315,8 +315,8 @@ function truncate(x::fmpq_abs_series, prec::Int)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpq_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &x, prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, x, prec)
    return z
 end
 
@@ -371,8 +371,8 @@ function ==(x::fmpq_abs_series, y::fmpq_abs_series)
    n = min(n, prec)
 
    return Bool(ccall((:fmpq_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &x, &y, n))
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               x, y, n))
 end
 
 function isequal(x::fmpq_abs_series, y::fmpq_abs_series)
@@ -383,8 +383,8 @@ function isequal(x::fmpq_abs_series, y::fmpq_abs_series)
       return false
    end
    return Bool(ccall((:fmpq_poly_equal, :libflint), Cint,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &x, &y, length(x)))
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               x, y, length(x)))
 end
 
 ###############################################################################
@@ -423,8 +423,8 @@ function divexact(x::fmpq_abs_series, y::fmpq_abs_series)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpq_poly_div_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, x, y, prec)
    return z
 end
 
@@ -439,8 +439,8 @@ function divexact(x::fmpq_abs_series, y::Int)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpq_poly_scalar_div_si, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &x, y)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, x, y)
    return z
 end
 
@@ -449,8 +449,8 @@ function divexact(x::fmpq_abs_series, y::fmpz)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -459,8 +459,8 @@ function divexact(x::fmpq_abs_series, y::fmpq)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq}),
-               &z, &x, &y)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq}),
+               z, x, y)
    return z
 end
 
@@ -480,8 +480,8 @@ function inv(a::fmpq_abs_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ccall((:fmpq_poly_inv_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -499,8 +499,8 @@ function Base.exp(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_exp_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -516,8 +516,8 @@ function log(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_log_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -533,8 +533,8 @@ function tan(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_tan_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -550,8 +550,8 @@ function tanh(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_tanh_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -567,8 +567,8 @@ function sin(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_sin_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -584,8 +584,8 @@ function sinh(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_sinh_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -601,8 +601,8 @@ function cos(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_cos_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -618,8 +618,8 @@ function cosh(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_cosh_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -635,8 +635,8 @@ function asin(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_asin_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -652,8 +652,8 @@ function asinh(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_asinh_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -669,8 +669,8 @@ function atan(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_atan_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -686,8 +686,8 @@ function atanh(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_atanh_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -701,8 +701,8 @@ function sqrt(a::fmpq_abs_series)
    z = parent(a)()
    z.prec = a.prec
    ccall((:fmpq_poly_sqrt_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -714,8 +714,8 @@ end
 
 function setcoeff!(z::fmpq_abs_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Int, Ptr{fmpq}),
-               &z, n, &x)
+                (Ref{fmpq_abs_series}, Int, Ref{fmpq}),
+               z, n, x)
    return z
 end
 
@@ -739,8 +739,8 @@ function mul!(z::fmpq_abs_series, a::fmpq_abs_series, b::fmpq_abs_series)
 
    z.prec = prec
    ccall((:fmpq_poly_mullow, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -756,8 +756,8 @@ function addeq!(a::fmpq_abs_series, b::fmpq_abs_series)
    lenz = max(lena, lenb)
    a.prec = prec
    ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Ptr{fmpq_abs_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
+               a, a, b, lenz)
    return a
 end
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -59,8 +59,8 @@ function Base.view(x::fmpq_mat, r1::Int, c1::Int, r2::Int, c2::Int)
   b = fmpq_mat()
   b.base_ring = x.base_ring
   ccall((:fmpq_mat_window_init, :libflint), Void,
-        (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Int, Int, Int, Int),
-            &b, &x, r1 - 1, c1 - 1, r2, c2)
+        (Ref{fmpq_mat}, Ref{fmpq_mat}, Int, Int, Int, Int),
+            b, x, r1 - 1, c1 - 1, r2, c2)
   finalizer(b, _fmpq_mat_window_clear_fn)
   return b
 end
@@ -70,7 +70,7 @@ function Base.view(x::fmpq_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fmpq_mat_window_clear_fn(a::fmpq_mat)
-   ccall((:fmpq_mat_window_clear, :libflint), Void, (Ptr{fmpq_mat},), &a)
+   ccall((:fmpq_mat_window_clear, :libflint), Void, (Ref{fmpq_mat},), a)
 end
 
 size(x::fmpq_mat) = tuple(rows(x), cols(x))
@@ -84,35 +84,35 @@ size(t::fmpq_mat, d) = d <= 2 ? size(t)[d] : 1
 ###############################################################################
 
 function getindex!(v::fmpq, a::fmpq_mat, r::Int, c::Int)
-   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &v, z)
+   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), v, z)
 end
 
 @inline function getindex(a::fmpq_mat, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpq()
-   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), &v, z)
+   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), v, z)
    return v
 end
 
 @inline function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry_num, :libflint), Ptr{fmpz},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), z, &d)
-   z = ccall((:fmpq_mat_entry_den, :libflint), Ptr{fmpz},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, 1)
+   z = ccall((:fmpq_mat_entry_num, :libflint), Ref{fmpz},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, d)
+   z = ccall((:fmpq_mat_entry_den, :libflint), Ref{fmpz},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set_si, :libflint), Void, (Ref{fmpz}, Int), z, 1)
 end
 
 @inline function setindex!(a::fmpq_mat, d::fmpq, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ptr{fmpq}), z, &d)
+   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, d)
 end
 
 Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
@@ -121,9 +121,9 @@ Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
 
 @inline function setindex!(a::fmpq_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
-             (Ptr{fmpq_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpq_set_si, :libflint), Void, (Ptr{fmpq}, Int, Int), z, d, 1)
+   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+             (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpq_set_si, :libflint), Void, (Ref{fmpq}, Int, Int), z, d, 1)
 end
 
 Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Rational,
@@ -139,10 +139,10 @@ zero(a::FmpqMatSpace) = a()
 one(a::FmpqMatSpace) = a(1)
 
 iszero(a::fmpq_mat) = ccall((:fmpq_mat_is_zero, :libflint), Bool,
-                            (Ptr{fmpq_mat},), &a)
+                            (Ref{fmpq_mat},), a)
 
 isone(a::fmpq_mat) = ccall((:fmpq_mat_is_one, :libflint), Bool,
-                           (Ptr{fmpq_mat},), &a)
+                           (Ref{fmpq_mat},), a)
 
 function deepcopy_internal(d::fmpq_mat, dict::ObjectIdDict)
    z = fmpq_mat(d)
@@ -199,7 +199,7 @@ show_minus_one(::Type{fmpq_mat}) = show_minus_one(fmpq)
 function -(x::fmpq_mat)
    z = similar(x)
    ccall((:fmpq_mat_neg, :libflint), Void,
-         (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+         (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -212,7 +212,7 @@ end
 function transpose(x::fmpq_mat)
    z = similar(x, cols(x), rows(x))
    ccall((:fmpq_mat_transpose, :libflint), Void,
-         (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+         (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -226,8 +226,8 @@ function +(x::fmpq_mat, y::fmpq_mat)
    check_parent(x, y)
    z = similar(x)
    ccall((:fmpq_mat_add, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat},  Ptr{fmpq_mat}),
-               &z, &x, &y)
+                (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
+               z, x, y)
    return z
 end
 
@@ -235,8 +235,8 @@ function -(x::fmpq_mat, y::fmpq_mat)
    check_parent(x, y)
    z = similar(x)
    ccall((:fmpq_mat_sub, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat},  Ptr{fmpq_mat}),
-               &z, &x, &y)
+                (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
+               z, x, y)
    return z
 end
 
@@ -244,8 +244,8 @@ function *(x::fmpq_mat, y::fmpq_mat)
    cols(x) != rows(y) && error("Incompatible matrix dimensions")
    z = similar(x, rows(x), cols(y))
    ccall((:fmpq_mat_mul, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat},  Ptr{fmpq_mat}),
-               &z, &x, &y)
+                (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
+               z, x, y)
    return z
 end
 
@@ -258,16 +258,16 @@ end
 function *(x::fmpz, y::fmpq_mat)
    z = similar(y)
    ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpz}), &z, &y, &x)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function *(x::fmpq, y::fmpq_mat)
    z = similar(y)
    ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq}), &z, &y, &numerator(x))
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), z, y, numerator(x))
    ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq}), &z, &z, &denominator(x))
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), z, z, denominator(x))
    return z
 end
 
@@ -348,7 +348,7 @@ end
 function ==(x::fmpq_mat, y::fmpq_mat)
    check_parent(x, y)
    ccall((:fmpq_mat_equal, :libflint), Bool,
-                                       (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &x, &y)
+                                       (Ref{fmpq_mat}, Ref{fmpq_mat}), x, y)
 end
 
 ###############################################################################
@@ -388,7 +388,7 @@ end
 function inv(x::fmpq_mat)
    z = similar(x)
    success = ccall((:fmpq_mat_inv, :libflint), Cint,
-         (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+         (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    success == 0 && error("Matrix not invertible")
    return z
 end
@@ -413,16 +413,16 @@ end
 function divexact(x::fmpq_mat, y::fmpq)
    z = similar(x)
    ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpz}), &z, &x, &numerator(y))
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, x, numerator(y))
    ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpz}), &z, &z, &denominator(y))
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, z, denominator(y))
    return z
 end
 
 function divexact(x::fmpq_mat, y::fmpz)
    z = similar(x)
    ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -440,7 +440,7 @@ function charpoly(R::FmpqPolyRing, x::fmpq_mat)
    rows(x) != cols(x) && error("Non-square")
    z = R()
    ccall((:fmpq_mat_charpoly, :libflint), Void,
-                (Ptr{fmpq_poly}, Ptr{fmpq_mat}), &z, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -454,7 +454,7 @@ function minpoly(R::FmpqPolyRing, x::fmpq_mat)
    rows(x) != cols(x) && error("Non-square")
    z = R()
    ccall((:fmpq_mat_minpoly, :libflint), Void,
-                (Ptr{fmpq_poly}, Ptr{fmpq_mat}), &z, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -468,7 +468,7 @@ function det(x::fmpq_mat)
    rows(x) != cols(x) && error("Non-square matrix")
    z = fmpq()
    ccall((:fmpq_mat_det, :libflint), Void,
-                (Ptr{fmpq}, Ptr{fmpq_mat}), &z, &x)
+                (Ref{fmpq}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -485,7 +485,7 @@ doc"""
 function gso(x::fmpq_mat)
    z = similar(x)
    ccall((:fmpq_mat_gso, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
 
@@ -503,7 +503,7 @@ doc"""
 function hilbert(R::FmpqMatSpace)
    z = R()
    ccall((:fmpq_mat_hilbert_matrix, :libflint), Bool,
-                   (Ptr{fmpq_mat},), &z)
+                   (Ref{fmpq_mat},), z)
    return z
 end
 
@@ -516,7 +516,7 @@ end
 function rank(x::fmpq_mat)
    z = similar(x)
    r = ccall((:fmpq_mat_rref, :libflint), Int,
-         (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+         (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return r
 end
 
@@ -529,7 +529,7 @@ end
 function rref(x::fmpq_mat)
    z = similar(x)
    r = ccall((:fmpq_mat_rref, :libflint), Int,
-         (Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x)
+         (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return r, z
 end
 
@@ -544,7 +544,7 @@ function solve(a::fmpq_mat, b::fmpq_mat)
    rows(b) != rows(a) && error("Incompatible dimensions in solve")
    z = similar(b)
    nonsing = ccall((:fmpq_mat_solve_fraction_free, :libflint), Bool,
-      (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &a, &b)
+      (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, a, b)
    !nonsing && error("Singular matrix in solve")
    return z
 end
@@ -559,7 +559,7 @@ function solve_dixon(a::fmpq_mat, b::fmpq_mat)
    rows(b) != rows(a) && error("Incompatible dimensions in solve")
    z = similar(b)
    nonsing = ccall((:fmpq_mat_solve_dixon, :libflint), Bool,
-      (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &a, &b)
+      (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, a, b)
    !nonsing && error("Singular matrix in solve")
    return z
 end
@@ -574,7 +574,7 @@ function trace(x::fmpq_mat)
    rows(x) != cols(x) && error("Not a square matrix in trace")
    d = fmpq()
    ccall((:fmpq_mat_trace, :libflint), Void,
-                (Ptr{fmpq}, Ptr{fmpq_mat}), &d, &x)
+                (Ref{fmpq}, Ref{fmpq_mat}), d, x)
    return d
 end
 
@@ -588,7 +588,7 @@ function hcat(a::fmpq_mat, b::fmpq_mat)
   rows(a) != rows(b) && error("Incompatible number of rows in hcat")
   c = similar(a, rows(a), cols(a) + cols(b))
   ccall((:fmpq_mat_concat_horizontal, :libflint), Void,
-        (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &c, &a, &b)
+        (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), c, a, b)
   return c
 end
 
@@ -596,7 +596,7 @@ function vcat(a::fmpq_mat, b::fmpq_mat)
   cols(a) != cols(b) && error("Incompatible number of columns in vcat")
   c = similar(a, rows(a) + rows(b), cols(a))
   ccall((:fmpq_mat_concat_vertical, :libflint), Void,
-        (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &c, &a, &b)
+        (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), c, a, b)
   return c
 end
 
@@ -608,7 +608,7 @@ end
 
 function similarity!(z::fmpq_mat, r::Int, d::fmpq)
    ccall((:fmpq_mat_similarity, :libflint), Void, 
-         (Ptr{fmpq_mat}, Int, Ptr{fmpq}), &z, r - 1, &d)
+         (Ref{fmpq_mat}, Int, Ref{fmpq}), z, r - 1, d)
 end
 
 ###############################################################################
@@ -619,31 +619,31 @@ end
 
 function mul!(z::fmpq_mat, x::fmpq_mat, y::fmpq_mat)
    ccall((:fmpq_mat_mul, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &x, &y)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, x, y)
    return z
 end
 
 function mul!(y::fmpq_mat, x::Int)
    ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq}), &y, &y, &fmpz(x))
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), y, y, fmpz(x))
    return y
 end
 
 function mul!(y::fmpq_mat, x::fmpz)
    ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpz}), &y, &y, &x)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), y, y, x)
    return y
 end
 
 function addeq!(z::fmpq_mat, x::fmpq_mat)
    ccall((:fmpq_mat_add, :libflint), Void,
-                (Ptr{fmpq_mat}, Ptr{fmpq_mat}, Ptr{fmpq_mat}), &z, &z, &x)
+                (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, z, x)
    return z
 end
 
 function zero!(z::fmpq_mat)
    ccall((:fmpq_mat_zero, :libflint), Void,
-                (Ptr{fmpq_mat},), &z)
+                (Ref{fmpq_mat},), z)
    return z
 end
 
@@ -739,7 +739,7 @@ end
 function (a::FmpqMatSpace)(M::fmpz_mat)
    (a.cols == cols(M) && a.rows == rows(M)) || error("wrong matrix dimension")
    z = a()
-   ccall((:fmpq_mat_set_fmpz_mat, :libflint), Void, (Ptr{fmpq_mat}, Ptr{fmpz_mat}), &z, &M)
+   ccall((:fmpq_mat_set_fmpz_mat, :libflint), Void, (Ref{fmpq_mat}, Ref{fmpz_mat}), z, M)
    return z
 end
 
@@ -824,7 +824,7 @@ end
 
 function identity_matrix(R::FlintRationalField, n::Int)
    z = fmpq_mat(n, n)
-   ccall((:fmpq_mat_one, :libflint), Void, (Ptr{fmpq_mat}, ), &z)
+   ccall((:fmpq_mat_one, :libflint), Void, (Ref{fmpq_mat}, ), z)
    z.base_ring = FlintQQ
    return z
 end

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -34,21 +34,21 @@ doc"""
 function denominator(a::fmpq_poly)
    z = fmpz()
    ccall((:fmpq_poly_get_denominator, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpq_poly}), &z, &a)
+         (Ref{fmpz}, Ref{fmpq_poly}), z, a)
    return z
 end
  
 length(x::fmpq_poly) = ccall((:fmpq_poly_length, :libflint), Int, 
-                                   (Ptr{fmpq_poly},), &x)
+                                   (Ref{fmpq_poly},), x)
 
 set_length!(x::fmpq_poly, n::Int) = ccall((:_fmpq_poly_set_length, :libflint), Void,
-                                   (Ptr{fmpq_poly}, Int), &x, n)
+                                   (Ref{fmpq_poly}, Int), x, n)
 
 function coeff(x::fmpq_poly, n::Int)
    n < 0 && throw(DomainError())
    z = fmpq()
    ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void, 
-               (Ptr{fmpq}, Ptr{fmpq_poly}, Int), &z, &x, n)
+               (Ref{fmpq}, Ref{fmpq_poly}, Int), z, x, n)
    return z
 end
 
@@ -59,7 +59,7 @@ one(a::FmpqPolyRing) = a(1)
 gen(a::FmpqPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 isgen(x::fmpq_poly) = ccall((:fmpq_poly_is_x, :libflint), Bool, 
-                            (Ptr{fmpq_poly},), &x)
+                            (Ref{fmpq_poly},), x)
 
 function deepcopy_internal(a::fmpq_poly, dict::ObjectIdDict)
    z = fmpq_poly(a)
@@ -88,7 +88,7 @@ function show(io::IO, x::fmpq_poly)
       print(io, "0")
    else
       cstr = ccall((:fmpq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-          (Ptr{fmpq_poly}, Ptr{UInt8}), &x, string(var(parent(x))))
+          (Ref{fmpq_poly}, Ptr{UInt8}), x, string(var(parent(x))))
 
       print(io, unsafe_string(cstr))
 
@@ -115,7 +115,7 @@ show_minus_one(::Type{fmpq_poly}) = show_minus_one(FracElem{fmpz})
 function -(x::fmpq_poly)
    z = parent(x)()
    ccall((:fmpq_poly_neg, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
 
@@ -129,8 +129,8 @@ function +(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_add, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly},  Ptr{fmpq_poly}), 
-               &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}), 
+               z, x, y)
    return z
 end
 
@@ -138,8 +138,8 @@ function -(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_sub, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly},  Ptr{fmpq_poly}), 
-               &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}), 
+               z, x, y)
    return z
 end
 
@@ -147,8 +147,8 @@ function *(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_mul, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly},  Ptr{fmpq_poly}), 
-               &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}), 
+               z, x, y)
    return z
 end
 
@@ -161,84 +161,84 @@ end
 function *(x::Int, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_scalar_mul_si, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &y, x)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpz}), &z, &y, &x)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function *(x::fmpq, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq}), &z, &y, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, y, x)
    return z
 end
 
 function +(x::fmpq_poly, y::Int)
    z = parent(x)()
    ccall((:fmpq_poly_add_si, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
 
 function +(x::fmpq_poly, y::fmpz)
    z = parent(x)()
    ccall((:fmpq_poly_add_fmpz, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function +(x::fmpq_poly, y::fmpq)
    z = parent(x)()
    ccall((:fmpq_poly_add_fmpq, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::Int)
    z = parent(x)()
    ccall((:fmpq_poly_sub_si, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::fmpz)
    z = parent(x)()
    ccall((:fmpq_poly_sub_fmpz, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::fmpq)
    z = parent(x)()
    ccall((:fmpq_poly_sub_fmpq, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
 function -(x::Int, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_si_sub, :libflint), Void, 
-                (Ptr{fmpq_poly}, Int, Ptr{fmpq_poly}), &z, x, &y)
+                (Ref{fmpq_poly}, Int, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpz, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_fmpz_sub, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpz}, Ptr{fmpq_poly}), &z, &x, &y)
+         (Ref{fmpq_poly}, Ref{fmpz}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpq, y::fmpq_poly)
    z = parent(y)()
    ccall((:fmpq_poly_fmpq_sub, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
@@ -288,8 +288,8 @@ function ^(x::fmpq_poly, y::Int)
    y < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpq_poly_pow, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), 
-               &z, &x, y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), 
+               z, x, y)
    return z
 end
 
@@ -302,7 +302,7 @@ end
 function ==(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    return ccall((:fmpq_poly_equal, :libflint), Bool, 
-                                      (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &x, &y)
+                                      (Ref{fmpq_poly}, Ref{fmpq_poly}), x, y)
 end
 
 ###############################################################################
@@ -317,9 +317,9 @@ function ==(x::fmpq_poly, y::fmpq)
    elseif length(x) == 1 
       z = fmpq()
       ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void, 
-                       (Ptr{fmpq}, Ptr{fmpq_poly}, Int), &z, &x, 0)
+                       (Ref{fmpq}, Ref{fmpq_poly}, Int), z, x, 0)
       return ccall((:fmpq_equal, :libflint), Bool, 
-               (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &y, 0)
+               (Ref{fmpq}, Ref{fmpq}, Int), z, y, 0)
    else
       return iszero(y)
    end 
@@ -346,7 +346,7 @@ function truncate(a::fmpq_poly, n::Int)
 
    z = parent(a)()
    ccall((:fmpq_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &a, n)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, a, n)
    return z
 end
 
@@ -356,7 +356,7 @@ function mullow(x::fmpq_poly, y::fmpq_poly, n::Int)
    
    z = parent(x)()
    ccall((:fmpq_poly_mullow, :libflint), Void,
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, &y, n)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y, n)
    return z
 end
 
@@ -370,7 +370,7 @@ function reverse(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpq_poly_reverse, :libflint), Void,
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, len)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
 
@@ -384,7 +384,7 @@ function shift_left(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-      (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, len)
+      (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
 
@@ -392,7 +392,7 @@ function shift_right(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpq_poly_shift_right, :libflint), Void,
-       (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, len)
+       (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
 
@@ -407,8 +407,8 @@ function mod(x::fmpq_poly, y::fmpq_poly)
    iszero(y) && throw(DivideError())
    r = parent(x)()
    ccall((:fmpq_poly_rem, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), 
-               &r, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), 
+               r, x, y)
    return r
 end
 
@@ -420,8 +420,8 @@ function divrem(x::fmpq_poly, y::fmpq_poly)
    q = parent(x)()
    r = parent(x)()
    ccall((:fmpq_poly_divrem, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), 
-               &q, &r, &x, &y)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), 
+               q, r, x, y)
    return q, r
 end
 
@@ -436,7 +436,7 @@ function div(x::fmpq_poly, y::fmpq_poly)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    ccall((:fmpq_poly_div, :libflint), Void, 
-            (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+            (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
@@ -452,7 +452,7 @@ function divexact(x::fmpq_poly, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Void, 
-          (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpz}), &z, &x, &y)
+          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -460,7 +460,7 @@ function divexact(x::fmpq_poly, y::fmpq)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void, 
-          (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq}), &z, &x, &y)
+          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
@@ -468,7 +468,7 @@ function divexact(x::fmpq_poly, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
    ccall((:fmpq_poly_scalar_div_si, :libflint), Void, 
-                        (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Int), &z, &x, y)
+                        (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
 
@@ -497,21 +497,21 @@ function gcd(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_gcd, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function content(x::fmpq_poly)
    z = fmpq()
    ccall((:fmpq_poly_content, :libflint), Void, 
-         (Ptr{fmpq}, Ptr{fmpq_poly}), &z, &x)
+         (Ref{fmpq}, Ref{fmpq_poly}), z, x)
    return z
 end
 
 function primpart(x::fmpq_poly)
    z = parent(x)()
    ccall((:fmpq_poly_primitive_part, :libflint), Void, 
-         (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x)
+         (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
 
@@ -524,14 +524,14 @@ end
 function evaluate(x::fmpq_poly, y::fmpz)
    z = fmpq()
    ccall((:fmpq_poly_evaluate_fmpz, :libflint), Void, 
-                (Ptr{fmpq}, Ptr{fmpq_poly}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function evaluate(x::fmpq_poly, y::fmpq)
    z = fmpq()
    ccall((:fmpq_poly_evaluate_fmpq, :libflint), Void, 
-                (Ptr{fmpq}, Ptr{fmpq_poly}, Ptr{fmpq}), &z, &x, &y)
+                (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
@@ -549,7 +549,7 @@ function compose(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_compose, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
@@ -562,7 +562,7 @@ end
 function derivative(x::fmpq_poly)
    z = parent(x)()
    ccall((:fmpq_poly_derivative, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
 
@@ -575,7 +575,7 @@ end
 function integral(x::fmpq_poly)
    z = parent(x)()
    ccall((:fmpq_poly_integral, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
 
@@ -589,7 +589,7 @@ function resultant(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = fmpq()
    ccall((:fmpq_poly_resultant, :libflint), Void, 
-                (Ptr{fmpq}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
@@ -605,8 +605,8 @@ function gcdx(x::fmpq_poly, y::fmpq_poly)
    u = parent(x)()
    v = parent(x)()
    ccall((:fmpq_poly_xgcd, :libflint), Void, 
-        (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}, 
-                                     Ptr{fmpq_poly}), &z, &u, &v, &x, &y)
+        (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, 
+                                     Ref{fmpq_poly}), z, u, v, x, y)
    return (z, u, v)
 end
 
@@ -629,17 +629,17 @@ function _factor(x::fmpq_poly)
    res = Dict{fmpq_poly, Int}()
    y = fmpz_poly()
    ccall((:fmpq_poly_get_numerator, :libflint), Void,
-         (Ptr{fmpz_poly}, Ptr{fmpq_poly}), &y, &x)
+         (Ref{fmpz_poly}, Ref{fmpq_poly}), y, x)
    fac = fmpz_poly_factor()
    ccall((:fmpz_poly_factor, :libflint), Void,
-              (Ptr{fmpz_poly_factor}, Ptr{fmpz_poly}), &fac, &y)
+              (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, y)
    z = fmpz()
    ccall((:fmpz_poly_factor_get_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_poly_factor}), &z, &fac)
+            (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
    f = fmpz_poly()
    for i in 1:fac.num
       ccall((:fmpz_poly_factor_get_fmpz_poly, :libflint), Void,
-            (Ptr{fmpz_poly}, Ptr{fmpz_poly_factor}, Int), &f, &fac, i - 1)
+            (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
       e = unsafe_load(fac.exp, i)
       res[parent(x)(f)] = e
    end
@@ -662,7 +662,7 @@ function signature(f::fmpq_poly)
    s = Array{Int}(1)
    z = fmpz_poly()
    ccall((:fmpq_poly_get_numerator, :libflint), Void,
-         (Ptr{fmpz_poly}, Ptr{fmpq_poly}), &z, &f)
+         (Ref{fmpz_poly}, Ref{fmpq_poly}), z, f)
    return signature(z)
 end
 
@@ -689,43 +689,43 @@ end
 
 function zero!(z::fmpq_poly)
    ccall((:fmpq_poly_zero, :libflint), Void, 
-                    (Ptr{fmpq_poly},), &z)
+                    (Ref{fmpq_poly},), z)
    return z
 end
 
 function fit!(z::fmpq_poly, n::Int)
    ccall((:fmpq_poly_fit_length, :libflint), Void, 
-                    (Ptr{fmpq_poly}, Int), &z, n)
+                    (Ref{fmpq_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpz)
    ccall((:fmpq_poly_set_coeff_fmpz, :libflint), Void, 
-                    (Ptr{fmpq_poly}, Int, Ptr{fmpz}), &z, n, &x)
+                    (Ref{fmpq_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void, 
-                    (Ptr{fmpq_poly}, Int, Ptr{fmpq}), &z, n, &x)
+                    (Ref{fmpq_poly}, Int, Ref{fmpq}), z, n, x)
    return z
 end
 
 function mul!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
    ccall((:fmpq_poly_mul, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpq_poly, x::fmpq_poly)
    ccall((:fmpq_poly_add, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &z, &x)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, z, x)
    return z
 end
 
 function add!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
    ccall((:fmpq_poly_add, :libflint), Void, 
-                (Ptr{fmpq_poly}, Ptr{fmpq_poly}, Ptr{fmpq_poly}), &z, &x, &y)
+                (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -40,20 +40,20 @@ function normalise(a::fmpq_rel_series, len::Int)
    if len > 0
       c = fmpq()
       ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq_rel_series}, Int), &c, &a, len - 1)
+         (Ref{fmpq}, Ref{fmpq_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-            (Ptr{fmpq}, Ptr{fmpq_rel_series}, Int), &c, &a, len - 1)
+            (Ref{fmpq}, Ref{fmpq_rel_series}, Int), c, a, len - 1)
       end
    end
    return len
 end
 
 function pol_length(x::fmpq_rel_series)
-   return ccall((:fmpq_poly_length, :libflint), Int, (Ptr{fmpq_rel_series},), &x)
+   return ccall((:fmpq_poly_length, :libflint), Int, (Ref{fmpq_rel_series},), x)
 end
 
 precision(x::fmpq_rel_series) = x.prec
@@ -64,7 +64,7 @@ function polcoeff(x::fmpq_rel_series, n::Int)
    end
    z = fmpq()
    ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-         (Ptr{fmpq}, Ptr{fmpq_rel_series}, Int), &z, &x, n)
+         (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, n)
    return z
 end
 
@@ -100,7 +100,7 @@ function renormalize!(z::fmpq_rel_series)
    else
       z.val = zval + i
       ccall((:fmpq_poly_shift_right, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int), &z, &z, i)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int), z, z, i)
    end
    return nothing
 end
@@ -127,8 +127,8 @@ show_minus_one(::Type{fmpq_rel_series}) = show_minus_one(fmpq)
 function -(x::fmpq_rel_series)
    z = parent(x)()
    ccall((:fmpq_poly_neg, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}),
-               &z, &x)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}),
+               z, x)
    z.prec = x.prec
    z.val = x.val
    return z
@@ -152,30 +152,30 @@ function +(a::fmpq_rel_series, b::fmpq_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -196,32 +196,32 @@ function -(a::fmpq_rel_series, b::fmpq_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpq_poly_neg, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}), &z, &z)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}), z, z)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpq_poly_sub_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpq_poly_sub_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -246,8 +246,8 @@ function *(a::fmpq_rel_series, b::fmpq_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fmpq_poly_mullow, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -262,8 +262,8 @@ function *(x::Int, y::fmpq_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpq_poly_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &y, x)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, y, x)
    return z
 end
 
@@ -274,8 +274,8 @@ function *(x::fmpz, y::fmpq_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpz}),
-               &z, &y, &x)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
+               z, y, x)
    return z
 end
 
@@ -284,8 +284,8 @@ function *(x::fmpq, y::fmpq_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq}),
-               &z, &y, &x)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
+               z, y, x)
    return z
 end
 
@@ -346,8 +346,8 @@ function shift_right(x::fmpq_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:fmpq_poly_shift_right, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &x, xlen - zlen)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, xlen - zlen)
       renormalize!(z)
    end
    return z
@@ -376,8 +376,8 @@ function truncate(x::fmpq_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &x, min(prec - xval, xlen))
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, min(prec - xval, xlen))
    end
    return z
 end
@@ -443,8 +443,8 @@ function ==(x::fmpq_rel_series, y::fmpq_rel_series)
       return false
    end
    return Bool(ccall((:fmpq_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &x, &y, xlen))
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               x, y, xlen))
 end
 
 function isequal(x::fmpq_rel_series, y::fmpq_rel_series)
@@ -455,8 +455,8 @@ function isequal(x::fmpq_rel_series, y::fmpq_rel_series)
       return false
    end
    return Bool(ccall((:fmpq_poly_equal, :libflint), Cint,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &x, &y, pol_length(x)))
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               x, y, pol_length(x)))
 end
 
 ###############################################################################
@@ -474,9 +474,9 @@ function ==(x::fmpq_rel_series, y::fmpq)
       if x.val == 0
          z = fmpq()
          ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-                       (Ptr{fmpq}, Ptr{fmpq_rel_series}, Int), &z, &x, 0)
+                       (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, 0)
          return ccall((:fmpq_equal, :libflint), Bool,
-               (Ptr{fmpq}, Ptr{fmpq}, Int), &z, &y, 0)
+               (Ref{fmpq}, Ref{fmpq}, Int), z, y, 0)
       else
          return false
       end
@@ -494,9 +494,9 @@ function ==(x::fmpq_rel_series, y::fmpz)
       if x.val == 0
          z = fmpq()
          ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Void,
-                       (Ptr{fmpq}, Ptr{fmpq_rel_series}, Int), &z, &x, 0)
+                       (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, 0)
          return isone(denominator(z)) && ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}, Int), &numerator(z), &y, 0)
+               (Ref{fmpz}, Ref{fmpz}, Int), numerator(z), y, 0)
       else
          return false
       end
@@ -541,8 +541,8 @@ function divexact(x::fmpq_rel_series, y::fmpq_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:fmpq_poly_div_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, y, prec)
    end
    return z
 end
@@ -559,8 +559,8 @@ function divexact(x::fmpq_rel_series, y::Int)
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpq_poly_scalar_divexact_si, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &x, y)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, y)
    return z
 end
 
@@ -571,8 +571,8 @@ function divexact(x::fmpq_rel_series, y::fmpz)
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpq_poly_scalar_divexact_fmpz, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -583,8 +583,8 @@ function divexact(x::fmpq_rel_series, y::fmpq)
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq}),
-               &z, &x, &y)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
+               z, x, y)
    return z
 end
 
@@ -605,8 +605,8 @@ function inv(a::fmpq_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:fmpq_poly_inv_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -625,11 +625,11 @@ function Base.exp(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_exp_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -647,8 +647,8 @@ function log(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_log_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.prec)
    renormalize!(z)
    return z
 end
@@ -666,11 +666,11 @@ function tan(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_tan_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -688,11 +688,11 @@ function tanh(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_tanh_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -710,14 +710,14 @@ function sin(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_truncate, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Int),
-               &z, a.prec)
+                (Ref{fmpq_rel_series}, Int),
+               z, a.prec)
    ccall((:fmpq_poly_sin_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -735,11 +735,11 @@ function sinh(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_sinh_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -757,14 +757,14 @@ function cos(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_truncate, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Int),
-               &z, a.prec)
+                (Ref{fmpq_rel_series}, Int),
+               z, a.prec)
    ccall((:fmpq_poly_cos_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -782,11 +782,11 @@ function cosh(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_cosh_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -804,11 +804,11 @@ function asin(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_asin_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -826,11 +826,11 @@ function asinh(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_asinh_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -848,11 +848,11 @@ function atan(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_atan_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -870,11 +870,11 @@ function atanh(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_shift_left, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.val)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.val)
    ccall((:fmpq_poly_atanh_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &z, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, z, a.prec)
    renormalize!(z)
    return z
 end
@@ -890,8 +890,8 @@ function sqrt(a::fmpq_rel_series)
    z.prec = a.prec
    z.val = 0
    ccall((:fmpq_poly_sqrt_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, a.prec)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, a.prec)
    return z
 end
 
@@ -903,15 +903,15 @@ end
 
 function zero!(z::fmpq_rel_series)
    ccall((:fmpq_poly_zero, :libflint), Void,
-                (Ptr{fmpq_rel_series},), &z)
+                (Ref{fmpq_rel_series},), z)
    z.prec = parent(z).prec_max
    return z
 end
 
 function setcoeff!(z::fmpq_rel_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Int, Ptr{fmpq}),
-               &z, n, &x)
+                (Ref{fmpq_rel_series}, Int, Ref{fmpq}),
+               z, n, x)
    return z
 end
 
@@ -930,8 +930,8 @@ function mul!(z::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
       lenz = 0
    end
    ccall((:fmpq_poly_mullow, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -946,30 +946,30 @@ function addeq!(a::fmpq_rel_series, b::fmpq_rel_series)
       z = fmpq_rel_series()
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpq_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &a, &a, &z, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpq_poly_truncate, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Int),
-            &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpq_rel_series}, Int),
+            a, max(0, lenz - a.val + b.val))
       ccall((:fmpq_poly_shift_left, :libflint), Void,
-            (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-            &a, &a, a.val - b.val)
+            (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+            a, a, a.val - b.val)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               a, a, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               a, a, b, lenz)
    end
    a.prec = prec
    a.val = val
@@ -989,8 +989,8 @@ function add!(c::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:fmpq_poly_add_series, :libflint), Void,
-                (Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Ptr{fmpq_rel_series}, Int),
-               &c, &a, &b, lenc)
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               c, a, b, lenc)
    return c
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -131,7 +131,7 @@ end
 
 function deepcopy_internal(a::fmpz, dict::ObjectIdDict)
    z = fmpz()
-   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &z, &a)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, a)
    return z
 end
 
@@ -152,7 +152,7 @@ doc"""
     sign(a::fmpz)
 > Returns the sign of $a$, i.e. $+1$, $0$ or $-1$.
 """
-sign(a::fmpz) = Int(ccall((:fmpz_sgn, :libflint), Cint, (Ptr{fmpz},), &a))
+sign(a::fmpz) = Int(ccall((:fmpz_sgn, :libflint), Cint, (Ref{fmpz},), a))
 
 doc"""
     fits(::Type{Int}, a::fmpz)
@@ -160,7 +160,7 @@ doc"""
 > `false`.
 """
 fits(::Type{Int}, a::fmpz) = ccall((:fmpz_fits_si, :libflint), Bool,
-                                   (Ptr{fmpz},), &a)
+                                   (Ref{fmpz},), a)
 
 doc"""
     fits(::Type{UInt}, a::fmpz)
@@ -168,32 +168,32 @@ doc"""
 > `false`.
 """
 fits(::Type{UInt}, a::fmpz) = sign(a) < 0 ? false :
-              ccall((:fmpz_abs_fits_ui, :libflint), Bool, (Ptr{fmpz},), &a)
+              ccall((:fmpz_abs_fits_ui, :libflint), Bool, (Ref{fmpz},), a)
 
 doc"""
     size(a::fmpz)
 > Returns the number of limbs required to store the absolute value of $a$.
 """
-size(a::fmpz) = Int(ccall((:fmpz_size, :libflint), Cint, (Ptr{fmpz},), &a))
+size(a::fmpz) = Int(ccall((:fmpz_size, :libflint), Cint, (Ref{fmpz},), a))
 
 doc"""
     isunit(a::fmpz)
 > Return `true` if the given integer is a unit, i.e. $\pm 1$, otherwise return
 > `false`.
 """
-isunit(a::fmpz) = ccall((:fmpz_is_pm1, :libflint), Bool, (Ptr{fmpz},), &a)
+isunit(a::fmpz) = ccall((:fmpz_is_pm1, :libflint), Bool, (Ref{fmpz},), a)
 
 doc"""
     iszero(a::fmpz)
 > Return `true` if the given integer is zero, otherwise return `false`.
 """
-iszero(a::fmpz) = ccall((:fmpz_is_zero, :libflint), Bool, (Ptr{fmpz},), &a)
+iszero(a::fmpz) = ccall((:fmpz_is_zero, :libflint), Bool, (Ref{fmpz},), a)
 
 doc"""
     isone(a::fmpz)
 > Return `true` if the given integer is one, otherwise return `false`.
 """
-isone(a::fmpz) = ccall((:fmpz_is_one, :libflint), Bool, (Ptr{fmpz},), &a)
+isone(a::fmpz) = ccall((:fmpz_is_one, :libflint), Bool, (Ref{fmpz},), a)
 
 doc"""
     denominator(a::fmpz)
@@ -245,19 +245,19 @@ canonical_unit(x::fmpz) = x < 0 ? fmpz(-1) : fmpz(1)
 
 function -(x::fmpz)
     z = fmpz()
-    ccall((:__fmpz_neg, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
+    ccall((:__fmpz_neg, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
 function ~(x::fmpz)
     z = fmpz()
-    ccall((:fmpz_complement, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
+    ccall((:fmpz_complement, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
 function abs(x::fmpz)
     z = fmpz()
-    ccall((:fmpz_abs, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
+    ccall((:fmpz_abs, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
@@ -276,7 +276,7 @@ for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
         function ($fJ)(x::fmpz, y::fmpz)
             z = fmpz()
             ccall(($(string(:fmpz_, fC)), :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+                  (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
             return z
         end
     end
@@ -291,7 +291,7 @@ for (fJ, fC) in ((:fdiv, :fdiv_q), (:cdiv, :cdiv_q), (:tdiv, :tdiv_q),
             iszero(y) && throw(DivideError())
             z = fmpz()
             ccall(($(string(:fmpz_, fC)), :libflint), Void,
-                  (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+                  (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
             return z
         end
     end
@@ -301,7 +301,7 @@ function divexact(x::fmpz, y::fmpz)
     iszero(y) && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_divexact, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
     z
 end
 
@@ -310,7 +310,7 @@ function rem(x::fmpz, c::fmpz)
     q = fmpz()
     r = fmpz()
     ccall((:fmpz_tdiv_qr, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &q, &r, &x, &abs(c))
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), q, r, x, abs(c))
     return r
 end
 
@@ -324,10 +324,10 @@ function +(x::fmpz, c::Int)
     z = fmpz()
     if c >= 0
        ccall((:fmpz_add_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
        ccall((:fmpz_sub_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, -c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
     return z
 end
@@ -338,10 +338,10 @@ function -(x::fmpz, c::Int)
     z = fmpz()
     if c >= 0
        ccall((:fmpz_sub_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
        ccall((:fmpz_add_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, -c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
     return z
 end
@@ -350,20 +350,20 @@ function -(c::Int, x::fmpz)
     z = fmpz()
     if c >= 0
        ccall((:fmpz_sub_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
        ccall((:fmpz_add_ui, :libflint), Void,
-             (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, -c)
+             (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
     ccall((:__fmpz_neg, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}), &z, &z)
+          (Ref{fmpz}, Ref{fmpz}), z, z)
     return z
 end
 
 function *(x::fmpz, c::Int)
     z = fmpz()
     ccall((:fmpz_mul_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -391,7 +391,7 @@ function divexact(x::fmpz, y::Int)
     y == 0 && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_divexact_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, y)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
     z
 end
 
@@ -407,7 +407,7 @@ divexact(x::Integer, y::fmpz) = divexact(fmpz(x), y)
 
 function rem(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
-    r = ccall((:fmpz_tdiv_ui, :libflint), Int, (Ptr{fmpz}, Int), &x, abs(c))
+    r = ccall((:fmpz_tdiv_ui, :libflint), Int, (Ref{fmpz}, Int), x, abs(c))
     return sign(x) > 0 ? r : -r
 end
 
@@ -415,7 +415,7 @@ function tdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_tdiv_q_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -423,7 +423,7 @@ function fdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_fdiv_q_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -431,7 +431,7 @@ function fmodpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_fdiv_r_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -439,7 +439,7 @@ function cdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_cdiv_q_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -447,7 +447,7 @@ function div(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_tdiv_q_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -455,7 +455,7 @@ function tdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_tdiv_q_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -463,7 +463,7 @@ function fdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_fdiv_q_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -471,7 +471,7 @@ function cdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
     ccall((:fmpz_cdiv_q_si, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -486,7 +486,7 @@ function divrem(x::fmpz, y::fmpz)
     z1 = fmpz()
     z2 = fmpz()
     ccall((:fmpz_tdiv_qr, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z1, &z2, &x, &y)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
 
@@ -495,7 +495,7 @@ function tdivrem(x::fmpz, y::fmpz)
     z1 = fmpz()
     z2 = fmpz()
     ccall((:fmpz_tdiv_qr, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z1, &z2, &x, &y)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
 
@@ -504,7 +504,7 @@ function fdivrem(x::fmpz, y::fmpz)
     z1 = fmpz()
     z2 = fmpz()
     ccall((:fmpz_fdiv_qr, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z1, &z2, &x, &y)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
 
@@ -522,7 +522,7 @@ function ^(x::fmpz, y::Int)
     if y == 0; return one(FlintZZ); end
     if y == 1; return x; end
     z = fmpz()
-    ccall((:fmpz_pow_ui, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}, UInt), &z, &x, UInt(y))
+    ccall((:fmpz_pow_ui, :libflint), Void, (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(y))
     return z
 end
 
@@ -534,7 +534,7 @@ end
 
 function cmp(x::fmpz, y::fmpz)
     Int(ccall((:fmpz_cmp, :libflint), Cint,
-              (Ptr{fmpz}, Ptr{fmpz}), &x, &y))
+              (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
 ==(x::fmpz, y::fmpz) = cmp(x,y) == 0
@@ -549,7 +549,7 @@ end
 
 function cmpabs(x::fmpz, y::fmpz)
     Int(ccall((:fmpz_cmpabs, :libflint), Cint,
-              (Ptr{fmpz}, Ptr{fmpz}), &x, &y))
+              (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
 isless(x::fmpz, y::fmpz) = x < y
@@ -561,7 +561,7 @@ isless(x::fmpz, y::fmpz) = x < y
 ###############################################################################
 
 function cmp(x::fmpz, y::Int)
-    Int(ccall((:fmpz_cmp_si, :libflint), Cint, (Ptr{fmpz}, Int), &x, y))
+    Int(ccall((:fmpz_cmp_si, :libflint), Cint, (Ref{fmpz}, Int), x, y))
 end
 
 ==(x::fmpz, y::Int) = cmp(x,y) == 0
@@ -585,7 +585,7 @@ end
 >(x::Int, y::fmpz) = cmp(y,x) < 0
 
 function cmp(x::fmpz, y::UInt)
-    Int(ccall((:fmpz_cmp_ui, :libflint), Cint, (Ptr{fmpz}, UInt), &x, y))
+    Int(ccall((:fmpz_cmp_ui, :libflint), Cint, (Ref{fmpz}, UInt), x, y))
 end
 
 ==(x::fmpz, y::UInt) = cmp(x,y) == 0
@@ -623,7 +623,7 @@ function <<(x::fmpz, c::Int)
     c == 0 && return x
     z = fmpz()
     ccall((:fmpz_mul_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -636,7 +636,7 @@ function >>(x::fmpz, c::Int)
     c == 0 && return x
     z = fmpz()
     ccall((:fmpz_fdiv_q_2exp, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, c)
+          (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
 
@@ -654,7 +654,7 @@ doc"""
 function mod(x::fmpz, y::fmpz)
    z = fmpz()
    ccall((:fmpz_mod, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -666,9 +666,9 @@ doc"""
 function mod(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     if c > 0
-        return ccall((:fmpz_fdiv_ui, :libflint), Int, (Ptr{fmpz}, Int), &x, c)
+        return ccall((:fmpz_fdiv_ui, :libflint), Int, (Ref{fmpz}, Int), x, c)
     else
-        r = ccall((:fmpz_fdiv_ui, :libflint), Int, (Ptr{fmpz}, Int), &x, -c)
+        r = ccall((:fmpz_fdiv_ui, :libflint), Int, (Ref{fmpz}, Int), x, -c)
         return r == 0 ? 0 : r + c
     end
 end
@@ -685,8 +685,8 @@ function powmod(x::fmpz, p::fmpz, m::fmpz)
     end
     r = fmpz()
     ccall((:fmpz_powm, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}),
-          &r, &x, &p, &m)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+          r, x, p, m)
     return r
 end
 
@@ -702,8 +702,8 @@ function powmod(x::fmpz, p::Int, m::fmpz)
     end
     r = fmpz()
     ccall((:fmpz_powm_ui, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Int, Ptr{fmpz}),
-          &r, &x, p, &m)
+          (Ref{fmpz}, Ref{fmpz}, Int, Ref{fmpz}),
+          r, x, p, m)
     return r
 end
 
@@ -718,7 +718,7 @@ function invmod(x::fmpz, m::fmpz)
         return fmpz(0)
     end
     if ccall((:fmpz_invmod, :libflint), Cint,
-             (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &m) == 0
+             (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, m) == 0
        error("Impossible inverse in invmod")
     end
     return z
@@ -734,7 +734,7 @@ function sqrtmod(x::fmpz, m::fmpz)
     m <= 0 && throw(DomainError())
     z = fmpz()
     if (ccall((:fmpz_sqrtmod, :libflint), Cint,
-              (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &m) == 0)
+              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, m) == 0)
         error("no square root exists")
     end
     return z
@@ -749,8 +749,8 @@ doc"""
 function crt(r1::fmpz, m1::fmpz, r2::fmpz, m2::fmpz, signed=false)
    z = fmpz()
    ccall((:fmpz_CRT, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Cint),
-          &z, &r1, &m1, &r2, &m2, signed)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Cint),
+          z, r1, m1, r2, m2, signed)
    return z
 end
 
@@ -765,8 +765,8 @@ function crt(r1::fmpz, m1::fmpz, r2::Int, m2::Int, signed=false)
    r2 < 0 && throw(DomainError())
    m2 < 0 && throw(DomainError())
    ccall((:fmpz_CRT_ui, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Int, Int, Cint),
-          &z, &r1, &m1, r2, m2, signed)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Int, Int, Cint),
+          z, r1, m1, r2, m2, signed)
    return z
 end
 
@@ -784,7 +784,7 @@ function flog(x::fmpz, c::fmpz)
     c <= 0 && throw(DomainError())
     x <= 0 && throw(DomainError())
     return ccall((:fmpz_flog, :libflint), Int,
-                 (Ptr{fmpz}, Ptr{fmpz}), &x, &c)
+                 (Ref{fmpz}, Ref{fmpz}), x, c)
 end
 
 doc"""
@@ -795,7 +795,7 @@ function clog(x::fmpz, c::fmpz)
     c <= 0 && throw(DomainError())
     x <= 0 && throw(DomainError())
     return ccall((:fmpz_clog, :libflint), Int,
-                 (Ptr{fmpz}, Ptr{fmpz}), &x, &c)
+                 (Ref{fmpz}, Ref{fmpz}), x, c)
 end
 
 doc"""
@@ -805,7 +805,7 @@ doc"""
 function flog(x::fmpz, c::Int)
     c <= 0 && throw(DomainError())
     return ccall((:fmpz_flog_ui, :libflint), Int,
-                 (Ptr{fmpz}, Int), &x, c)
+                 (Ref{fmpz}, Int), x, c)
 end
 
 doc"""
@@ -815,7 +815,7 @@ doc"""
 function clog(x::fmpz, c::Int)
     c <= 0 && throw(DomainError())
     return ccall((:fmpz_clog_ui, :libflint), Int,
-                 (Ptr{fmpz}, Int), &x, c)
+                 (Ref{fmpz}, Int), x, c)
 end
 
 ###############################################################################
@@ -832,7 +832,7 @@ doc"""
 function gcd(x::fmpz, y::fmpz)
    z = fmpz()
    ccall((:fmpz_gcd, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -851,11 +851,11 @@ function gcd(x::Array{fmpz, 1})
 
    z = fmpz()
    ccall((:fmpz_gcd, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x[1], &x[2])
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x[1], x[2])
 
    for i in 3:length(x)
       ccall((:fmpz_gcd, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x[i])
+            (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x[i])
       if isone(z)
          return z
       end
@@ -872,7 +872,7 @@ doc"""
 function lcm(x::fmpz, y::fmpz)
    z = fmpz()
    ccall((:fmpz_lcm, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -890,11 +890,11 @@ function lcm(x::Array{fmpz, 1})
 
    z = fmpz()
    ccall((:fmpz_lcm, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x[1], &x[2])
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x[1], x[2])
 
    for i in 3:length(x)
       ccall((:fmpz_lcm, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x[i])
+            (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x[i])
    end
 
    return z
@@ -919,8 +919,8 @@ function gcdx(a::fmpz, b::fmpz)
     s = fmpz()
     t = fmpz()
     ccall((:fmpz_xgcd, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}),
-        &g, &s, &t, &a, &b)
+        (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+        g, s, t, a, b)
     g, s, t
 end
 
@@ -938,8 +938,8 @@ function gcdinv(a::fmpz, b::fmpz)
    g = fmpz()
    s = fmpz()
    ccall((:fmpz_gcdinv, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}),
-        &g, &s, &a, &b)
+        (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+        g, s, a, b)
    return g, s
 end
 
@@ -956,7 +956,7 @@ doc"""
 function isqrt(x::fmpz)
     x < 0 && throw(DomainError())
     z = fmpz()
-    ccall((:fmpz_sqrt, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
+    ccall((:fmpz_sqrt, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
@@ -970,7 +970,7 @@ function isqrtrem(x::fmpz)
     s = fmpz()
     r = fmpz()
     ccall((:fmpz_sqrtrem, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &s, &r, &x)
+          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), s, r, x)
     return s, r
 end
 
@@ -984,7 +984,7 @@ function root(x::fmpz, n::Int)
    n <= 0 && throw(DomainError())
    z = fmpz()
    ccall((:fmpz_root, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, n)
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, n)
    return z
 end
 
@@ -1002,12 +1002,12 @@ function _factor(a::fmpz)
    end
 
    F = fmpz_factor()
-   ccall((:fmpz_factor, :libflint), Void, (Ptr{fmpz_factor}, Ptr{fmpz}), &F, &a)
+   ccall((:fmpz_factor, :libflint), Void, (Ref{fmpz_factor}, Ref{fmpz}), F, a)
    res = Dict{fmpz, Int}()
    for i in 1:F.num
      z = fmpz()
      ccall((:fmpz_factor_get_fmpz, :libflint), Void,
-           (Ptr{fmpz}, Ptr{fmpz_factor}, Int), &z, &F, i - 1)
+           (Ref{fmpz}, Ref{fmpz_factor}, Int), z, F, i - 1)
      res[z] = unsafe_load(F.exp, i)
    end
    return res, canonical_unit(a)
@@ -1032,7 +1032,7 @@ doc"""
 function divisible(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
    Bool(ccall((:fmpz_divisible, :libflint), Cint,
-              (Ptr{fmpz}, Ptr{fmpz}), &x, &y))
+              (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
 doc"""
@@ -1043,7 +1043,7 @@ doc"""
 function divisible(x::fmpz, y::Int)
    y == 0 && throw(DivideError())
    Bool(ccall((:fmpz_divisible_si, :libflint), Cint,
-              (Ptr{fmpz}, Int), &x, y))
+              (Ref{fmpz}, Int), x, y))
 end
 
 doc"""
@@ -1051,7 +1051,7 @@ doc"""
 > Return `true` if $x$ is a square, otherwise return `false`.
 """
 issquare(x::fmpz) = Bool(ccall((:fmpz_is_square, :libflint), Cint,
-                               (Ptr{fmpz},), &x))
+                               (Ref{fmpz},), x))
 
 doc"""
     is_prime(x::UInt)
@@ -1065,7 +1065,7 @@ doc"""
 """
 # flint's fmpz_is_prime doesn't work yet
 isprime(x::fmpz) = Bool(ccall((:fmpz_is_probabprime, :libflint), Cint,
-                              (Ptr{fmpz},), &x))
+                              (Ref{fmpz},), x))
 
 doc"""
     isprobabprime(x::fmpz)
@@ -1074,7 +1074,7 @@ doc"""
 > that infinitely many exist.
 """
 isprobabprime(x::fmpz) = Bool(ccall((:fmpz_is_probabprime, :libflint), Cint,
-                                    (Ptr{fmpz},), &x))
+                                    (Ref{fmpz},), x))
 
 doc"""
     remove(x::fmpz, y::fmpz)
@@ -1084,7 +1084,7 @@ function remove(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
    z = fmpz()
    num = ccall((:fmpz_remove, :libflint), Int,
-               (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return num, z
 end
 
@@ -1122,7 +1122,7 @@ function divisor_lenstra(n::fmpz, r::fmpz, m::fmpz)
    n <= m && throw(DomainError())
    z = fmpz()
    if !Bool(ccall((:fmpz_divisor_in_residue_class_lenstra, :libflint),
-       Cint, (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &n, &r, &m))
+       Cint, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, n, r, m))
       z = 0
    end
    return z
@@ -1136,7 +1136,7 @@ doc"""
 function fac(x::Int)
     x < 0 && throw(DomainError())
     z = fmpz()
-    ccall((:fmpz_fac_ui, :libflint), Void, (Ptr{fmpz}, UInt), &z, x)
+    ccall((:fmpz_fac_ui, :libflint), Void, (Ref{fmpz}, UInt), z, x)
     return z
 end
 
@@ -1149,7 +1149,7 @@ function risingfac(x::fmpz, y::Int)
     y < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_rfac_ui, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz}, UInt), &z, &x, y)
+          (Ref{fmpz}, Ref{fmpz}, UInt), z, x, y)
     return z
 end
 
@@ -1168,7 +1168,7 @@ function risingfac(x::Int, y::Int)
        end
     else
        ccall((:fmpz_rfac_uiui, :libflint), Void,
-             (Ptr{fmpz}, UInt, UInt), &z, x, y)
+             (Ref{fmpz}, UInt, UInt), z, x, y)
     end
     return z
 end
@@ -1182,7 +1182,7 @@ function primorial(x::Int)
     x < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_primorial, :libflint), Void,
-          (Ptr{fmpz}, UInt), &z, x)
+          (Ref{fmpz}, UInt), z, x)
     return z
 end
 
@@ -1196,7 +1196,7 @@ function fib(x::Int)
     x < 0 && throw(DomainError())
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Void,
-          (Ptr{fmpz}, UInt), &z, x)
+          (Ref{fmpz}, UInt), z, x)
     return z
 end
 
@@ -1208,7 +1208,7 @@ function bell(x::Int)
     x < 0 && throw(DomainError())
     z = fmpz()
     ccall((:arith_bell_number, :libflint), Void,
-          (Ptr{fmpz}, UInt), &z, x)
+          (Ref{fmpz}, UInt), z, x)
     return z
 end
 
@@ -1222,7 +1222,7 @@ function binom(n::Int, k::Int)
     k < 0 && return fmpz(0)
     z = fmpz()
     ccall((:fmpz_bin_uiui, :libflint), Void,
-          (Ptr{fmpz}, UInt, UInt), &z, n, k)
+          (Ref{fmpz}, UInt, UInt), z, n, k)
     return z
 end
 
@@ -1234,7 +1234,7 @@ doc"""
 function moebiusmu(x::fmpz)
    x < 0 && throw(DomainError())
    return Int(ccall((:fmpz_moebius_mu, :libflint), Cint,
-                    (Ptr{fmpz},), &x))
+                    (Ref{fmpz},), x))
 end
 
 doc"""
@@ -1246,7 +1246,7 @@ function jacobi(x::fmpz, y::fmpz)
    y <= x && throw(DomainError())
    x < 0 && throw(DomainError())
    return Int(ccall((:fmpz_jacobi, :libflint), Cint,
-                    (Ptr{fmpz}, Ptr{fmpz}), &x, &y))
+                    (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
 doc"""
@@ -1258,7 +1258,7 @@ function sigma(x::fmpz, y::Int)
    y < 0 && throw(DomainError())
    z = fmpz()
    ccall((:fmpz_divisor_sigma, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, y)
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
    return z
 end
 
@@ -1271,7 +1271,7 @@ function eulerphi(x::fmpz)
    x < 0 && throw(DomainError())
    z = fmpz()
    ccall((:fmpz_euler_phi, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}), &z, &x)
+         (Ref{fmpz}, Ref{fmpz}), z, x)
    return z
 end
 
@@ -1287,7 +1287,7 @@ function numpart(x::Int)
    x < 0 && throw(DomainError())
    z = fmpz()
    ccall((:partitions_fmpz_ui, :libarb), Void,
-         (Ptr{fmpz}, UInt), &z, x)
+         (Ref{fmpz}, UInt), z, x)
    return z
 end
 
@@ -1303,7 +1303,7 @@ function numpart(x::fmpz)
    x < 0 && throw(DomainError())
    z = fmpz()
    ccall((:partitions_fmpz_fmpz, :libarb), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &x, 0)
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, 0)
    return z
 end
 
@@ -1344,7 +1344,7 @@ doc"""
 function base(n::fmpz, b::Integer)
     2 <= b <= 62 || error("invalid base: $b")
     p = ccall((:fmpz_get_str,:libflint), Ptr{UInt8},
-              (Ptr{UInt8}, Cint, Ptr{fmpz}), C_NULL, b, &n)
+              (Ptr{UInt8}, Cint, Ref{fmpz}), C_NULL, b, n)
     s = unsafe_string(p)
     ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), p)
     return s
@@ -1353,7 +1353,7 @@ end
 function ndigits_internal(x::fmpz, b::Integer = 10)
     # fmpz_sizeinbase might return an answer 1 too big
     n = Int(ccall((:fmpz_sizeinbase, :libflint), UInt,
-                  (Ptr{fmpz}, Int32), &x, b))
+                  (Ref{fmpz}, Int32), x, b))
     abs(x) < fmpz(b)^(n - 1) ? n - 1 : n
 end
 
@@ -1368,7 +1368,7 @@ doc"""
 > Return the number of binary bits of $x$. We return zero if $x = 0$.
 """
 nbits(x::fmpz) = iszero(x) ? 0 : Int(ccall((:fmpz_sizeinbase, :libflint), UInt,
-                  (Ptr{fmpz}, Int32), &x, 2))  # docu states: always correct
+                  (Ref{fmpz}, Int32), x, 2))  # docu states: always correct
                                 #if base is power of 2
 
 ###############################################################################
@@ -1382,7 +1382,7 @@ doc"""
 > Return the number of ones in the binary representation of $x$.
 """
 popcount(x::fmpz) = Int(ccall((:fmpz_popcnt, :libflint), UInt,
-                              (Ptr{fmpz},), &x))
+                              (Ref{fmpz},), x))
 
 doc"""
     prevpow2(x::fmpz)
@@ -1403,7 +1403,7 @@ doc"""
 > Count the trailing zeros in the binary representation of $x$.
 """
 trailing_zeros(x::fmpz) = ccall((:fmpz_val2, :libflint), Int,
-                                (Ptr{fmpz},), &x)
+                                (Ref{fmpz},), x)
 
 ###############################################################################
 #
@@ -1418,7 +1418,7 @@ doc"""
 """
 function clrbit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
-    ccall((:fmpz_clrbit, :libflint), Void, (Ptr{fmpz}, Int), &x, c)
+    ccall((:fmpz_clrbit, :libflint), Void, (Ref{fmpz}, Int), x, c)
 end
 
 doc"""
@@ -1428,7 +1428,7 @@ doc"""
 """
 function setbit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
-    ccall((:fmpz_setbit, :libflint), Void, (Ptr{fmpz}, Int), &x, c)
+    ccall((:fmpz_setbit, :libflint), Void, (Ref{fmpz}, Int), x, c)
 end
 
 doc"""
@@ -1438,7 +1438,7 @@ doc"""
 """
 function combit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError())
-    ccall((:fmpz_combit, :libflint), Void, (Ptr{fmpz}, Int), &x, c)
+    ccall((:fmpz_combit, :libflint), Void, (Ref{fmpz}, Int), x, c)
 end
 
 ###############################################################################
@@ -1449,31 +1449,31 @@ end
 
 function mul!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_mul, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function addmul!(z::fmpz, x::fmpz, y::fmpz, c::fmpz)
    ccall((:fmpz_addmul, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpz, x::fmpz)
    ccall((:fmpz_add, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &z, &x)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x)
    return z
 end
 
 function add!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_add, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz}, Ptr{fmpz}), &z, &x, &y)
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function zero!(z::fmpz)
    ccall((:fmpz_zero, :libflint), Void,
-         (Ptr{fmpz},), &z)
+         (Ref{fmpz},), z)
    return z
 end
 
@@ -1511,8 +1511,8 @@ function parse(::Type{fmpz}, s::String, base::Int = 10)
     i = 1 + (sgn == -1)
     z = fmpz()
     err = ccall((:fmpz_set_str, :libflint),
-               Int32, (Ptr{fmpz}, Ptr{UInt8}, Int32),
-               &z, string(SubString(s, i)), base)
+               Int32, (Ref{fmpz}, Ptr{UInt8}, Int32),
+               z, string(SubString(s, i)), base)
     err == 0 || error("Invalid big integer: $(repr(s))")
     return sgn < 0 ? -z : z
 end
@@ -1551,32 +1551,46 @@ fmpz(z::BigFloat) = fmpz(BigInt(z))
 
 convert(::Type{fmpz}, a::Integer) = fmpz(a)
 
-function convert(::Type{BigInt}, a::fmpz)
+function (::Type{BigInt})(a::fmpz)
    r = BigInt()
-   ccall((:fmpz_get_mpz, :libflint), Void, (Ptr{BigInt}, Ptr{fmpz}), &r, &a)
+   ccall((:fmpz_get_mpz, :libflint), Void, (Ref{BigInt}, Ref{fmpz}), r, a)
    return r
 end
 
-function convert(::Type{Int}, a::fmpz)
+convert(::Type{BigInt}, a::fmpz) = BigInt(a)
+
+function (::Type{Int})(a::fmpz)
    (a > typemax(Int) || a < typemin(Int)) && throw(InexactError())
-   return ccall((:fmpz_get_si, :libflint), Int, (Ptr{fmpz},), &a)
+   return ccall((:fmpz_get_si, :libflint), Int, (Ref{fmpz},), a)
 end
 
-function convert(::Type{UInt}, a::fmpz)
+convert(::Type{Int}, a::fmpz) = Int(a)
+
+function (::Type{UInt})(a::fmpz)
    (a > typemax(UInt) || a < 0) && throw(InexactError())
-   return ccall((:fmpz_get_ui, :libflint), UInt, (Ptr{fmpz}, ), &a)
+   return ccall((:fmpz_get_ui, :libflint), UInt, (Ref{fmpz}, ), a)
 end
 
-function convert(::Type{Float64}, n::fmpz)
+convert(::Type{UInt}, a::fmpz) = UInt(a)
+
+function (::Type{Float64})(n::fmpz)
     # rounds to zero
-    ccall((:fmpz_get_d, :libflint), Float64, (Ptr{fmpz},), &n)
+    ccall((:fmpz_get_d, :libflint), Float64, (Ref{fmpz},), n)
 end
 
-convert(::Type{Float32}, n::fmpz) = Float32(Float64(n))
+convert(::Type{Float64}, n::fmpz) = Float64(n)
 
-convert(::Type{Float16}, n::fmpz) = Float16(Float64(n))
+(::Type{Float32})(n::fmpz) = Float32(Float64(n))
 
-convert(::Type{BigFloat}, n::fmpz) = BigFloat(BigInt(n))
+convert(::Type{Float32}, n::fmpz) = Float32(n)
+
+(::Type{Float16})(n::fmpz) = Float16(Float64(n))
+
+convert(::Type{Float16}, n::fmpz) = Float16(n)
+
+(::Type{BigFloat})(n::fmpz) = BigFloat(BigInt(n))
+
+convert(::Type{BigFloat}, n::fmpz) = BigFloat(n)
 
 Base.promote_rule(::Type{fmpz}, ::Type{T}) where {T <: Integer} = fmpz
 

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -43,13 +43,13 @@ function normalise(a::fmpz_abs_series, len::Int)
    if len > 0
       c = fmpz()
       ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_abs_series}, Int), &c, &a, len - 1)
+         (Ref{fmpz}, Ref{fmpz_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_abs_series}, Int), &c, &a, len - 1)
+            (Ref{fmpz}, Ref{fmpz_abs_series}, Int), c, a, len - 1)
       end
    end
 
@@ -57,7 +57,7 @@ function normalise(a::fmpz_abs_series, len::Int)
 end
 
 function length(x::fmpz_abs_series)
-   return ccall((:fmpz_poly_length, :libflint), Int, (Ptr{fmpz_abs_series},), &x)
+   return ccall((:fmpz_poly_length, :libflint), Int, (Ref{fmpz_abs_series},), x)
 end
 
 precision(x::fmpz_abs_series) = x.prec
@@ -68,7 +68,7 @@ function coeff(x::fmpz_abs_series, n::Int)
    end
    z = fmpz()
    ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_abs_series}, Int), &z, &x, n)
+         (Ref{fmpz}, Ref{fmpz_abs_series}, Int), z, x, n)
    return z
 end
 
@@ -91,7 +91,7 @@ end
 
 function isgen(a::fmpz_abs_series)
    return precision(a) == 0 || ccall((:fmpz_poly_is_x, :libflint), Bool,
-                            (Ptr{fmpz_abs_series},), &a)
+                            (Ref{fmpz_abs_series},), a)
 end
 
 iszero(a::fmpz_abs_series) = length(a) == 0
@@ -100,7 +100,7 @@ isunit(a::fmpz_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpz_abs_series)
    return precision(a) == 0 || ccall((:fmpz_poly_is_one, :libflint), Bool,
-                                (Ptr{fmpz_abs_series},), &a)
+                                (Ref{fmpz_abs_series},), a)
 end
 
 # todo: write an fmpz_poly_valuation
@@ -135,8 +135,8 @@ show_minus_one(::Type{fmpz_abs_series}) = show_minus_one(GenRes{fmpz})
 function -(x::fmpz_abs_series)
    z = parent(x)()
    ccall((:fmpz_poly_neg, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}),
-               &z, &x)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}),
+               z, x)
    z.prec = x.prec
    return z
 end
@@ -161,8 +161,8 @@ function +(a::fmpz_abs_series, b::fmpz_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -180,8 +180,8 @@ function -(a::fmpz_abs_series, b::fmpz_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpz_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -209,8 +209,8 @@ function *(a::fmpz_abs_series, b::fmpz_abs_series)
    lenz = min(lena + lenb - 1, prec)
 
    ccall((:fmpz_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -224,8 +224,8 @@ function *(x::Int, y::fmpz_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpz_poly_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &y, x)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, y, x)
    return z
 end
 
@@ -235,8 +235,8 @@ function *(x::fmpz, y::fmpz_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz}),
-               &z, &y, &x)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz}),
+               z, y, x)
    return z
 end
 
@@ -254,8 +254,8 @@ function shift_left(x::fmpz_abs_series, len::Int)
    z = parent(x)()
    z.prec = x.prec + len
    ccall((:fmpz_poly_shift_left, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, x, len)
    return z
 end
 
@@ -268,8 +268,8 @@ function shift_right(x::fmpz_abs_series, len::Int)
    else
       z.prec = x.prec - len
       ccall((:fmpz_poly_shift_right, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, x, len)
    end
    return z
 end
@@ -288,8 +288,8 @@ function truncate(x::fmpz_abs_series, prec::Int)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpz_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &x, prec)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, x, prec)
    return z
 end
 
@@ -314,8 +314,8 @@ function ^(a::fmpz_abs_series, b::Int)
       z.prec = a.prec + (b - 1)*valuation(a)
       z.prec = min(z.prec, max_precision(parent(a)))
       ccall((:fmpz_poly_pow_trunc, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int, Int),
-               &z, &a, b, z.prec)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int, Int),
+               z, a, b, z.prec)
    end
    return z
 end
@@ -334,8 +334,8 @@ function ==(x::fmpz_abs_series, y::fmpz_abs_series)
    n = min(n, prec)
 
    return Bool(ccall((:fmpz_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &x, &y, n))
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               x, y, n))
 end
 
 function isequal(x::fmpz_abs_series, y::fmpz_abs_series)
@@ -346,8 +346,8 @@ function isequal(x::fmpz_abs_series, y::fmpz_abs_series)
       return false
    end
    return Bool(ccall((:fmpz_poly_equal, :libflint), Cint,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &x, &y, length(x)))
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               x, y, length(x)))
 end
 
 ###############################################################################
@@ -362,9 +362,9 @@ function ==(x::fmpz_abs_series, y::fmpz)
    elseif length(x) == 1
       z = fmpz()
       ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_abs_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_abs_series}, Int), z, x, 0)
       return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &y, 0)
+               (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
    else
       return precision(x) == 0 || iszero(y)
    end
@@ -398,8 +398,8 @@ function divexact(x::fmpz_abs_series, y::fmpz_abs_series)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpz_poly_div_series, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, x, y, prec)
    return z
 end
 
@@ -414,8 +414,8 @@ function divexact(x::fmpz_abs_series, y::Int)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpz_poly_scalar_divexact_si, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &x, y)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, x, y)
    return z
 end
 
@@ -424,8 +424,8 @@ function divexact(x::fmpz_abs_series, y::fmpz)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -443,8 +443,8 @@ function inv(a::fmpz_abs_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ccall((:fmpz_poly_inv_series, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -456,8 +456,8 @@ end
 
 function setcoeff!(z::fmpz_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Int, Ptr{fmpz}),
-               &z, n, &x)
+                (Ref{fmpz_abs_series}, Int, Ref{fmpz}),
+               z, n, x)
    return z
 end
 
@@ -481,8 +481,8 @@ function mul!(z::fmpz_abs_series, a::fmpz_abs_series, b::fmpz_abs_series)
 
    z.prec = prec
    ccall((:fmpz_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -498,8 +498,8 @@ function addeq!(a::fmpz_abs_series, b::fmpz_abs_series)
    lenz = max(lena, lenb)
    a.prec = prec
    ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Ptr{fmpz_abs_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
+               a, a, b, lenz)
    return a
 end
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -64,8 +64,8 @@ function Base.view(x::fmpz_mat, r1::Int, c1::Int, r2::Int, c2::Int)
   b = fmpz_mat()
   b.base_ring = FlintZZ
   ccall((:fmpz_mat_window_init, :libflint), Void,
-        (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int, Int, Int, Int),
-            &b, &x, r1 - 1, c1 - 1, r2, c2)
+        (Ref{fmpz_mat}, Ref{fmpz_mat}, Int, Int, Int, Int),
+            b, x, r1 - 1, c1 - 1, r2, c2)
   finalizer(b, _fmpz_mat_window_clear_fn)
   return b
 end
@@ -75,7 +75,7 @@ function Base.view(x::fmpz_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fmpz_mat_window_clear_fn(a::fmpz_mat)
-   ccall((:fmpz_mat_window_clear, :libflint), Void, (Ptr{fmpz_mat},), &a)
+   ccall((:fmpz_mat_window_clear, :libflint), Void, (Ref{fmpz_mat},), a)
 end
 
 size(x::fmpz_mat) = tuple(rows(x), cols(x))
@@ -89,34 +89,34 @@ size(t::fmpz_mat, d) = d <= 2 ? size(t)[d] : 1
 ###############################################################################
 
 function getindex!(v::fmpz, a::fmpz_mat, r::Int, c::Int)
-   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-             (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &v, z)
+   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+             (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), v, z)
 end
 
 @inline function getindex(a::fmpz_mat, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpz()
-   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-             (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), &v, z)
+   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+             (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), v, z)
    return v
 end
 
 @inline function setindex!(a::fmpz_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-             (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ptr{fmpz}), z, &d)
+   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+             (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, d)
 end
 
 @inline setindex!(a::fmpz_mat, d::Integer, r::Int, c::Int) = setindex!(a, fmpz(d), r, c)
 
 @inline function setindex!(a::fmpz_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
-             (Ptr{fmpz_mat}, Int, Int), &a, r - 1, c - 1)
-   ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, d)
+   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+             (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
+   ccall((:fmpz_set_si, :libflint), Void, (Ref{fmpz}, Int), z, d)
 end
 
 @inline rows(a::fmpz_mat) = a.r
@@ -128,10 +128,10 @@ zero(a::FmpzMatSpace) = a()
 one(a::FmpzMatSpace) = a(1)
 
 iszero(a::fmpz_mat) = ccall((:fmpz_mat_is_zero, :libflint), Bool,
-                            (Ptr{fmpz_mat},), &a)
+                            (Ref{fmpz_mat},), a)
 
 isone(a::fmpz_mat) = ccall((:fmpz_mat_is_one, :libflint), Bool,
-                           (Ptr{fmpz_mat},), &a)
+                           (Ref{fmpz_mat},), a)
 
 function deepcopy_internal(d::fmpz_mat, dict::ObjectIdDict)
    z = fmpz_mat(d)
@@ -188,7 +188,7 @@ show_minus_one(::Type{fmpz_mat}) = show_minus_one(fmpz)
 function -(x::fmpz_mat)
    z = similar(x)
    ccall((:fmpz_mat_neg, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -201,7 +201,7 @@ end
 function transpose(x::fmpz_mat)
    z = similar(x, cols(x), rows(x))
    ccall((:fmpz_mat_transpose, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -215,8 +215,8 @@ function +(x::fmpz_mat, y::fmpz_mat)
    check_parent(x, y)
    z = similar(x)
    ccall((:fmpz_mat_add, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat},  Ptr{fmpz_mat}),
-               &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
+               z, x, y)
    return z
 end
 
@@ -224,8 +224,8 @@ function -(x::fmpz_mat, y::fmpz_mat)
    check_parent(x, y)
    z = similar(x)
    ccall((:fmpz_mat_sub, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat},  Ptr{fmpz_mat}),
-               &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
+               z, x, y)
    return z
 end
 
@@ -237,8 +237,8 @@ function *(x::fmpz_mat, y::fmpz_mat)
       z = similar(x, rows(x), cols(y))
    end
    ccall((:fmpz_mat_mul, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat},  Ptr{fmpz_mat}),
-               &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
+               z, x, y)
    return z
 end
 
@@ -251,14 +251,14 @@ end
 function *(x::Int, y::fmpz_mat)
    z = similar(y)
    ccall((:fmpz_mat_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int), &z, &y, x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpz_mat)
    z = similar(y)
    ccall((:fmpz_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &z, &y, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, y, x)
    return z
 end
 
@@ -324,8 +324,8 @@ function <<(x::fmpz_mat, y::Int)
    y < 0 && throw(DomainError())
    z = similar(x)
    ccall((:fmpz_mat_scalar_mul_2exp, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int),
-               &z, &x, y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
+               z, x, y)
    return z
 end
 
@@ -337,8 +337,8 @@ function >>(x::fmpz_mat, y::Int)
    y < 0 && throw(DomainError())
    z = similar(x)
    ccall((:fmpz_mat_scalar_tdiv_q_2exp, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int),
-               &z, &x, y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
+               z, x, y)
    return z
 end
 
@@ -353,8 +353,8 @@ function ^(x::fmpz_mat, y::Int)
    rows(x) != cols(x) && error("Incompatible matrix dimensions")
    z = similar(x)
    ccall((:fmpz_mat_pow, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int),
-               &z, &x, y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
+               z, x, y)
    return z
 end
 
@@ -367,7 +367,7 @@ end
 function ==(x::fmpz_mat, y::fmpz_mat)
    check_parent(x, y)
    ccall((:fmpz_mat_equal, :libflint), Bool,
-                                       (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &x, &y)
+                                       (Ref{fmpz_mat}, Ref{fmpz_mat}), x, y)
 end
 
 ###############################################################################
@@ -408,7 +408,7 @@ function inv(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
    ccall((:fmpz_mat_inv, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}), &z, &d, &x)
+         (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    if d == 1
       return z
    end
@@ -433,7 +433,7 @@ function pseudo_inv(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
    ccall((:fmpz_mat_inv, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}), &z, &d, &x)
+         (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    if !iszero(d)
       return (z, d)
    end
@@ -460,14 +460,14 @@ end
 function divexact(x::fmpz_mat, y::Int)
    z = similar(x)
    ccall((:fmpz_mat_scalar_divexact_si, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int), &z, &x, y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, x, y)
    return z
 end
 
 function divexact(x::fmpz_mat, y::fmpz)
    z = similar(x)
    ccall((:fmpz_mat_scalar_divexact_fmpz, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -486,7 +486,7 @@ doc"""
 function reduce_mod(x::fmpz_mat, y::fmpz)
    z = similar(x)
    ccall((:fmpz_mat_scalar_mod_fmpz, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -506,7 +506,7 @@ function charpoly(R::FmpzPolyRing, x::fmpz_mat)
    rows(x) != cols(x) && error("Non-square")
    z = R()
    ccall((:fmpz_mat_charpoly, :libflint), Void,
-                (Ptr{fmpz_poly}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_poly}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -520,7 +520,7 @@ function minpoly(R::FmpzPolyRing, x::fmpz_mat)
    rows(x) != cols(x) && error("Non-square")
    z = R()
    ccall((:fmpz_mat_minpoly, :libflint), Void,
-                (Ptr{fmpz_poly}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_poly}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -534,7 +534,7 @@ function det(x::fmpz_mat)
    rows(x) != cols(x) && error("Non-square matrix")
    z = fmpz()
    ccall((:fmpz_mat_det, :libflint), Void,
-                (Ptr{fmpz}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -547,7 +547,7 @@ function det_divisor(x::fmpz_mat)
    rows(x) != cols(x) && error("Non-square matrix")
    z = fmpz()
    ccall((:fmpz_mat_det_divisor, :libflint), Void,
-                (Ptr{fmpz}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -561,7 +561,7 @@ function det_given_divisor(x::fmpz_mat, d::fmpz, proved=true)
    rows(x) != cols(x) && error("Non-square")
    z = fmpz()
    ccall((:fmpz_mat_det_modular_given_divisor, :libflint), Void,
-               (Ptr{fmpz}, Ptr{fmpz_mat}, Ptr{fmpz}, Cint), &z, &x, &d, proved)
+               (Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz}, Cint), z, x, d, proved)
    return z
 end
 
@@ -584,7 +584,7 @@ end
 function gram(x::fmpz_mat)
    z = similar(x, rows(x), rows(x))
    ccall((:fmpz_mat_gram, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -603,7 +603,7 @@ function hadamard(R::FmpzMatSpace)
    R.rows != R.cols && error("Unable to create Hadamard matrix")
    z = R()
    success = ccall((:fmpz_mat_hadamard, :libflint), Bool,
-                   (Ptr{fmpz_mat},), &z)
+                   (Ref{fmpz_mat},), z)
    !success && error("Unable to create Hadamard matrix")
    return z
 end
@@ -614,7 +614,7 @@ doc"""
 """
 function ishadamard(x::fmpz_mat)
    return ccall((:fmpz_mat_is_hadamard, :libflint), Bool,
-                   (Ptr{fmpz_mat},), &x)
+                   (Ref{fmpz_mat},), x)
 end
 
 ###############################################################################
@@ -630,7 +630,7 @@ doc"""
 function hnf(x::fmpz_mat)
    z = similar(x)
    ccall((:fmpz_mat_hnf, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -643,7 +643,7 @@ function hnf_with_transform(x::fmpz_mat)
    z = similar(x)
    u = similar(x, rows(x), rows(x))
    ccall((:fmpz_mat_hnf_transform, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &u, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, u, x)
    return z, u
 end
 
@@ -655,7 +655,7 @@ doc"""
 function hnf_modular(x::fmpz_mat, d::fmpz)
    z = similar(x)
    ccall((:fmpz_mat_hnf_modular, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &z, &x, &d)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, d)
    return z
 end
 
@@ -669,7 +669,7 @@ function hnf_modular_eldiv(x::fmpz_mat, d::fmpz)
                 error("Matrix must have at least as many rows as columns")
    z = deepcopy(x)
    ccall((:fmpz_mat_hnf_modular_eldiv, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz}), &z, &d)
+                (Ref{fmpz_mat}, Ref{fmpz}), z, d)
    return z
 end
 
@@ -680,7 +680,7 @@ doc"""
 """
 function ishnf(x::fmpz_mat)
    return ccall((:fmpz_mat_is_in_hnf, :libflint), Bool,
-                   (Ptr{fmpz_mat},), &x)
+                   (Ref{fmpz_mat},), x)
 end
 
 ###############################################################################
@@ -716,7 +716,7 @@ function lll_with_transform(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51))
       u[i, i] = 1
    end
    ccall((:fmpz_lll, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{lll_ctx}), &z, &u, &ctx)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z, u
 end
 
@@ -735,7 +735,7 @@ function lll(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51))
    end
    u = similar(x, rows(x), rows(x))
    ccall((:fmpz_lll, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{lll_ctx}), &z, &u, &ctx)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z
 end
 
@@ -752,7 +752,7 @@ function lll_gram_with_transform(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51,
       u[i, i] = 1
    end
    ccall((:fmpz_lll, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{lll_ctx}), &z, &u, &ctx)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z, u
 end
 
@@ -765,7 +765,7 @@ function lll_gram(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51, :gram))
    z = deepcopy(x)
    u = similar(x, rows(x), rows(x))
    ccall((:fmpz_lll, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{lll_ctx}), &z, &u, &ctx)
+         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z
 end
 
@@ -782,7 +782,7 @@ function lll_with_removal_transform(x::fmpz_mat, b::fmpz, ctx::lll_ctx = lll_ctx
       u[i, i] = 1
    end
    d = Int(ccall((:fmpz_lll_with_removal, :libflint), Cint,
-    (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{lll_ctx}), &z, &u, &b, &ctx))
+    (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}, Ref{lll_ctx}), z, u, b, ctx))
    return d, z, u
 end
 
@@ -796,7 +796,7 @@ function lll_with_removal(x::fmpz_mat, b::fmpz, ctx::lll_ctx = lll_ctx(0.99, 0.5
    z = deepcopy(x)
    u = similar(x, rows(x), rows(x))
    d = Int(ccall((:fmpz_lll_with_removal, :libflint), Cint,
-    (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{lll_ctx}), &z, &u, &b, &ctx))
+    (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}, Ref{lll_ctx}), z, u, b, ctx))
    return d, z
 end
 
@@ -807,7 +807,7 @@ end
 ###############################################################################
 
 function nullspace(x::fmpz_mat)
-  H, T = hnf_with_transform(x')
+  H, T = hnf_with_transform(transpose(x))
   for i = rows(H):-1:1
     for j = 1:cols(H)
       if !iszero(H[i, j])
@@ -834,7 +834,7 @@ function nullspace_right_rational(x::fmpz_mat)
    z = similar(x)
    u = similar(x, cols(x), cols(x))
    rank = ccall((:fmpz_mat_nullspace, :libflint), Cint,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &u, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}), u, x)
    return u, rank
 end
 
@@ -846,7 +846,7 @@ end
 
 function rank(x::fmpz_mat)
    return ccall((:fmpz_mat_rank, :libflint), Int,
-                (Ptr{fmpz_mat},), &x)
+                (Ref{fmpz_mat},), x)
 end
 
 ###############################################################################
@@ -859,7 +859,7 @@ function rref(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
    ccall((:fmpz_mat_rref, :libflint), Void,
-         (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}), &z, &d, &x)
+         (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    return z, d
 end
 
@@ -876,7 +876,7 @@ doc"""
 function snf(x::fmpz_mat)
    z = similar(x)
    ccall((:fmpz_mat_snf, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -887,7 +887,7 @@ doc"""
 function snf_diagonal(x::fmpz_mat)
    z = similar(x)
    ccall((:fmpz_mat_snf_diagonal, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
 
@@ -897,7 +897,7 @@ doc"""
 """
 function issnf(x::fmpz_mat)
    return ccall((:fmpz_mat_is_in_snf, :libflint), Bool,
-                   (Ptr{fmpz_mat},), &x)
+                   (Ref{fmpz_mat},), x)
 end
 
 ###############################################################################
@@ -927,7 +927,7 @@ doc"""
 """
 function cansolve(a::fmpz_mat, b::fmpz_mat)
    rows(b) != rows(a) && error("Incompatible dimensions in cansolve")
-   H, T = hnf_with_transform(a')
+   H, T = hnf_with_transform(transpose(a))
    b = deepcopy(b)
    z = similar(a, cols(b), cols(a))
    l = min(rows(a), cols(a))
@@ -953,7 +953,7 @@ function cansolve(a::fmpz_mat, b::fmpz_mat)
    if !iszero(b)
      return false, b
    end
-   return true, (z*T)'
+   return true, transpose(z*T)
 end
 
 doc"""
@@ -964,7 +964,7 @@ doc"""
 """
 function cansolve_with_nullspace(a::fmpz_mat, b::fmpz_mat)
    rows(b) != rows(a) && error("Incompatible dimensions in cansolve_with_nullspace")
-   H, T = hnf_with_transform(a')
+   H, T = hnf_with_transform(transpose(a))
    z = similar(a, cols(b), cols(a))
    l = min(rows(a), cols(a))
    for i=1:cols(b)
@@ -999,7 +999,7 @@ function cansolve_with_nullspace(a::fmpz_mat, b::fmpz_mat)
              N[k,l] = T[rows(T) - l + 1, k]
            end
          end
-         return true, (z*T)', N
+         return true, transpose(z*T), N
        end
      end
    end
@@ -1021,7 +1021,7 @@ function solve_rational(a::fmpz_mat, b::fmpz_mat)
    z = similar(b)
    d = fmpz()
    nonsing = ccall((:fmpz_mat_solve, :libflint), Bool,
-      (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &d, &a, &b)
+      (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, d, a, b)
    !nonsing && error("Singular matrix in solve_rational")
    return z, d
 end
@@ -1043,7 +1043,7 @@ function solve_dixon(a::fmpz_mat, b::fmpz_mat)
    z = similar(b)
    d = fmpz()
    nonsing = ccall((:fmpz_mat_solve_dixon, :libflint), Bool,
-      (Ptr{fmpz_mat}, Ptr{fmpz}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &d, &a, &b)
+      (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, d, a, b)
    !nonsing && error("Singular matrix in solve")
    return z, d
 end
@@ -1058,7 +1058,7 @@ function trace(x::fmpz_mat)
    rows(x) != cols(x) && error("Not a square matrix in trace")
    d = fmpz()
    ccall((:fmpz_mat_trace, :libflint), Int,
-                (Ptr{fmpz}, Ptr{fmpz_mat}), &d, &x)
+                (Ref{fmpz}, Ref{fmpz_mat}), d, x)
    return d
 end
 
@@ -1071,7 +1071,7 @@ end
 function content(x::fmpz_mat)
   d = fmpz()
   ccall((:fmpz_mat_content, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz_mat}), &d, &x)
+        (Ref{fmpz}, Ref{fmpz_mat}), d, x)
   return d
 end
 
@@ -1085,7 +1085,7 @@ function hcat(a::fmpz_mat, b::fmpz_mat)
   rows(a) != rows(b) && error("Incompatible number of rows in hcat")
   c = similar(a, rows(a), cols(a) + cols(b))
   ccall((:fmpz_mat_concat_horizontal, :libflint), Void,
-        (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &c, &a, &b)
+        (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), c, a, b)
   return c
 end
 
@@ -1093,7 +1093,7 @@ function vcat(a::fmpz_mat, b::fmpz_mat)
   cols(a) != cols(b) && error("Incompatible number of columns in vcat")
   c = similar(a, rows(a) + rows(b), cols(a))
   ccall((:fmpz_mat_concat_vertical, :libflint), Void,
-        (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &c, &a, &b)
+        (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), c, a, b)
   return c
 end
 
@@ -1105,43 +1105,43 @@ end
 
 function mul!(z::fmpz_mat, x::fmpz_mat, y::fmpz_mat)
    ccall((:fmpz_mat_mul, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &x, &y)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, x, y)
    return z
 end
 
 function mul!(y::fmpz_mat, x::Int)
    ccall((:fmpz_mat_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int), &y, &y, x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), y, y, x)
    return y
 end
 
 function mul!(y::fmpz_mat, x::fmpz)
    ccall((:fmpz_mat_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &y, &y, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), y, y, x)
    return y
 end
 
 function addmul!(z::fmpz_mat, y::fmpz_mat, x::fmpz)
    ccall((:fmpz_mat_scalar_addmul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz}), &z, &y, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, y, x)
    return y
 end
 
 function addmul!(z::fmpz_mat, y::fmpz_mat, x::Int)
    ccall((:fmpz_mat_scalar_addmul_si, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Int), &z, &y, x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, y, x)
    return y
 end
 
 function addeq!(z::fmpz_mat, x::fmpz_mat)
    ccall((:fmpz_mat_add, :libflint), Void,
-                (Ptr{fmpz_mat}, Ptr{fmpz_mat}, Ptr{fmpz_mat}), &z, &z, &x)
+                (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, z, x)
    return z
 end
 
 function zero!(z::fmpz_mat)
    ccall((:fmpz_mat_zero, :libflint), Void,
-                (Ptr{fmpz_mat},), &z)
+                (Ref{fmpz_mat},), z)
    return z
 end
 
@@ -1209,7 +1209,7 @@ promote_rule(::Type{fmpz_mat}, ::Type{T}) where {T <: Integer} = fmpz_mat
 
 promote_rule(::Type{fmpz_mat}, ::Type{fmpz}) = fmpz_mat
 
-function convert(::Type{Matrix{Int}}, A::fmpz_mat)
+function (::Type{Base.Array{Int, 2}})(A::fmpz_mat)
     m, n = size(A)
 
     fittable = [fits(Int, A[i, j]) for i in 1:m, j in 1:n]
@@ -1221,7 +1221,7 @@ function convert(::Type{Matrix{Int}}, A::fmpz_mat)
     return mat
 end
 
-function convert(::Type{Matrix{BigInt}}, A::fmpz_mat)
+function (::Type{Base.Array{BigInt, 2}})(A::fmpz_mat)
     m, n = size(A)
     # No check: always ensured to fit a BigInt.
     mat::Matrix{BigInt} = BigInt[A[i, j] for i in 1:m, j in 1:n]
@@ -1280,7 +1280,7 @@ end
 
 function identity_matrix(R::FlintIntegerRing, n::Int)
    z = fmpz_mat(n, n)
-   ccall((:fmpz_mat_one, :libflint), Void, (Ptr{fmpz_mat}, ), &z)
+   ccall((:fmpz_mat_one, :libflint), Void, (Ref{fmpz_mat}, ), z)
    z.base_ring = FlintZZ
    return z
 end

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -43,20 +43,20 @@ function normalise(a::fmpz_mod_abs_series, len::Int)
    if len > 0
       c = fmpz()
       ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_mod_abs_series}, Int), &c, &a, len - 1)
+         (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_mod_abs_series}, Int), &c, &a, len - 1)
+            (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), c, a, len - 1)
       end
    end
    return len
 end
 
 function length(x::fmpz_mod_abs_series)
-   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ptr{fmpz_mod_abs_series},), &x)
+   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ref{fmpz_mod_abs_series},), x)
 end
 
 precision(x::fmpz_mod_abs_series) = x.prec
@@ -68,7 +68,7 @@ function coeff(x::fmpz_mod_abs_series, n::Int)
    end
    z = fmpz()
    ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_mod_abs_series}, Int), &z, &x, n)
+         (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, n)
    return R(z)
 end
 
@@ -91,7 +91,7 @@ end
 
 function isgen(a::fmpz_mod_abs_series)
    return precision(a) == 0 || ccall((:fmpz_mod_poly_is_x, :libflint), Bool,
-                            (Ptr{fmpz_mod_abs_series},), &a)
+                            (Ref{fmpz_mod_abs_series},), a)
 end
 
 iszero(a::fmpz_mod_abs_series) = length(a) == 0
@@ -100,7 +100,7 @@ isunit(a::fmpz_mod_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpz_mod_abs_series)
    return precision(a) == 0 || ccall((:fmpz_mod_poly_is_one, :libflint), Bool,
-                                (Ptr{fmpz_mod_abs_series},), &a)
+                                (Ref{fmpz_mod_abs_series},), a)
 end
 
 # todo: write an fmpz_mod_poly_valuation
@@ -135,8 +135,8 @@ show_minus_one(::Type{fmpz_mod_abs_series}) = show_minus_one(fmpz)
 function -(x::fmpz_mod_abs_series)
    z = parent(x)()
    ccall((:fmpz_mod_poly_neg, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}),
-               &z, &x)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}),
+               z, x)
    z.prec = x.prec
    return z
 end
@@ -161,8 +161,8 @@ function +(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -180,8 +180,8 @@ function -(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fmpz_mod_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -209,8 +209,8 @@ function *(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    lenz = min(lena + lenb - 1, prec)
 
    ccall((:fmpz_mod_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -224,8 +224,8 @@ function *(x::Generic.Res{fmpz}, y::fmpz_mod_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz}),
-               &z, &y, &x.data)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
+               z, y, x.data)
    return z
 end
 
@@ -236,8 +236,8 @@ function *(x::fmpz, y::fmpz_mod_abs_series)
    z.prec = y.prec
    r = mod(x, modulus(y))
    ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz}),
-               &z, &y, &r)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
+               z, y, r)
    return z
 end
 
@@ -257,8 +257,8 @@ function shift_left(x::fmpz_mod_abs_series, len::Int)
    z = parent(x)()
    z.prec = x.prec + len
    ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, x, len)
    return z
 end
 
@@ -271,8 +271,8 @@ function shift_right(x::fmpz_mod_abs_series, len::Int)
    else
       z.prec = x.prec - len
       ccall((:fmpz_mod_poly_shift_right, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &x, len)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, x, len)
    end
    return z
 end
@@ -291,8 +291,8 @@ function truncate(x::fmpz_mod_abs_series, prec::Int)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &x, prec)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, x, prec)
    return z
 end
 
@@ -317,8 +317,8 @@ function ^(a::fmpz_mod_abs_series, b::Int)
       z.prec = a.prec + (b - 1)*valuation(a)
       z.prec = min(z.prec, max_precision(parent(a)))
       ccall((:fmpz_mod_poly_pow_trunc, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int, Int),
-               &z, &a, b, z.prec)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int, Int),
+               z, a, b, z.prec)
    end
    return z
 end
@@ -337,8 +337,8 @@ function ==(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
    n = min(n, prec)
 
    return Bool(ccall((:fmpz_mod_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &x, &y, n))
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               x, y, n))
 end
 
 function isequal(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
@@ -349,8 +349,8 @@ function isequal(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
       return false
    end
    return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Cint,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &x, &y, length(x)))
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               x, y, length(x)))
 end
 
 ###############################################################################
@@ -365,9 +365,9 @@ function ==(x::fmpz_mod_abs_series, y::Generic.Res{fmpz})
    elseif length(x) == 1
       z = fmpz()
       ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_mod_abs_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, 0)
       return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}), &z, &y)
+               (Ref{fmpz}, Ref{fmpz}), z, y)
    else
       return precision(x) == 0 || iszero(y)
    end
@@ -382,9 +382,9 @@ function ==(x::fmpz_mod_abs_series, y::fmpz)
       z = fmpz()
       r = mod(y, modulus(x))
       ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_mod_abs_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, 0)
       return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}), &z, &r)
+               (Ref{fmpz}, Ref{fmpz}), z, r)
    else
       r = mod(y, modulus(x))
       return precision(x) == 0 || iszero(r)
@@ -419,8 +419,8 @@ function divexact(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
    z = parent(x)()
    z.prec = prec
    ccall((:fmpz_mod_poly_div_series, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, x, y, prec)
    return z
 end
 
@@ -435,8 +435,8 @@ function divexact(x::fmpz_mod_abs_series, y::Generic.Res{fmpz})
    z = parent(x)()
    z.prec = x.prec
    ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -446,8 +446,8 @@ function divexact(x::fmpz_mod_abs_series, y::fmpz)
    z.prec = x.prec
    r = mod(y, modulus(x))
    ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -465,8 +465,8 @@ function inv(a::fmpz_mod_abs_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ccall((:fmpz_mod_poly_inv_series, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -478,8 +478,8 @@ end
 
 function setcoeff!(z::fmpz_mod_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Int, Ptr{fmpz}),
-               &z, n, &x)
+                (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}),
+               z, n, x)
    return z
 end
 
@@ -503,8 +503,8 @@ function mul!(z::fmpz_mod_abs_series, a::fmpz_mod_abs_series, b::fmpz_mod_abs_se
 
    z.prec = prec
    ccall((:fmpz_mod_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -520,8 +520,8 @@ function addeq!(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    lenz = max(lena, lenb)
    a.prec = prec
    ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Ptr{fmpz_mod_abs_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
+               a, a, b, lenz)
    return a
 end
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -36,16 +36,16 @@ end
 ################################################################################
 
 length(x::fmpz_mod_poly) = ccall((:fmpz_mod_poly_length, :libflint), Int,
-                               (Ptr{fmpz_mod_poly}, ), &x)
+                               (Ref{fmpz_mod_poly}, ), x)
 
 degree(x::fmpz_mod_poly) = ccall((:fmpz_mod_poly_degree, :libflint), Int,
-                               (Ptr{fmpz_mod_poly}, ), &x)
+                               (Ref{fmpz_mod_poly}, ), x)
 
 function coeff(x::fmpz_mod_poly, n::Int)
   n < 0 && throw(DomainError())
   z = fmpz()
   ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Int), &z, &x, n)
+        (Ref{fmpz}, Ref{fmpz_mod_poly}, Int), z, x, n)
   return base_ring(x)(z)
 end
 
@@ -59,7 +59,7 @@ isgen(a::fmpz_mod_poly) = (degree(a) == 1 &&
                               iszero(coeff(a,0)) && isone(coeff(a,1)))
 
 iszero(a::fmpz_mod_poly) = Bool(ccall((:fmpz_mod_poly_is_zero, :libflint), Int32,
-                              (Ptr{fmpz_mod_poly}, ), &a))
+                              (Ref{fmpz_mod_poly}, ), a))
 
 var(R::FmpzModPolyRing) = R.S
 
@@ -156,7 +156,7 @@ canonical_unit(a::fmpz_mod_poly) = canonical_unit(lead(a))
 function -(x::fmpz_mod_poly)
   z = parent(x)()
   ccall((:fmpz_mod_poly_neg, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &z, &x)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), z, x)
   return z
 end
 
@@ -170,8 +170,8 @@ function +(x::fmpz_mod_poly, y::fmpz_mod_poly)
   check_parent(x,y)
   z = parent(x)()
   ccall((:fmpz_mod_poly_add, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), 
-               &z, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), 
+               z, x, y)
   return z
 end
 
@@ -179,8 +179,8 @@ function -(x::fmpz_mod_poly, y::fmpz_mod_poly)
   check_parent(x,y)
   z = parent(x)()
   ccall((:fmpz_mod_poly_sub, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), 
-              &z, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), 
+              z, x, y)
   return z
 end
 
@@ -188,8 +188,8 @@ function *(x::fmpz_mod_poly, y::fmpz_mod_poly)
   check_parent(x,y)
   z = parent(x)()
   ccall((:fmpz_mod_poly_mul, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), 
-              &z, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), 
+              z, x, y)
   return z
 end
 
@@ -202,7 +202,7 @@ end
 function *(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
   ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
 
@@ -222,7 +222,7 @@ end
 function +(x::fmpz_mod_poly, y::Int)
   z = parent(x)()
   ccall((:fmpz_mod_poly_add_si, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, y)
+    (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, y)
   return z
 end
 
@@ -231,7 +231,7 @@ end
 function +(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
   ccall((:fmpz_mod_poly_add_fmpz, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &x, &y)
+    (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
 
@@ -251,28 +251,28 @@ end
 function -(x::fmpz_mod_poly, y::Int)
   z = parent(x)()
   ccall((:fmpz_mod_poly_sub_si, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, y)
+    (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, y)
   return z
 end
 
 function -(x::Int, y::fmpz_mod_poly)
   z = parent(y)()
   ccall((:fmpz_mod_poly_si_sub, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz_mod_poly}), &z, x, &y)
+    (Ref{fmpz_mod_poly}, Int, Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 
 function -(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
   ccall((:fmpz_mod_poly_sub_fmpz, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &x, &y)
+    (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
 
 function -(x::fmpz, y::fmpz_mod_poly)
   z = parent(y)()
   ccall((:fmpz_mod_poly_fmpz_sub, :libflint), Void,
-    (Ptr{fmpz_mod_poly}, Ptr{fmpz}, Ptr{fmpz_mod_poly}), &z, &x, &y)
+    (Ref{fmpz_mod_poly}, Ref{fmpz}, Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 
@@ -300,7 +300,7 @@ function ^(x::fmpz_mod_poly, y::Int)
   y < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:fmpz_mod_poly_pow, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, y)
   return z
 end
 
@@ -313,7 +313,7 @@ end
 function ==(x::fmpz_mod_poly, y::fmpz_mod_poly)
   check_parent(x, y)
   return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Int32,
-             (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &x, &y))
+             (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), x, y))
 end
 
 ################################################################################
@@ -329,7 +329,7 @@ function ==(x::fmpz_mod_poly, y::Generic.Res{fmpz})
   elseif length(x) == 1 
      u = fmpz()
      ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void, 
-            (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Int), &u, &x, 0)
+            (Ref{fmpz}, Ref{fmpz_mod_poly}, Int), u, x, 0)
      return u == y
   else
     return iszero(y)
@@ -354,7 +354,7 @@ function truncate(a::fmpz_mod_poly, n::Int)
   end
 
   ccall((:fmpz_mod_poly_truncate, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Int), &z, n)
+          (Ref{fmpz_mod_poly}, Int), z, n)
   return z
 end
 
@@ -364,8 +364,8 @@ function mullow(x::fmpz_mod_poly, y::fmpz_mod_poly, n::Int)
 
   z = parent(x)()
   ccall((:fmpz_mod_poly_mullow, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), 
-                &z, &x, &y, n)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), 
+                z, x, y, n)
   return z
 end
 
@@ -379,7 +379,7 @@ function reverse(x::fmpz_mod_poly, len::Int)
   len < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:fmpz_mod_poly_reverse, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, len)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, len)
   return z
 end
 
@@ -393,7 +393,7 @@ function shift_left(x::fmpz_mod_poly, len::Int)
   len < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, len)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, len)
   return z
 end
 
@@ -401,7 +401,7 @@ function shift_right(x::fmpz_mod_poly, len::Int)
   len < 0 && throw(DomainError())
   z = parent(x)()
   ccall((:fmpz_mod_poly_shift_right, :libflint), Void,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int), &z, &x, len)
+            (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, len)
   return z
 end
 
@@ -418,8 +418,8 @@ function divexact(x::fmpz_mod_poly, y::fmpz_mod_poly)
   q = parent(x)()
   r = parent(x)()
   ccall((:fmpz_mod_poly_divrem_f, :libflint), Void, 
-        (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), 
-               &d, &q, &r, &x, &y)
+        (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), 
+               d, q, r, x, y)
   d != 1 && error("Impossible inverse in divexact")
   return q
 end
@@ -437,8 +437,8 @@ function divexact(x::fmpz_mod_poly, y::Generic.Res{fmpz})
   iszero(y) && throw(DivideError())
   q = parent(x)()
   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), 
-               &q, &x, &y.data)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), 
+               q, x, y.data)
   return q
 end
    
@@ -446,8 +446,8 @@ function divexact(x::fmpz_mod_poly, y::fmpz)
   y == 0 && throw(DivideError())
   q = parent(x)()
   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), 
-               &q, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), 
+               q, x, y)
   return q
 end
    
@@ -455,8 +455,8 @@ function divexact(x::fmpz_mod_poly, y::Int)
   y == 0 && throw(DivideError())
   q = parent(x)()
   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void, 
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), 
-               &q, &x, &fmpz(y))
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), 
+               q, x, fmpz(y))
   return q
 end
    
@@ -473,8 +473,8 @@ function divrem(x::fmpz_mod_poly, y::fmpz_mod_poly)
   r = parent(x)()
   d = fmpz()
   ccall((:fmpz_mod_poly_divrem_f, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}),
-          &d, &q, &r, &x, &y)
+        (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}),
+          d, q, r, x, y)
   d > 1 && error("Impossible inverse in divrem")
   return q, r
 end
@@ -514,8 +514,8 @@ function gcd(x::fmpz_mod_poly, y::fmpz_mod_poly)
   z = parent(x)()
   f = fmpz()
   ccall((:fmpz_mod_poly_gcd_f, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), 
-              &f, &z, &x, &y)
+          (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), 
+              f, z, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
   return z
 end 
@@ -527,8 +527,8 @@ function gcdx(x::fmpz_mod_poly, y::fmpz_mod_poly)
   t = parent(x)()
   f = fmpz()
   ccall((:fmpz_mod_poly_xgcd_f, :libflint), Void,
-        (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},
-         Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &f, &g, &s, &t, &x, &y)
+        (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},
+         Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), f, g, s, t, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
   return g, s, t
 end
@@ -540,8 +540,8 @@ function gcdinv(x::fmpz_mod_poly, y::fmpz_mod_poly)
   s = parent(x)()
   f = fmpz()
   ccall((:fmpz_mod_poly_gcdinv_f, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}),
-          &f, &g, &s, &x, &y)
+          (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}),
+          f, g, s, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
   return g, s
 end 
@@ -560,8 +560,8 @@ function invmod(x::fmpz_mod_poly, y::fmpz_mod_poly)
   end
   z = parent(x)()
   r = ccall((:fmpz_mod_poly_invmod, :libflint), Int32,
-            (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}),
-               &z, &x, &y)
+            (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}),
+               z, x, y)
   r == 0 ? error("Impossible inverse in invmod") : return z
 end
 
@@ -570,8 +570,8 @@ function mulmod(x::fmpz_mod_poly, y::fmpz_mod_poly, z::fmpz_mod_poly)
   check_parent(y, z)
   w = parent(x)()
   ccall((:fmpz_mod_poly_mulmod, :libflint), Void,
-        (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}),
-        &w, &x, &y, &z)
+        (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}),
+        w, x, y, z)
   return w
 end
 
@@ -588,7 +588,7 @@ function powmod(x::fmpz_mod_poly, e::Int, y::fmpz_mod_poly)
   end
 
   ccall((:fmpz_mod_poly_powmod_ui_binexp, :libflint), Void,
-        (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Int, Ptr{fmpz_mod_poly}), &z, &x, e, &y)
+        (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int, Ref{fmpz_mod_poly}), z, x, e, y)
 
   return z
 end
@@ -609,8 +609,8 @@ function powmod(x::fmpz_mod_poly, e::fmpz, y::fmpz_mod_poly)
   end
 
   ccall((:fmpz_mod_poly_powmod_fmpz_binexp, :libflint), Void,
-        (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz}, Ptr{fmpz_mod_poly}), 
-            &z, &x, &e, &y)
+        (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}, Ref{fmpz_mod_poly}), 
+            z, x, e, y)
   return z
 end
 
@@ -626,7 +626,7 @@ function resultant(x::fmpz_mod_poly, y::fmpz_mod_poly)
   !isprobabprime(modulus(x)) && error("Modulus not prime in resultant")
   r = fmpz()
   ccall((:fmpz_mod_poly_resultant, :libflint), Void,
-          (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &r, &x, &y)
+          (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), r, x, y)
   return base_ring(x)(r)
 end
 
@@ -640,7 +640,7 @@ function evaluate(x::fmpz_mod_poly, y::Generic.Res{fmpz})
   base_ring(x) != parent(y) && error("Elements must have same parent")
   z = fmpz()
   ccall((:fmpz_mod_poly_evaluate_fmpz, :libflint), Void,
-              (Ptr{fmpz}, Ptr{fmpz_mod_poly}, Ptr{fmpz}), &z, &x, &(y.data))
+              (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y.data)
   return parent(y)(z)
 end
 
@@ -653,7 +653,7 @@ end
 function derivative(x::fmpz_mod_poly)
   z = parent(x)()
   ccall((:fmpz_mod_poly_derivative, :libflint), Void,
-        (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), &z, &x)
+        (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), z, x)
   return z
 end
 
@@ -683,8 +683,8 @@ function compose(x::fmpz_mod_poly, y::fmpz_mod_poly)
   check_parent(x,y)
   z = parent(x)()
   ccall((:fmpz_mod_poly_compose, :libflint), Void,
-          (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly}), 
-               &z, &x, &y)
+          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), 
+               z, x, y)
   return z
 end
 
@@ -704,7 +704,7 @@ doc"""
 function lift(R::FmpzPolyRing, y::fmpz_mod_poly)
    z = fmpz_poly()
    ccall((:fmpz_mod_poly_get_fmpz_poly, :libflint), Void,
-          (Ptr{fmpz_poly}, Ptr{fmpz_mod_poly}), &z, &y)
+          (Ref{fmpz_poly}, Ref{fmpz_mod_poly}), z, y)
    z.parent = R
   return z
 end
@@ -722,7 +722,7 @@ doc"""
 function isirreducible(x::fmpz_mod_poly)
   !isprobabprime(modulus(x)) && error("Modulus not prime in isirreducible")
   return Bool(ccall((:fmpz_mod_poly_is_irreducible, :libflint), Int32,
-          (Ptr{fmpz_mod_poly}, ), &x))
+          (Ref{fmpz_mod_poly}, ), x))
 end
 
 ################################################################################
@@ -738,7 +738,7 @@ doc"""
 function issquarefree(x::fmpz_mod_poly)
    !isprobabprime(modulus(x)) && error("Modulus not prime in issquarefree")
    return Bool(ccall((:fmpz_mod_poly_is_squarefree, :libflint), Int32, 
-      (Ptr{fmpz_mod_poly}, ), &x))
+      (Ref{fmpz_mod_poly}, ), x))
 end
 
 ################################################################################
@@ -760,12 +760,12 @@ end
 function _factor(x::fmpz_mod_poly)
   fac = fmpz_mod_poly_factor(parent(x).n)
   ccall((:fmpz_mod_poly_factor, :libflint), UInt,
-          (Ptr{fmpz_mod_poly_factor}, Ptr{fmpz_mod_poly}), &fac, &x)
+          (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}), fac, x)
   res = Dict{fmpz_mod_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Void,
-         (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly_factor}, Int), &f, &fac, i - 1)
+         (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
   end
@@ -785,12 +785,12 @@ end
 function _factor_squarefree(x::fmpz_mod_poly)
   fac = fmpz_mod_poly_factor(parent(x).n)
   ccall((:fmpz_mod_poly_factor_squarefree, :libflint), UInt,
-          (Ptr{fmpz_mod_poly_factor}, Ptr{fmpz_mod_poly}), &fac, &x)
+          (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}), fac, x)
   res = Dict{fmpz_mod_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Void,
-         (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly_factor}, Int), &f, &fac, i - 1)
+         (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
   end
@@ -808,13 +808,13 @@ function factor_distinct_deg(x::fmpz_mod_poly)
   degss = [ pointer(degs) ]
   fac = fmpz_mod_poly_factor(parent(x).n)
   ccall((:fmpz_mod_poly_factor_distinct_deg, :libflint), UInt,
-          (Ptr{fmpz_mod_poly_factor}, Ptr{fmpz_mod_poly}, Ptr{Ptr{Int}}),
-          &fac, &x, degss)
+          (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}, Ptr{Ptr{Int}}),
+          fac, x, degss)
   res = Dict{Int, fmpz_mod_poly}()
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Void,
-         (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly_factor}, Int), &f, &fac, i - 1)
+         (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     res[degs[i]] = f
   end
   return res 
@@ -828,31 +828,31 @@ end
 
 function zero!(x::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_zero, :libflint), Void, 
-                   (Ptr{fmpz_mod_poly}, ), &x)
+                   (Ref{fmpz_mod_poly}, ), x)
   return x
 end
 
 function fit!(x::fmpz_mod_poly, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void, 
-                   (Ptr{fmpz_mod_poly}, Int), &x, n)
+                   (Ref{fmpz_mod_poly}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::UInt)
   ccall((:fmpz_mod_poly_set_coeff_ui, :libflint), Void, 
-                   (Ptr{fmpz_mod_poly}, Int, UInt), &x, n, y)
+                   (Ref{fmpz_mod_poly}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::Int)
   ccall((:fmpz_mod_poly_set_coeff_si, :libflint), Void, 
-                   (Ptr{fmpz_mod_poly}, Int, UInt), &x, n, y)
+                   (Ref{fmpz_mod_poly}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::fmpz_mod_poly, n::Int, y::fmpz)
   ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void, 
-                   (Ptr{fmpz_mod_poly}, Int, Ptr{fmpz}), &x, n, &y)
+                   (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), x, n, y)
   return x
 end
 
@@ -862,25 +862,25 @@ setcoeff!(x::fmpz_mod_poly, n::Int, y::Generic.Res{fmpz}) = setcoeff!(x, n, y.da
 
 function add!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_add, :libflint), Void, 
-     (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 
 function addeq!(z::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_add, :libflint), Void, 
-     (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &z, &y)
+     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), z, z, y)
   return z
 end
 
 function sub!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_sub, :libflint), Void, 
-     (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 
 function mul!(z::fmpz_mod_poly, x::fmpz_mod_poly, y::fmpz_mod_poly)
   ccall((:fmpz_mod_poly_mul, :libflint), Void, 
-     (Ptr{fmpz_mod_poly}, Ptr{fmpz_mod_poly},  Ptr{fmpz_mod_poly}), &z, &x, &y)
+     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly},  Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -40,20 +40,20 @@ function normalise(a::fmpz_mod_rel_series, len::Int)
    if len > 0
       c = fmpz()
       ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_mod_rel_series}, Int), &c, &a, len - 1)
+         (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_mod_rel_series}, Int), &c, &a, len - 1)
+            (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), c, a, len - 1)
       end
    end
    return len
 end
 
 function pol_length(x::fmpz_mod_rel_series)
-   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ptr{fmpz_mod_rel_series},), &x)
+   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ref{fmpz_mod_rel_series},), x)
 end
 
 precision(x::fmpz_mod_rel_series) = x.prec
@@ -65,7 +65,7 @@ function polcoeff(x::fmpz_mod_rel_series, n::Int)
    end
    z = fmpz()
    ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_mod_rel_series}, Int), &z, &x, n)
+         (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, n)
    return R(z)
 end
 
@@ -103,7 +103,7 @@ function renormalize!(z::fmpz_mod_rel_series)
    else
       z.val = zval + i
       ccall((:fmpz_mod_poly_shift_right, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int), &z, &z, i)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int), z, z, i)
    end
    return nothing
 end
@@ -130,8 +130,8 @@ show_minus_one(::Type{fmpz_mod_rel_series}) = show_minus_one(fmpz)
 function -(x::fmpz_mod_rel_series)
    z = parent(x)()
    ccall((:fmpz_mod_poly_neg, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}),
-               &z, &x)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}),
+               z, x)
    z.prec = x.prec
    z.val = x.val
    return z
@@ -155,30 +155,30 @@ function +(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -199,32 +199,32 @@ function -(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_mod_poly_neg, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}), &z, &z)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}), z, z)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpz_mod_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_mod_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -249,8 +249,8 @@ function *(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fmpz_mod_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, a, b, lenz)
    renormalize!(z)
    return z
 end
@@ -266,8 +266,8 @@ function *(x::Generic.Res{fmpz}, y::fmpz_mod_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz}),
-               &z, &y, &x.data)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
+               z, y, x.data)
    renormalize!(z)
    return z
 end
@@ -280,8 +280,8 @@ function *(x::fmpz, y::fmpz_mod_rel_series)
    z.val = y.val
    r = mod(x, modulus(y))
    ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz}),
-               &z, &y, &r)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
+               z, y, r)
    renormalize!(z)
    return z
 end
@@ -321,8 +321,8 @@ function shift_right(x::fmpz_mod_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:fmpz_mod_poly_shift_right, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &x, xlen - zlen)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, x, xlen - zlen)
       renormalize!(z)
    end
    return z
@@ -351,8 +351,8 @@ function truncate(x::fmpz_mod_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &x, min(prec - xval, xlen))
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, x, min(prec - xval, xlen))
    end
    return z
 end
@@ -386,8 +386,8 @@ function ^(a::fmpz_mod_rel_series, b::Int)
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
       ccall((:fmpz_mod_poly_pow_trunc, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int, Int),
-               &z, &a, b, z.prec - z.val)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int, Int),
+               z, a, b, z.prec - z.val)
    end
    renormalize!(z)
    return z
@@ -414,8 +414,8 @@ function ==(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
       return false
    end
    return Bool(ccall((:fmpz_mod_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &x, &y, xlen))
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               x, y, xlen))
 end
 
 function isequal(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
@@ -426,8 +426,8 @@ function isequal(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
       return false
    end
    return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Cint,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &x, &y, pol_length(x)))
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               x, y, pol_length(x)))
 end
 
 ###############################################################################
@@ -445,9 +445,9 @@ function ==(x::fmpz_mod_rel_series, y::Generic.Res{fmpz})
       if x.val == 0
          z = fmpz()
          ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_mod_rel_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, 0)
          return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}), &z, &y.data)
+               (Ref{fmpz}, Ref{fmpz}), z, y.data)
       else
          return false
       end
@@ -467,10 +467,10 @@ function ==(x::fmpz_mod_rel_series, y::fmpz)
       if x.val == 0
          z = fmpz()
          ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_mod_rel_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, 0)
          r = mod(y, modulus(x))
          return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &r, 0)
+               (Ref{fmpz}, Ref{fmpz}, Int), z, r, 0)
       else
          return false
       end
@@ -510,8 +510,8 @@ function divexact(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:fmpz_mod_poly_div_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, x, y, prec)
    end
    return z
 end
@@ -528,8 +528,8 @@ function divexact(x::fmpz_mod_rel_series, y::Generic.Res{fmpz})
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz}),
-               &z, &x, &y.data)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
+               z, x, y.data)
    return z
 end
 
@@ -541,8 +541,8 @@ function divexact(x::fmpz_mod_rel_series, y::fmpz)
    z.val = x.val
    r = mod(y, modulus(x))
    ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz}),
-               &z, &x, &r)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
+               z, x, r)
    return z
 end
 
@@ -561,8 +561,8 @@ function inv(a::fmpz_mod_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:fmpz_mod_poly_inv_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -599,7 +599,7 @@ function Base.exp(a::fmpz_mod_rel_series)
    end
    z = parent(a)(d, preca, preca, 0)
    ccall((:_fmpz_mod_poly_set_length, :libflint), Void,
-         (Ptr{fmpz_mod_rel_series}, Int), &z, normalise(z, preca))
+         (Ref{fmpz_mod_rel_series}, Int), z, normalise(z, preca))
    return z
 end
 
@@ -611,28 +611,28 @@ end
 
 function zero!(x::fmpz_mod_rel_series)
   ccall((:fmpz_mod_poly_zero, :libflint), Void,
-                   (Ptr{fmpz_mod_rel_series},), &x)
+                   (Ref{fmpz_mod_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(x::fmpz_mod_rel_series, n::Int)
   ccall((:fmpz_mod_poly_fit_length, :libflint), Void,
-                   (Ptr{fmpz_mod_rel_series}, Int), &x, n)
+                   (Ref{fmpz_mod_rel_series}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::fmpz)
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}),
-               &z, n, &x)
+                (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}),
+               z, n, x)
    return z
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::Generic.Res{fmpz})
    ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Int, Ptr{fmpz}),
-               &z, n, &x.data)
+                (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}),
+               z, n, x.data)
    return z
 end
 
@@ -651,8 +651,8 @@ function mul!(z::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
       lenz = 0
    end
    ccall((:fmpz_mod_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               z, a, b, lenz)
    renormalize!(z)
    return z
 end
@@ -669,30 +669,30 @@ function addeq!(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
       z = fmpz_mod_rel_series(modulus)
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_mod_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &a, &a, &z, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_mod_poly_truncate, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Int),
-            &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_mod_rel_series}, Int),
+            a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_mod_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-            &a, &a, a.val - b.val)
+            (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+            a, a, a.val - b.val)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               a, a, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               a, a, b, lenz)
    end
    a.prec = prec
    a.val = val
@@ -712,8 +712,8 @@ function add!(c::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:fmpz_mod_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Ptr{fmpz_mod_rel_series}, Int),
-               &c, &a, &b, lenc)
+                (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
+               c, a, b, lenc)
    return c
 end
 

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -23,7 +23,7 @@ function gens{S, N}(R::FmpzMPolyRing{S, N})
    for i = 1:R.num_vars
       z = R()
       ccall((:fmpz_mpoly_gen, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, i - 1, &R)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, i - 1, R)
       A[i] = z
    end
    return A
@@ -32,35 +32,35 @@ end
 function gen{S, N}(R::FmpzMPolyRing{S, N}, i::Int)
    z = R()
    ccall((:fmpz_mpoly_gen, :libflint), Void,
-            (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &z, i - 1, &R)
+            (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, i - 1, R)
    return z
 end
 
 function isgen(a::fmpz_mpoly)
    R = parent(a)
    return Bool(ccall((:fmpz_mpoly_is_gen, :libflint), Cint,
-              (Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &a.parent))
+              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent))
 end
 
 function isgen(a::fmpz_mpoly, i::Int)
    R = parent(a)
    return Bool(ccall((:fmpz_mpoly_is_gen_i, :libflint), Cint,
-              (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), &a, i - 1, &a.parent))
+              (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, i - 1, a.parent))
 end
 
 function coeff(a::fmpz_mpoly, i::Int)
    z = fmpz()
    ccall((:fmpz_mpoly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}),
-         &z, &a, i, &a.parent)
+         (Ref{fmpz}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+         z, a, i, a.parent)
    return z
 end
 
 function deepcopy(a::fmpz_mpoly)
    z = parent(a)()
    ccall((:fmpz_mpoly_set, :libflint), Void,
-         (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-         &z, &a, &a.parent)
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+         z, a, a.parent)
    return z
 end
 
@@ -76,7 +76,7 @@ function max_degrees{S, N}(a::fmpz_mpoly{S, N})
    R = a.parent
    A = Array(Int, N)
    ccall((:fmpz_mpoly_max_degrees, :libflint), Void,
-         (Ptr{Int}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), A, &a, &R)
+         (Ptr{Int}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), A, a, R)
    biggest = 0
    for i = 1:N
       if A[i] > biggest
@@ -97,8 +97,8 @@ function show(io::IO, x::fmpz_mpoly)
       print(io, "0")
    else
       cstr = ccall((:fmpz_mpoly_get_str_pretty, :libflint), Ptr{UInt8}, 
-          (Ptr{fmpz_mpoly}, Ptr{Ptr{UInt8}}, Ptr{FmpzMPolyRing}), 
-          &x, [string(s) for s in vars(parent(x))], &x.parent)
+          (Ref{fmpz_mpoly}, Ptr{Ptr{UInt8}}, Ref{FmpzMPolyRing}), 
+          x, [string(s) for s in vars(parent(x))], x.parent)
       print(io, unsafe_string(cstr))
 
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
@@ -133,40 +133,40 @@ end
 function -(a::fmpz_mpoly)
    z = parent(a)()
    ccall((:fmpz_mpoly_neg, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, a.parent)
    return z
 end
 
 function +{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    ccall((:fmpz_mpoly_add, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent)
    return z
 end
 
 function -{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    ccall((:fmpz_mpoly_sub, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent)
    return z
 end
 
 function *{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    ccall((:fmpz_mpoly_mul_johnson, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent)
    return z
 end
 
 function mul_array{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    ccall((:fmpz_mpoly_mul_array, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent)
    return z
 end
 
@@ -179,16 +179,16 @@ end
 function *(a::fmpz_mpoly, b::Int)
    r = parent(a)()
    ccall((:fmpz_mpoly_scalar_mul_si, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), 
-        &r, &a, b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
 function *(a::fmpz_mpoly, b::fmpz)
    r = parent(a)()
    ccall((:fmpz_mpoly_scalar_mul_fmpz, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}), 
-        &r, &a, &b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
@@ -199,16 +199,16 @@ end
 function +(a::fmpz_mpoly, b::Int)
    r = parent(a)()
    ccall((:fmpz_mpoly_add_si, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), 
-        &r, &a, b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
 function +(a::fmpz_mpoly, b::fmpz)
    r = parent(a)()
    ccall((:fmpz_mpoly_add_fmpz, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}), 
-        &r, &a, &b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
@@ -219,16 +219,16 @@ end
 function -(a::fmpz_mpoly, b::Int)
    r = parent(a)()
    ccall((:fmpz_mpoly_sub_si, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), 
-        &r, &a, b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
 function -(a::fmpz_mpoly, b::fmpz)
    r = parent(a)()
    ccall((:fmpz_mpoly_sub_fmpz, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}), 
-        &r, &a, &b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
@@ -246,8 +246,8 @@ function ^(a::fmpz_mpoly, b::Int)
    b < 0 && throw(DomainError())
    z = parent(a)()
    ccall((:fmpz_mpoly_pow_fps, :libflint), Void,
-         (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}),
-         &z, &a, b, &parent(a))
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+         z, a, b, parent(a))
    return z
 end
 
@@ -259,8 +259,8 @@ end
 
 function =={S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    return Bool(ccall((:fmpz_mpoly_equal, :libflint), Cint,
-               (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-               &a, &b, &a.parent))
+               (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+               a, b, a.parent))
 end
 
 ###############################################################################
@@ -271,16 +271,16 @@ end
 
 function ==(a::fmpz_mpoly, b::Int)
    return Bool(ccall((:fmpz_mpoly_equal_si, :libflint), Cint,
-               (Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}),
-               &a, b, &a.parent))
+               (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+               a, b, a.parent))
 end
 
 ==(a::Int, b::fmpz_mpoly) = b == a
 
 function ==(a::fmpz_mpoly, b::fmpz)
    return Bool(ccall((:fmpz_mpoly_equal_fmpz, :libflint), Cint,
-               (Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}),
-               &a, &b, &a.parent))
+               (Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}),
+               a, b, a.parent))
 end
 
 ==(a::fmpz, b::fmpz_mpoly) = b == a
@@ -298,8 +298,8 @@ end
 function divides_array{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    d = ccall((:fmpz_mpoly_divides_array, :libflint), Cint, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent)
    d == -1 && error("Polynomial too large for divides_array")
    return d == 1, z
 end
@@ -307,8 +307,8 @@ end
 function divides_monagan_pearce{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    z = parent(a)()
    d = Bool(ccall((:fmpz_mpoly_divides_monagan_pearce, :libflint), Cint, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &z, &a, &b, &a.parent))
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       z, a, b, a.parent))
    return d, z
 end
 
@@ -321,9 +321,9 @@ end
 function div_monagan_pearce{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    q = parent(a)()
    ccall((:fmpz_mpoly_div_monagan_pearce, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-        Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &q, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+        Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       q, a, b, a.parent)
    return q
 end
 
@@ -331,9 +331,9 @@ function divrem_monagan_pearce{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    q = parent(a)()
    r = parent(a)()
    ccall((:fmpz_mpoly_divrem_monagan_pearce, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-        Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &q, &r, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+        Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       q, r, a, b, a.parent)
    return q, r
 end
 
@@ -341,9 +341,9 @@ function divrem_array{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    q = parent(a)()
    r = parent(a)()
    d = ccall((:fmpz_mpoly_divrem_array, :libflint), Cint, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-        Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}),
-       &q, &r, &a, &b, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+        Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+       q, r, a, b, a.parent)
    d == 0 && error("Polynomials too large for divrem_array")
    return q, r
 end
@@ -353,9 +353,9 @@ function divrem_monagan_pearce{S, N}(a::fmpz_mpoly{S, N}, b::Array{fmpz_mpoly{S,
    q = [parent(a)() for i in 1:len]
    r = parent(a)()
    ccall((:fmpz_mpoly_divrem_ideal, :libflint), Void, 
-       (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-        Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}),
-       q, &r, &a, b, len, &a.parent)
+       (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+        Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+       q, r, a, b, len, a.parent)
    return q, r
 end
 
@@ -368,16 +368,16 @@ end
 function divexact(a::fmpz_mpoly, b::Int)
    r = parent(a)()
    ccall((:fmpz_mpoly_scalar_divexact_si, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Int, Ptr{FmpzMPolyRing}), 
-        &r, &a, b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
 function divexact(a::fmpz_mpoly, b::fmpz)
    r = parent(a)()
    ccall((:fmpz_mpoly_scalar_divexact_fmpz, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly}, Ptr{fmpz}, Ptr{FmpzMPolyRing}), 
-        &r, &a, &b, &a.parent)
+        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), 
+        r, a, b, a.parent)
    return r
 end
 
@@ -391,28 +391,28 @@ divexact(a::fmpz_mpoly, b::Integer) = divexact(a, fmpz(b))
 
 function addeq!{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N})
    ccall((:fmpz_mpoly_add, :libflint), Void,
-         (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-          Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &a, &b, &a.parent)
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+          Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a, b, a.parent)
    return a
 end
 
 function mul!{S, N}(a::fmpz_mpoly{S, N}, b::fmpz_mpoly{S, N}, c::fmpz_mpoly{S, N})
    ccall((:fmpz_mpoly_mul_johnson, :libflint), Void,
-         (Ptr{fmpz_mpoly}, Ptr{fmpz_mpoly},
-          Ptr{fmpz_mpoly}, Ptr{FmpzMPolyRing}), &a, &b, &c, &a.parent)
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
+          Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, b, c, a.parent)
    return a
 end
 
 function setcoeff!(a::fmpz_mpoly, i::Int, c::Int)
    ccall((:fmpz_mpoly_set_coeff_si, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Int, Int, Ptr{FmpzMPolyRing}), &a, i, c, &a.parent)
+        (Ref{fmpz_mpoly}, Int, Int, Ref{FmpzMPolyRing}), a, i, c, a.parent)
    return a
 end
 
 function setcoeff!(a::fmpz_mpoly, i::Int, c::fmpz)
    ccall((:fmpz_mpoly_set_coeff_fmpz, :libflint), Void,
-        (Ptr{fmpz_mpoly}, Int, Ptr{fmpz}, Ptr{FmpzMPolyRing}),
-                                                          &a, i, &c, &a.parent)
+        (Ref{fmpz_mpoly}, Int, Ref{fmpz}, Ref{FmpzMPolyRing}),
+                                                          a, i, c, a.parent)
    return a
 end
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -30,13 +30,13 @@ var(a::FmpzPolyRing) = a.S
 ###############################################################################   
    
 length(x::fmpz_poly) = ccall((:fmpz_poly_length, :libflint), Int, 
-                             (Ptr{fmpz_poly},), &x)
+                             (Ref{fmpz_poly},), x)
 
 function coeff(x::fmpz_poly, n::Int)
    n < 0 && throw(DomainError())
    z = fmpz()
    ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void, 
-               (Ptr{fmpz}, Ptr{fmpz_poly}, Int), &z, &x, n)
+               (Ref{fmpz}, Ref{fmpz_poly}, Int), z, x, n)
    return z
 end
 
@@ -47,7 +47,7 @@ one(a::FmpzPolyRing) = a(1)
 gen(a::FmpzPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 isgen(x::fmpz_poly) = ccall((:fmpz_poly_is_x, :libflint), Bool, 
-                            (Ptr{fmpz_poly},), &x)
+                            (Ref{fmpz_poly},), x)
 
 function deepcopy_internal(a::fmpz_poly, dict::ObjectIdDict)
    z = fmpz_poly(a)
@@ -74,7 +74,7 @@ function show(io::IO, x::fmpz_poly)
       print(io, "0")
    else
       cstr = ccall((:fmpz_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-          (Ptr{fmpz_poly}, Ptr{UInt8}), &x, string(var(parent(x))))
+          (Ref{fmpz_poly}, Ptr{UInt8}), x, string(var(parent(x))))
 
       print(io, unsafe_string(cstr))
 
@@ -100,7 +100,7 @@ show_minus_one(::Type{fmpz_poly}) = show_minus_one(fmpz)
 function -(x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_neg, :libflint), Void, 
-         (Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x)
+         (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
 
@@ -114,8 +114,8 @@ function +(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_add, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly},  Ptr{fmpz_poly}), 
-               &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}), 
+               z, x, y)
    return z
 end
 
@@ -123,8 +123,8 @@ function -(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_sub, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly},  Ptr{fmpz_poly}), 
-               &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}), 
+               z, x, y)
    return z
 end
 
@@ -132,8 +132,8 @@ function *(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_mul, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly},  Ptr{fmpz_poly}), 
-               &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}), 
+               z, x, y)
    return z
 end
 
@@ -146,56 +146,56 @@ end
 function *(x::Int, y::fmpz_poly)
    z = parent(y)()
    ccall((:fmpz_poly_scalar_mul_si, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &y, x)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpz_poly)
    z = parent(y)()
    ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz}), &z, &y, &x)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function +(x::fmpz_poly, y::Int)
    z = parent(x)()
    ccall((:fmpz_poly_add_si, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
 
 function +(x::fmpz_poly, y::fmpz)
    z = parent(x)()
    ccall((:fmpz_poly_add_fmpz, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::fmpz_poly, y::Int)
    z = parent(x)()
    ccall((:fmpz_poly_sub_si, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
 
 function -(x::fmpz_poly, y::fmpz)
    z = parent(x)()
    ccall((:fmpz_poly_sub_fmpz, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::Int, y::fmpz_poly)
    z = parent(y)()
    ccall((:fmpz_poly_si_sub, :libflint), Void, 
-                (Ptr{fmpz_poly}, Int, Ptr{fmpz_poly}), &z, x, &y)
+                (Ref{fmpz_poly}, Int, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpz, y::fmpz_poly)
    z = parent(y)()
    ccall((:fmpz_poly_fmpz_sub, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
@@ -229,8 +229,8 @@ function ^(x::fmpz_poly, y::Int)
    y < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpz_poly_pow, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), 
-               &z, &x, y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), 
+               z, x, y)
    return z
 end
 
@@ -243,7 +243,7 @@ end
 function ==(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    return ccall((:fmpz_poly_equal, :libflint), Bool, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}), &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}), x, y)
 end
 
 ###############################################################################
@@ -258,9 +258,9 @@ function ==(x::fmpz_poly, y::fmpz)
    elseif length(x) == 1 
       z = fmpz()
       ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void, 
-                       (Ptr{fmpz}, Ptr{fmpz_poly}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_poly}, Int), z, x, 0)
       return ccall((:fmpz_equal, :libflint), Bool, 
-               (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &y, 0)
+               (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
    else
       return iszero(y)
    end 
@@ -287,7 +287,7 @@ function truncate(a::fmpz_poly, n::Int)
 
    z = parent(a)()
    ccall((:fmpz_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &a, n)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, a, n)
    return z
 end
 
@@ -297,7 +297,7 @@ function mullow(x::fmpz_poly, y::fmpz_poly, n::Int)
    
    z = parent(x)()
    ccall((:fmpz_poly_mullow, :libflint), Void,
-         (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, &y, n)
+         (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y, n)
    return z
 end
 
@@ -311,7 +311,7 @@ function reverse(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpz_poly_reverse, :libflint), Void,
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, len)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
 
@@ -325,7 +325,7 @@ function shift_left(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpz_poly_shift_left, :libflint), Void,
-      (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, len)
+      (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
 
@@ -333,7 +333,7 @@ function shift_right(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fmpz_poly_shift_right, :libflint), Void,
-       (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, len)
+       (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
 
@@ -348,7 +348,7 @@ function divexact(x::fmpz_poly, y::fmpz_poly)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    ccall((:fmpz_poly_div, :libflint), Void, 
-            (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+            (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
@@ -358,7 +358,7 @@ function divrem(x::fmpz_poly, y::fmpz_poly)
    z = parent(x)()
    r = parent(x)()
    ccall((:fmpz_poly_divrem, :libflint), Void, 
-            (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &r, &x, &y)
+            (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, r, x, y)
    return z, r
 end
 
@@ -367,7 +367,7 @@ function divides(x::fmpz_poly, y::fmpz_poly)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    flag = Bool(ccall((:fmpz_poly_divides, :libflint), Cint,
-           (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y))
+           (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y))
    return flag, z
 end
 
@@ -381,7 +381,7 @@ function divexact(x::fmpz_poly, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Void, 
-          (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz}), &z, &x, &y)
+          (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -389,7 +389,7 @@ function divexact(x::fmpz_poly, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
    ccall((:fmpz_poly_scalar_divexact_si, :libflint), Void, 
-                        (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Int), &z, &x, y)
+                        (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
 
@@ -408,7 +408,7 @@ function pseudorem(x::fmpz_poly, y::fmpz_poly)
    r = parent(x)()
    d = Array{Int}(1)
    ccall((:fmpz_poly_pseudo_rem, :libflint), Void, 
-     (Ptr{fmpz_poly}, Ptr{Int}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &r, d, &x, &y)
+     (Ref{fmpz_poly}, Ptr{Int}, Ref{fmpz_poly}, Ref{fmpz_poly}), r, d, x, y)
    if (diff > d[1])
       return lead(y)^(diff - d[1])*r
    else
@@ -424,8 +424,8 @@ function pseudodivrem(x::fmpz_poly, y::fmpz_poly)
    r = parent(x)()
    d = Array{Int}(1)
    ccall((:fmpz_poly_pseudo_divrem_divconquer, :libflint), Void, 
-    (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{Int}, Ptr{fmpz_poly}, Ptr{fmpz_poly}),
-               &q, &r, d, &x, &y)
+    (Ref{fmpz_poly}, Ref{fmpz_poly}, Ptr{Int}, Ref{fmpz_poly}, Ref{fmpz_poly}),
+               q, r, d, x, y)
    if (diff > d[1])
       m = lead(y)^(diff - d[1])
       return m*q, m*r
@@ -444,21 +444,21 @@ function gcd(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_gcd, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function content(x::fmpz_poly)
    z = fmpz()
    ccall((:fmpz_poly_content, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_poly}), &z, &x)
+         (Ref{fmpz}, Ref{fmpz_poly}), z, x)
    return z
 end
 
 function primpart(x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_primitive_part, :libflint), Void, 
-         (Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x)
+         (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
 
@@ -471,7 +471,7 @@ end
 function evaluate(x::fmpz_poly, y::fmpz)
    z = fmpz()
    ccall((:fmpz_poly_evaluate_fmpz, :libflint), Void, 
-        (Ptr{fmpz}, Ptr{fmpz_poly}, Ptr{fmpz}), &z, &x, &y)
+        (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
@@ -487,7 +487,7 @@ function compose(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_compose, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
@@ -500,7 +500,7 @@ end
 function derivative(x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_derivative, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
 
@@ -514,7 +514,7 @@ function resultant(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = fmpz()
    ccall((:fmpz_poly_resultant, :libflint), Void, 
-                (Ptr{fmpz}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
@@ -527,7 +527,7 @@ end
 function discriminant(x::fmpz_poly)
    z = fmpz()
    ccall((:fmpz_poly_discriminant, :libflint), Void, 
-                (Ptr{fmpz}, Ptr{fmpz_poly}), &z, &x)
+                (Ref{fmpz}, Ref{fmpz_poly}), z, x)
    return z
 end
 
@@ -553,8 +553,8 @@ function resx(a::fmpz_poly, b::fmpz_poly)
    x = divexact(a, c1)
    y = divexact(b, c2)
    ccall((:fmpz_poly_xgcd_modular, :libflint), Void, 
-   (Ptr{fmpz}, Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), 
-            &z, &u, &v, &x, &y)
+   (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), 
+            z, u, v, x, y)
    r = z*c1^(lenb - 1)*c2^(lena - 1)
    if lenb > 1
       u *= c1^(lenb - 2)*c2^(lena - 1)
@@ -587,7 +587,7 @@ function signature(f::fmpz_poly)
    r = Array{Int}(1)
    s = Array{Int}(1)
    ccall((:fmpz_poly_signature, :libflint), Void,
-         (Ptr{Int}, Ptr{Int}, Ptr{fmpz_poly}), r, s, &f)
+         (Ptr{Int}, Ptr{Int}, Ref{fmpz_poly}), r, s, f)
    return (r[1], s[1])
 end
 
@@ -612,8 +612,8 @@ function interpolate(R::FmpzPolyRing, x::Array{fmpz, 1},
   end
 
   ccall((:fmpz_poly_interpolate_fmpz_vec, :libflint), Void,
-          (Ptr{fmpz_poly}, Ptr{Int}, Ptr{Int}, Int),
-          &z, ax, ay, length(x))
+          (Ref{fmpz_poly}, Ptr{Int}, Ptr{Int}, Int),
+          z, ax, ay, length(x))
   return z
 end
 
@@ -641,15 +641,15 @@ end
 function _factor(x::fmpz_poly)
   fac = fmpz_poly_factor()
   ccall((:fmpz_poly_factor, :libflint), Void,
-              (Ptr{fmpz_poly_factor}, Ptr{fmpz_poly}), &fac, &x)
+              (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, x)
   res = Dict{fmpz_poly,Int}()
   z = fmpz()
   ccall((:fmpz_poly_factor_get_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_poly_factor}), &z, &fac)
+            (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fmpz_poly_factor_get_fmpz_poly, :libflint), Void,
-            (Ptr{fmpz_poly}, Ptr{fmpz_poly_factor}, Int), &f, &fac, i - 1)
+            (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
   end
@@ -665,14 +665,14 @@ end
 function chebyshev_t(n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_chebyshev_t, :libflint), Void, 
-                                                  (Ptr{fmpz_poly}, Int), &z, n)
+                                                  (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
    
 function chebyshev_u(n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_chebyshev_u, :libflint), Void, 
-                                                  (Ptr{fmpz_poly}, Int), &z, n)
+                                                  (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
 
@@ -685,7 +685,7 @@ doc"""
 function cyclotomic(n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_cyclotomic, :libflint), Void, 
-                                                  (Ptr{fmpz_poly}, Int), &z, n)
+                                                  (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
    
@@ -701,7 +701,7 @@ doc"""
 function swinnerton_dyer(n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_swinnerton_dyer, :libflint), Void, 
-                                                  (Ptr{fmpz_poly}, Int), &z, n)
+                                                  (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
    
@@ -714,7 +714,7 @@ doc"""
 function cos_minpoly(n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_cos_minpoly, :libflint), Void, 
-                                                  (Ptr{fmpz_poly}, Int), &z, n)
+                                                  (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
    
@@ -727,7 +727,7 @@ doc"""
 function theta_qexp(e::Int, n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_theta_qexp, :libflint), Void, 
-                                          (Ptr{fmpz_poly}, Int, Int), &z, e, n)
+                                          (Ref{fmpz_poly}, Int, Int), z, e, n)
    return isgen(x) ? z : compose(z, x)
 end
 
@@ -744,7 +744,7 @@ doc"""
 function eta_qexp(e::Int, n::Int, x::fmpz_poly)
    z = parent(x)()
    ccall((:fmpz_poly_eta_qexp, :libflint), Void, 
-                                          (Ptr{fmpz_poly}, Int, Int), &z, e, n)
+                                          (Ref{fmpz_poly}, Int, Int), z, e, n)
    return isgen(x) ? z : compose(z, x)
 end
 
@@ -771,37 +771,37 @@ end
 
 function zero!(z::fmpz_poly)
    ccall((:fmpz_poly_zero, :libflint), Void, 
-                    (Ptr{fmpz_poly},), &z)
+                    (Ref{fmpz_poly},), z)
    return z
 end
 
 function fit!(z::fmpz_poly, n::Int)
    ccall((:fmpz_poly_fit_length, :libflint), Void, 
-                    (Ptr{fmpz_poly}, Int), &z, n)
+                    (Ref{fmpz_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::fmpz_poly, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void, 
-                    (Ptr{fmpz_poly}, Int, Ptr{fmpz}), &z, n, &x)
+                    (Ref{fmpz_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function mul!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
    ccall((:fmpz_poly_mul, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpz_poly, x::fmpz_poly)
    ccall((:fmpz_poly_add, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &z, &x)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, z, x)
    return z
 end
 
 function add!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
    ccall((:fmpz_poly_add, :libflint), Void, 
-                (Ptr{fmpz_poly}, Ptr{fmpz_poly}, Ptr{fmpz_poly}), &z, &x, &y)
+                (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -40,20 +40,20 @@ function normalise(a::fmpz_rel_series, len::Int)
    if len > 0
       c = fmpz()
       ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_rel_series}, Int), &c, &a, len - 1)
+         (Ref{fmpz}, Ref{fmpz_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-            (Ptr{fmpz}, Ptr{fmpz_rel_series}, Int), &c, &a, len - 1)
+            (Ref{fmpz}, Ref{fmpz_rel_series}, Int), c, a, len - 1)
       end
    end
    return len
 end
 
 function pol_length(x::fmpz_rel_series)
-   return ccall((:fmpz_poly_length, :libflint), Int, (Ptr{fmpz_rel_series},), &x)
+   return ccall((:fmpz_poly_length, :libflint), Int, (Ref{fmpz_rel_series},), x)
 end
 
 precision(x::fmpz_rel_series) = x.prec
@@ -64,7 +64,7 @@ function polcoeff(x::fmpz_rel_series, n::Int)
    end
    z = fmpz()
    ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fmpz_rel_series}, Int), &z, &x, n)
+         (Ref{fmpz}, Ref{fmpz_rel_series}, Int), z, x, n)
    return z
 end
 
@@ -100,7 +100,7 @@ function renormalize!(z::fmpz_rel_series)
    else
       z.val = zval + i
       ccall((:fmpz_poly_shift_right, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int), &z, &z, i)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int), z, z, i)
    end
    return nothing
 end
@@ -127,8 +127,8 @@ show_minus_one(::Type{fmpz_rel_series}) = show_minus_one(fmpz)
 function -(x::fmpz_rel_series)
    z = parent(x)()
    ccall((:fmpz_poly_neg, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}),
-               &z, &x)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}),
+               z, x)
    z.prec = x.prec
    z.val = x.val
    return z
@@ -152,30 +152,30 @@ function +(a::fmpz_rel_series, b::fmpz_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -196,32 +196,32 @@ function -(a::fmpz_rel_series, b::fmpz_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_poly_neg, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}), &z, &z)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}), z, z)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:fmpz_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_poly_sub_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -246,8 +246,8 @@ function *(a::fmpz_rel_series, b::fmpz_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fmpz_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, a, b, lenz)
 
    return z
 end
@@ -263,8 +263,8 @@ function *(x::Int, y::fmpz_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpz_poly_scalar_mul_si, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &y, x)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, y, x)
    return z
 end
 
@@ -275,8 +275,8 @@ function *(x::fmpz, y::fmpz_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz}),
-               &z, &y, &x)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz}),
+               z, y, x)
    return z
 end
 
@@ -311,8 +311,8 @@ function shift_right(x::fmpz_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:fmpz_poly_shift_right, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &x, xlen - zlen)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, x, xlen - zlen)
       renormalize!(z)
    end
    return z
@@ -341,8 +341,8 @@ function truncate(x::fmpz_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &x, min(prec - xval, xlen))
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, x, min(prec - xval, xlen))
    end
    return z
 end
@@ -374,8 +374,8 @@ function ^(a::fmpz_rel_series, b::Int)
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
       ccall((:fmpz_poly_pow_trunc, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int, Int),
-               &z, &a, b, z.prec - z.val)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int, Int),
+               z, a, b, z.prec - z.val)
    end
    return z
 end
@@ -401,8 +401,8 @@ function ==(x::fmpz_rel_series, y::fmpz_rel_series)
       return false
    end
    return Bool(ccall((:fmpz_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &x, &y, xlen))
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               x, y, xlen))
 end
 
 function isequal(x::fmpz_rel_series, y::fmpz_rel_series)
@@ -413,8 +413,8 @@ function isequal(x::fmpz_rel_series, y::fmpz_rel_series)
       return false
    end
    return Bool(ccall((:fmpz_poly_equal, :libflint), Cint,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &x, &y, pol_length(x)))
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               x, y, pol_length(x)))
 end
 
 ###############################################################################
@@ -432,9 +432,9 @@ function ==(x::fmpz_rel_series, y::fmpz)
       if x.val == 0
          z = fmpz()
          ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-                       (Ptr{fmpz}, Ptr{fmpz_rel_series}, Int), &z, &x, 0)
+                       (Ref{fmpz}, Ref{fmpz_rel_series}, Int), z, x, 0)
          return ccall((:fmpz_equal, :libflint), Bool,
-               (Ptr{fmpz}, Ptr{fmpz}, Int), &z, &y, 0)
+               (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
       else
          return false
       end
@@ -473,8 +473,8 @@ function divexact(x::fmpz_rel_series, y::fmpz_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:fmpz_poly_div_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, x, y, prec)
    end
    return z
 end
@@ -491,8 +491,8 @@ function divexact(x::fmpz_rel_series, y::Int)
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpz_poly_scalar_divexact_si, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &x, y)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, x, y)
    return z
 end
 
@@ -503,8 +503,8 @@ function divexact(x::fmpz_rel_series, y::fmpz)
    z.prec = x.prec
    z.val = x.val
    ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz}),
-               &z, &x, &y)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz}),
+               z, x, y)
    return z
 end
 
@@ -523,8 +523,8 @@ function inv(a::fmpz_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:fmpz_poly_inv_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -536,15 +536,15 @@ end
 
 function zero!(x::fmpz_rel_series)
   ccall((:fmpz_poly_zero, :libflint), Void,
-                   (Ptr{fmpz_rel_series},), &x)
+                   (Ref{fmpz_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function setcoeff!(z::fmpz_rel_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Int, Ptr{fmpz}),
-               &z, n, &x)
+                (Ref{fmpz_rel_series}, Int, Ref{fmpz}),
+               z, n, x)
    return z
 end
 
@@ -563,8 +563,8 @@ function mul!(z::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
       lenz = 0
    end
    ccall((:fmpz_poly_mullow, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               z, a, b, lenz)
    return z
 end
 
@@ -579,30 +579,30 @@ function addeq!(a::fmpz_rel_series, b::fmpz_rel_series)
       z = fmpz_rel_series()
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_poly_set_trunc, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &a, &a, &z, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fmpz_poly_truncate, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Int),
-            &a, max(0, lenz - a.val + b.val))
+            (Ref{fmpz_rel_series}, Int),
+            a, max(0, lenz - a.val + b.val))
       ccall((:fmpz_poly_shift_left, :libflint), Void,
-            (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-            &a, &a, a.val - b.val)
+            (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+            a, a, a.val - b.val)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               a, a, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               a, a, b, lenz)
    end
    a.prec = prec
    a.val = val
@@ -622,8 +622,8 @@ function add!(c::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:fmpz_poly_add_series, :libflint), Void,
-                (Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Ptr{fmpz_rel_series}, Int),
-               &c, &a, &b, lenc)
+                (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
+               c, a, b, lenc)
    return c
 end
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -65,7 +65,7 @@ function coeff(x::fq, n::Int)
    n < 0 && throw(DomainError())
    z = fmpz()
    ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Void,
-               (Ptr{fmpz}, Ptr{fq}, Int), &z, &x, n)
+               (Ref{fmpz}, Ref{fq}, Int), z, x, n)
    return z
 end
 
@@ -75,7 +75,7 @@ doc"""
 """
 function zero(a::FqFiniteField)
    d = a()
-   ccall((:fq_zero, :libflint), Void, (Ptr{fq}, Ptr{FqFiniteField}), &d, &a)
+   ccall((:fq_zero, :libflint), Void, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -85,7 +85,7 @@ doc"""
 """
 function one(a::FqFiniteField)
    d = a()
-   ccall((:fq_one, :libflint), Void, (Ptr{fq}, Ptr{FqFiniteField}), &d, &a)
+   ccall((:fq_one, :libflint), Void, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -97,7 +97,7 @@ doc"""
 """
 function gen(a::FqFiniteField)
    d = a()
-   ccall((:fq_gen, :libflint), Void, (Ptr{fq}, Ptr{FqFiniteField}), &d, &a)
+   ccall((:fq_gen, :libflint), Void, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -107,7 +107,7 @@ doc"""
 > `false`.
 """
 iszero(a::fq) = ccall((:fq_is_zero, :libflint), Bool,
-                     (Ptr{fq}, Ptr{FqFiniteField}), &a, &a.parent)
+                     (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 doc"""
     isone(a::fq)
@@ -115,7 +115,7 @@ doc"""
 > `false`.
 """
 isone(a::fq) = ccall((:fq_is_one, :libflint), Bool,
-                    (Ptr{fq}, Ptr{FqFiniteField}), &a, &a.parent)
+                    (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 doc"""
     isgen(a::fq)
@@ -130,7 +130,7 @@ doc"""
 > otherwise return `false`.
 """
 isunit(a::fq) = ccall((:fq_is_invertible, :libflint), Bool,
-                     (Ptr{fq}, Ptr{FqFiniteField}), &a, &a.parent)
+                     (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 doc"""
     characteristic(a::FqFiniteField)
@@ -139,7 +139,7 @@ doc"""
 function characteristic(a::FqFiniteField)
    d = fmpz()
    ccall((:__fq_ctx_prime, :libflint), Void,
-         (Ptr{fmpz}, Ptr{FqFiniteField}), &d, &a)
+         (Ref{fmpz}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -150,7 +150,7 @@ doc"""
 function order(a::FqFiniteField)
    d = fmpz()
    ccall((:fq_ctx_order, :libflint), Void,
-         (Ptr{fmpz}, Ptr{FqFiniteField}), &d, &a)
+         (Ref{fmpz}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -159,7 +159,7 @@ doc"""
 > Return the degree of the given finite field.
 """
 function degree(a::FqFiniteField)
-   return ccall((:fq_ctx_degree, :libflint), Int, (Ptr{FqFiniteField},), &a)
+   return ccall((:fq_ctx_degree, :libflint), Int, (Ref{FqFiniteField},), a)
 end
 
 function deepcopy_internal(d::fq, dict::ObjectIdDict)
@@ -183,7 +183,7 @@ canonical_unit(x::fq) = x
 
 function show(io::IO, x::fq)
    cstr = ccall((:fq_get_str_pretty, :libflint), Ptr{UInt8},
-                (Ptr{fq}, Ptr{FqFiniteField}), &x, &x.parent)
+                (Ref{fq}, Ref{FqFiniteField}), x, x.parent)
 
    print(io, unsafe_string(cstr))
 
@@ -210,7 +210,7 @@ show_minus_one(::Type{fq}) = true
 function -(x::fq)
    z = parent(x)()
    ccall((:fq_neg, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &x.parent)
+         (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
 
@@ -224,7 +224,7 @@ function +(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_add, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
@@ -232,7 +232,7 @@ function -(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_sub, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
@@ -240,7 +240,7 @@ function *(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_mul, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
@@ -253,7 +253,7 @@ end
 function *(x::Int, y::fq)
    z = parent(y)()
    ccall((:fq_mul_si, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Int, Ptr{FqFiniteField}), &z, &y, x, &y.parent)
+         (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, y, x, y.parent)
    return z
 end
 
@@ -264,8 +264,8 @@ end
 function *(x::fmpz, y::fq)
    z = parent(y)()
    ccall((:fq_mul_fmpz, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Ptr{fmpz}, Ptr{FqFiniteField}),
-                                            &z, &y, &x, &y.parent)
+         (Ref{fq}, Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}),
+                                            z, y, x, y.parent)
    return z
 end
 
@@ -300,7 +300,7 @@ function ^(x::fq, y::Int)
    end
    z = parent(x)()
    ccall((:fq_pow_ui, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Int, Ptr{FqFiniteField}), &z, &x, y, &x.parent)
+         (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, x, y, x.parent)
    return z
 end
 
@@ -311,8 +311,8 @@ function ^(x::fq, y::fmpz)
    end
    z = parent(x)()
    ccall((:fq_pow, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Ptr{fmpz}, Ptr{FqFiniteField}),
-                                            &z, &x, &y, &x.parent)
+         (Ref{fq}, Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}),
+                                            z, x, y, x.parent)
    return z
 end
 
@@ -325,7 +325,7 @@ end
 function ==(x::fq, y::fq)
    check_parent(x, y)
    ccall((:fq_equal, :libflint), Bool,
-         (Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &x, &y, &y.parent)
+         (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), x, y, y.parent)
 end
 
 ###############################################################################
@@ -353,7 +353,7 @@ function divexact(x::fq, y::fq)
    iszero(y) && throw(DivideError())
    z = parent(y)()
    ccall((:fq_div, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
@@ -390,7 +390,7 @@ function inv(x::fq)
    iszero(x) && throw(DivideError())
    z = parent(x)()
    ccall((:fq_inv, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &x.parent)
+         (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
 
@@ -408,7 +408,7 @@ doc"""
 function pth_root(x::fq)
    z = parent(x)()
    ccall((:fq_pth_root, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &x.parent)
+         (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
 
@@ -420,7 +420,7 @@ doc"""
 function trace(x::fq)
    z = fmpz()
    ccall((:fq_trace, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &x.parent)
+         (Ref{fmpz}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
@@ -432,7 +432,7 @@ doc"""
 function norm(x::fq)
    z = fmpz()
    ccall((:fq_norm, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &x.parent)
+         (Ref{fmpz}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
@@ -446,7 +446,7 @@ doc"""
 function frobenius(x::fq, n = 1)
    z = parent(x)()
    ccall((:fq_frobenius, :libflint), Void,
-         (Ptr{fq}, Ptr{fq}, Int, Ptr{FqFiniteField}), &z, &x, n, &x.parent)
+         (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, x, n, x.parent)
    return z
 end
 
@@ -458,28 +458,27 @@ end
 
 function zero!(z::fq)
    ccall((:fq_zero, :libflint), Void,
-        (Ptr{fq}, Ptr{FqFiniteField}), &z, &z.parent)
+        (Ref{fq}, Ref{FqFiniteField}), z, z.parent)
    return z
 end
 
 function mul!(z::fq, x::fq, y::fq)
    ccall((:fq_mul, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &y.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
 function addeq!(z::fq, x::fq)
    ccall((:fq_add, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &z, &x, &x.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, z, x, x.parent)
    return z
 end
 
 function add!(z::fq, x::fq, y::fq)
    ccall((:fq_add, :libflint), Void,
-        (Ptr{fq}, Ptr{fq}, Ptr{fq}, Ptr{FqFiniteField}), &z, &x, &y, &x.parent)
+        (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, x.parent)
    return z
 end
-
 
 ###############################################################################
 #
@@ -492,6 +491,8 @@ function rand(K::FinField)
 	r = degree(K)
 	alpha = gen(K)
 	res = zero(K)
+  range = BigInt(0):BigInt(p - 1)
+  return rand(range)
 	for i = 0 : (r-1)
 		c = rand(BigInt(0) : BigInt(p - 1))
 		res += c * alpha^i

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -44,15 +44,15 @@ function normalise(a::fq_abs_series, len::Int)
    if len > 0
       c = base_ring(a)()
       ccall((:fq_poly_get_coeff, :libflint), Void,
-         (Ptr{fq}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-          &c, &a, len - 1, &ctx)
+         (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+          c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fq_poly_get_coeff, :libflint), Void,
-            (Ptr{fq}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-             &c, &a, len - 1, &ctx)
+            (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+             c, a, len - 1, ctx)
       end
    end
 
@@ -61,7 +61,7 @@ end
 
 function length(x::fq_abs_series)
    return ccall((:fq_poly_length, :libflint), Int,
-                (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &x, &base_ring(x))
+                (Ref{fq_abs_series}, Ref{FqFiniteField}), x, base_ring(x))
 end
 
 precision(x::fq_abs_series) = x.prec
@@ -72,8 +72,8 @@ function coeff(x::fq_abs_series, n::Int)
    end
    z = base_ring(x)()
    ccall((:fq_poly_get_coeff, :libflint), Void,
-         (Ptr{fq}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-          &z, &x, n, &base_ring(x))
+         (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+          z, x, n, base_ring(x))
    return z
 end
 
@@ -97,7 +97,7 @@ end
 
 function isgen(a::fq_abs_series)
    return precision(a) == 0 || ccall((:fq_poly_is_gen, :libflint), Bool,
-                   (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &a, &base_ring(a))
+                   (Ref{fq_abs_series}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
 iszero(a::fq_abs_series) = length(a) == 0
@@ -106,7 +106,7 @@ isunit(a::fq_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fq_abs_series)
    return precision(a) == 0 || ccall((:fq_poly_is_one, :libflint), Bool,
-                   (Ptr{fq_abs_series}, Ptr{FqFiniteField}), &a, &base_ring(a))
+                   (Ref{fq_abs_series}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
 # todo: write an fq_poly_valuation
@@ -141,8 +141,8 @@ show_minus_one(::Type{fq_abs_series}) = show_minus_one(fq)
 function -(x::fq_abs_series)
    z = parent(x)()
    ccall((:fq_poly_neg, :libflint), Void,
-                (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Ptr{FqFiniteField}),
-               &z, &x, &base_ring(x))
+                (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{FqFiniteField}),
+               z, x, base_ring(x))
    z.prec = x.prec
    return z
 end
@@ -164,9 +164,9 @@ function +(a::fq_abs_series, b::fq_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fq_poly_add_series, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -181,9 +181,9 @@ function -(a::fq_abs_series, b::fq_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fq_poly_sub_series, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -204,9 +204,9 @@ function *(a::fq_abs_series, b::fq_abs_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fq_poly_mullow, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -220,8 +220,8 @@ function *(x::fq, y::fq_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fq_poly_scalar_mul_fq, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, &y, &x, &base_ring(y))
+         (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{fq}, Ref{FqFiniteField}),
+               z, y, x, base_ring(y))
    return z
 end
 
@@ -239,8 +239,8 @@ function shift_left(x::fq_abs_series, len::Int)
    z = parent(x)()
    z.prec = x.prec + len
    ccall((:fq_poly_shift_left, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &x, len, &base_ring(x))
+         (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, x, len, base_ring(x))
    return z
 end
 
@@ -253,8 +253,8 @@ function shift_right(x::fq_abs_series, len::Int)
    else
       z.prec = x.prec - len
       ccall((:fq_poly_shift_right, :libflint), Void,
-            (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &x, len, &base_ring(x))
+            (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, x, len, base_ring(x))
    end
    return z
 end
@@ -273,8 +273,8 @@ function truncate(x::fq_abs_series, prec::Int)
    z = parent(x)()
    z.prec = prec
    ccall((:fq_poly_set_trunc, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &x, prec, &base_ring(x))
+         (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, x, prec, base_ring(x))
    return z
 end
 
@@ -323,8 +323,8 @@ function ==(x::fq_abs_series, y::fq_abs_series)
    n = max(length(x), length(y))
    n = min(n, prec)
    return Bool(ccall((:fq_poly_equal_trunc, :libflint), Cint,
-             (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &x, &y, n, &base_ring(x)))
+             (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               x, y, n, base_ring(x)))
 end
 
 function isequal(x::fq_abs_series, y::fq_abs_series)
@@ -335,8 +335,8 @@ function isequal(x::fq_abs_series, y::fq_abs_series)
       return false
    end
    return Bool(ccall((:fq_poly_equal, :libflint), Cint,
-             (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &x, &y, length(x), &base_ring(x)))
+             (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               x, y, length(x), base_ring(x)))
 end
 
 ###############################################################################
@@ -351,8 +351,8 @@ function ==(x::fq_abs_series, y::fq)
    elseif length(x) == 1
       z = base_ring(x)()
       ccall((:fq_poly_get_coeff, :libflint), Void,
-            (Ptr{fq}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-             &z, &x, 0, &base_ring(x))
+            (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+             z, x, 0, base_ring(x))
       return z == y
    else
       return precision(x) == 0 || iszero(y)
@@ -367,8 +367,8 @@ function ==(x::fq_abs_series, y::fmpz)
    elseif length(x) == 1
       z = base_ring(x)()
       ccall((:fq_poly_get_coeff, :libflint), Void,
-            (Ptr{fq}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-             &z, &x, 0, &base_ring(x))
+            (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+             z, x, 0, base_ring(x))
       return z == y
    else
       return precision(x) == 0 || iszero(y)
@@ -403,9 +403,9 @@ function divexact(x::fq_abs_series, y::fq_abs_series)
    z = parent(x)()
    z.prec = prec
    ccall((:fq_poly_div_series, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &x, &y, prec, &base_ring(x))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, x, y, prec, base_ring(x))
    return z
 end
 
@@ -420,8 +420,8 @@ function divexact(x::fq_abs_series, y::fq)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fq_poly_scalar_div_fq, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, &x, &y, &base_ring(x))
+         (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{fq}, Ref{FqFiniteField}),
+               z, x, y, base_ring(x))
    return z
 end
 
@@ -437,8 +437,8 @@ function inv(a::fq_abs_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ccall((:fq_poly_inv_series, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &ainv, &a, a.prec, &base_ring(a))
+         (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               ainv, a, a.prec, base_ring(a))
    return ainv
 end
 
@@ -450,15 +450,15 @@ end
 
 function fit!(z::fq_abs_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void,
-         (Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-         &z, n, &base_ring(z))
+         (Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+         z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_abs_series, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void,
-                (Ptr{fq_abs_series}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_abs_series}, Int, Ref{fq}, Ref{FqFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
@@ -477,9 +477,9 @@ function mul!(z::fq_abs_series, a::fq_abs_series, b::fq_abs_series)
    end
    z.prec = prec
    ccall((:fq_poly_mullow, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(z))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(z))
    return z
 end
 
@@ -492,9 +492,9 @@ function addeq!(a::fq_abs_series, b::fq_abs_series)
    lenz = max(lena, lenb)
    a.prec = prec
    ccall((:fq_poly_add_series, :libflint), Void,
-         (Ptr{fq_abs_series}, Ptr{fq_abs_series},
-          Ptr{fq_abs_series}, Int, Ptr{FqFiniteField}),
-               &a, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_abs_series}, Ref{fq_abs_series},
+          Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
+               a, a, b, lenz, base_ring(a))
    return a
 end
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -46,58 +46,58 @@ end
 function coeff(x::fq_nmod, n::Int)
    n < 0 && throw(DomainError())
    return ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-                (Ptr{fq_nmod}, Int), &x, n)
+                (Ref{fq_nmod}, Int), x, n)
 end
 
 function zero(a::FqNmodFiniteField)
    d = a()
    ccall((:fq_nmod_zero, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &a)
+         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function one(a::FqNmodFiniteField)
    d = a()
    ccall((:fq_nmod_one, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &a)
+         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function gen(a::FqNmodFiniteField)
    d = a()
    ccall((:fq_nmod_gen, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &d, &a)
+         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 iszero(a::fq_nmod) = ccall((:fq_nmod_is_zero, :libflint), Bool,
-                     (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &a, &a.parent)
+                     (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
 isone(a::fq_nmod) = ccall((:fq_nmod_is_one, :libflint), Bool,
-                    (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &a, &a.parent)
+                    (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
 isgen(a::fq_nmod) = a == gen(parent(a)) # there is no isgen in flint
 
 isunit(a::fq_nmod) = ccall((:fq_nmod_is_invertible, :libflint), Bool,
-                     (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &a, &a.parent)
+                     (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
 function characteristic(a::FqNmodFiniteField)
    d = fmpz()
    ccall((:__fq_nmod_ctx_prime, :libflint), Void,
-         (Ptr{fmpz}, Ptr{FqNmodFiniteField}), &d, &a)
+         (Ref{fmpz}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function order(a::FqNmodFiniteField)
    d = fmpz()
    ccall((:fq_nmod_ctx_order, :libflint), Void,
-         (Ptr{fmpz}, Ptr{FqNmodFiniteField}), &d, &a)
+         (Ref{fmpz}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function degree(a::FqNmodFiniteField)
    return ccall((:fq_nmod_ctx_degree, :libflint), Int,
-                (Ptr{FqNmodFiniteField},), &a)
+                (Ref{FqNmodFiniteField},), a)
 end
 
 function deepcopy_internal(d::fq_nmod, dict::ObjectIdDict)
@@ -122,7 +122,7 @@ canonical_unit(x::fq_nmod) = x
 
 function show(io::IO, x::fq_nmod)
    cstr = ccall((:fq_nmod_get_str_pretty, :libflint), Ptr{UInt8},
-                (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &x, &x.parent)
+                (Ref{fq_nmod}, Ref{FqNmodFiniteField}), x, x.parent)
 
    print(io, unsafe_string(cstr))
 
@@ -149,7 +149,7 @@ show_minus_one(::Type{fq_nmod}) = true
 function -(x::fq_nmod)
    z = parent(x)()
    ccall((:fq_nmod_neg, :libflint), Void,
-       (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &x, &x.parent)
+       (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
 
@@ -163,8 +163,8 @@ function +(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_nmod_add, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, y.parent)
    return z
 end
 
@@ -172,8 +172,8 @@ function -(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_nmod_sub, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, y.parent)
    return z
 end
 
@@ -181,8 +181,8 @@ function *(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
    ccall((:fq_nmod_mul, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, y.parent)
    return z
 end
 
@@ -195,8 +195,8 @@ end
 function *(x::Int, y::fq_nmod)
    z = parent(y)()
    ccall((:fq_nmod_mul_si, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Int, Ptr{FqNmodFiniteField}),
-                                               &z, &y, x, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
+                                               z, y, x, y.parent)
    return z
 end
 
@@ -209,8 +209,8 @@ end
 function *(x::fmpz, y::fq_nmod)
    z = parent(y)()
    ccall((:fq_nmod_mul_fmpz, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fmpz}, Ptr{FqNmodFiniteField}),
-                                                    &z, &y, &x, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}),
+                                                    z, y, x, y.parent)
    return z
 end
 
@@ -245,8 +245,8 @@ function ^(x::fq_nmod, y::Int)
    end
    z = parent(x)()
    ccall((:fq_nmod_pow_ui, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Int, Ptr{FqNmodFiniteField}),
-                                               &z, &x, y, &x.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
+                                               z, x, y, x.parent)
    return z
 end
 
@@ -257,8 +257,8 @@ function ^(x::fq_nmod, y::fmpz)
    end
    z = parent(x)()
    ccall((:fq_nmod_pow, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fmpz}, Ptr{FqNmodFiniteField}),
-                                                    &z, &x, &y, &x.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}),
+                                                    z, x, y, x.parent)
    return z
 end
 
@@ -271,7 +271,7 @@ end
 function ==(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    ccall((:fq_nmod_equal, :libflint), Bool,
-       (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &x, &y, &y.parent)
+       (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), x, y, y.parent)
 end
 
 ###############################################################################
@@ -298,7 +298,7 @@ function inv(x::fq_nmod)
    iszero(x) && throw(DivideError())
    z = parent(x)()
    ccall((:fq_nmod_inv, :libflint), Void,
-       (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &x, &x.parent)
+       (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
 
@@ -313,8 +313,8 @@ function divexact(x::fq_nmod, y::fq_nmod)
    iszero(y) && throw(DivideError())
    z = parent(y)()
    ccall((:fq_nmod_div, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, y.parent)
    return z
 end
 
@@ -346,29 +346,29 @@ divexact(x::fmpz, y::fq_nmod) = divexact(parent(y)(x), y)
 function pth_root(x::fq_nmod)
    z = parent(x)()
    ccall((:fq_nmod_pth_root, :libflint), Void,
-       (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &x, &x.parent)
+       (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
 
 function trace(x::fq_nmod)
    z = fmpz()
    ccall((:fq_nmod_trace, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &x, &x.parent)
+         (Ref{fmpz}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
 function norm(x::fq_nmod)
    z = fmpz()
    ccall((:fq_nmod_norm, :libflint), Void,
-         (Ptr{fmpz}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &x, &x.parent)
+         (Ref{fmpz}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
 function frobenius(x::fq_nmod, n = 1)
    z = parent(x)()
    ccall((:fq_nmod_frobenius, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Int, Ptr{FqNmodFiniteField}),
-                                               &z, &x, n, &x.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
+                                               z, x, n, x.parent)
    return z
 end
 
@@ -380,28 +380,28 @@ end
 
 function zero!(z::fq_nmod)
    ccall((:fq_nmod_zero, :libflint), Void,
-        (Ptr{fq_nmod}, Ptr{FqNmodFiniteField}), &z, &z.parent)
+        (Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, z.parent)
    return z
 end
 
 function mul!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
    ccall((:fq_nmod_mul, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &y.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, y.parent)
    return z
 end
 
 function addeq!(z::fq_nmod, x::fq_nmod)
    ccall((:fq_nmod_add, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &z, &x, &x.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, z, x, x.parent)
    return z
 end
 
 function add!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
    ccall((:fq_nmod_add, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                                                       &z, &x, &y, &x.parent)
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                                                       z, x, y, x.parent)
    return z
 end
 

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -44,15 +44,15 @@ function normalise(a::fq_nmod_abs_series, len::Int)
    if len > 0
       c = base_ring(a)()
       ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-          &c, &a, len - 1, &ctx)
+         (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+          c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-             &c, &a, len - 1, &ctx)
+            (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+             c, a, len - 1, ctx)
       end
    end
 
@@ -61,7 +61,7 @@ end
 
 function length(x::fq_nmod_abs_series)
    return ccall((:fq_nmod_poly_length, :libflint), Int,
-                (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &x, &base_ring(x))
+                (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
 end
 
 precision(x::fq_nmod_abs_series) = x.prec
@@ -72,8 +72,8 @@ function coeff(x::fq_nmod_abs_series, n::Int)
    end
    z = base_ring(x)()
    ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-          &z, &x, n, &base_ring(x))
+         (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+          z, x, n, base_ring(x))
    return z
 end
 
@@ -97,7 +97,7 @@ end
 
 function isgen(a::fq_nmod_abs_series)
    return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, :libflint), Bool,
-                   (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &a, &base_ring(a))
+                   (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
 iszero(a::fq_nmod_abs_series) = length(a) == 0
@@ -106,7 +106,7 @@ isunit(a::fq_nmod_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fq_nmod_abs_series)
    return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, :libflint), Bool,
-                   (Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}), &a, &base_ring(a))
+                   (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
 # todo: write an fq_nmod_poly_valuation
@@ -141,8 +141,8 @@ show_minus_one(::Type{fq_nmod_abs_series}) = show_minus_one(fq)
 function -(x::fq_nmod_abs_series)
    z = parent(x)()
    ccall((:fq_nmod_poly_neg, :libflint), Void,
-                (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Ptr{FqNmodFiniteField}),
-               &z, &x, &base_ring(x))
+                (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}),
+               z, x, base_ring(x))
    z.prec = x.prec
    return z
 end
@@ -164,9 +164,9 @@ function +(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fq_nmod_poly_add_series, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -181,9 +181,9 @@ function -(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    z = parent(a)()
    z.prec = prec
    ccall((:fq_nmod_poly_sub_series, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -204,9 +204,9 @@ function *(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fq_nmod_poly_mullow, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -220,8 +220,8 @@ function *(x::fq_nmod, y::fq_nmod_abs_series)
    z = parent(y)()
    z.prec = y.prec
    ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, &y, &x, &parent(x))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, y, x, parent(x))
    return z
 end
 
@@ -239,8 +239,8 @@ function shift_left(x::fq_nmod_abs_series, len::Int)
    z = parent(x)()
    z.prec = x.prec + len
    ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &x, len, &base_ring(x))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, x, len, base_ring(x))
    return z
 end
 
@@ -253,8 +253,8 @@ function shift_right(x::fq_nmod_abs_series, len::Int)
    else
       z.prec = x.prec - len
       ccall((:fq_nmod_poly_shift_right, :libflint), Void,
-            (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &x, len, &base_ring(x))
+            (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, x, len, base_ring(x))
    end
    return z
 end
@@ -273,8 +273,8 @@ function truncate(x::fq_nmod_abs_series, prec::Int)
    z = parent(x)()
    z.prec = prec
    ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &x, prec, &base_ring(x))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, x, prec, base_ring(x))
    return z
 end
 
@@ -323,8 +323,8 @@ function ==(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
    n = max(length(x), length(y))
    n = min(n, prec)
    return Bool(ccall((:fq_nmod_poly_equal_trunc, :libflint), Cint,
-             (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &x, &y, n, &base_ring(x)))
+             (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               x, y, n, base_ring(x)))
 end
 
 function isequal(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
@@ -335,8 +335,8 @@ function isequal(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
       return false
    end
    return Bool(ccall((:fq_nmod_poly_equal, :libflint), Cint,
-             (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &x, &y, length(x), &base_ring(x)))
+             (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               x, y, length(x), base_ring(x)))
 end
 
 ###############################################################################
@@ -351,8 +351,8 @@ function ==(x::fq_nmod_abs_series, y::fq_nmod)
    elseif length(x) == 1
       z = base_ring(x)()
       ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-             &z, &x, 0, &base_ring(x))
+            (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+             z, x, 0, base_ring(x))
       return z == y
    else
       return precision(x) == 0 || iszero(y)
@@ -367,8 +367,8 @@ function ==(x::fq_nmod_abs_series, y::fmpz)
    elseif length(x) == 1
       z = base_ring(x)()
       ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-             &z, &x, 0, &base_ring(x))
+            (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+             z, x, 0, base_ring(x))
       return z == y
    else
       return precision(x) == 0 || iszero(y)
@@ -403,9 +403,9 @@ function divexact(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
    z = parent(x)()
    z.prec = prec
    ccall((:fq_nmod_poly_div_series, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &x, &y, prec, &base_ring(x))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, x, y, prec, base_ring(x))
    return z
 end
 
@@ -420,8 +420,8 @@ function divexact(x::fq_nmod_abs_series, y::fq_nmod)
    z = parent(x)()
    z.prec = x.prec
    ccall((:fq_nmod_poly_scalar_div_fq_nmod, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, &x, &y, &base_ring(x))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, x, y, base_ring(x))
    return z
 end
 
@@ -437,8 +437,8 @@ function inv(a::fq_nmod_abs_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ccall((:fq_nmod_poly_inv_series, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &ainv, &a, a.prec, &base_ring(a))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               ainv, a, a.prec, base_ring(a))
    return ainv
 end
 
@@ -450,15 +450,15 @@ end
 
 function fit!(z::fq_nmod_abs_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-         &z, n, &base_ring(z))
+         (Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+         z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_abs_series, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-                (Ptr{fq_nmod_abs_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_nmod_abs_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
@@ -477,9 +477,9 @@ function mul!(z::fq_nmod_abs_series, a::fq_nmod_abs_series, b::fq_nmod_abs_serie
    end
    z.prec = prec
    ccall((:fq_nmod_poly_mullow, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(z))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(z))
    return z
 end
 
@@ -492,9 +492,9 @@ function addeq!(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    lenz = max(lena, lenb)
    a.prec = prec
    ccall((:fq_nmod_poly_add_series, :libflint), Void,
-         (Ptr{fq_nmod_abs_series}, Ptr{fq_nmod_abs_series},
-          Ptr{fq_nmod_abs_series}, Int, Ptr{FqNmodFiniteField}),
-               &a, &a, &b, lenz, &base_ring(a))
+         (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
+          Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
+               a, a, b, lenz, base_ring(a))
    return a
 end
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -34,18 +34,18 @@ end
 ################################################################################
    
 length(x::fq_nmod_poly) = ccall((:fq_nmod_poly_length, :libflint), Int,
-                                (Ptr{fq_nmod_poly},), &x)
+                                (Ref{fq_nmod_poly},), x)
 
 set_length!(x::fq_nmod_poly, n::Int) = ccall((:_fq_nmod_poly_set_length, :libflint), Void,
-                              (Ptr{fq_nmod_poly}, Int), &x, n)
+                              (Ref{fq_nmod_poly}, Int), x, n)
 
 function coeff(x::fq_nmod_poly, n::Int)
    n < 0 && throw(DomainError())
    F = (x.parent).base_ring
    temp = F(1)
    ccall((:fq_nmod_poly_get_coeff, :libflint), Void, 
-         (Ptr{fq_nmod}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &temp, &x, n, &F)
+         (Ref{fq_nmod}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         temp, x, n, F)
    return temp
 end
 
@@ -56,16 +56,16 @@ one(a::FqNmodPolyRing) = a(one(base_ring(a)))
 gen(a::FqNmodPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 iszero(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_zero, :libflint), Bool,
-                              (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                              x, base_ring(x.parent))
 
 isone(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_one, :libflint), Bool,
-                              (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                              x, base_ring(x.parent))
 
 isgen(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_gen, :libflint), Bool,
-                              (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                              x, base_ring(x.parent))
 
 degree(f::fq_nmod_poly) = f.length - 1
 
@@ -94,9 +94,9 @@ function show(io::IO, x::fq_nmod_poly)
       print(io, "0")
    else
       cstr = ccall((:fq_nmod_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-                  (Ptr{fq_nmod_poly}, Ptr{UInt8}, Ptr{FqNmodFiniteField}),
-                  &x, string(var(parent(x))),
-                  &((x.parent).base_ring))
+                  (Ref{fq_nmod_poly}, Ptr{UInt8}, Ref{FqNmodFiniteField}),
+                  x, string(var(parent(x))),
+                  (x.parent).base_ring)
       print(io, unsafe_string(cstr))
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -120,8 +120,8 @@ show_minus_one(::Type{fq_nmod_poly}) = show_minus_one(fq_nmod)
 function -(x::fq_nmod_poly)
    z = parent(x)()
    ccall((:fq_nmod_poly_neg, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &x, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, x, base_ring(parent(x)))
    return z
 end
 
@@ -135,9 +135,9 @@ function +(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_add, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -145,9 +145,9 @@ function -(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_sub, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -155,9 +155,9 @@ function *(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_mul, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -172,9 +172,9 @@ function *(x::fq_nmod, y::fq_nmod_poly)
          error("Coefficient rings must be equal")
    z = parent(y)()
    ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-         &z, &y, &x, &parent(x))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+         z, y, x, parent(x))
   return z
 end
 
@@ -222,8 +222,8 @@ function ^(x::fq_nmod_poly, y::Int)
    y < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_nmod_poly_pow, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}), 
-         &z, &x, y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}), 
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -236,8 +236,8 @@ end
 function ==(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    r = ccall((:fq_nmod_poly_equal, :libflint), Cint,
-             (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-             &x, &y, &base_ring(parent(x)))
+             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+             x, y, base_ring(parent(x)))
    return Bool(r)
 end
 
@@ -253,8 +253,8 @@ function ==(x::fq_nmod_poly, y::fq_nmod)
       return false
    elseif length(x) == 1 
       r = ccall((:fq_nmod_poly_equal_fq_nmod, :libflint), Cint, 
-                (Ptr{fq_nmod_poly}, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-                &x, &y, &base_ring(parent(x)))
+                (Ref{fq_nmod_poly}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+                x, y, base_ring(parent(x)))
       return Bool(r)
    else
       return iszero(y)
@@ -284,8 +284,8 @@ function truncate(x::fq_nmod_poly, n::Int)
    end
    z = parent(x)()
    ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &z, &x, n, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         z, x, n, base_ring(parent(x)))
    return z
 end
 
@@ -294,9 +294,9 @@ function mullow(x::fq_nmod_poly, y::fq_nmod_poly, n::Int)
    n < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_nmod_poly_mullow, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Int, Ptr{FqNmodFiniteField}),
-         &z, &x, &y, n, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Int, Ref{FqNmodFiniteField}),
+         z, x, y, n, base_ring(parent(x)))
    return z
 end
 
@@ -310,8 +310,8 @@ function reverse(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_nmod_poly_reverse, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -325,8 +325,8 @@ function shift_left(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -334,8 +334,8 @@ function shift_right(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_nmod_poly_shift_right, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -349,8 +349,8 @@ function div(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_div_basecase, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
   return z
 end
 
@@ -358,8 +358,8 @@ function rem(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_rem, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
   return z
 end
 
@@ -369,9 +369,9 @@ function divrem(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    r = parent(x)()
-   ccall((:fq_nmod_poly_divrem, :libflint), Void, (Ptr{fq_nmod_poly},
-         Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &r, &x, &y, &base_ring(parent(x)))
+   ccall((:fq_nmod_poly_divrem, :libflint), Void, (Ref{fq_nmod_poly},
+         Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, r, x, y, base_ring(parent(x)))
    return z,r
 end
 
@@ -393,8 +393,8 @@ function remove(z::fq_nmod_poly, p::fq_nmod_poly)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
    v = ccall((:fq_nmod_poly_remove, :libflint), Int,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-             &z,  &p, &base_ring(parent(z)))
+            (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+             z,  p, base_ring(parent(z)))
    return v, z
 end
 
@@ -402,9 +402,9 @@ function divides(z::fq_nmod_poly, x::fq_nmod_poly)
    check_parent(z, x)
    q = parent(z)()
    v = Bool(ccall((:fq_nmod_poly_divides, :libflint), Cint,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-             Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-             &q, &z, &x, &base_ring(parent(z))))
+            (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+             Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+             q, z, x, base_ring(parent(z))))
    return v, q
 end
 
@@ -427,8 +427,8 @@ function powmod(x::fq_nmod_poly, n::Int, y::fq_nmod_poly)
    end
 
    ccall((:fq_nmod_poly_powmod_ui_binexp, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, n, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
 end
 
@@ -442,8 +442,8 @@ function gcd(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_gcd, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -453,9 +453,9 @@ function gcdinv(x::fq_nmod_poly, y::fq_nmod_poly)
    s = parent(x)()
    t = parent(x)()
    ccall((:fq_nmod_poly_xgcd, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, 
-          Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-           Ptr{FqNmodFiniteField}), &z, &s, &t, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, 
+          Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+           Ref{FqNmodFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s
 end
 
@@ -465,9 +465,9 @@ function gcdx(x::fq_nmod_poly, y::fq_nmod_poly)
    s = parent(x)()
    t = parent(x)()
    ccall((:fq_nmod_poly_xgcd, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, 
-          Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-           Ptr{FqNmodFiniteField}), &z, &s, &t, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, 
+          Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+           Ref{FqNmodFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s, t
 end
 
@@ -481,8 +481,8 @@ function evaluate(x::fq_nmod_poly, y::fq_nmod)
    base_ring(parent(x)) != parent(y) && error("Incompatible coefficient rings")
    z = parent(y)()
    ccall((:fq_nmod_poly_evaluate_fq_nmod, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod_poly}, Ptr{fq_nmod},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod}, Ref{fq_nmod_poly}, Ref{fq_nmod},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -496,8 +496,8 @@ function compose(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_nmod_poly_compose, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -510,8 +510,8 @@ end
 function derivative(x::fq_nmod_poly)
    z = parent(x)()
    ccall((:fq_nmod_poly_derivative, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &x, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, x, base_ring(parent(x)))
    return z
 end
 
@@ -523,17 +523,17 @@ end
 
 function inflate(x::fq_nmod_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_nmod_poly_inflate, :libflint), Void, (Ptr{fq_nmod_poly},
-         Ptr{fq_nmod_poly}, Culong, Ptr{FqNmodFiniteField}),
-         &z, &x, UInt(n), &base_ring(parent(x)))
+   ccall((:fq_nmod_poly_inflate, :libflint), Void, (Ref{fq_nmod_poly},
+         Ref{fq_nmod_poly}, Culong, Ref{FqNmodFiniteField}),
+         z, x, UInt(n), base_ring(parent(x)))
    return z
 end
 
 function deflate(x::fq_nmod_poly, n::Int)
    z = parent(x)()
    ccall((:fq_nmod_poly_deflate, :libflint), Void,
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Culong, Ptr{FqNmodFiniteField}),
-         &z, &x, UInt(n), &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Culong, Ref{FqNmodFiniteField}),
+         z, x, UInt(n), base_ring(parent(x)))
   return z
 end
 
@@ -549,8 +549,8 @@ doc"""
 """
 function isirreducible(x::fq_nmod_poly)
   return Bool(ccall((:fq_nmod_poly_is_irreducible, :libflint), Int32,
-                    (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField} ),
-                    &x, &base_ring(parent(x))))
+                    (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField} ),
+                    x, base_ring(parent(x))))
 end
 
 ################################################################################
@@ -565,7 +565,7 @@ doc"""
 """
 function issquarefree(x::fq_nmod_poly)
    return Bool(ccall((:fq_nmod_poly_is_squarefree, :libflint), Int32,
-       (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}), &x, &base_ring(parent(x))))
+       (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), x, base_ring(parent(x))))
 end
 
 ################################################################################
@@ -588,15 +588,15 @@ function _factor(x::fq_nmod_poly)
    F = base_ring(R)
    a = F()
    fac = fq_nmod_poly_factor(F)
-   ccall((:fq_nmod_poly_factor, :libflint), Void, (Ptr{fq_nmod_poly_factor},
-         Ptr{fq_nmod}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &fac, &a, &x, &F)
+   ccall((:fq_nmod_poly_factor, :libflint), Void, (Ref{fq_nmod_poly_factor},
+         Ref{fq_nmod}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         fac, a, x, F)
    res = Dict{fq_nmod_poly,Int}()
    for i in 1:fac.num
       f = R()
       ccall((:fq_nmod_poly_factor_get_poly, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly_factor}, Int,
-            Ptr{FqNmodFiniteField}), &f, &fac, i-1, &F)
+            (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
+            Ref{FqNmodFiniteField}), f, fac, i-1, F)
       e = unsafe_load(fac.exp,i)
       res[f] = e
    end
@@ -616,13 +616,13 @@ function _factor_squarefree(x::fq_nmod_poly)
   F = base_ring(parent(x))
   fac = fq_nmod_poly_factor(F)
   ccall((:fq_nmod_poly_factor_squarefree, :libflint), UInt,
-        (Ptr{fq_nmod_poly_factor}, Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}), &fac, &x, &F)
+        (Ref{fq_nmod_poly_factor}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), fac, x, F)
   res = Dict{fq_nmod_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fq_nmod_poly_factor_get_poly, :libflint), Void,
-          (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly_factor}, Int,
-           Ptr{FqNmodFiniteField}), &f, &fac, i-1, &F)
+          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
+           Ref{FqNmodFiniteField}), f, fac, i-1, F)
     e = unsafe_load(fac.exp, i)
     res[f] = e
   end
@@ -637,21 +637,17 @@ function factor_distinct_deg(x::fq_nmod_poly)
    R = parent(x)
    F = base_ring(R)
    fac = fq_nmod_poly_factor(F)
-   tmp = fq_nmod_poly_factor(F)
-   ccall((:fq_nmod_poly_factor_fit_length, :libflint), Void,
-         (Ptr{fq_nmod_poly_factor}, Int, Ptr{FqNmodFiniteField}),
-         &tmp, degree(x), &F)
+   degrees = Vector{Int}(degree(x))
    ccall((:fq_nmod_poly_factor_distinct_deg, :libflint), Void,
-         (Ptr{fq_nmod_poly_factor}, Ptr{fq_nmod_poly}, Ptr{Int},
-         Ptr{FqNmodFiniteField}), &fac, &x, &tmp.exp, &F)
+         (Ref{fq_nmod_poly_factor}, Ref{fq_nmod_poly}, Ref{Vector{Int}},
+         Ref{FqNmodFiniteField}), fac, x, degrees, F)
    res = Dict{Int, fq_nmod_poly}()
    for i in 1:fac.num
       f = R()
       ccall((:fq_nmod_poly_factor_get_poly, :libflint), Void,
-            (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly_factor}, Int,
-            Ptr{FqNmodFiniteField}), &f, &fac, i-1, &F)
-      d = unsafe_load(tmp.exp,i)
-      res[d] = f
+            (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
+            Ref{FqNmodFiniteField}), f, fac, i-1, F)
+      res[degrees[i]] = f
    end
    return res
 end
@@ -664,51 +660,51 @@ end
 
 function zero!(z::fq_nmod_poly)
    ccall((:fq_nmod_poly_zero, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{FqNmodFiniteField}),
-         &z, &base_ring(parent(z)))
+         (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+         z, base_ring(parent(z)))
    return z
 end
 
 function fit!(z::fq_nmod_poly, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Int, Ptr{FqNmodFiniteField}),
-         &z, n, &base_ring(parent(z)))
+         (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
+         z, n, base_ring(parent(z)))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_poly, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-         &z, n, &x, &base_ring(parent(z)))
+         (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+         z, n, x, base_ring(parent(z)))
    return z
 end
 
 function mul!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_mul, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function add!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_add, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function sub!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
    ccall((:fq_nmod_poly_sub, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 
 function addeq!(z::fq_nmod_poly, x::fq_nmod_poly)
    ccall((:fq_nmod_poly_add, :libflint), Void, 
-         (Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly}, Ptr{fq_nmod_poly},
-         Ptr{FqNmodFiniteField}), &z, &z, &x, &base_ring(parent(x)))
+         (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
+         Ref{FqNmodFiniteField}), z, z, x, base_ring(parent(x)))
    return z
 end
 

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -41,15 +41,15 @@ function normalise(a::fq_nmod_rel_series, len::Int)
    if len > 0
       c = base_ring(a)()
       ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-                                                         &c, &a, len - 1, &ctx)
+         (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+                                                         c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-            (Ptr{fq_nmod}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-                                                         &c, &a, len - 1, &ctx)
+            (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+                                                         c, a, len - 1, ctx)
       end
    end
    return len
@@ -57,7 +57,7 @@ end
 
 function pol_length(x::fq_nmod_rel_series)
    return ccall((:fq_nmod_poly_length, :libflint), Int,
-                (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &x, &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
 end
 
 precision(x::fq_nmod_rel_series) = x.prec
@@ -68,8 +68,8 @@ function polcoeff(x::fq_nmod_rel_series, n::Int)
       return z
    end
    ccall((:fq_nmod_poly_get_coeff, :libflint), Void,
-         (Ptr{fq_nmod}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-                                                      &z, &x, n, &base_ring(x))
+         (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+                                                      z, x, n, base_ring(x))
    return z
 end
 
@@ -105,8 +105,8 @@ function renormalize!(z::fq_nmod_rel_series)
    else
       z.val = zval + i
       ccall((:fq_nmod_poly_shift_right, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-                                                      &z, &z, i, &base_ring(z))
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+                                                      z, z, i, base_ring(z))
    end
    return nothing
 end
@@ -133,8 +133,8 @@ show_minus_one(::Type{fq_nmod_rel_series}) = show_minus_one(fq_nmod)
 function -(x::fq_nmod_rel_series)
    z = parent(x)()
    ccall((:fq_nmod_poly_neg, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}),
-               &z, &x, &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}),
+               z, x, base_ring(x))
    z.prec = x.prec
    z.val = x.val
    return z
@@ -159,33 +159,33 @@ function +(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &z, b.val - a.val, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &z, &a, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &z, a.val - b.val, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, z, a.val - b.val, ctx)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &z, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, ctx)
    end
    z.prec = prec
    z.val = val
@@ -207,36 +207,36 @@ function -(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &z, b.val - a.val, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_nmod_poly_neg, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}),
-            &z, &z, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}),
+            z, z, ctx)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &z, &a, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &z, a.val - b.val, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, z, a.val - b.val, ctx)
       ccall((:fq_nmod_poly_sub_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &z, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_nmod_poly_sub_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, ctx)
    end
    z.prec = prec
    z.val = val
@@ -261,9 +261,9 @@ function *(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fq_nmod_poly_mullow, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -278,9 +278,9 @@ function *(x::fq_nmod, y::fq_nmod_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, &y, &x, &base_ring(y))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, y, x, base_ring(y))
    return z
 end
 
@@ -315,9 +315,9 @@ function shift_right(x::fq_nmod_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:fq_nmod_poly_shift_right, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Int, Ptr{FqNmodFiniteField}),
-               &z, &x, xlen - zlen, &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Int, Ref{FqNmodFiniteField}),
+               z, x, xlen - zlen, base_ring(x))
       renormalize!(z)
    end
    return z
@@ -346,9 +346,9 @@ function truncate(x::fq_nmod_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Int, Ptr{FqNmodFiniteField}),
-               &z, &x, min(prec - xval, xlen), &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Int, Ref{FqNmodFiniteField}),
+               z, x, min(prec - xval, xlen), base_ring(x))
    end
    return z
 end
@@ -414,9 +414,9 @@ function ==(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
       return false
    end
    return Bool(ccall((:fq_nmod_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Int, Ptr{FqNmodFiniteField}),
-               &x, &y, xlen, &base_ring(x)))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Int, Ref{FqNmodFiniteField}),
+               x, y, xlen, base_ring(x)))
 end
 
 function isequal(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
@@ -427,9 +427,9 @@ function isequal(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
       return false
    end
    return Bool(ccall((:fq_nmod_poly_equal, :libflint), Cint,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Int, Ptr{FqNmodFiniteField}),
-               &x, &y, pol_length(x), &base_ring(x)))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Int, Ref{FqNmodFiniteField}),
+               x, y, pol_length(x), base_ring(x)))
 end
 
 ###############################################################################
@@ -456,9 +456,9 @@ function divexact(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:fq_nmod_poly_div_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &x, &y, prec, &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, x, y, prec, base_ring(x))
    end
    return z
 end
@@ -476,9 +476,9 @@ function divexact(x::fq_nmod_rel_series, y::fq_nmod)
    z.prec = x.prec
    z.val = x.val
    ccall((:fq_nmod_poly_scalar_div_fq_nmod, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, &x, &y, &base_ring(x))
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, x, y, base_ring(x))
    return z
 end
 
@@ -495,8 +495,8 @@ function inv(a::fq_nmod_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:fq_nmod_poly_inv_series, :libflint), Void,
-         (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &ainv, &a, a.prec, &base_ring(a))
+         (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               ainv, a, a.prec, base_ring(a))
    return ainv
 end
 
@@ -508,29 +508,29 @@ end
 
 function zero!(x::fq_nmod_rel_series)
   ccall((:fq_nmod_poly_zero, :libflint), Void,
-                   (Ptr{fq_nmod_rel_series}, Ptr{FqNmodFiniteField}), &x, &base_ring(x))
+                   (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(z::fq_nmod_rel_series, n::Int)
    ccall((:fq_nmod_poly_fit_length, :libflint), Void,
-         (Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-         &z, n, &base_ring(z))
+         (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+         z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fmpz)
    ccall((:fq_nmod_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Int, Ptr{fmpz}, Ptr{FqNmodFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_nmod_rel_series}, Int, Ref{fmpz}, Ref{FqNmodFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fq_nmod)
    ccall((:fq_nmod_poly_set_coeff, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Int, Ptr{fq_nmod}, Ptr{FqNmodFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_nmod_rel_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
@@ -549,9 +549,9 @@ function mul!(z::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
       lenz = 0
    end
    ccall((:fq_nmod_poly_mullow, :libflint), Void,
-         (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-          Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &z, &a, &b, lenz, &base_ring(z))
+         (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+          Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               z, a, b, lenz, base_ring(z))
    return z
 end
 
@@ -567,33 +567,33 @@ function addeq!(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
       z = fq_nmod_rel_series(base_ring(a))
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &z, &z, b.val - a.val, ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &a, &a, &z, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               a, a, z, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_nmod_poly_truncate, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_nmod_poly_shift_left, :libflint), Void,
-            (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-            &a, &a, a.val - b.val, &ctx)
+            (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+            a, a, a.val - b.val, ctx)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &a, &a, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               a, a, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_nmod_poly_add_series, :libflint), Void,
-                (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series},
-                 Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &a, &a, &b, lenz, &ctx)
+                (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
+                 Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               a, a, b, lenz, ctx)
    end
    a.prec = prec
    a.val = val
@@ -614,8 +614,8 @@ function add!(c::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:fq_nmod_poly_add_series, :libflint), Void,
-     (Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Ptr{fq_nmod_rel_series}, Int, Ptr{FqNmodFiniteField}),
-               &c, &a, &b, lenc, &ctx)
+     (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
+               c, a, b, lenc, ctx)
    return c
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -34,20 +34,20 @@ end
 ################################################################################
    
 length(x::fq_poly) = ccall((:fq_poly_length, :libflint), Int,
-                                (Ptr{fq_poly},), &x)
+                                (Ref{fq_poly},), x)
 
 function coeff(x::fq_poly, n::Int)
    n < 0 && throw(DomainError())
    F = (x.parent).base_ring
    temp = F(1)
    ccall((:fq_poly_get_coeff, :libflint), Void, 
-         (Ptr{fq}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &temp, &x, n, &F)
+         (Ref{fq}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         temp, x, n, F)
    return temp
 end
 
 set_length!(x::fq_poly, n::Int) = ccall((:_fq_poly_set_length, :libflint), Void,
-                              (Ptr{fq_poly}, Int), &x, n)
+                              (Ref{fq_poly}, Int), x, n)
 
 zero(a::FqPolyRing) = a(zero(base_ring(a)))
 
@@ -56,16 +56,16 @@ one(a::FqPolyRing) = a(one(base_ring(a)))
 gen(a::FqPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 isgen(x::fq_poly) = ccall((:fq_poly_is_gen, :libflint), Bool,
-                              (Ptr{fq_poly}, Ptr{FqFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_poly}, Ref{FqFiniteField}),
+                              x, base_ring(x.parent))
 
 iszero(x::fq_poly) = ccall((:fq_poly_is_zero, :libflint), Bool,
-                              (Ptr{fq_poly}, Ptr{FqFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_poly}, Ref{FqFiniteField}),
+                              x, base_ring(x.parent))
 
 isone(x::fq_poly) = ccall((:fq_poly_is_one, :libflint), Bool,
-                              (Ptr{fq_poly}, Ptr{FqFiniteField}),
-                              &x, &base_ring(x.parent))
+                              (Ref{fq_poly}, Ref{FqFiniteField}),
+                              x, base_ring(x.parent))
 
 degree(f::fq_poly) = f.length - 1
 
@@ -94,9 +94,9 @@ function show(io::IO, x::fq_poly)
       print(io, "0")
    else
       cstr = ccall((:fq_poly_get_str_pretty, :libflint), Ptr{UInt8}, 
-                  (Ptr{fq_poly}, Ptr{UInt8}, Ptr{FqFiniteField}),
-                  &x, string(var(parent(x))),
-                  &((x.parent).base_ring))
+                  (Ref{fq_poly}, Ptr{UInt8}, Ref{FqFiniteField}),
+                  x, string(var(parent(x))),
+                  (x.parent).base_ring)
       print(io, unsafe_string(cstr))
       ccall((:flint_free, :libflint), Void, (Ptr{UInt8},), cstr)
    end
@@ -120,8 +120,8 @@ show_minus_one(::Type{fq_poly}) = show_minus_one(fq)
 function -(x::fq_poly)
    z = parent(x)()
    ccall((:fq_poly_neg, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &x, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+         z, x, base_ring(parent(x)))
    return z
 end
 
@@ -135,9 +135,9 @@ function +(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_add, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly},
+         Ref{fq_poly}, Ref{FqFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -145,9 +145,9 @@ function -(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_sub, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly},
+         Ref{fq_poly}, Ref{FqFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -155,9 +155,9 @@ function *(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_mul, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly},
+         Ref{fq_poly}, Ref{FqFiniteField}),
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -172,9 +172,9 @@ function *(x::fq, y::fq_poly)
          error("Coefficient rings must be equal")
    z = parent(y)()
    ccall((:fq_poly_scalar_mul_fq, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{fq}, Ptr{FqFiniteField}),
-         &z, &y, &x, &parent(x))
+         (Ref{fq_poly}, Ref{fq_poly},
+         Ref{fq}, Ref{FqFiniteField}),
+         z, y, x, parent(x))
   return z
 end
 
@@ -222,8 +222,8 @@ function ^(x::fq_poly, y::Int)
    y < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_poly_pow, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}), 
-         &z, &x, y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}), 
+         z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -236,8 +236,8 @@ end
 function ==(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    r = ccall((:fq_poly_equal, :libflint), Cint,
-             (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-             &x, &y, &base_ring(parent(x)))
+             (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+             x, y, base_ring(parent(x)))
    return Bool(r)
 end
 
@@ -253,8 +253,8 @@ function ==(x::fq_poly, y::fq)
       return false
    elseif length(x) == 1 
       r = ccall((:fq_poly_equal_fq, :libflint), Cint, 
-                (Ptr{fq_poly}, Ptr{fq}, Ptr{FqFiniteField}),
-                &x, &y, &base_ring(parent(x)))
+                (Ref{fq_poly}, Ref{fq}, Ref{FqFiniteField}),
+                x, y, base_ring(parent(x)))
       return Bool(r)
    else
       return iszero(y)
@@ -284,8 +284,8 @@ function truncate(x::fq_poly, n::Int)
    end
    z = parent(x)()
    ccall((:fq_poly_set_trunc, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &z, &x, n, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         z, x, n, base_ring(parent(x)))
    return z
 end
 
@@ -294,9 +294,9 @@ function mullow(x::fq_poly, y::fq_poly, n::Int)
    n < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_poly_mullow, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Int, Ptr{FqFiniteField}),
-         &z, &x, &y, n, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Int, Ref{FqFiniteField}),
+         z, x, y, n, base_ring(parent(x)))
    return z
 end
 
@@ -310,8 +310,8 @@ function reverse(x::fq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_poly_reverse, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -325,8 +325,8 @@ function shift_left(x::fq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_poly_shift_left, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -334,8 +334,8 @@ function shift_right(x::fq_poly, len::Int)
    len < 0 && throw(DomainError())
    z = parent(x)()
    ccall((:fq_poly_shift_right, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &z, &x, len, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         z, x, len, base_ring(parent(x)))
    return z
 end
 
@@ -349,8 +349,8 @@ function div(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_div_basecase, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
   return z
 end
 
@@ -358,8 +358,8 @@ function rem(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_rem, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
   return z
 end
 
@@ -369,9 +369,9 @@ function divrem(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    r = parent(x)()
-   ccall((:fq_poly_divrem, :libflint), Void, (Ptr{fq_poly},
-         Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &r, &x, &y, &base_ring(parent(x)))
+   ccall((:fq_poly_divrem, :libflint), Void, (Ref{fq_poly},
+         Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, r, x, y, base_ring(parent(x)))
    return z, r
 end
 
@@ -393,8 +393,8 @@ function remove(z::fq_poly, p::fq_poly)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
    v = ccall((:fq_poly_remove, :libflint), Int,
-            (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-             &z,  &p, &base_ring(parent(z)))
+            (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+             z,  p, base_ring(parent(z)))
    return v, z
 end
 
@@ -402,9 +402,9 @@ function divides(z::fq_poly, x::fq_poly)
    check_parent(z, x)
    q = parent(z)()
    v = Bool(ccall((:fq_poly_divides, :libflint), Cint,
-            (Ptr{fq_poly}, Ptr{fq_poly},
-             Ptr{fq_poly}, Ptr{FqFiniteField}),
-             &q, &z, &x, &base_ring(parent(z))))
+            (Ref{fq_poly}, Ref{fq_poly},
+             Ref{fq_poly}, Ref{FqFiniteField}),
+             q, z, x, base_ring(parent(z))))
    return v, q
 end
 
@@ -427,8 +427,8 @@ function powmod(x::fq_poly, n::Int, y::fq_poly)
    end
 
    ccall((:fq_poly_powmod_ui_binexp, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Int, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, n, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
 end
 
@@ -442,8 +442,8 @@ function gcd(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_gcd, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -453,8 +453,8 @@ function gcdinv(x::fq_poly, y::fq_poly)
    s = parent(x)()
    t = parent(x)()
    ccall((:fq_poly_xgcd, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &s, &t, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s
 end
 
@@ -464,8 +464,8 @@ function gcdx(x::fq_poly, y::fq_poly)
    s = parent(x)()
    t = parent(x)()
    ccall((:fq_poly_xgcd, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &s, &t, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s, t
 end
 
@@ -479,8 +479,8 @@ function evaluate(x::fq_poly, y::fq)
    base_ring(parent(x)) != parent(y) && error("Incompatible coefficient rings")
    z = parent(y)()
    ccall((:fq_poly_evaluate_fq, :libflint), Void,
-         (Ptr{fq}, Ptr{fq_poly}, Ptr{fq},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq}, Ref{fq_poly}, Ref{fq},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -494,8 +494,8 @@ function compose(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    ccall((:fq_poly_compose, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
@@ -508,8 +508,8 @@ end
 function derivative(x::fq_poly)
    z = parent(x)()
    ccall((:fq_poly_derivative, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &x, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+         z, x, base_ring(parent(x)))
    return z
 end
 
@@ -521,17 +521,17 @@ end
 
 function inflate(x::fq_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_poly_inflate, :libflint), Void, (Ptr{fq_poly},
-         Ptr{fq_poly}, Culong, Ptr{FqFiniteField}),
-         &z, &x, UInt(n), &base_ring(parent(x)))
+   ccall((:fq_poly_inflate, :libflint), Void, (Ref{fq_poly},
+         Ref{fq_poly}, Culong, Ref{FqFiniteField}),
+         z, x, UInt(n), base_ring(parent(x)))
    return z
 end
 
 function deflate(x::fq_poly, n::Int)
    z = parent(x)()
    ccall((:fq_poly_deflate, :libflint), Void,
-         (Ptr{fq_poly}, Ptr{fq_poly}, Culong, Ptr{FqFiniteField}),
-         &z, &x, UInt(n), &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Culong, Ref{FqFiniteField}),
+         z, x, UInt(n), base_ring(parent(x)))
   return z
 end
 
@@ -547,8 +547,8 @@ doc"""
 """
 function isirreducible(x::fq_poly)
   return Bool(ccall((:fq_poly_is_irreducible, :libflint), Int32,
-                    (Ptr{fq_poly}, Ptr{FqFiniteField} ),
-                    &x, &base_ring(parent(x))))
+                    (Ref{fq_poly}, Ref{FqFiniteField} ),
+                    x, base_ring(parent(x))))
 end
 
 ################################################################################
@@ -563,7 +563,7 @@ doc"""
 """
 function issquarefree(x::fq_poly)
    return Bool(ccall((:fq_poly_is_squarefree, :libflint), Int32, 
-       (Ptr{fq_poly}, Ptr{FqFiniteField}), &x, &base_ring(parent(x))))
+       (Ref{fq_poly}, Ref{FqFiniteField}), x, base_ring(parent(x))))
 end
 
 ################################################################################
@@ -586,15 +586,15 @@ function _factor(x::fq_poly)
    F = base_ring(R)
    a = F()
    fac = fq_poly_factor(F)
-   ccall((:fq_poly_factor, :libflint), Void, (Ptr{fq_poly_factor},
-         Ptr{fq}, Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &fac, &a, &x, &F)
+   ccall((:fq_poly_factor, :libflint), Void, (Ref{fq_poly_factor},
+         Ref{fq}, Ref{fq_poly}, Ref{FqFiniteField}),
+         fac, a, x, F)
    res = Dict{fq_poly,Int}()
    for i in 1:fac.num
       f = R()
       ccall((:fq_poly_factor_get_poly, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{fq_poly_factor}, Int,
-            Ptr{FqFiniteField}), &f, &fac, i-1, &F)
+            (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
+            Ref{FqFiniteField}), f, fac, i-1, F)
       e = unsafe_load(fac.exp,i)
       res[f] = e
    end
@@ -614,13 +614,13 @@ function _factor_squarefree(x::fq_poly)
   F = base_ring(parent(x))
   fac = fq_poly_factor(F)
   ccall((:fq_poly_factor_squarefree, :libflint), UInt,
-        (Ptr{fq_poly_factor}, Ptr{fq_poly}, Ptr{FqFiniteField}), &fac, &x, &F)
+        (Ref{fq_poly_factor}, Ref{fq_poly}, Ref{FqFiniteField}), fac, x, F)
   res = Dict{fq_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
     ccall((:fq_poly_factor_get_poly, :libflint), Void,
-          (Ptr{fq_poly}, Ptr{fq_poly_factor}, Int,
-          Ptr{FqFiniteField}), &f, &fac, i-1, &F)
+          (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
+          Ref{FqFiniteField}), f, fac, i-1, F)
     e = unsafe_load(fac.exp, i)
     res[f] = e
   end
@@ -635,21 +635,17 @@ function factor_distinct_deg(x::fq_poly)
    R = parent(x)
    F = base_ring(R)
    fac = fq_poly_factor(F)
-   tmp = fq_poly_factor(F)
-   ccall((:fq_poly_factor_fit_length, :libflint), Void,
-         (Ptr{fq_poly_factor}, Int, Ptr{FqFiniteField}),
-         &tmp, degree(x), &F)
+   degrees = Vector{Int}(degree(x))
    ccall((:fq_poly_factor_distinct_deg, :libflint), Void, 
-         (Ptr{fq_poly_factor}, Ptr{fq_poly}, Ptr{Int},
-         Ptr{FqFiniteField}), &fac, &x, &tmp.exp, &F)
+         (Ref{fq_poly_factor}, Ref{fq_poly}, Ref{Vector{Int}},
+         Ref{FqFiniteField}), fac, x, degrees, F)
    res = Dict{Int, fq_poly}()
    for i in 1:fac.num
       f = R()
       ccall((:fq_poly_factor_get_poly, :libflint), Void,
-            (Ptr{fq_poly}, Ptr{fq_poly_factor}, Int,
-            Ptr{FqFiniteField}), &f, &fac, i-1, &F)
-      d = unsafe_load(tmp.exp,i)
-      res[d] = f
+            (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
+            Ref{FqFiniteField}), f, fac, i-1, F)
+      res[degrees[i]] = f
    end
    return res
 end
@@ -662,51 +658,51 @@ end
 
 function zero!(z::fq_poly)
    ccall((:fq_poly_zero, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{FqFiniteField}),
-         &z, &base_ring(parent(z)))
+         (Ref{fq_poly}, Ref{FqFiniteField}),
+         z, base_ring(parent(z)))
    return z
 end
 
 function fit!(z::fq_poly, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void, 
-         (Ptr{fq_poly}, Int, Ptr{FqFiniteField}),
-         &z, n, &base_ring(parent(z)))
+         (Ref{fq_poly}, Int, Ref{FqFiniteField}),
+         z, n, base_ring(parent(z)))
    return nothing
 end
 
 function setcoeff!(z::fq_poly, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void, 
-         (Ptr{fq_poly}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-         &z, n, &x, &base_ring(parent(z)))
+         (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
+         z, n, x, base_ring(parent(z)))
    return z
 end
 
 function mul!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_mul, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function add!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_add, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function sub!(z::fq_poly, x::fq_poly, y::fq_poly)
    ccall((:fq_poly_sub, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &x, &y, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 
 function addeq!(z::fq_poly, x::fq_poly)
    ccall((:fq_poly_add, :libflint), Void, 
-         (Ptr{fq_poly}, Ptr{fq_poly}, Ptr{fq_poly},
-         Ptr{FqFiniteField}), &z, &z, &x, &base_ring(parent(x)))
+         (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
+         Ref{FqFiniteField}), z, z, x, base_ring(parent(x)))
    return z
 end
 

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -41,15 +41,15 @@ function normalise(a::fq_rel_series, len::Int)
    if len > 0
       c = base_ring(a)()
       ccall((:fq_poly_get_coeff, :libflint), Void,
-         (Ptr{fq}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-                                                         &c, &a, len - 1, &ctx)
+         (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+                                                         c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          ccall((:fq_poly_get_coeff, :libflint), Void,
-            (Ptr{fq}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-                                                         &c, &a, len - 1, &ctx)
+            (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+                                                         c, a, len - 1, ctx)
       end
    end
    return len
@@ -57,7 +57,7 @@ end
 
 function pol_length(x::fq_rel_series)
    return ccall((:fq_poly_length, :libflint), Int,
-                (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &x, &base_ring(x))
+                (Ref{fq_rel_series}, Ref{FqFiniteField}), x, base_ring(x))
 end
 
 precision(x::fq_rel_series) = x.prec
@@ -68,8 +68,8 @@ function polcoeff(x::fq_rel_series, n::Int)
       return z
    end
    ccall((:fq_poly_get_coeff, :libflint), Void,
-         (Ptr{fq}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-                                                      &z, &x, n, &base_ring(x))
+         (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+                                                      z, x, n, base_ring(x))
    return z
 end
 
@@ -105,8 +105,8 @@ function renormalize!(z::fq_rel_series)
    else
       z.val = zval + i
       ccall((:fq_poly_shift_right, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-                                                      &z, &z, i, &base_ring(z))
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+                                                      z, z, i, base_ring(z))
    end
    return nothing
 end
@@ -133,8 +133,8 @@ show_minus_one(::Type{fq_rel_series}) = show_minus_one(fq)
 function -(x::fq_rel_series)
    z = parent(x)()
    ccall((:fq_poly_neg, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Ptr{FqFiniteField}),
-               &z, &x, &base_ring(x))
+                (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}),
+               z, x, base_ring(x))
    z.prec = x.prec
    z.val = x.val
    return z
@@ -159,33 +159,33 @@ function +(a::fq_rel_series, b::fq_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &z, b.val - a.val, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &z, &a, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &z, a.val - b.val, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, z, a.val - b.val, ctx)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &z, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, ctx)
    end
    z.prec = prec
    z.val = val
@@ -207,36 +207,36 @@ function -(a::fq_rel_series, b::fq_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &z, b.val - a.val, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_poly_neg, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Ptr{FqFiniteField}),
-            &z, &z, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}),
+            z, z, ctx)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &z, &a, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &z, a.val - b.val, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, z, a.val - b.val, ctx)
       ccall((:fq_poly_sub_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &z, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_poly_sub_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, ctx)
    end
    z.prec = prec
    z.val = val
@@ -261,9 +261,9 @@ function *(a::fq_rel_series, b::fq_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:fq_poly_mullow, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(a))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(a))
    return z
 end
 
@@ -278,9 +278,9 @@ function *(x::fq, y::fq_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:fq_poly_scalar_mul_fq, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq}, Ptr{FqFiniteField}),
-               &z, &y, &x, &base_ring(y))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq}, Ref{FqFiniteField}),
+               z, y, x, base_ring(y))
    return z
 end
 
@@ -315,9 +315,9 @@ function shift_right(x::fq_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:fq_poly_shift_right, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Int, Ptr{FqFiniteField}),
-               &z, &x, xlen - zlen, &base_ring(x))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Int, Ref{FqFiniteField}),
+               z, x, xlen - zlen, base_ring(x))
       renormalize!(z)
    end
    return z
@@ -346,9 +346,9 @@ function truncate(x::fq_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:fq_poly_set_trunc, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Int, Ptr{FqFiniteField}),
-               &z, &x, min(prec - xval, xlen), &base_ring(x))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Int, Ref{FqFiniteField}),
+               z, x, min(prec - xval, xlen), base_ring(x))
    end
    return z
 end
@@ -414,9 +414,9 @@ function ==(x::fq_rel_series, y::fq_rel_series)
       return false
    end
    return Bool(ccall((:fq_poly_equal_trunc, :libflint), Cint,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Int, Ptr{FqFiniteField}),
-               &x, &y, xlen, &base_ring(x)))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Int, Ref{FqFiniteField}),
+               x, y, xlen, base_ring(x)))
 end
 
 function isequal(x::fq_rel_series, y::fq_rel_series)
@@ -427,9 +427,9 @@ function isequal(x::fq_rel_series, y::fq_rel_series)
       return false
    end
    return Bool(ccall((:fq_poly_equal, :libflint), Cint,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Int, Ptr{FqFiniteField}),
-               &x, &y, pol_length(x), &base_ring(x)))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Int, Ref{FqFiniteField}),
+               x, y, pol_length(x), base_ring(x)))
 end
 
 ###############################################################################
@@ -456,9 +456,9 @@ function divexact(x::fq_rel_series, y::fq_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:fq_poly_div_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &x, &y, prec, &base_ring(x))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, x, y, prec, base_ring(x))
    end
    return z
 end
@@ -476,9 +476,9 @@ function divexact(x::fq_rel_series, y::fq)
    z.prec = x.prec
    z.val = x.val
    ccall((:fq_poly_scalar_div_fq, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq}, Ptr{FqFiniteField}),
-               &z, &x, &y, &base_ring(x))
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq}, Ref{FqFiniteField}),
+               z, x, y, base_ring(x))
    return z
 end
 
@@ -495,8 +495,8 @@ function inv(a::fq_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:fq_poly_inv_series, :libflint), Void,
-         (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &ainv, &a, a.prec, &base_ring(a))
+         (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               ainv, a, a.prec, base_ring(a))
    return ainv
 end
 
@@ -508,29 +508,29 @@ end
 
 function zero!(x::fq_rel_series)
   ccall((:fq_poly_zero, :libflint), Void,
-                   (Ptr{fq_rel_series}, Ptr{FqFiniteField}), &x, &base_ring(x))
+                   (Ref{fq_rel_series}, Ref{FqFiniteField}), x, base_ring(x))
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(z::fq_rel_series, n::Int)
    ccall((:fq_poly_fit_length, :libflint), Void,
-         (Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-         &z, n, &base_ring(z))
+         (Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+         z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fmpz)
    ccall((:fq_poly_set_coeff_fmpz, :libflint), Void,
-                (Ptr{fq_rel_series}, Int, Ptr{fmpz}, Ptr{FqFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_rel_series}, Int, Ref{fmpz}, Ref{FqFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fq)
    ccall((:fq_poly_set_coeff, :libflint), Void,
-                (Ptr{fq_rel_series}, Int, Ptr{fq}, Ptr{FqFiniteField}),
-               &z, n, &x, &base_ring(z))
+                (Ref{fq_rel_series}, Int, Ref{fq}, Ref{FqFiniteField}),
+               z, n, x, base_ring(z))
    return z
 end
 
@@ -549,9 +549,9 @@ function mul!(z::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
       lenz = 0
    end
    ccall((:fq_poly_mullow, :libflint), Void,
-         (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-          Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &z, &a, &b, lenz, &base_ring(z))
+         (Ref{fq_rel_series}, Ref{fq_rel_series},
+          Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               z, a, b, lenz, base_ring(z))
    return z
 end
 
@@ -567,33 +567,33 @@ function addeq!(a::fq_rel_series, b::fq_rel_series)
       z = fq_rel_series(base_ring(a))
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fq_poly_set_trunc, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &b, max(0, lenz - b.val + a.val), ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, b, max(0, lenz - b.val + a.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &z, &z, b.val - a.val, ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            z, z, b.val - a.val, ctx)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &a, &a, &z, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               a, a, z, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:fq_poly_truncate, :libflint), Void,
-            (Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &a, max(0, lenz - a.val + b.val), &ctx)
+            (Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            a, max(0, lenz - a.val + b.val), ctx)
       ccall((:fq_poly_shift_left, :libflint), Void,
-            (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-            &a, &a, a.val - b.val, &ctx)
+            (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+            a, a, a.val - b.val, ctx)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &a, &a, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               a, a, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
       ccall((:fq_poly_add_series, :libflint), Void,
-                (Ptr{fq_rel_series}, Ptr{fq_rel_series},
-                 Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &a, &a, &b, lenz, &ctx)
+                (Ref{fq_rel_series}, Ref{fq_rel_series},
+                 Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               a, a, b, lenz, ctx)
    end
    a.prec = prec
    a.val = val
@@ -614,8 +614,8 @@ function add!(c::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:fq_poly_add_series, :libflint), Void,
-     (Ptr{fq_rel_series}, Ptr{fq_rel_series}, Ptr{fq_rel_series}, Int, Ptr{FqFiniteField}),
-               &c, &a, &b, lenc, &ctx)
+     (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
+               c, a, b, lenc, ctx)
    return c
 end
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -437,8 +437,8 @@ function (R::NmodRing)(a::UInt)
 end
 
 function (R::NmodRing)(a::fmpz)
-   d = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt),
-             &a, R.n)
+   d = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt),
+             a, R.n)
    return nmod(d, R)
 end
 

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -39,20 +39,20 @@ max_precision(R::NmodRelSeriesRing) = R.prec_max
 function normalise(a::nmod_rel_series, len::Int)
    if len > 0
       c = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-         (Ptr{nmod_rel_series}, Int), &a, len - 1)
+         (Ref{nmod_rel_series}, Int), a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
          c = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-            (Ptr{nmod_rel_series}, Int), &a, len - 1)
+            (Ref{nmod_rel_series}, Int), a, len - 1)
       end
    end
    return len
 end
 
 function pol_length(x::nmod_rel_series)
-   return ccall((:nmod_poly_length, :libflint), Int, (Ptr{nmod_rel_series},), &x)
+   return ccall((:nmod_poly_length, :libflint), Int, (Ref{nmod_rel_series},), x)
 end
 
 precision(x::nmod_rel_series) = x.prec
@@ -63,7 +63,7 @@ function polcoeff(x::nmod_rel_series, n::Int)
       return R(0)
    end
    z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-         (Ptr{nmod_rel_series}, Int), &x, n)
+         (Ref{nmod_rel_series}, Int), x, n)
    return R(z)
 end
 
@@ -101,7 +101,7 @@ function renormalize!(z::nmod_rel_series)
    else
       z.val = zval + i
       ccall((:nmod_poly_shift_right, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int), &z, &z, i)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int), z, z, i)
    end
    return nothing
 end
@@ -128,8 +128,8 @@ show_minus_one(::Type{nmod_rel_series}) = true
 function -(x::nmod_rel_series)
    z = parent(x)()
    ccall((:nmod_poly_neg, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}),
-               &z, &x)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}),
+               z, x)
    z.prec = x.prec
    z.val = x.val
    return z
@@ -153,30 +153,30 @@ function +(a::nmod_rel_series, b::nmod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -197,32 +197,32 @@ function -(a::nmod_rel_series, b::nmod_rel_series)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:nmod_poly_neg, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}), &z, &z)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}), z, z)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &z, &a, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &a, max(0, lenz - a.val + b.val))
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, a, max(0, lenz - a.val + b.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &z, a.val - b.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, z, a.val - b.val)
       ccall((:nmod_poly_sub_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &z, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, z, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:nmod_poly_sub_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, a, b, lenz)
    end
    z.prec = prec
    z.val = val
@@ -247,8 +247,8 @@ function *(a::nmod_rel_series, b::nmod_rel_series)
    end
    lenz = min(lena + lenb - 1, prec)
    ccall((:nmod_poly_mullow, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, a, b, lenz)
    renormalize!(z)
    return z
 end
@@ -264,8 +264,8 @@ function *(x::nmod, y::nmod_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &y, data(x))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, y, data(x))
    renormalize!(z)
    return z
 end
@@ -276,10 +276,10 @@ function *(x::fmpz, y::nmod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &x, modulus(y))
+   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, modulus(y))
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &y, r)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, y, r)
    renormalize!(z)
    return z
 end
@@ -289,8 +289,8 @@ function *(x::UInt, y::nmod_rel_series)
    z.prec = y.prec
    z.val = y.val
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &y, mod(x, modulus(y)))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, y, mod(x, modulus(y)))
    renormalize!(z)
    return z
 end
@@ -332,8 +332,8 @@ function shift_right(x::nmod_rel_series, len::Int)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
       ccall((:nmod_poly_shift_right, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &x, xlen - zlen)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, x, xlen - zlen)
       renormalize!(z)
    end
    return z
@@ -362,8 +362,8 @@ function truncate(x::nmod_rel_series, prec::Int)
    else
       z.val = xval
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &x, min(prec - xval, xlen))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, x, min(prec - xval, xlen))
    end
    return z
 end
@@ -397,8 +397,8 @@ function ^(a::nmod_rel_series, b::Int)
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
       ccall((:nmod_poly_pow_trunc, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int, Int),
-               &z, &a, b, z.prec - z.val)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int, Int),
+               z, a, b, z.prec - z.val)
    end
    renormalize!(z)
    return z
@@ -425,8 +425,8 @@ function ==(x::nmod_rel_series, y::nmod_rel_series)
       return false
    end
    return Bool(ccall((:nmod_poly_equal_trunc, :libflint), Cint,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &x, &y, xlen))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               x, y, xlen))
 end
 
 function isequal(x::nmod_rel_series, y::nmod_rel_series)
@@ -437,8 +437,8 @@ function isequal(x::nmod_rel_series, y::nmod_rel_series)
       return false
    end
    return Bool(ccall((:nmod_poly_equal, :libflint), Cint,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &x, &y, pol_length(x)))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               x, y, pol_length(x)))
 end
 
 ###############################################################################
@@ -455,7 +455,7 @@ function ==(x::nmod_rel_series, y::nmod)
    elseif pol_length(x) == 1
       if x.val == 0
          z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-                       (Ptr{nmod_rel_series}, Int), &x, 0)
+                       (Ref{nmod_rel_series}, Int), x, 0)
          return data(y) == z
       else
          return false
@@ -474,15 +474,15 @@ function ==(x::nmod_rel_series, y::fmpz)
       return false
    elseif pol_length(x) == 1
       if x.val == 0
-         r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &y, modulus(x))
+         r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
          z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-                       (Ptr{nmod_rel_series}, Int), &x, 0)
+                       (Ref{nmod_rel_series}, Int), x, 0)
          return r == z
       else
          return false
       end
    else
-      r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &y, modulus(x))
+      r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
       return r == UInt(0)
    end
 end
@@ -498,7 +498,7 @@ function ==(x::nmod_rel_series, y::UInt)
       if x.val == 0
          r = mod(y, modulus(x))
          z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
-                       (Ptr{nmod_rel_series}, Int), &x, 0)
+                       (Ref{nmod_rel_series}, Int), x, 0)
          return r == z
       else
          return false
@@ -539,8 +539,8 @@ function divexact(x::nmod_rel_series, y::nmod_rel_series)
    z.prec = prec + z.val
    if prec != 0
       ccall((:nmod_poly_div_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &x, &y, prec)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, x, y, prec)
    end
    return z
 end
@@ -558,8 +558,8 @@ function divexact(x::nmod_rel_series, y::nmod)
    z.val = x.val
    r = inv(y)
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &x, data(r))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, x, data(r))
    return z
 end
 
@@ -569,11 +569,11 @@ function divexact(x::nmod_rel_series, y::fmpz)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &y, modulus(x))
+   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
    rinv = inv(base_ring(x)(r))
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &x, data(rinv))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, x, data(rinv))
    return z
 end
 
@@ -586,8 +586,8 @@ function divexact(x::nmod_rel_series, y::UInt)
    r = mod(y, modulus(x))
    rinv = inv(base_ring(x)(r))
    ccall((:nmod_poly_scalar_mul_nmod, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, UInt),
-               &z, &x, data(rinv))
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
+               z, x, data(rinv))
    return z
 end
 
@@ -606,8 +606,8 @@ function inv(a::nmod_rel_series)
    ainv.prec = a.prec
    ainv.val = 0
    ccall((:nmod_poly_inv_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &ainv, &a, a.prec)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               ainv, a, a.prec)
    return ainv
 end
 
@@ -644,7 +644,7 @@ function Base.exp(a::nmod_rel_series)
    end
    z = parent(a)(d, preca, preca, 0)
    ccall((:_nmod_poly_set_length, :libflint), Void,
-         (Ptr{nmod_rel_series}, Int), &z, normalise(z, preca))
+         (Ref{nmod_rel_series}, Int), z, normalise(z, preca))
    return z
 end
 
@@ -656,37 +656,37 @@ end
 
 function zero!(x::nmod_rel_series)
   ccall((:nmod_poly_zero, :libflint), Void,
-                   (Ptr{nmod_rel_series},), &x)
+                   (Ref{nmod_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(x::nmod_rel_series, n::Int)
   ccall((:nmod_poly_fit_length, :libflint), Void,
-                   (Ptr{nmod_rel_series}, Int), &x, n)
+                   (Ref{nmod_rel_series}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::fmpz)
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ptr{fmpz}, UInt), &x, modulus(z))
+   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, modulus(z))
    ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                (Ptr{nmod_rel_series}, Int, UInt),
-               &z, n, r)
+                (Ref{nmod_rel_series}, Int, UInt),
+               z, n, r)
    return z
 end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::UInt)
    r = mod(x, modulus(z))
    ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                (Ptr{nmod_rel_series}, Int, UInt),
-               &z, n, r)
+                (Ref{nmod_rel_series}, Int, UInt),
+               z, n, r)
    return z
 end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::nmod)
    ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
-                (Ptr{nmod_rel_series}, Int, UInt),
-               &z, n, data(x))
+                (Ref{nmod_rel_series}, Int, UInt),
+               z, n, data(x))
    return z
 end
 
@@ -705,8 +705,8 @@ function mul!(z::nmod_rel_series, a::nmod_rel_series, b::nmod_rel_series)
       lenz = 0
    end
    ccall((:nmod_poly_mullow, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &z, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               z, a, b, lenz)
    renormalize!(z)
    return z
 end
@@ -723,30 +723,30 @@ function addeq!(a::nmod_rel_series, b::nmod_rel_series)
       z = nmod_rel_series(modulus)
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:nmod_poly_set_trunc, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &b, max(0, lenz - b.val + a.val))
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, b, max(0, lenz - b.val + a.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &z, &z, b.val - a.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            z, z, b.val - a.val)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &a, &a, &z, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
       ccall((:nmod_poly_truncate, :libflint), Void,
-            (Ptr{nmod_rel_series}, Int),
-            &a, max(0, lenz - a.val + b.val))
+            (Ref{nmod_rel_series}, Int),
+            a, max(0, lenz - a.val + b.val))
       ccall((:nmod_poly_shift_left, :libflint), Void,
-            (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-            &a, &a, a.val - b.val)
+            (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+            a, a, a.val - b.val)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               a, a, b, lenz)
    else
       lenz = max(lena, lenb)
       ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &a, &a, &b, lenz)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               a, a, b, lenz)
    end
    a.prec = prec
    a.val = val
@@ -766,8 +766,8 @@ function add!(c::nmod_rel_series, a::nmod_rel_series, b::nmod_rel_series)
    lenc = max(lena, lenb)
    c.prec = prec
    ccall((:nmod_poly_add_series, :libflint), Void,
-                (Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Ptr{nmod_rel_series}, Int),
-               &c, &a, &b, lenc)
+                (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
+               c, a, b, lenc)
    return c
 end
 

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -112,7 +112,7 @@ doc"""
 function prime(R::FlintPadicField)
    z = fmpz()
    ccall((:padic_ctx_pow_ui, :libflint), Void,
-         (Ptr{fmpz}, Int, Ptr{FlintPadicField}), &z, 1, &R)
+         (Ref{fmpz}, Int, Ref{FlintPadicField}), z, 1, R)
    return z
 end
 
@@ -139,7 +139,7 @@ function lift(R::FlintRationalField, a::padic)
     ctx = parent(a)
     r = fmpq()
     ccall((:padic_get_fmpq, :libflint), Void,
-          (Ptr{fmpq}, Ptr{padic}, Ptr{FlintPadicField}), &r, &a, &ctx)
+          (Ref{fmpq}, Ref{padic}, Ref{FlintPadicField}), r, a, ctx)
     return r
 end
 
@@ -151,7 +151,7 @@ function lift(R::FlintIntegerRing, a::padic)
     ctx = parent(a)
     r = fmpz()
     ccall((:padic_get_fmpz, :libflint), Void,
-          (Ptr{fmpz}, Ptr{padic}, Ptr{FlintPadicField}), &r, &a, &ctx)
+          (Ref{fmpz}, Ref{padic}, Ref{FlintPadicField}), r, a, ctx)
     return r
 end
 
@@ -161,7 +161,7 @@ doc"""
 """
 function zero(R::FlintPadicField)
    z = padic(R.prec_max)
-   ccall((:padic_zero, :libflint), Void, (Ptr{padic},), &z)
+   ccall((:padic_zero, :libflint), Void, (Ref{padic},), z)
    z.parent = R
    return z
 end
@@ -172,7 +172,7 @@ doc"""
 """
 function one(R::FlintPadicField)
    z = padic(R.prec_max)
-   ccall((:padic_one, :libflint), Void, (Ptr{padic},), &z)
+   ccall((:padic_one, :libflint), Void, (Ref{padic},), z)
    z.parent = R
    return z
 end
@@ -183,7 +183,7 @@ doc"""
 > `false`.
 """
 iszero(a::padic) = Bool(ccall((:padic_is_zero, :libflint), Cint,
-                              (Ptr{padic},), &a))
+                              (Ref{padic},), a))
 
 doc"""
     isone(a::padic)
@@ -191,7 +191,7 @@ doc"""
 > `false`.
 """
 isone(a::padic) = Bool(ccall((:padic_is_one, :libflint), Cint,
-                             (Ptr{padic},), &a))
+                             (Ref{padic},), a))
 
 doc"""
     isunit(a::padic)
@@ -199,7 +199,7 @@ doc"""
 > otherwise return `false`.
 """
 isunit(a::padic) = !Bool(ccall((:padic_is_zero, :libflint), Cint,
-                              (Ptr{padic},), &a))
+                              (Ref{padic},), a))
 
 ###############################################################################
 #
@@ -210,8 +210,8 @@ isunit(a::padic) = !Bool(ccall((:padic_is_zero, :libflint), Cint,
 function show(io::IO, x::padic)
    ctx = parent(x)
    cstr = ccall((:padic_get_str, :libflint), Ptr{UInt8},
-               (Ptr{Void}, Ptr{padic}, Ptr{FlintPadicField}),
-                   C_NULL, &x, &ctx)
+               (Ptr{Void}, Ref{padic}, Ref{FlintPadicField}),
+                   C_NULL, x, ctx)
 
    print(io, unsafe_string(cstr))
 
@@ -252,8 +252,8 @@ function -(x::padic)
    ctx = parent(x)
    z = padic(x.N)
    ccall((:padic_neg, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-                     &z, &x, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+                     z, x, ctx)
    z.parent = ctx
    return z
 end
@@ -270,8 +270,8 @@ function +(x::padic, y::padic)
    z = padic(min(x.N, y.N))
    z.parent = ctx
    ccall((:padic_add, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, x, y, ctx)
    return z
 end
 
@@ -281,8 +281,8 @@ function -(x::padic, y::padic)
    z = padic(min(x.N, y.N))
    z.parent = ctx
    ccall((:padic_sub, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-                  &z, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+                  z, x, y, ctx)
    return z
 end
 
@@ -292,8 +292,8 @@ function *(x::padic, y::padic)
    z = padic(min(x.N + y.v, y.N + x.v))
    z.parent = ctx
    ccall((:padic_mul, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, x, y, ctx)
    return z
 end
 
@@ -350,10 +350,10 @@ function ==(a::padic, b::padic)
    ctx = parent(a)
    z = padic(min(a.N, b.N))
    ccall((:padic_sub, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &a, &b, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, a, b, ctx)
    return Bool(ccall((:padic_is_zero, :libflint), Cint,
-                (Ptr{padic},), &z))
+                (Ref{padic},), z))
 end
 
 function isequal(a::padic, b::padic)
@@ -392,8 +392,8 @@ function ^(a::padic, n::Int)
    z = padic(a.N + (n - 1)*a.v)
    z.parent = ctx
    ccall((:padic_pow_si, :libflint), Void,
-                (Ptr{padic}, Ptr{padic}, Int, Ptr{FlintPadicField}),
-               &z, &a, n, &ctx)
+                (Ref{padic}, Ref{padic}, Int, Ref{FlintPadicField}),
+               z, a, n, ctx)
    return z
 end
 
@@ -410,8 +410,8 @@ function divexact(a::padic, b::padic)
    z = padic(min(a.N - b.v, b.N - 2*b.v + a.v))
    z.parent = ctx
    ccall((:padic_div, :libflint), Cint,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &a, &b, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, a, b, ctx)
    return z
 end
 
@@ -449,7 +449,7 @@ function inv(a::padic)
    z = padic(a.N - 2*a.v)
    z.parent = ctx
    ccall((:padic_inv, :libflint), Cint,
-         (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), &z, &a, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx)
    return z
 end
 
@@ -510,7 +510,7 @@ function sqrt(a::padic)
    z = padic(a.N - div(a.v, 2))
    z.parent = ctx
    res = Bool(ccall((:padic_sqrt, :libflint), Cint,
-                    (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), &z, &a, &ctx))
+                    (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Square root of p-adic does not exist")
    return z
 end
@@ -534,7 +534,7 @@ function Base.exp(a::padic)
    z = padic(a.N)
    z.parent = ctx
    res = Bool(ccall((:padic_exp, :libflint), Cint,
-                    (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), &z, &a, &ctx))
+                    (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Unable to compute exponential")
    return z
 end
@@ -552,7 +552,7 @@ function log(a::padic)
    z = padic(a.N)
    z.parent = ctx
    res = Bool(ccall((:padic_log, :libflint), Cint,
-                    (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), &z, &a, &ctx))
+                    (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Unable to compute logarithm")
    return z
 end
@@ -571,7 +571,7 @@ function teichmuller(a::padic)
    z = padic(a.N)
    z.parent = ctx
    ccall((:padic_teichmuller, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}), &z, &a, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx)
    return z
 end
 
@@ -585,7 +585,7 @@ function zero!(z::padic)
    z.N = parent(z).prec_max
    ctx = parent(z)
    ccall((:padic_zero, :libflint), Void,
-         (Ptr{padic}, Ptr{FlintPadicField}), &z, &ctx)
+         (Ref{padic}, Ref{FlintPadicField}), z, ctx)
    return z
 end
 
@@ -593,8 +593,8 @@ function mul!(z::padic, x::padic, y::padic)
    z.N = min(x.N + y.v, y.N + x.v)
    ctx = parent(x)
    ccall((:padic_mul, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, x, y, ctx)
    return z
 end
 
@@ -602,8 +602,8 @@ function addeq!(x::padic, y::padic)
    x.N = min(x.N, y.N)
    ctx = parent(x)
    ccall((:padic_add, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &x, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               x, x, y, ctx)
    return x
 end
 
@@ -611,8 +611,8 @@ function addeq!(z::padic, x::padic, y::padic)
    z.N = min(x.N, y.N)
    ctx = parent(x)
    ccall((:padic_add, :libflint), Void,
-         (Ptr{padic}, Ptr{padic}, Ptr{padic}, Ptr{FlintPadicField}),
-               &z, &x, &y, &ctx)
+         (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
+               z, x, y, ctx)
    return z
 end
 
@@ -649,7 +649,7 @@ function (R::FlintPadicField)(n::fmpz)
    end
    z = padic(N + R.prec_max)
    ccall((:padic_set_fmpz, :libflint), Void,
-         (Ptr{padic}, Ptr{fmpz}, Ptr{FlintPadicField}), &z, &n, &R)
+         (Ref{padic}, Ref{fmpz}, Ref{FlintPadicField}), z, n, R)
    z.parent = R
    return z
 end
@@ -667,7 +667,7 @@ function (R::FlintPadicField)(n::fmpq)
    end
    z = padic(N + R.prec_max)
    ccall((:padic_set_fmpq, :libflint), Void,
-         (Ptr{padic}, Ptr{fmpq}, Ptr{FlintPadicField}), &z, &n, &R)
+         (Ref{padic}, Ref{fmpq}, Ref{FlintPadicField}), z, n, R)
    z.parent = R
    return z
 end

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -110,7 +110,7 @@ end
 
 function zero!(a::BigFloat)
    ccall((:mpfr_set_si, :libmpfr), Void,
-         (Ptr{BigFloat}, Int, Int32), &a, 0, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Int, Int32), a, 0, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 
@@ -120,8 +120,8 @@ end
 
 function mul!(a::BigFloat, b::BigFloat, c::BigFloat)
    ccall((:mpfr_mul, :libmpfr), Void,
-         (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
-                 &a, &b, &c, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+                 a, b, c, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 
@@ -131,8 +131,8 @@ end
 
 function add!(a::BigFloat, b::BigFloat, c::BigFloat)
    ccall((:mpfr_add, :libmpfr), Void,
-         (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
-                 &a, &b, &c, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+                 a, b, c, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 
@@ -142,8 +142,8 @@ end
 
 function addeq!(a::BigFloat, b::BigFloat)
    ccall((:mpfr_add, :libmpfr), Void,
-         (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
-                 &a, &a, &b, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+                 a, a, b, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 
@@ -153,8 +153,8 @@ end
 
 function addmul!(a::BigFloat, b::BigFloat, c::BigFloat, d::BigFloat)
    ccall((:mpfr_fma, :libmpfr), Void,
-         (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
-                 &a, &b, &c, &a, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+                 a, b, c, a, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 
@@ -164,8 +164,8 @@ end
 
 function addmul!(a::BigFloat, b::BigFloat, c::BigFloat) # special case, no temporary required
    ccall((:mpfr_fma, :libmpfr), Void,
-         (Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Ptr{BigFloat}, Int32),
-                 &a, &b, &c, &a, Base.MPFR.ROUNDING_MODE[])
+         (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+                 a, b, c, a, Base.MPFR.ROUNDING_MODE[])
    return a
 end
 

--- a/src/julia/Integer.jl
+++ b/src/julia/Integer.jl
@@ -145,7 +145,7 @@ function zero!(a::Integer)
 end
 
 function zero!(a::BigInt)
-   ccall((:__gmpz_set_si, :libgmp), Void, (Ptr{BigInt}, Int), &a, 0)
+   ccall((:__gmpz_set_si, :libgmp), Void, (Ref{BigInt}, Int), a, 0)
    return a
 end
 
@@ -154,7 +154,7 @@ function mul!(a::T, b::T, c::T) where T <: Integer
 end
 
 function mul!(a::BigInt, b::BigInt, c::BigInt)
-   ccall((:__gmpz_mul, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &a, &b, &c)
+   ccall((:__gmpz_mul, :libgmp), Void, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
    return a
 end
 
@@ -163,7 +163,7 @@ function add!(a::T, b::T, c::T) where T <: Integer
 end
 
 function add!(a::BigInt, b::BigInt, c::BigInt)
-   ccall((:__gmpz_add, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &a, &b, &c)
+   ccall((:__gmpz_add, :libgmp), Void, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
    return a
 end
 
@@ -172,7 +172,7 @@ function addeq!(a::T, b::T) where T <: Integer
 end
 
 function addeq!(a::BigInt, b::BigInt)
-   ccall((:__gmpz_add, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &a, &a, &b)
+   ccall((:__gmpz_add, :libgmp), Void, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, a, b)
    return a
 end
 
@@ -181,7 +181,7 @@ function addmul!(a::T, b::T, c::T, d::T) where T <: Integer
 end
 
 function addmul!(a::BigInt, b::BigInt, c::BigInt, d::BigInt)
-   ccall((:__gmpz_addmul, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &a, &b, &c)
+   ccall((:__gmpz_addmul, :libgmp), Void, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
    return a
 end
 
@@ -190,7 +190,7 @@ function addmul!(a::T, b::T, c::T) where T <: Integer # special case, no tempora
 end
 
 function addmul!(a::BigInt, b::BigInt, c::BigInt) # special case, no temporary required
-   ccall((:__gmpz_addmul, :libgmp), Void, (Ptr{BigInt}, Ptr{BigInt}, Ptr{BigInt}), &a, &b, &c)
+   ccall((:__gmpz_addmul, :libgmp), Void, (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}), a, b, c)
    return a
 end
 

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -149,7 +149,7 @@ function test_acb_mat_transpose()
 
    C = transpose(A)*A
 
-   @test overlaps(C', C)
+   @test overlaps(transpose(C), C)
 
    println("PASS")
 end
@@ -431,19 +431,19 @@ function test_acb_mat_linear_solving()
    @test overlaps(L*U, p*A)
    @test r == 3
 
-   y = solve(A, b')
+   y = solve(A, transpose(b))
 
-   @test overlaps(A * y, b')
+   @test overlaps(A * y, transpose(b))
 
-   @test contains(y', ZZ[1 1 1])
+   @test contains(transpose(y), ZZ[1 1 1])
 
    Nemo.lufact!(p, A)
 
-   y = solve_lu_precomp(p, A, b')
+   y = solve_lu_precomp(p, A, transpose(b))
 
-   @test overlaps(B*y, b')
+   @test overlaps(B*y, transpose(b))
 
-   @test contains(y', ZZ[1 1 1])
+   @test contains(transpose(y), ZZ[1 1 1])
 
    println("PASS")
 end

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -150,7 +150,7 @@ function test_arb_mat_transpose()
 
    C = transpose(A)*A
 
-   @test overlaps(C', C)
+   @test overlaps(transpose(C), C)
 
    println("PASS")
 end
@@ -404,19 +404,19 @@ function test_arb_mat_linear_solving()
    @test overlaps(L*U, p*A)
    @test r == 3
 
-   y = solve(A, b')
+   y = solve(A, transpose(b))
 
-   @test overlaps(A*y, b')
+   @test overlaps(A*y, transpose(b))
 
-   @test contains(y', ZZ[1 1 1])
+   @test contains(transpose(y), ZZ[1 1 1])
 
    Nemo.lufact!(p, A)
 
-   y = solve_lu_precomp(p, A, b')
+   y = solve_lu_precomp(p, A, transpose(b))
 
-   @test overlaps(B*y, b')
+   @test overlaps(B*y, transpose(b))
 
-   @test contains(y', ZZ[1 1 1])
+   @test contains(transpose(y), ZZ[1 1 1])
 
    println("PASS")
 end

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -352,7 +352,7 @@ function test_fmpq_mat_transpose()
 
    C = transpose(A)*A
 
-   @test C' == C
+   @test transpose(C) == C
 
    println("PASS")
 end

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -297,7 +297,7 @@ function test_fmpz_mat_transpose()
 
    C = transpose(A)*A
 
-   @test C' == C
+   @test transpose(C) == C
 
    println("PASS")
 end

--- a/test/generic/Fraction-test.jl
+++ b/test/generic/Fraction-test.jl
@@ -149,7 +149,7 @@ function test_gen_frac_adhoc_comparison()
 end
 
 function test_gen_frac_powering()
-   print("Generic.Frac.powering()...")
+   print("Generic.Frac.powering...")
 
    S, x = PolynomialRing(ZZ, "x")
 
@@ -161,7 +161,7 @@ function test_gen_frac_powering()
 end
 
 function test_gen_frac_inversion()
-   print("Generic.Frac.inversion()...")
+   print("Generic.Frac.inversion...")
 
    S, x = PolynomialRing(ZZ, "x")
 


### PR DESCRIPTION
- Change Ptr -> Ref, &x -> x
- Simplification in distinct degree factorization of fq_poly and fq_nmod_poly
- Adjust to convert changes (constructors don't fall back to convert anymore)
