### PR TITLE
Fix lu factorization again

### DIFF
--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -421,6 +421,9 @@ function lufact!(P::Generic.perm, x::fq_mat)
     P.d[i] += 1
   end
 
+  # flint does x == PLU instead of Px == LU (docs are wrong)
+  inv!(P)
+
   return rank
 end
 

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -421,6 +421,9 @@ function lufact!(P::Generic.perm, x::fq_nmod_mat)
     P.d[i] += 1
   end
 
+  # flint does x == PLU instead of Px == LU (docs are wrong)
+  inv!(P)
+
   return rank
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -480,6 +480,9 @@ function lufact!(P::Generic.perm, x::nmod_mat)
     P.d[i] += 1
   end
 
+  # flint does x == PLU instead of Px == LU (docs are wrong)
+  inv!(P)
+
   return rank
 end
 

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -559,6 +559,13 @@ function test_fq_mat_lu()
 
   @test l*u == P*b
 
+  c = matrix(F17, 6, 3, [0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+  r, P, l, u = lufact(c)
+
+  @test r == 3
+  @test l*u == P*c
+
   println("PASS")
 end
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -559,6 +559,13 @@ function test_fq_nmod_mat_lu()
 
   @test l*u == P*b
 
+  c = matrix(F17, 6, 3, [0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+  r, P, l, u = lufact(c)
+
+  @test r == 3
+  @test l*u == P*c
+
   println("PASS")
 end
 

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -604,6 +604,13 @@ function test_nmod_mat_lu()
 
   @test l*u == P*b
 
+  c = matrix(Z17, 6, 3, [0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+  r, P, l, u = lufact(c)
+
+  @test r == 3
+  @test l*u == P*c
+
   println("PASS")
 end
 


### PR DESCRIPTION
flint claims in the docs that it does `PA = LU` but it is doing `A = PLU`:
```
julia> R = ResidueRing(ZZ, 17)
julia> A = matrix(R, 6, 3, [0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
[0 0 1]
[0 0 0]
[0 0 0]
[1 0 0]
[0 1 0]
[0 0 1]

julia> B = deepcopy(A)
julia> P = PermGroup(6)()
[1, 2, 3, 4, 5, 6]

julia> r = lufact!(P, B)
3

julia> P * A == B
false

julia> P * B == A
true
```
Easy fix is to just invert the permutation.
