### PR TITLE
Fix ccalls for arb module

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -133,7 +133,7 @@ mutable struct arb <: FieldElem
   #function arb(x::arf)
   #  z = new()
   #  ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
-  #  ccall((:arb_set_arf, :libarb), Void, (Ref{arb}, Ref{arf}), z, x)
+  #  ccall((:arb_set_arf, :libarb), Void, (Ref{arb}, Ptr{arf}), z, x)
   #  finalizer(z, _arb_clear_fn)
   #  return z
   #end
@@ -525,7 +525,7 @@ mutable struct arb_mat <: MatElem{arb}
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[i, j])
       end
@@ -540,7 +540,7 @@ mutable struct arb_mat <: MatElem{arb}
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[(i-1)*c+j])
       end
@@ -555,7 +555,7 @@ mutable struct arb_mat <: MatElem{arb}
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[i, j], prec)
       end
@@ -570,7 +570,7 @@ mutable struct arb_mat <: MatElem{arb}
     finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -680,7 +680,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
@@ -695,7 +695,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
@@ -710,7 +710,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
@@ -725,7 +725,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
@@ -740,7 +740,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
@@ -755,7 +755,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
@@ -770,7 +770,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -785,7 +785,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -801,7 +801,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
@@ -817,7 +817,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
@@ -833,7 +833,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
@@ -849,7 +849,7 @@ mutable struct acb_mat <: MatElem{acb}
     finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -113,13 +113,13 @@ end
 ################################################################################
 
 function convert(::Type{Complex128}, x::acb)
-    re = ccall((:acb_real_ptr, :libarb), Ref{arb_struct}, (Ref{acb}, ), x)
-    im = ccall((:acb_imag_ptr, :libarb), Ref{arb_struct}, (Ref{acb}, ), x)
-    t = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), re)
-    u = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), im)
+    re = ccall((:acb_real_ptr, :libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
+    im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
+    t = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), re)
+    u = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), im)
     # 4 == round to nearest
-    v = ccall((:arf_get_d, :libarb), Float64, (Ref{arf_struct}, Int), t, 4)
-    w = ccall((:arf_get_d, :libarb), Float64, (Ref{arf_struct}, Int), u, 4)
+    v = ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
+    w = ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), u, 4)
     return complex(v, w)
 end
 
@@ -1458,7 +1458,7 @@ end
 #
 ################################################################################
 
-for (typeofx, passtoc) in ((acb, Ref{acb}), (Ref{acb}, Ref{acb}))
+for (typeofx, passtoc) in ((acb, Ref{acb}), (Ptr{acb}, Ptr{acb}))
   for (f,t) in (("acb_set_si", Int), ("acb_set_ui", UInt),
                 ("acb_set_d", Float64))
     @eval begin
@@ -1509,24 +1509,24 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ref{acb}, Ref{acb}))
     end
 
     function _acb_set(x::($typeofx), y::AbstractString, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Void, (Ref{arb}, ), i)
+      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, :libarb), Void, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::BigFloat)
-      r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y)
-      i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Void, (Ref{arb}, ), i)
+      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, :libarb), Void, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::BigFloat, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Void, (Ref{arb}, ), i)
+      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, :libarb), Void, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::Int, z::Int, p::Int)
@@ -1548,16 +1548,16 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ref{acb}, Ref{acb}))
     end
 
     function _acb_set(x::($typeofx), y::fmpq, z::fmpq, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(i, z, p)
     end
 
     function _acb_set(x::($typeofx), y::T, z::T, p::Int) where {T <: AbstractString}
-      r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(i, z, p)
     end
 
@@ -1566,16 +1566,16 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ref{acb}, Ref{acb}))
   for T in (Float64, BigFloat, UInt, fmpz)
     @eval begin
       function _acb_set(x::($typeofx), y::($T), z::($T))
-        r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+        r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(r, y)
-        i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+        i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(i, z)
       end
 
       function _acb_set(x::($typeofx), y::($T), z::($T), p::Int)
-        r = ccall((:acb_real_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+        r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(r, y, p)
-        i = ccall((:acb_imag_ptr, :libarb), Ref{arb}, (($passtoc), ), x)
+        i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(i, z, p)
       end
     end

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -47,9 +47,9 @@ base_ring(a::AcbMatSpace) = a.base_ring
 base_ring(a::acb_mat) = a.base_ring
 
 function getindex!(z::acb, x::acb_mat, r::Int, c::Int)
-  v = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+  v = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
               (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
-  ccall((:acb_set, :libarb), Void, (Ref{acb}, Ref{acb}), z, v)
+  ccall((:acb_set, :libarb), Void, (Ref{acb}, Ptr{acb}), z, v)
   return z
 end
 
@@ -57,9 +57,9 @@ end
   @boundscheck Generic._checkbounds(x, r, c)
 
   z = base_ring(x)()
-  v = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+  v = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
               (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
-  ccall((:acb_set, :libarb), Void, (Ref{acb}, Ref{acb}), z, v)
+  ccall((:acb_set, :libarb), Void, (Ref{acb}, Ptr{acb}), z, v)
   return z
 end
 
@@ -68,7 +68,7 @@ for T in [Integer, Float64, fmpz, fmpq, arb, BigFloat, acb, AbstractString]
       @inline function setindex!(x::acb_mat, y::$T, r::Int, c::Int)
          @boundscheck Generic._checkbounds(x, r, c)
 
-         z = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+         z = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                    (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
          _acb_set(z, y, prec(base_ring(x)))
       end
@@ -84,7 +84,7 @@ for T in [Integer, Float64, fmpz, fmpq, arb, BigFloat, AbstractString]
       @inline function setindex!(x::acb_mat, y::Tuple{$T, $T}, r::Int, c::Int)
          @boundscheck Generic._checkbounds(x, r, c)
 
-         z = ccall((:acb_mat_entry_ptr, :libarb), Ref{acb},
+         z = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
                    (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
          _acb_set(z, y[1], y[2], prec(base_ring(x)))
       end
@@ -678,9 +678,9 @@ function bound_inf_norm(x::acb_mat)
   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
   ccall((:acb_mat_bound_inf_norm, :libarb), Void,
               (Ptr{mag_struct}, Ref{acb_mat}), t, x)
-  s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
+  s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
   ccall((:arf_set_mag, :libarb), Void,
-              (Ref{arf_struct}, Ptr{mag_struct}), s, t)
+              (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
   ccall((:mag_zero, :libarb), Void,
               (Ptr{mag_struct},), t)
   return ArbField(prec(base_ring(x)))(z)

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -655,8 +655,8 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
                     im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct},
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
-                    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), re)
-                    u = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), im)
+                    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), re)
+                    u = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), im)
                     ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
                         (Ptr{mag_struct}, Int), t, -target) <= 0)
                     ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
@@ -725,10 +725,10 @@ function roots_upper_bound(x::acb_poly)
    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
    ccall((:acb_poly_root_bound_fujiwara, :libarb), Void,
          (Ptr{mag_struct}, Ref{acb_poly}), t, x)
-   s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
-   ccall((:arf_set_mag, :libarb), Void, (Ref{arf_struct}, Ptr{mag_struct}), s, t)
+   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
    ccall((:arf_set_round, :libarb), Void,
-         (Ref{arf_struct}, Ref{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
    ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
    return z
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -99,9 +99,9 @@ doc"""
 > Return the midpoint of $x$ rounded down to a machine double.
 """
 function convert(::Type{Float64}, x::arb)
-    t = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), x)
+    t = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), x)
     # 4 == round to nearest
-    return ccall((:arf_get_d, :libarb), Float64, (Ref{arf_struct}, Int), t, 4)
+    return ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
 end
 
 ################################################################################
@@ -1751,7 +1751,7 @@ end
 #
 ################################################################################
 
-for (typeofx, passtoc) in ((arb, Ref{arb}), (Ref{arb}, Ref{arb}))
+for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
   for (f,t) in (("arb_set_si", Int), ("arb_set_ui", UInt),
                 ("arb_set_d", Float64))
     @eval begin
@@ -1799,20 +1799,20 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ref{arb}, Ref{arb}))
     end
 
     function _arb_set(x::($typeofx), y::BigFloat)
-      m = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct},
+      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct},
                   (($passtoc), ), x)
       r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct},
                   (($passtoc), ), x)
       ccall((:arf_set_mpfr, :libarb), Void,
-                  (Ref{arf_struct}, Ref{BigFloat}), m, y)
+                  (Ptr{arf_struct}, Ref{BigFloat}), m, y)
       ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
     end
 
     function _arb_set(x::($typeofx), y::BigFloat, p::Int)
-      m = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (($passtoc), ), x)
+      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (($passtoc), ), x)
       r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (($passtoc), ), x)
       ccall((:arf_set_mpfr, :libarb), Void,
-                  (Ref{arf_struct}, Ref{BigFloat}), m, y)
+                  (Ptr{arf_struct}, Ref{BigFloat}), m, y)
       ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct}, ), r)
       ccall((:arb_set_round, :libarb), Void,
                   (($passtoc), ($passtoc), Int), x, x, p)

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -47,9 +47,9 @@ parent(x::arb_mat, cached::Bool = true) =
 prec(x::ArbMatSpace) = prec(x.base_ring)
 
 function getindex!(z::arb, x::arb_mat, r::Int, c::Int)
-  v = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+  v = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
               (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
-  ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), z, v)
+  ccall((:arb_set, :libarb), Void, (Ref{arb}, Ptr{arb}), z, v)
   return z
 end
 
@@ -57,9 +57,9 @@ end
   @boundscheck Generic._checkbounds(x, r, c)
 
   z = base_ring(x)()
-  v = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+  v = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
               (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
-  ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), z, v)
+  ccall((:arb_set, :libarb), Void, (Ref{arb}, Ptr{arb}), z, v)
   return z
 end
 
@@ -68,7 +68,7 @@ for T in [Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString]
       @inline function setindex!(x::arb_mat, y::$T, r::Int, c::Int)
          @boundscheck Generic._checkbounds(x, r, c)
 
-         z = ccall((:arb_mat_entry_ptr, :libarb), Ref{arb},
+         z = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
                    (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
          Nemo._arb_set(z, y, prec(base_ring(x)))
       end
@@ -615,9 +615,9 @@ function bound_inf_norm(x::arb_mat)
   t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
   ccall((:arb_mat_bound_inf_norm, :libarb), Void,
               (Ptr{mag_struct}, Ref{arb_mat}), t, x)
-  s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
+  s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
   ccall((:arf_set_mag, :libarb), Void,
-              (Ref{arf_struct}, Ptr{mag_struct}), s, t)
+              (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
   ccall((:mag_zero, :libarb), Void,
               (Ptr{mag_struct},), t)
   return base_ring(x)(z)

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -625,10 +625,10 @@ function roots_upper_bound(x::arb_poly)
    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
    ccall((:arb_poly_root_bound_fujiwara, :libarb), Void,
          (Ptr{mag_struct}, Ref{arb_poly}), t, x)
-   s = ccall((:arb_mid_ptr, :libarb), Ref{arf_struct}, (Ref{arb}, ), z)
-   ccall((:arf_set_mag, :libarb), Void, (Ref{arf_struct}, Ptr{mag_struct}), s, t)
+   s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+   ccall((:arf_set_mag, :libarb), Void, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
    ccall((:arf_set_round, :libarb), Void,
-         (Ref{arf_struct}, Ref{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
+         (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
    ccall((:mag_zero, :libarb), Void, (Ptr{mag_struct},), t)
    return z
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1998,10 +1998,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpq}), el, arr[i, j])
+                  (Ptr{fmpq}, Ref{fmpq}), el, arr[i, j])
          end
       end
       return z
@@ -2015,10 +2015,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       b = fmpz(1)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[i, j], b)
+                  (Ptr{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[i, j], b)
          end
       end
       return z
@@ -2032,10 +2032,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpq}), el, arr[(i-1)*c+j])
+                  (Ptr{fmpq}, Ref{fmpq}), el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -2049,10 +2049,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       b = fmpz(1)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set_fmpz_frac, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j], b)
+                  (Ptr{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j], b)
          end
       end
       return z
@@ -2066,10 +2066,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpq}), el, fmpq(arr[i, j]))
+                  (Ptr{fmpq}, Ref{fmpq}), el, fmpq(arr[i, j]))
          end
       end
       return z
@@ -2082,10 +2082,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpq_set, :libflint), Void,
-                  (Ref{fmpq}, Ref{fmpq}), el, fmpq(arr[(i-1)*c+j]))
+                  (Ptr{fmpq}, Ref{fmpq}), el, fmpq(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -2097,10 +2097,10 @@ mutable struct fmpq_mat <: MatElem{fmpq}
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpq_mat_clear_fn)
       for i = 1:min(r, c)
-         el = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+         el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
                     (Ref{fmpq_mat}, Int, Int), z, i - 1, i - 1)
          ccall((:fmpq_set, :libflint), Void,
-               (Ref{fmpq}, Ref{fmpq}), el, d)
+               (Ptr{fmpq}, Ref{fmpq}), el, d)
       end
       return z
    end
@@ -2172,10 +2172,10 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ref{fmpz}, Ref{fmpz}), el, arr[i, j])
+                  (Ptr{fmpz}, Ref{fmpz}), el, arr[i, j])
          end
       end
       return z
@@ -2188,10 +2188,10 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
+                  (Ptr{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -2204,10 +2204,10 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ref{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
+                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
          end
       end
       return z
@@ -2220,10 +2220,10 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
             ccall((:fmpz_set, :libflint), Void,
-                  (Ref{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
+                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -2235,10 +2235,10 @@ mutable struct fmpz_mat <: MatElem{fmpz}
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:min(r, c)
-         el = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+         el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                     (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
          ccall((:fmpz_set, :libflint), Void,
-               (Ref{fmpz}, Ref{fmpz}), el, d)
+               (Ptr{fmpz}, Ref{fmpz}), el, d)
       end
       return z
    end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -84,35 +84,35 @@ size(t::fmpq_mat, d) = d <= 2 ? size(t)[d] : 1
 ###############################################################################
 
 function getindex!(v::fmpq, a::fmpq_mat, r::Int, c::Int)
-   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), v, z)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ptr{fmpq}), v, z)
 end
 
 @inline function getindex(a::fmpq_mat, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpq()
-   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), v, z)
+   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ptr{fmpq}), v, z)
    return v
 end
 
 @inline function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry_num, :libflint), Ref{fmpz},
+   z = ccall((:fmpq_mat_entry_num, :libflint), Ptr{fmpz},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, d)
-   z = ccall((:fmpq_mat_entry_den, :libflint), Ref{fmpz},
+   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ref{fmpz}), z, d)
+   z = ccall((:fmpq_mat_entry_den, :libflint), Ptr{fmpz},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set_si, :libflint), Void, (Ref{fmpz}, Int), z, 1)
+   ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, 1)
 end
 
 @inline function setindex!(a::fmpq_mat, d::fmpq, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpq_set, :libflint), Void, (Ref{fmpq}, Ref{fmpq}), z, d)
+   ccall((:fmpq_set, :libflint), Void, (Ptr{fmpq}, Ref{fmpq}), z, d)
 end
 
 Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
@@ -121,9 +121,9 @@ Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
 
 @inline function setindex!(a::fmpq_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpq_mat_entry, :libflint), Ref{fmpq},
+   z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
              (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpq_set_si, :libflint), Void, (Ref{fmpq}, Int, Int), z, d, 1)
+   ccall((:fmpq_set_si, :libflint), Void, (Ptr{fmpq}, Int, Int), z, d, 1)
 end
 
 Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Rational,

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -89,34 +89,34 @@ size(t::fmpz_mat, d) = d <= 2 ? size(t)[d] : 1
 ###############################################################################
 
 function getindex!(v::fmpz, a::fmpz_mat, r::Int, c::Int)
-   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), v, z)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ptr{fmpz}), v, z)
 end
 
 @inline function getindex(a::fmpz_mat, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpz()
-   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), v, z)
+   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ptr{fmpz}), v, z)
    return v
 end
 
 @inline function setindex!(a::fmpz_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set, :libflint), Void, (Ref{fmpz}, Ref{fmpz}), z, d)
+   ccall((:fmpz_set, :libflint), Void, (Ptr{fmpz}, Ref{fmpz}), z, d)
 end
 
 @inline setindex!(a::fmpz_mat, d::Integer, r::Int, c::Int) = setindex!(a, fmpz(d), r, c)
 
 @inline function setindex!(a::fmpz_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
-   z = ccall((:fmpz_mat_entry, :libflint), Ref{fmpz},
+   z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
              (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-   ccall((:fmpz_set_si, :libflint), Void, (Ref{fmpz}, Int), z, d)
+   ccall((:fmpz_set_si, :libflint), Void, (Ptr{fmpz}, Int), z, d)
 end
 
 @inline rows(a::fmpz_mat) = a.r

--- a/src/generic/MPoly.jl
+++ b/src/generic/MPoly.jl
@@ -2900,6 +2900,11 @@ function (a::MPolyRing{T})(b::Union{Integer, Rational, AbstractFloat}) where {T 
    return z
 end
 
+function (a::MPolyRing{T})(b::T) where {T <: Union{Integer, Rational, AbstractFloat}}
+   z = MPoly{T}(a, b)
+   return z
+end
+
 function (a::MPolyRing{T})(b::T) where {T <: RingElement}
    parent(b) != base_ring(a) && error("Unable to coerce to polynomial")
    z = MPoly{T}(a, b)


### PR DESCRIPTION
Hecke came crashing down with the newest Nemo version.

My brainless search and replace did not work so well for arb, since we do a lot of stuff with raw pointers. So I did it again (by hand). This should work now.

There were also some bugs in the flint module.