### PR TITLE
Fmpqseriesdiv

### DIFF
--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -289,6 +289,41 @@ function *(x::fmpq, y::fmpq_rel_series)
    return z
 end
 
+function //(x::fmpq_rel_series, y::Int)
+   y == 0 && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_si, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, y)
+   return z
+end
+
+function //(x::fmpq_rel_series, y::fmpz)
+   iszero(y) && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
+               z, x, y)
+   return z
+end
+
+function //(x::fmpq_rel_series, y::fmpq)
+   iszero(y) && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
+               z, x, y)
+   return z
+end
+
 *(x::fmpq_rel_series, y::fmpz) = y * x
 
 *(x::fmpq_rel_series, y::fmpq) = y * x
@@ -553,40 +588,7 @@ end
 #
 ###############################################################################
 
-function divexact(x::fmpq_rel_series, y::Int)
-   y == 0 && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_divexact_si, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
-               z, x, y)
-   return z
-end
-
-function divexact(x::fmpq_rel_series, y::fmpz)
-   iszero(y) && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_divexact_fmpz, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
-               z, x, y)
-   return z
-end
-
-function divexact(x::fmpq_rel_series, y::fmpq)
-   iszero(y) && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
-               z, x, y)
-   return z
-end
+divexact(x::fmpq_rel_series, y::Union{Int,fmpz,fmpq}) = x // y
 
 divexact(x::fmpq_rel_series, y::Integer) = divexact(x, fmpz(y))
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -289,41 +289,6 @@ function *(x::fmpq, y::fmpq_rel_series)
    return z
 end
 
-function //(x::fmpq_rel_series, y::Int)
-   y == 0 && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_div_si, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
-               z, x, y)
-   return z
-end
-
-function //(x::fmpq_rel_series, y::fmpz)
-   iszero(y) && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
-               z, x, y)
-   return z
-end
-
-function //(x::fmpq_rel_series, y::fmpq)
-   iszero(y) && throw(DivideError())
-   z = parent(x)()
-   z.prec = x.prec
-   z.prec = x.prec
-   z.val = x.val
-   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
-                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
-               z, x, y)
-   return z
-end
-
 *(x::fmpq_rel_series, y::fmpz) = y * x
 
 *(x::fmpq_rel_series, y::fmpq) = y * x
@@ -588,11 +553,40 @@ end
 #
 ###############################################################################
 
-divexact(x::fmpq_rel_series, y::Int) = x // y
+function divexact(x::fmpq_rel_series, y::Int)
+   y == 0 && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_si, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
+               z, x, y)
+   return z
+end
 
-divexact(x::fmpq_rel_series, y::fmpz) = x // y
+function divexact(x::fmpq_rel_series, y::fmpz)
+   iszero(y) && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
+               z, x, y)
+   return z
+end
 
-divexact(x::fmpq_rel_series, y::fmpq) = x // y
+function divexact(x::fmpq_rel_series, y::fmpq)
+   iszero(y) && throw(DivideError())
+   z = parent(x)()
+   z.prec = x.prec
+   z.prec = x.prec
+   z.val = x.val
+   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Void,
+                (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
+               z, x, y)
+   return z
+end
 
 divexact(x::fmpq_rel_series, y::Integer) = divexact(x, fmpz(y))
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -588,7 +588,11 @@ end
 #
 ###############################################################################
 
-divexact(x::fmpq_rel_series, y::Union{Int,fmpz,fmpq}) = x // y
+divexact(x::fmpq_rel_series, y::Int) = x // y
+
+divexact(x::fmpq_rel_series, y::fmpz) = x // y
+
+divexact(x::fmpq_rel_series, y::fmpq) = x // y
 
 divexact(x::fmpq_rel_series, y::Integer) = divexact(x, fmpz(y))
 

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -472,6 +472,7 @@ function test_fmpq_rel_series()
    test_fmpq_rel_series_shift()
    test_fmpq_rel_series_truncation()
    test_fmpq_rel_series_exact_division()
+   test_fmpq_rel_series_adhoc_exact_division()
    test_fmpq_rel_series_inversion()
    test_fmpq_rel_series_special()
 

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -265,6 +265,8 @@ function test_fmpq_rel_series_adhoc_binary_ops()
 
    @test fmpq(2, 3)*c == 2*x^2 + fmpz(2)//3*x + fmpz(2)//3+O(x^5)
 
+   @test c//fmpq(2,1) == 3*x^2//2 + x//fmpz(2) + 1//2
+
    println("PASS")
 end
 
@@ -400,7 +402,7 @@ end
 function test_fmpq_rel_series_adhoc_exact_division()
    print("fmpq_rel_series.adhoc_exact_division...")
 
-   R, x = PolynomialRing(QQ, "x")
+   R, x = PowerSeriesRing(QQ, 30, "x")
    
    a = x + x^3
    b = O(x^4)

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -265,8 +265,6 @@ function test_fmpq_rel_series_adhoc_binary_ops()
 
    @test fmpq(2, 3)*c == 2*x^2 + fmpz(2)//3*x + fmpz(2)//3+O(x^5)
 
-   @test c//fmpq(2,1) == 3*x^2//2 + x//fmpz(2) + 1//2
-
    println("PASS")
 end
 


### PR DESCRIPTION
The divexact test for power series was incorrect, so that the calling of non-existent C functions remained undetected. This provides //-division via C calls and redirects divexact to there.