### PR TITLE
Import fix

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -34,8 +34,8 @@ import AbstractAlgebra: nullspace
 # We don't want the QQ, ZZ, FiniteField, NumberField from AbstractAlgebra
 # as they are for parents of Julia types or naive implementations
 # We only import AbstractAlgebra, not export
-# We do not want the AbstractAlgebra version of numerator, denominator, exp and sqrt,
-# but the Base version which is the only place user friendly exp and sqrt are defined
+# We do not want the AbstractAlgebra version of certain functions as the Base version
+# is the only place user friendly versions are defined
 # AbstractAlgebra/Nemo has its own promote_rule, distinct from Base
 # Set, Module, Ring, Group and Field are too generic to pollute the users namespace with
 exclude = try

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -12,7 +12,7 @@ end
 
 import Base: Array, abs, acos, acosh, asin, asinh, atan, atanh, 
              bin, ceil, checkbounds, conj, convert, cmp, cos, cosh,
-             cospi, cot, coth, dec, deepcopy, deepcopy_internal, 
+             cospi, cot, coth, dec, deepcopy, deepcopy_internal, denominator, 
              div, divrem, expm1, exp, floor, gcd, gcdx, getindex,
              hash, hcat, hex, hypot, intersect, inv, invmod, isequal,
              isfinite, isinteger, isless, isqrt, isreal, iszero, lcm, ldexp, length,
@@ -34,15 +34,19 @@ import AbstractAlgebra: nullspace
 # We don't want the QQ, ZZ, FiniteField, NumberField from AbstractAlgebra
 # as they are for parents of Julia types or naive implementations
 # We only import AbstractAlgebra, not export
-# We do not want the AbstractAlgebra version of exp and sqrt, but the Base version
-# which is the only place user friendly exp and sqrt are defined
+# We do not want the AbstractAlgebra version of numerator, denominator, exp and sqrt,
+# but the Base version which is the only place user friendly exp and sqrt are defined
 # AbstractAlgebra/Nemo has its own promote_rule, distinct from Base
 # Set, Module, Ring, Group and Field are too generic to pollute the users namespace with
-exclude = [:QQ, :ZZ, :RR, :RealField, :FiniteField, :NumberField,
+exclude = try
+   AbstractAlgebra.import_exclude
+catch
+   [:import_exclude, :QQ, :ZZ, :RR, :RealField, :FiniteField, :NumberField,
            :AbstractAlgebra, 
            :exp, :sqrt,
            :promote_rule,
            :Set, :Module, :Ring, :Group, :Field]
+end
 
 for i in names(AbstractAlgebra)
   i in exclude && continue


### PR DESCRIPTION
* Fixes imports to use an exclusion list supplied by AbstractAlgebra (if available).
* A similar patch should be applied to Hecke, etc.
