### PR TITLE
Bump version number and add a "make clean" version

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,6 +12,24 @@ pkgdir = dirname(dirname(@__FILE__))
 wdir = joinpath(pkgdir, "deps")
 vdir = joinpath(pkgdir, "local")
 
+if "NEMO_MAKE_CLEAN" in keys(ENV) && ENV["NEMO_MAKE_CLEAN"] == "1"
+  print("
+===============================================================================
+=
+=  NEMO_MAKE_CLEAN = 1
+=  Removing old sources and builds
+=
+================================================================================\n")
+
+  rm(joinpath(wdir, "flint2"), force = true, recursive = true)
+  rm(joinpath(wdir, "arb"), force = true, recursive = true)
+  rm(joinpath(wdir, "antic"), force = true, recursive = true)
+  rm(joinpath(wdir, "mpfr-4.0.0"), force = true, recursive = true)
+  rm(joinpath(wdir, "mpir-3.0.0"), force = true, recursive = true)
+  rm(joinpath(wdir, "yasm-1.3.0"), force = true, recursive = true)
+  rm(vdir, force = true, recursive = true)
+end
+
 if is_apple() && !("CC" in keys(ENV))
    ENV["CC"] = "clang"
    ENV["CXX"] = "clang++"

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -228,7 +228,7 @@ function __init__()
       (Ptr{Void},), cfunction(flint_abort, Void, ()))
 
    println("")
-   println("Welcome to Nemo version 0.8.3")
+   println("Welcome to Nemo version 0.8.4")
    println("")
    println("Nemo comes with absolutely no warranty whatsoever")
    println("")
@@ -249,7 +249,7 @@ end
 ################################################################################
 
 function versioninfo()
-  print("Nemo version 0.8.3\n")
+  print("Nemo version 0.8.4\n")
   nemorepo = dirname(dirname(@__FILE__))
 
   print("Nemo: ")


### PR DESCRIPTION
I added a "make clean" version, which you can trigger with the environment variable `NEMO_MAKE_CLEAN=1`. If you set `NEMO_MAKE_CLEAN=1` and run `Pkg.build("Nemo")`, he will first remove all sources and installed header/libraries. Could help with `https://github.com/Nemocas/Nemo.jl/issues/426` when updating from older Nemo versions.