### PR TITLE
rename isnegative to displayed_with_minus_in_front

### DIFF
--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -273,7 +273,7 @@ end
 
 needs_parentheses(::Nemo.nf_elem) = true
 
-isnegative(::nf_elem) = false
+displayed_with_minus_in_front(::nf_elem) = false
 
 canonical_unit(x::nf_elem) = x
 

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -484,6 +484,11 @@ function isnegative(x::arb)
    return Bool(ccall((:arb_is_negative, :libarb), Cint, (Ref{arb},), x))
 end
 
+# TODO: return true if printed without brackets and x is negative
+function displayed_with_minus_in_front(x::arb)
+   return false
+end
+
 doc"""
     isnonpositive(x::arb)
 > Return `true` if $x$ is certainly nonpositive, otherwise return `false`.

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -283,7 +283,7 @@ function show(io::IO, x::FlintPuiseuxSeriesElem)
          c = polcoeff(x.data, i)
          bracket = needs_parentheses(c)
          if !iszero(c)
-            if coeff_printed && !isnegative(c)
+            if coeff_printed && !displayed_with_minus_in_front(c)
                print(io, "+")
             end
             if i*sc + valuation(x.data) != 0
@@ -331,7 +331,7 @@ end
 
 needs_parentheses(x::FlintPuiseuxSeriesElem) = pol_length(x.data) > 1
 
-isnegative(x::FlintPuiseuxSeriesElem) = pol_length(x) <= 1 && isnegative(polcoeff(x.data, 0))
+displayed_with_minus_in_front(x::FlintPuiseuxSeriesElem) = pol_length(x) <= 1 && displayed_with_minus_in_front(polcoeff(x.data, 0))
 
 show_minus_one(::Type{FlintPuiseuxSeriesElem{T}}) where T <: RingElem = show_minus_one(T)
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -165,7 +165,7 @@ end
 
 needs_parentheses(x::fmpq) = false
 
-isnegative(x::fmpq) = x < 0
+displayed_with_minus_in_front(x::fmpq) = x < 0
 
 show_minus_one(::Type{fmpq}) = false
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -39,7 +39,7 @@ export fmpz, FlintZZ, FlintIntegerRing, parent, show, convert, hash, fac, bell,
        combit!, crt, divisible, divisor_lenstra, fdivrem, tdivrem, fmodpow2,
        gcdinv, isprobabprime, issquare, jacobi, remove, root, size, isqrtrem,
        sqrtmod, trailing_zeros, sigma, eulerphi, fib, moebiusmu, primorial,
-       risingfac, numpart, canonical_unit, needs_parentheses, isnegative,
+       risingfac, numpart, canonical_unit, needs_parentheses, displayed_with_minus_in_front,
        show_minus_one, parseint, addeq!, mul!, isunit, isequal, num, den,
        iszero, rand
 
@@ -225,7 +225,7 @@ show(io::IO, a::FlintIntegerRing) = print(io, "Integer Ring")
 
 needs_parentheses(x::fmpz) = false
 
-isnegative(x::fmpz) = x < 0
+displayed_with_minus_in_front(x::fmpz) = x < 0
 
 show_minus_one(::Type{fmpz}) = false
 

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -356,7 +356,7 @@ function show(io::IO, x::fmpz_laurent_series)
          c = polcoeff(x, i)
          bracket = needs_parentheses(c)
          if !iszero(c)
-            if coeff_printed && !isnegative(c)
+            if coeff_printed && !displayed_with_minus_in_front(c)
                print(io, "+")
             end
             if i*sc + valuation(x) != 0
@@ -397,7 +397,7 @@ end
 
 needs_parentheses(x::fmpz_laurent_series) = pol_length(x) > 1
 
-isnegative(x::fmpz_laurent_series) = pol_length(x) <= 1 && isnegative(polcoeff(x, 0))
+displayed_with_minus_in_front(x::fmpz_laurent_series) = pol_length(x) <= 1 && displayed_with_minus_in_front(polcoeff(x, 0))
 
 show_minus_one(::Type{fmpz_laurent_series})  = show_minus_one(T)
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -90,7 +90,7 @@ function show(io::IO, x::fmpz_mod_poly)
          c = coeff(x, len - i)
          bracket = needs_parentheses(c)
          if !iszero(c)
-            if i != 1 && !isnegative(c)
+            if i != 1 && !displayed_with_minus_in_front(c)
                print(io, "+")
             end
             if !isone(c) && (c != -1 || show_minus_one(typeof(c)))
@@ -116,7 +116,7 @@ function show(io::IO, x::fmpz_mod_poly)
       c = coeff(x, 0)
       bracket = needs_parentheses(c)
       if !iszero(c)
-         if len != 1 && !isnegative(c)
+         if len != 1 && !displayed_with_minus_in_front(c)
             print(io, "+")
          end
          if bracket

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -197,7 +197,7 @@ end
 
 needs_parentheses(x::fq) = x.length > 1
 
-isnegative(x::fq) = false
+displayed_with_minus_in_front(x::fq) = false
 
 show_minus_one(::Type{fq}) = true
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -136,7 +136,7 @@ end
 
 needs_parentheses(x::fq_nmod) = x.length > 1
 
-isnegative(x::fq_nmod) = false
+displayed_with_minus_in_front(x::fq_nmod) = false
 
 show_minus_one(::Type{fq_nmod}) = true
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -102,7 +102,7 @@ end
 
 needs_parentheses(x::nmod) = false
 
-isnegative(x::nmod) = false
+displayed_with_minus_in_front(x::nmod) = false
 
 show_minus_one(::Type{nmod}) = true
 

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -227,7 +227,7 @@ end
 
 needs_parentheses(x::padic) = true
 
-isnegative(x::padic) = false
+displayed_with_minus_in_front(x::padic) = false
 
 show_minus_one(::Type{padic}) = true
 


### PR DESCRIPTION
An exception is `isnegative` in `src/arb/arb.jl`. In this case I introduced a new function `displayed_with_minus_in_front` that returns `false` for the moment being.