### PR TITLE
add canonical_unit for arb and acb

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -20,7 +20,7 @@ export rsqrt, log, log1p, exppii, sin, cos, tan, cot,
        erf, erfi, erfc, ei, si, ci, shi, chi, li, lioffset, expint, gamma,
        besselj, bessely, besseli, besselk, hyp1f1, hyp1f1r, hyperu, hyp2f1,
        jtheta, modeta, modj, modlambda, moddelta, ellipwp, ellipk, ellipe,
-       modweber_f, modweber_f1, modweber_f2
+       modweber_f, modweber_f1, modweber_f2, canonical_unit
 
 ###############################################################################
 #
@@ -102,6 +102,10 @@ function deepcopy_internal(a::acb, dict::ObjectIdDict)
   b = parent(a)()
   ccall((:acb_set, :libarb), Void, (Ref{acb}, Ref{acb}), b, a)
   return b
+end
+
+function canonical_unit(x::acb)
+   return x
 end
 
 # TODO: implement hash

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -26,7 +26,7 @@ export ball, radius, midpoint, contains, contains_zero,
        sincos, sincospi, sinhcosh, atan2,
        agm, fac, binom, fib, bernoulli, risingfac, risingfac2, polylog,
        chebyshev_t, chebyshev_t2, chebyshev_u, chebyshev_u2, bell, numpart,
-       lindep
+       lindep, canonical_unit
 
 ###############################################################################
 #
@@ -87,6 +87,10 @@ function deepcopy_internal(a::arb, dict::ObjectIdDict)
   b = parent(a)()
   ccall((:arb_set, :libarb), Void, (Ref{arb}, Ref{arb}), b, a)
   return b
+end
+
+function canonical_unit(x::arb)
+   return x
 end
 
 ################################################################################


### PR DESCRIPTION
According to the documentation of AbstractAlgebra the function `canonical_form` must always exists for ring elements. It further states that for field elements it should return the field elements themselves. Here I add it for arguments of type `arb` and `acb`.