### PR TITLE
Revert "replace the finalizers by direct c-functions to avoid some of the gc"

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -77,12 +77,7 @@ mutable struct nf_elem <: FieldElem
       ccall((:nf_elem_init, :libflint), Void, 
             (Ref{nf_elem}, Ref{AnticNumberField}), r, p)
       r.parent = p
-      if p.pol_length > 3
-        #the other "proper" finalizer needs the ring as well...
-        finalizer(r, cglobal((:fmpq_poly_clear, :libflint)))
-      else
-        finalizer(r, _nf_elem_clear_fn)
-      end
+      finalizer(r, _nf_elem_clear_fn)
       return r
    end
 
@@ -93,11 +88,7 @@ mutable struct nf_elem <: FieldElem
       ccall((:nf_elem_set, :libflint), Void,
             (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}), r, a, p)
       r.parent = p
-      if p.pol_length > 3
-        finalizer(r, cglobal((:fmpq_poly_clear, :libflint)))
-      else
-        finalizer(r, _nf_elem_clear_fn)
-      end
+      finalizer(r, _nf_elem_clear_fn)
       return r
    end
 end

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -100,7 +100,7 @@ mutable struct arb <: FieldElem
   function arb()
     z = new()
     ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
-    finalizer(z, cglobal((:arb_clear, :libarb)))
+    finalizer(z, _arb_clear_fn)
     return z
   end
 
@@ -109,7 +109,7 @@ mutable struct arb <: FieldElem
     z = new()
     ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     _arb_set(z, x, p)
-    finalizer(z, cglobal((:arb_clear, :libarb)))
+    finalizer(z, _arb_clear_fn)
     return z
   end
 
@@ -117,7 +117,7 @@ mutable struct arb <: FieldElem
     z = new()
     ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     _arb_set(z, x)
-    finalizer(z, cglobal((:arb_clear, :libarb)))
+    finalizer(z, _arb_clear_fn)
     return z
   end
 
@@ -126,7 +126,7 @@ mutable struct arb <: FieldElem
     ccall((:arb_init, :libarb), Void, (Ref{arb}, ), z)
     ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), z, mid)
     ccall((:arb_add_error, :libarb), Void, (Ref{arb}, Ref{arb}), z, rad)
-    finalizer(z, cglobal((:arb_clear, :libarb)))
+    finalizer(z, _arb_clear_fn)
     return z
   end
 
@@ -137,6 +137,10 @@ mutable struct arb <: FieldElem
   #  finalizer(z, _arb_clear_fn)
   #  return z
   #end
+end
+
+function _arb_clear_fn(x::arb)
+  ccall((:arb_clear, :libarb), Void, (Ref{arb}, ), x)
 end
 
 ################################################################################
@@ -184,7 +188,7 @@ mutable struct acb <: FieldElem
   function acb()
     z = new()
     ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
-    finalizer(z, cglobal((:acb_clear, :libarb)))
+    finalizer(z, _acb_clear_fn)
     return z
   end
 
@@ -192,7 +196,7 @@ mutable struct acb <: FieldElem
     z = new()
     ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x)
-    finalizer(z, cglobal((:acb_clear, :libarb)))
+    finalizer(z, _acb_clear_fn)
     return z
   end
 
@@ -201,7 +205,7 @@ mutable struct acb <: FieldElem
     z = new()
     ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x, p)
-    finalizer(z, cglobal((:acb_clear, :libarb)))
+    finalizer(z, _acb_clear_fn)
     return z
   end
 
@@ -217,10 +221,15 @@ mutable struct acb <: FieldElem
     z = new()
     ccall((:acb_init, :libarb), Void, (Ref{acb}, ), z)
     _acb_set(z, x, y, p)
-    finalizer(z, cglobal((:acb_clear, :libarb)))
+    finalizer(z, _acb_clear_fn)
     return z
   end
 end
+
+function _acb_clear_fn(x::acb)
+  ccall((:acb_clear, :libarb), Void, (Ref{acb}, ), x)
+end
+
 
 ################################################################################
 #
@@ -256,7 +265,7 @@ mutable struct arb_poly <: PolyElem{arb}
   function arb_poly()
     z = new()
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -265,7 +274,7 @@ mutable struct arb_poly <: PolyElem{arb}
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_coeff_arb, :libarb), Void,
                 (Ref{arb_poly}, Int, Ref{arb}), z, 0, x)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -276,7 +285,7 @@ mutable struct arb_poly <: PolyElem{arb}
         ccall((:arb_poly_set_coeff_arb, :libarb), Void,
                 (Ref{arb_poly}, Int, Ref{arb}), z, i - 1, x[i])
     end
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -284,7 +293,7 @@ mutable struct arb_poly <: PolyElem{arb}
     z = new() 
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set, :libarb), Void, (Ref{arb_poly}, Ref{arb_poly}), z, x)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -293,7 +302,7 @@ mutable struct arb_poly <: PolyElem{arb}
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_round, :libarb), Void,
                 (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -302,7 +311,7 @@ mutable struct arb_poly <: PolyElem{arb}
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_fmpz_poly, :libarb), Void,
                 (Ref{arb_poly}, Ref{fmpz_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
 
@@ -311,9 +320,13 @@ mutable struct arb_poly <: PolyElem{arb}
     ccall((:arb_poly_init, :libarb), Void, (Ref{arb_poly}, ), z)
     ccall((:arb_poly_set_fmpq_poly, :libarb), Void,
                 (Ref{arb_poly}, Ref{fmpq_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:arb_poly_clear, :libarb)))
+    finalizer(z, _arb_poly_clear_fn)
     return z
   end
+end
+
+function _arb_poly_clear_fn(x::arb_poly)
+  ccall((:arb_poly_clear, :libarb), Void, (Ref{arb_poly}, ), x)
 end
 
 parent(x::arb_poly) = x.parent
@@ -360,7 +373,7 @@ mutable struct acb_poly <: PolyElem{acb}
   function acb_poly()
     z = new()
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -369,7 +382,7 @@ mutable struct acb_poly <: PolyElem{acb}
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_coeff_acb, :libarb), Void,
                 (Ref{acb_poly}, Int, Ref{acb}), z, 0, x)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -380,7 +393,7 @@ mutable struct acb_poly <: PolyElem{acb}
         ccall((:acb_poly_set_coeff_acb, :libarb), Void,
                 (Ref{acb_poly}, Int, Ref{acb}), z, i - 1, x[i])
     end
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -388,7 +401,7 @@ mutable struct acb_poly <: PolyElem{acb}
     z = new() 
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set, :libarb), Void, (Ref{acb_poly}, Ref{acb_poly}), z, x)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -399,7 +412,7 @@ mutable struct acb_poly <: PolyElem{acb}
                 (Ref{acb_poly}, Ref{arb_poly}, Int), z, x, p)
     ccall((:acb_poly_set_round, :libarb), Void,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, z, p)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -408,7 +421,7 @@ mutable struct acb_poly <: PolyElem{acb}
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_round, :libarb), Void,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -417,7 +430,7 @@ mutable struct acb_poly <: PolyElem{acb}
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_fmpz_poly, :libarb), Void,
                 (Ref{acb_poly}, Ref{fmpz_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
 
@@ -426,9 +439,13 @@ mutable struct acb_poly <: PolyElem{acb}
     ccall((:acb_poly_init, :libarb), Void, (Ref{acb_poly}, ), z)
     ccall((:acb_poly_set_fmpq_poly, :libarb), Void,
                 (Ref{acb_poly}, Ref{fmpq_poly}, Int), z, x, p)
-    finalizer(z, cglobal((:acb_poly_clear, :libarb)))
+    finalizer(z, _acb_poly_clear_fn)
     return z
   end
+end
+
+function _acb_poly_clear_fn(x::acb_poly)
+  ccall((:acb_poly_clear, :libarb), Void, (Ref{acb_poly}, ), x)
 end
 
 parent(x::acb_poly) = x.parent
@@ -477,7 +494,7 @@ mutable struct arb_mat <: MatElem{arb}
   function arb_mat(r::Int, c::Int)
     z = new()
     ccall((:arb_mat_init, :libarb), Void, (Ref{arb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     return z
   end
 
@@ -487,7 +504,7 @@ mutable struct arb_mat <: MatElem{arb}
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_fmpz_mat, :libarb), Void,
                 (Ref{arb_mat}, Ref{fmpz_mat}), z, a)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     return z
   end
   
@@ -497,7 +514,7 @@ mutable struct arb_mat <: MatElem{arb}
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_round_fmpz_mat, :libarb), Void,
                 (Ref{arb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     return z
   end
 
@@ -505,7 +522,7 @@ mutable struct arb_mat <: MatElem{arb}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
@@ -520,7 +537,7 @@ mutable struct arb_mat <: MatElem{arb}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
@@ -535,7 +552,7 @@ mutable struct arb_mat <: MatElem{arb}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
@@ -550,7 +567,7 @@ mutable struct arb_mat <: MatElem{arb}
     z = new()
     ccall((:arb_mat_init, :libarb), Void, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
@@ -567,9 +584,13 @@ mutable struct arb_mat <: MatElem{arb}
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
     ccall((:arb_mat_set_fmpq_mat, :libarb), Void,
                 (Ref{arb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
-    finalizer(z, cglobal((:arb_mat_clear, :libarb)))
+    finalizer(z, _arb_mat_clear_fn)
     return z
   end
+end
+
+function _arb_mat_clear_fn(x::arb_mat)
+  ccall((:arb_mat_clear, :libarb), Void, (Ref{arb_mat}, ), x)
 end
 
 ################################################################################
@@ -608,7 +629,7 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int)
     z = new()
     ccall((:acb_mat_init, :libarb), Void, (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
 
@@ -618,7 +639,7 @@ mutable struct acb_mat <: MatElem{acb}
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_fmpz_mat, :libarb), Void,
                 (Ref{acb_mat}, Ref{fmpz_mat}), z, a)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
   
@@ -628,7 +649,7 @@ mutable struct acb_mat <: MatElem{acb}
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_round_fmpz_mat, :libarb), Void,
                 (Ref{acb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
 
@@ -638,7 +659,7 @@ mutable struct acb_mat <: MatElem{acb}
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_arb_mat, :libarb), Void,
                 (Ref{acb_mat}, Ref{arb_mat}), z, a)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
 
@@ -648,7 +669,7 @@ mutable struct acb_mat <: MatElem{acb}
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_round_arb_mat, :libarb), Void,
                 (Ref{acb_mat}, Ref{arb_mat}, Int), z, a, prec)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
    
@@ -656,7 +677,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -671,7 +692,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -686,7 +707,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -701,7 +722,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -716,7 +737,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -731,7 +752,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -746,7 +767,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -761,7 +782,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -777,7 +798,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -793,7 +814,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -809,7 +830,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -825,7 +846,7 @@ mutable struct acb_mat <: MatElem{acb}
     z = new()
     ccall((:acb_mat_init, :libarb), Void, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
@@ -842,8 +863,12 @@ mutable struct acb_mat <: MatElem{acb}
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
     ccall((:acb_mat_set_fmpq_mat, :libarb), Void,
                 (Ref{acb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
-    finalizer(z, cglobal((:acb_mat_clear, :libarb)))
+    finalizer(z, _acb_mat_clear_fn)
     return z
   end
+end
+
+function _acb_mat_clear_fn(x::acb_mat)
+  ccall((:acb_mat_clear, :libarb), Void, (Ref{acb_mat}, ), x)
 end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -21,21 +21,21 @@ mutable struct fmpz <: RingElem
     function fmpz()
         z = new()
         ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
-        finalizer(z, cglobal((:fmpz_clear, :libflint)))
+        finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     function fmpz(x::Int)
         z = new()
         ccall((:fmpz_init_set_si, :libflint), Void, (Ref{fmpz}, Int), z, x)
-        finalizer(z, cglobal((:fmpz_clear, :libflint)))
+        finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     function fmpz(x::UInt)
         z = new()
         ccall((:fmpz_init_set_ui, :libflint), Void, (Ref{fmpz}, UInt), z, x)
-        finalizer(z, cglobal((:fmpz_clear, :libflint)))
+        finalizer(z, _fmpz_clear_fn)
         return z
     end
 
@@ -43,7 +43,7 @@ mutable struct fmpz <: RingElem
         z = new()
         ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
         ccall((:fmpz_set_mpz, :libflint), Void, (Ref{fmpz}, Ref{BigInt}), z, x)
-        finalizer(z, cglobal((:fmpz_clear, :libflint)))
+        finalizer(z, _fmpz_clear_fn)
         return z
     end
 
@@ -52,11 +52,15 @@ mutable struct fmpz <: RingElem
         z = new()
         ccall((:fmpz_init, :libflint), Void, (Ref{fmpz},), z)
         ccall((:fmpz_set_d, :libflint), Void, (Ref{fmpz}, Cdouble), z, x)
-        finalizer(z, cglobal((:fmpz_clear, :libflint)))
+        finalizer(z, _fmpz_clear_fn)
         return z
     end
 
     fmpz(x::fmpz) = x
+end
+
+function _fmpz_clear_fn(a::fmpz)
+   ccall((:fmpz_clear, :libflint), Void, (Ref{fmpz},), a)
 end
 
 mutable struct fmpz_factor
@@ -69,9 +73,14 @@ mutable struct fmpz_factor
    function fmpz_factor()
       z = new()
       ccall((:fmpz_factor_init, :libflint), Void, (Ref{fmpz_factor}, ), z)
-      finalizer(z, cglobal((:fmpz_factor_clear, :libflint)))
+      finalizer(z, _fmpz_factor_clear_fn)
       return z
    end
+end
+
+function _fmpz_factor_clear_fn(a::fmpz_factor)
+   ccall((:fmpz_factor_clear, :libflint), Void,
+         (Ref{fmpz_factor}, ), a)
 end
 
 ###############################################################################
@@ -92,7 +101,7 @@ mutable struct fmpq <: FracElem{fmpz}
    function fmpq()
       z = new()
       ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
-      finalizer(z, cglobal((:fmpq_clear, :libflint)))
+      finalizer(z, _fmpq_clear_fn)
       return z
    end
 
@@ -102,7 +111,7 @@ mutable struct fmpq <: FracElem{fmpz}
       ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_fmpz_frac, :libflint), Void,
             (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
-      finalizer(z, cglobal((:fmpq_clear, :libflint)))
+      finalizer(z, _fmpq_clear_fn)
       return z
    end
 
@@ -112,7 +121,7 @@ mutable struct fmpq <: FracElem{fmpz}
       b = fmpz(1)
       ccall((:fmpq_set_fmpz_frac, :libflint), Void,
             (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
-      finalizer(z, cglobal((:fmpq_clear, :libflint)))
+      finalizer(z, _fmpq_clear_fn)
       return z
    end
 
@@ -122,7 +131,7 @@ mutable struct fmpq <: FracElem{fmpz}
       ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_si, :libflint), Void,
             (Ref{fmpq}, Int, Int), z, a, b)
-      finalizer(z, cglobal((:fmpq_clear, :libflint)))
+      finalizer(z, _fmpq_clear_fn)
       return z
    end
 
@@ -131,10 +140,12 @@ mutable struct fmpq <: FracElem{fmpz}
       ccall((:fmpq_init, :libflint), Void, (Ref{fmpq},), z)
       ccall((:fmpq_set_si, :libflint), Void,
             (Ref{fmpq}, Int, Int), z, a, 1)
-      finalizer(z, cglobal((:fmpq_clear, :libflint)))
+      finalizer(z, _fmpq_clear_fn)
       return z
    end
 end
+
+_fmpq_clear_fn(a::fmpq) = ccall((:fmpq_clear, :libflint), Void, (Ref{fmpq},), a)
 
 ###############################################################################
 #
@@ -170,7 +181,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
    function fmpz_poly()
       z = new()
       ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
-      finalizer(z, cglobal((:fmpz_poly_clear, :libflint)))
+      finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
@@ -182,7 +193,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
          ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Void,
                      (Ref{fmpz_poly}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
-      finalizer(z, cglobal((:fmpz_poly_clear, :libflint)))
+      finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
@@ -190,7 +201,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
       z = new()
       ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       ccall((:fmpz_poly_set_si, :libflint), Void, (Ref{fmpz_poly}, Int), z, a)
-      finalizer(z, cglobal((:fmpz_poly_clear, :libflint)))
+      finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
@@ -199,7 +210,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
       ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       ccall((:fmpz_poly_set_fmpz, :libflint), Void,
             (Ref{fmpz_poly}, Ref{fmpz}), z, a)
-      finalizer(z, cglobal((:fmpz_poly_clear, :libflint)))
+      finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
 
@@ -208,9 +219,13 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
       ccall((:fmpz_poly_init, :libflint), Void, (Ref{fmpz_poly},), z)
       ccall((:fmpz_poly_set, :libflint), Void,
             (Ref{fmpz_poly}, Ref{fmpz_poly}), z, a)
-      finalizer(z, cglobal((:fmpz_poly_clear, :libflint)))
+      finalizer(z, _fmpz_poly_clear_fn)
       return z
    end
+end
+
+function _fmpz_poly_clear_fn(a::fmpz_poly)
+   ccall((:fmpz_poly_clear, :libflint), Void, (Ref{fmpz_poly},), a)
 end
 
 mutable struct fmpz_poly_factor
@@ -224,9 +239,15 @@ mutable struct fmpz_poly_factor
     z = new()
     ccall((:fmpz_poly_factor_init, :libflint), Void,
                 (Ref{fmpz_poly_factor}, ), z)
-    finalizer(z, cglobal((:fmpz_poly_factor_clear, :libflint)))
+    finalizer(z, _fmpz_poly_factor_clear_fn)
     return z
   end
+end
+
+function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
+  ccall((:fmpz_poly_factor_clear, :libflint), Void,
+            (Ref{fmpz_poly_factor}, ), f)
+  nothing
 end
 
 ###############################################################################
@@ -264,7 +285,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
    function fmpq_poly()
       z = new()
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -276,7 +297,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
          ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Void,
                      (Ref{fmpq_poly}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -284,7 +305,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
       z = new()
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_si, :libflint), Void, (Ref{fmpq_poly}, Int), z, a)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -293,7 +314,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpz, :libflint), Void,
             (Ref{fmpq_poly}, Ref{fmpz}), z, a)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -302,7 +323,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpq, :libflint), Void,
             (Ref{fmpq_poly}, Ref{fmpq}), z, a)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -311,7 +332,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set_fmpz_poly, :libflint), Void,
             (Ref{fmpq_poly}, Ref{fmpz_poly}), z, a)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
 
@@ -320,9 +341,13 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
       ccall((:fmpq_poly_init, :libflint), Void, (Ref{fmpq_poly},), z)
       ccall((:fmpq_poly_set, :libflint), Void,
             (Ref{fmpq_poly}, Ref{fmpq_poly}), z, a)
-      finalizer(z, cglobal((:fmpq_poly_clear, :libflint)))
+      finalizer(z, _fmpq_poly_clear_fn)
       return z
    end
+end
+
+function _fmpq_poly_clear_fn(a::fmpq_poly)
+   ccall((:fmpq_poly_clear, :libflint), Void, (Ref{fmpq_poly},), a)
 end
 
 ###############################################################################
@@ -395,7 +420,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
    function nmod_poly(n::UInt)
       z = new()
       ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -404,7 +429,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
       ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
       ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{nmod_poly}, Int, UInt), z, 0, a)
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -413,7 +438,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
       ccall((:nmod_poly_init, :libflint), Void, (Ref{nmod_poly}, UInt), z, n)
       ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{nmod_poly}, Int, UInt), z, 0, mod(a, n))
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -426,7 +451,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{nmod_poly}, Int, UInt), z, i - 1, tt)
       end
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -438,7 +463,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{nmod_poly}, Int, UInt), z, i - 1, arr[i])
       end
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -450,7 +475,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
          ccall((:nmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{nmod_poly}, Int, UInt), z, i-1, arr[i].data)
       end
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -460,7 +485,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
             (Ref{nmod_poly}, UInt, Int), z, n, length(f))
       ccall((:fmpz_poly_get_nmod_poly, :libflint), Void,
             (Ref{nmod_poly}, Ref{fmpz_poly}), z, f)
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
 
@@ -470,9 +495,13 @@ mutable struct nmod_poly <: PolyElem{nmod}
             (Ref{nmod_poly}, UInt, Int), z, n, length(f))
       ccall((:nmod_poly_set, :libflint), Void,
             (Ref{nmod_poly}, Ref{nmod_poly}), z, f)
-      finalizer(z, cglobal((:nmod_poly_clear, :libflint)))
+      finalizer(z, _nmod_poly_clear_fn)
       return z
    end
+end
+
+function _nmod_poly_clear_fn(x::nmod_poly)
+  ccall((:nmod_poly_clear, :libflint), Void, (Ref{nmod_poly}, ), x)
 end
 
 mutable struct nmod_poly_factor
@@ -487,9 +516,14 @@ mutable struct nmod_poly_factor
     ccall((:nmod_poly_factor_init, :libflint), Void,
             (Ref{nmod_poly_factor}, ), z)
     z.n = n
-    finalizer(z, cglobal((:nmod_poly_factor_clear, :libflint)))
+    finalizer(z, _nmod_poly_factor_clear_fn)
     return z
   end
+end
+
+function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
+  ccall((:nmod_poly_factor_clear, :libflint), Void,
+          (Ref{nmod_poly_factor}, ), a)
 end
 
 ###############################################################################
@@ -530,7 +564,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
       z = new()
       ccall((:fmpz_mod_poly_init, :libflint), Void,
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -540,7 +574,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       ccall((:fmod_poly_set_coeff_ui, :libflint), Void,
               (Ref{fmpz_mod_poly}, Int, UInt), z, 0, a)
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -550,7 +584,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, 0, a)
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -563,7 +597,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i])
       end
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -575,7 +609,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
          ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Void,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i].data)
       end
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -585,7 +619,7 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
       ccall((:fmpz_mod_poly_set_fmpz_poly, :libflint), Void,
             (Ref{fmpz_mod_poly}, Ref{fmpz_poly}), z, f)
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
 
@@ -595,9 +629,13 @@ mutable struct fmpz_mod_poly <: PolyElem{Generic.Res{fmpz}}
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
       ccall((:fmpz_mod_poly_set, :libflint), Void,
             (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), z, f)
-      finalizer(z, cglobal((:fmpz_mod_poly_clear, :libflint)))
+      finalizer(z, _fmpz_mod_poly_clear_fn)
       return z
    end
+end
+
+function _fmpz_mod_poly_clear_fn(x::fmpz_mod_poly)
+  ccall((:fmpz_mod_poly_clear, :libflint), Void, (Ref{fmpz_mod_poly}, ), x)
 end
 
 mutable struct fmpz_mod_poly_factor
@@ -612,9 +650,14 @@ mutable struct fmpz_mod_poly_factor
     ccall((:fmpz_mod_poly_factor_init, :libflint), Void,
             (Ref{fmpz_mod_poly_factor}, ), z)
     z.n = n
-    finalizer(z, cglobal((:fmpz_mod_poly_factor_clear, :libflint)))
+    finalizer(z, _fmpz_mod_poly_factor_clear_fn)
     return z
   end
+end
+
+function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
+  ccall((:fmpz_mod_poly_factor_clear, :libflint), Void,
+          (Ref{fmpz_mod_poly_factor}, ), a)
 end
 
 ###############################################################################
@@ -791,7 +834,7 @@ mutable struct FqNmodFiniteField <: FinField
          if cached
             FqNmodFiniteFieldID[c, deg, s] = d
          end
-         finalizer(d, cglobal((:fq_nmod_ctx_clear, :libflint)))
+         finalizer(d, _FqNmodFiniteField_clear_fn)
          return d
       end
    end
@@ -807,7 +850,7 @@ mutable struct FqNmodFiniteField <: FinField
          if cached
             FqNmodFiniteFieldIDPol[parent(f), f, s] = z
          end
-         finalizer(z, cglobal((:fq_nmod_ctx_clear, :libflint)))
+         finalizer(z, _FqNmodFiniteField_clear_fn)
          return z
       end
    end
@@ -817,6 +860,10 @@ const FqNmodFiniteFieldID = Dict{Tuple{fmpz, Int, Symbol}, FqNmodFiniteField}()
 
 const FqNmodFiniteFieldIDPol = Dict{Tuple{NmodPolyRing, nmod_poly, Symbol},
                                     FqNmodFiniteField}()
+
+function _FqNmodFiniteField_clear_fn(a :: FqNmodFiniteField)
+   ccall((:fq_nmod_ctx_clear, :libflint), Void, (Ref{FqNmodFiniteField},), a)
+end
 
 mutable struct fq_nmod <: FinFieldElem
    coeffs :: Ptr{Void}
@@ -2114,7 +2161,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       return z
    end
 
@@ -2122,7 +2169,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
@@ -2138,7 +2185,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
@@ -2154,7 +2201,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
@@ -2170,7 +2217,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:r
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
@@ -2186,7 +2233,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init, :libflint), Void,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       for i = 1:min(r, c)
          el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                     (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
@@ -2200,9 +2247,13 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       z = new()
       ccall((:fmpz_mat_init_set, :libflint), Void,
             (Ref{fmpz_mat}, Ref{fmpz_mat}), z, m)
-      finalizer(z, cglobal((:fmpz_mat_clear, :libflint)))
+      finalizer(z, _fmpz_mat_clear_fn)
       return z
    end
+end
+
+function _fmpz_mat_clear_fn(a::fmpz_mat)
+   ccall((:fmpz_mat_clear, :libflint), Void, (Ref{fmpz_mat},), a)
 end
 
 ###############################################################################
@@ -2254,7 +2305,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     return z
   end
 
@@ -2262,7 +2313,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r,c = c,r
@@ -2281,7 +2332,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r,c = c,r
@@ -2300,7 +2351,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r,c = c,r
@@ -2319,7 +2370,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r,c = c,r
@@ -2348,7 +2399,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r,c = c,r
@@ -2367,7 +2418,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     if transpose
       se = set_entry_t!
       r, c = c, r
@@ -2386,7 +2437,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     z = new()
     ccall((:nmod_mat_init, :libflint), Void,
             (Ref{nmod_mat}, Int, Int, UInt), z, b.r, b.c, n)
-    finalizer(z, cglobal((:nmod_mat_clear, :libflint)))
+    finalizer(z, _nmod_mat_clear_fn)
     ccall((:fmpz_mat_get_nmod_mat, :libflint), Void,
             (Ref{nmod_mat}, Ref{fmpz_mat}), z, b)
     return z
@@ -2403,6 +2454,10 @@ mutable struct nmod_mat <: MatElem{nmod}
           error("Modulus must be smaller than ", fmpz(typemax(UInt)))
     return nmod_mat(UInt(n), b)
   end
+end
+
+function _nmod_mat_clear_fn(mat::nmod_mat)
+  ccall((:nmod_mat_clear, :libflint), Void, (Ref{nmod_mat}, ), mat)
 end
 
 ###############################################################################
@@ -2439,7 +2494,7 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly()
       z = new()
       ccall((:fq_poly_init, :libflint), Void, (Ref{fq_poly},), z)
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
 
@@ -2451,7 +2506,7 @@ mutable struct fq_poly <: PolyElem{fq}
       ccall((:fq_poly_set, :libflint), Void,
             (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
             z, a, ctx)
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
 
@@ -2463,7 +2518,7 @@ mutable struct fq_poly <: PolyElem{fq}
       ccall((:fq_poly_set_fq, :libflint), Void,
             (Ref{fq_poly}, Ref{fq}, Ref{FqFiniteField}),
             z, a, ctx)
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
 
@@ -2478,7 +2533,7 @@ mutable struct fq_poly <: PolyElem{fq}
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, a[i], ctx)
       end
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
 
@@ -2494,7 +2549,7 @@ mutable struct fq_poly <: PolyElem{fq}
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, temp, ctx)
       end
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
 
@@ -2509,9 +2564,13 @@ mutable struct fq_poly <: PolyElem{fq}
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, temp, ctx)
       end
-      finalizer(z, cglobal((:fq_poly_clear, :libflint)))
+      finalizer(z, _fq_poly_clear_fn)
       return z
    end
+end
+
+function _fq_poly_clear_fn(a::fq_poly)
+   ccall((:fq_poly_clear, :libflint), Void, (Ref{fq_poly},), a)
 end
 
 mutable struct fq_poly_factor
@@ -2571,7 +2630,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly()
       z = new()
       ccall((:fq_nmod_poly_init, :libflint), Void, (Ref{fq_nmod_poly},), z)
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
 
@@ -2583,7 +2642,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       ccall((:fq_nmod_poly_set, :libflint), Void,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
             z, a, ctx)
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
 
@@ -2595,7 +2654,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
       ccall((:fq_nmod_poly_set_fq_nmod, :libflint), Void,
             (Ref{fq_nmod_poly}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
             z, a, ctx)
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
 
@@ -2610,7 +2669,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, a[i], ctx)
       end
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
 
@@ -2626,7 +2685,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, temp, ctx)
       end
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
 
@@ -2641,9 +2700,13 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, temp, ctx)
       end
-      finalizer(z, cglobal((:fq_nmod_poly_clear, :libflint)))
+      finalizer(z, _fq_nmod_poly_clear_fn)
       return z
    end
+end
+
+function _fq_nmod_poly_clear_fn(a::fq_nmod_poly)
+   ccall((:fq_nmod_poly_clear, :libflint), Void, (Ref{fq_nmod_poly},), a)
 end
 
 mutable struct fq_nmod_poly_factor


### PR DESCRIPTION
Reverts Nemocas/Nemo.jl#393.

This is currently not GC safe, since fmpz_clear will call gc_alloc again (see flint2/fmpz/fmpz.c). This does not happen if the finalizer is a julia function, see gc.c.