### PR TITLE
Make Nemo work on 0.7

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -17,8 +17,8 @@ import Base: Array, abs, acos, acosh, asin, asinh, atan, atan2, atanh, base,
              prevpow2, rand, rank, Rational, rem, reverse, serialize,
              setindex!, show, similar, sign, sin, sinh, sinpi, size, sqrt, string,
              tan, tanh, trace, trailing_zeros, transpose, transpose!, truncate,
-             typed_hvcat, typed_hcat, var, vcat, zero, zeros, +, -, *, ==, ^,
-             &, |, $, <<, >>, ~, <=, >=, <, >, //, /, !=
+             typed_hvcat, typed_hcat, var, vcat, xor, zero, zeros, +, -, *, ==, ^,
+             &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
 
 import AbstractAlgebra
 
@@ -37,7 +37,7 @@ exclude = [:QQ, :ZZ, :RR, :RealField, :FiniteField, :NumberField,
 
 for i in names(AbstractAlgebra)
   i in exclude && continue
-  eval(Expr(:import, :AbstractAlgebra, i))
+  eval(parse("import AbstractAlgebra." * string(i)))
   eval(Expr(:export, i))
 end
 

--- a/src/arb/acb_calc.jl
+++ b/src/arb/acb_calc.jl
@@ -54,19 +54,17 @@ function integrate(C::AcbField, F, a, b;
 
    res = C()
 
-   ptrF = pointer_from_objref(F)
-
    status = ccall((:acb_calc_integrate, :libarb), UInt,
                   (Ref{acb},                       #res
                    Ptr{Void},                      #func
-                   Ptr{Void},                      #params
+                   Any,                            #params
                    Ref{acb},                       #a
                    Ref{acb},                       #b
                    Int,                            #rel_goal
                    Ref{mag_struct},                #abs_tol
                    Ref{acb_calc_integrate_opts},   #opts
                    Int),
-      res, acb_calc_func_wrap_c(), ptrF, lower, upper, cgoal, ctol, opts, prec(C))
+      res, acb_calc_func_wrap_c(), F, lower, upper, cgoal, ctol, opts, prec(C))
 
    ccall((:mag_clear, :libarb), Void, (Ref{mag_struct},), ctol)
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -268,10 +268,10 @@ end
 ###############################################################################
 
 # Metaprogram to define functions +, -, *, gcd, lcm,
-#                                 &, |, $
+#                                 &, |, $ (xor)
 
 for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
-                 (:&, :and), (:|, :or), (:$, :xor))
+                 (:&, :and), (:|, :or), (:xor, :xor))
     @eval begin
         function ($fJ)(x::fmpz, y::fmpz)
             z = fmpz()

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -421,7 +421,7 @@ function test_acb_functions()
    println("PASS")
 end
 
-function test_lindep()
+function test_acb_lindep()
    print("acb.lindep...")
 
    CC = ComplexField(200)
@@ -474,7 +474,7 @@ function test_acb()
    test_acb_unsafe_ops()
    test_acb_constants()
    test_acb_functions()
-   test_lindep()
+   test_acb_lindep()
    test_acb_integration()
 
    println("")

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -462,7 +462,7 @@ function test_fmpq_arb_special_functions()
    println("PASS")
 end
 
-function test_lindep()
+function test_arb_lindep()
    print("arb.lindep...")
 
    CC = ComplexField(64)
@@ -491,7 +491,7 @@ function test_arb()
    test_arb_constants()
    test_arb_functions()
    test_fmpq_arb_special_functions()
-   test_lindep()
+   test_arb_lindep()
 
    println("")
 end

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -117,7 +117,7 @@ function test_fmpz_binary_ops()
 
    @test b|a == 30
 
-   @test b$a == 22
+   @test xor(b, a) == 22
 
    println("PASS")
 end


### PR DESCRIPTION
- $ is not a valid identifier anymore (use xor)
- Avoid function redefinition
- Make the integrate code work on 0.7
- Make the import stuff work on 0.7

(Don't know why the import thing did not work any more.)