### PR TITLE
Fix rref for nmod_mat

### DIFF
--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -126,7 +126,19 @@ end
 function strong_echelon_form(a::gfp_mat)
   (rows(a) < cols(a)) &&
               error("Matrix must have at least as many rows as columns")
-  return rref(a)
+  r, z = rref(a)
+  j_new =  1
+  for i in 1:r
+    for j in j_new:cols(a)
+      if isone(a[i, j]) && i != j
+        z[i, j] = 0
+        z[j, j] = 1
+        j_new = j
+        continue
+      end
+    end
+  end
+  return z
 end
 
 @doc Markdown.doc"""
@@ -137,8 +149,7 @@ end
 function howell_form(a::gfp_mat)
   (rows(a) < cols(a)) &&
               error("Matrix must have at least as many rows as columns")
-
-  return rref(a)
+  return rref(a)[2]
 end
 
 ################################################################################

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -497,6 +497,27 @@ end
 
 ################################################################################
 #
+#  Row swapping
+#
+################################################################################
+
+function swap_rows(x::T, i::Int, j::Int) where T <: Zmodn_mat
+   n = rows(x)
+   (i < 1 || i > n) && error("Index $i must be between 1 and $n")
+   (j < 1 || j > n) && error("Index $j must be between 1 and $n")
+   z = deepcopy(x)
+   swap_rows!(z, i, j)
+   return z
+end
+
+function swap_rows!(x::T, i::Int, j::Int) where T <: Zmodn_mat
+   ccall((:nmod_mat_swap_rows, :libflint), Nothing,
+         (Ref{T}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
+   return x
+end
+
+################################################################################
+#
 #  Windowing
 #
 ################################################################################

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -224,7 +224,7 @@ function test_fq_mat_manipulation()
 
   @test iszero(e)
 
-  @test_throws ErrorException one(MatrixSpace(ResidueRing(ZZ, 2), 1, 2))
+  @test_throws ErrorException one(MatrixSpace(F9, 1, 2))
 
   @test issquare(a)
 
@@ -395,7 +395,7 @@ end
 function test_fq_mat_row_echelon_form()
   print("fq_mat.row_echelon_form...")
 
-  F17 = ResidueRing(ZZ,17)
+  F17, _ = FlintFiniteField(fmpz(17), 1, "a")
   R = MatrixSpace(F17, 3, 4)
   RR = MatrixSpace(F17, 4, 3)
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -224,7 +224,7 @@ function test_fq_nmod_mat_manipulation()
 
   @test iszero(e)
 
-  @test_throws ErrorException one(MatrixSpace(ResidueRing(ZZ, 2), 1, 2))
+  @test_throws ErrorException one(MatrixSpace(F9, 1, 2))
 
   @test issquare(a)
 
@@ -395,7 +395,7 @@ end
 function test_fq_nmod_mat_row_echelon_form()
   print("fq_nmod_mat.row_echelon_form...")
 
-  F17 = ResidueRing(ZZ,17)
+  F17, _ = FlintFiniteField(17, 1, "a")
   R = MatrixSpace(F17, 3, 4)
   RR = MatrixSpace(F17, 4, 3)
 

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -253,11 +253,11 @@ end
 function test_gfp_mat_unary_ops()
   print("gfp_mat.unary_ops...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
   RR = MatrixSpace(Z17, 4, 3)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
   S = MatrixSpace(Z2, 3, 4)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
@@ -276,7 +276,7 @@ end
 function test_gfp_mat_binary_ops()
   print("gfp_mat.binary_ops...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
 
@@ -308,10 +308,10 @@ end
 function test_gfp_mat_adhoc_binary()
   print("gfp_mat.adhoc_binary...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
 
@@ -351,7 +351,7 @@ end
 function test_gfp_mat_comparison()
   print("gfp_mat.comparison...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
 
@@ -369,7 +369,7 @@ end
 function test_gfp_mat_adhoc_comparison()
   print("gfp_mat.comparison...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
 
@@ -387,7 +387,7 @@ end
 function test_gfp_mat_powering()
   print("gfp_mat.powering...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
 
   R = MatrixSpace(Z17, 3, 4)
 
@@ -411,10 +411,10 @@ end
 function test_gfp_mat_row_echelon_form()
   print("gfp_mat.row_echelon_form...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 4)
   RR = MatrixSpace(Z17, 4, 3)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
   S = MatrixSpace(Z2, 3, 4)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
@@ -461,16 +461,19 @@ function test_gfp_mat_howell_form()
   @test howell_form(b) == 1
   @test strong_echelon_form(d) == R([1 0 0; 0 0 0; 0 0 1])
 
+  a = matrix(Z17, [0 1 0 0; 0 0 1 0; 0 0 0 1; 0 0 0 0])
+  @test strong_echelon_form(a) == matrix(Z17, [0 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1])
+
   println("PASS")
 end
 
 function test_gfp_mat_trace_det()
   print("gfp_mat.trace_det...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 4)
   RR = MatrixSpace(Z17, 4, 3)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
   S = MatrixSpace(Z2, 3, 4)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
@@ -505,10 +508,10 @@ end
 function test_gfp_mat_rank()
   print("gfp_mat.rank...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 4)
   RR = MatrixSpace(Z17, 4, 3)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
   S = MatrixSpace(Z2, 3, 4)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
@@ -535,10 +538,10 @@ end
 function test_gfp_mat_inv()
   print("gfp_mat.inv...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 4)
   RR = MatrixSpace(Z17, 4, 3)
-  Z2 = ResidueRing(ZZ,2)
+  Z2 = GF(2)
   S = MatrixSpace(Z2, 3, 4)
 
   a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
@@ -561,7 +564,7 @@ end
 function test_gfp_mat_solve()
   print("gfp_mat.solve...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 3)
   S = MatrixSpace(Z17, 3, 4)
 
@@ -586,7 +589,7 @@ function test_gfp_mat_lu()
   print("gfp_mat.lu...")
 
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 3)
   S = MatrixSpace(Z17, 3, 4)
 
@@ -614,6 +617,24 @@ function test_gfp_mat_lu()
   println("PASS")
 end
 
+function test_gfp_mat_swap_rows()
+  print("gfp_mat.swap_rows...")
+
+  Z17 = GF(17)
+
+  A = matrix(Z17, 5, 1, [1, 2, 3, 4, 5])
+
+  B = swap_rows(A, 3, 4)
+  @test B == matrix(Z17, 5, 1, [1, 2, 4, 3, 5])
+
+  swap_rows!(A, 3, 4)
+  @test A == matrix(Z17, 5, 1, [1, 2, 4, 3, 5])
+
+  @test_throws ErrorException swap_rows(A, 0, 5)
+  @test_throws ErrorException swap_rows(A, 4, 6)
+
+  println("PASS")
+end
 function test_gfp_mat_view()
   print("gfp_mat.view...")
 
@@ -708,7 +729,7 @@ end
 function test_gfp_mat_concatenation()
   print("gfp_mat.concatenation...")
 
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = GF(17)
   R = MatrixSpace(Z17, 3, 3)
   S = MatrixSpace(Z17, 3, 4)
 
@@ -811,6 +832,7 @@ function test_gfp_mat()
   test_gfp_mat_inv()
   test_gfp_mat_lu()
   test_gfp_mat_view()
+  test_gfp_mat_swap_rows()
   test_gfp_mat_sub()
   test_gfp_mat_concatenation()
   test_gfp_mat_conversion()

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -617,6 +617,25 @@ function test_nmod_mat_lu()
   println("PASS")
 end
 
+function test_nmod_mat_swap_rows()
+  print("nmod_mat.swap_rows...")
+
+  Z17 = ResidueRing(ZZ, 17)
+
+  A = matrix(Z17, 5, 1, [1, 2, 3, 4, 5])
+
+  B = swap_rows(A, 3, 4)
+  @test B == matrix(Z17, 5, 1, [1, 2, 4, 3, 5])
+
+  swap_rows!(A, 3, 4)
+  @test A == matrix(Z17, 5, 1, [1, 2, 4, 3, 5])
+
+  @test_throws ErrorException swap_rows(A, 0, 5)
+  @test_throws ErrorException swap_rows(A, 4, 6)
+
+  println("PASS")
+end
+
 function test_nmod_mat_view()
   print("nmod_mat.view...")
 
@@ -813,6 +832,7 @@ function test_nmod_mat()
   test_nmod_mat_rank()
   test_nmod_mat_inv()
   test_nmod_mat_lu()
+  test_nmod_mat_swap_rows()
   test_nmod_mat_view()
   test_nmod_mat_sub()
   test_nmod_mat_concatenation()


### PR DESCRIPTION
Before we were treating `nmod_mat` sometimes as matrices over a field, which was necessary (due to the lack of GF(p)) but led to some inconsistencies:
```julia
julia> F = ResidueRing(ZZ, 2)
Integers modulo 2

julia> A = matrix(F, 2, 2, [1, 2, 3, 4])
[1 0]
[1 0]

julia> rref(A)
(1, [1 0]
[0 0])

julia> F = ResidueRing(ZZ, ZZ(2))
Residue ring of Integer Ring modulo 2

julia> A = matrix(F, 2, 2, [1, 2, 3, 4])
[1 0]
[1 0]

julia> rref(A)
(1, 1, [1 0]
[0 0])
```
This fixes this by treating `nmod_mat` as matrices over a ring when calling `rref`. No functionality is lost since we now have GF(p) (thanks @wbhart).