### PR TITLE
Delayed reduction tests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 1.0
-AbstractAlgebra 0.3.0
+AbstractAlgebra 0.2.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 1.0
-AbstractAlgebra 0.2.0
+AbstractAlgebra 0.3.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 1.0
-AbstractAlgebra 0.3.0
+AbstractAlgebra 0.3.1

--- a/test/Generic-test.jl
+++ b/test/Generic-test.jl
@@ -1,7 +1,9 @@
 include("generic/Poly-test.jl")
 include("generic/MPoly-test.jl")
+include("generic/Matrix-test.jl")
 
 function test_generic()
    test_Poly()
    test_MPoly()
+   test_Matrix()
 end

--- a/test/Generic-test.jl
+++ b/test/Generic-test.jl
@@ -1,5 +1,7 @@
 include("generic/Poly-test.jl")
+include("generic/MPoly-test.jl")
 
 function test_generic()
    test_Poly()
+   test_MPoly()
 end

--- a/test/Generic-test.jl
+++ b/test/Generic-test.jl
@@ -1,0 +1,5 @@
+include("generic/Poly-test.jl")
+
+function test_generic()
+   test_Poly()
+end

--- a/test/Nemo-test.jl
+++ b/test/Nemo-test.jl
@@ -1,9 +1,11 @@
 include("Rings-test.jl")
 include("Fields-test.jl")
+include("Generic-test.jl")
 include("Benchmark-test.jl")
 
 function test_all()
    test_rings()
    test_fields()
+   test_generic()
    test_benchmarks()
 end

--- a/test/generic/MPoly-test.jl
+++ b/test/generic/MPoly-test.jl
@@ -1,0 +1,146 @@
+function test_MPoly_binary_ops_delayed_reduction()
+   print("MPoly.binary_ops_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      S, varlist = PolynomialRing(K, var_names, ordering = ord)
+
+      for iter = 1:10
+         f = rand(S, 0:5, 0:100, -100:100)
+         g = rand(S, 0:5, 0:100, -100:100)
+         h = rand(S, 0:5, 0:100, -100:100)
+
+         @test f*g == g*f
+         @test f*g + f*h == f*(g + h)
+         @test f*g - f*h == f*(g - h)
+
+         @test f*g == Generic.mul_classical(f, g)
+      end
+   end
+
+   println("PASS")
+end
+
+function test_MPoly_powering_delayed_reduction()
+   print("MPoly.powering_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      S, varlist = PolynomialRing(K, var_names, ordering = ord)
+
+      for iter = 1:10
+         f = rand(S, 0:5, 0:100, -100:100)
+
+         expn = rand(0:10)
+
+         r = S(1)
+         for i = 1:expn
+            r *= f
+         end
+
+         @test (f == 0 && expn == 0 && f^expn == 0) || f^expn == r
+      end
+   end
+
+   println("PASS")
+end
+
+function test_MPoly_divides_delayed_reduction()
+   print("MPoly.divides_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      S, varlist = PolynomialRing(K, var_names, ordering = ord)
+
+      for iter = 1:10
+         f = S(0)
+         f = rand(S, 0:5, 0:100, -100:100)
+         g = rand(S, 0:5, 0:100, -100:100)
+
+         p = f*g
+
+         flag, q = divides(p, f)
+         flag2, q2 = divides(f, p)
+
+         @test flag == true
+
+         @test q * f == p
+
+         q1 = divexact(p, f)
+
+         @test q1 * f == p
+
+         if !iszero(p)
+           @test q1 == g
+         end
+      end
+   end
+
+   println("PASS")
+end
+
+function test_MPoly_euclidean_division_delayed_reduction()
+   print("MPoly.euclidean_division_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for num_vars = 1:10
+      var_names = ["x$j" for j in 1:num_vars]
+      ord = rand_ordering()
+
+      S, varlist = PolynomialRing(K, var_names, ordering = ord)
+
+      for iter = 1:10
+         f = S(0)
+         while iszero(f)
+            f = rand(S, 0:5, 0:100, -100:100)
+         end
+         g = rand(S, 0:5, 0:100, -100:100)
+
+         p = f*g
+
+         q1, r = divrem(p, f)
+         q2 = div(p, f)
+
+         @test q1 == g
+         @test q2 == g
+         @test f*q1 + r == p
+
+         q3, r3 = divrem(g, f)
+         q4 = div(g, f)
+         flag, q5 = divides(g, f)
+
+         @test q3*f + r3 == g
+         @test q3 == q4
+         @test (r3 == 0 && flag == true && q5 == q3) || (r3 != 0 && flag == false)
+      end
+   end
+
+   println("PASS")
+end
+
+function test_MPoly()
+   test_MPoly_binary_ops_delayed_reduction()
+   test_MPoly_powering_delayed_reduction()
+   test_MPoly_divides_delayed_reduction()
+   test_MPoly_euclidean_division_delayed_reduction()
+
+   println("")
+end
+

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1,0 +1,161 @@
+function test_Matrix_binary_ops_delayed_reduction()
+   print("Matrix.binary_ops_delayed_reduction...")
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   S = MatrixSpace(K, 5, 5)
+
+   for iter = 1:10
+      f = rand(S, -10:10)
+      g = rand(S, -10:10)
+      h = rand(S, -10:10)
+
+      @test f*(g + h) == f*g + f*h
+      @test f*(g - h) == f*g - f*h
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_lu_delayed_reduction()
+   print("Matrix.lu_delayed_reduction...")
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   S = MatrixSpace(K, 5, 5)
+
+   for iter = 1:10
+      rk = rand(0:5)
+      A = randmat_with_rank(S, rk, -10:10)
+
+      r, P, L, U = lu(A)
+
+      @test r == rk
+      @test P*A == L*U
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_fflu_delayed_reduction()
+   print("Matrix.fflu_delayed_reduction...")
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   S = MatrixSpace(K, 5, 5)
+
+   for iter = 1:20
+      rk = rand(0:5)
+      A = randmat_with_rank(S, rk, -10:10)
+
+      r, d, P, L, U = fflu(A)
+
+      if r == 5
+         D = S()
+         D[1, 1] = inv(U[1, 1])
+         D[2, 2] = inv(U[1, 1]*U[2, 2])
+         D[3, 3] = inv(U[2, 2]*U[3, 3])
+         D[4, 4] = inv(U[3, 3]*U[4, 4])
+         D[5, 5] = inv(U[4, 4])
+      end
+
+      @test r == rk && (r < 5 || P*A == L*D*U)
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_minpoly_delayed_reduction()
+   print("Matrix.minpoly_delayed_reduction...")
+
+   # Tests reduce_row!
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   S = MatrixSpace(K, 6, 6)
+   U, z = PolynomialRing(K, "z")
+
+   M = S()
+   for i = 1:3
+      for j = 1:3
+         M[i, j] = rand(K, -10:10)
+         M[i + 3, j + 3] = deepcopy(M[i, j])
+      end
+   end
+
+   p1 = minpoly(U, M)
+
+   for i = 1:10
+      similarity!(M, rand(1:6), rand(K, -3:3))
+   end
+
+   p2 = minpoly(U, M)
+
+   @test p1 == p2
+
+   println("PASS")
+end
+
+function test_Matrix_solve_fflu_delayed_reduction()
+   print("Matrix.solve_fflu_delayed_reduction...")
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for dim = 0:5
+      S = MatrixSpace(K, dim, dim)
+      T = MatrixSpace(K, dim, rand(1:5))
+
+      M = randmat_with_rank(S, dim, -100:100)
+      b = rand(T, -100:100)
+
+      x, d = Generic.solve_fflu(M, b)
+
+      @test divexact(M, d)*x == b
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_solve_lu_delayed_reduction()
+   print("Matrix.solve_lu_delayed_reduction...")
+
+   R, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+
+   for dim = 0:5
+      S = MatrixSpace(K, dim, dim)
+      T = MatrixSpace(K, dim, rand(1:5))
+
+      M = randmat_with_rank(S, dim, -100:100)
+      b = rand(T, -100:100)
+
+      x = Generic.solve_lu(M, b)
+
+      @test M*x == b
+   end
+
+   println("PASS")
+end
+
+#=
+   TODO: Add tests for the following when there are rings that are not fields
+         that have delayed reduction
+     - fflu over a ring
+     - rref over a ring
+     - minpoly over an integrally closed domain
+
+   Note: backsolve! is also not tested as it appears to be unused.
+=#
+
+function test_Matrix()
+   test_Matrix_binary_ops_delayed_reduction()
+   test_Matrix_lu_delayed_reduction()
+   test_Matrix_fflu_delayed_reduction()
+   test_Matrix_minpoly_delayed_reduction()
+   test_Matrix_solve_fflu_delayed_reduction()
+   test_Matrix_solve_lu_delayed_reduction()
+
+   println("")
+end
+

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -16,6 +16,29 @@ function istriu(A::Generic.Mat)
    return true
 end
 
+function is_snf(A::Generic.Mat)
+   m = rows(A)
+   n = cols(A)
+   a = A[1,1]
+   for i = 2:min(m,n)
+      q, r = divrem(A[i,i], a)
+      if !iszero(r)
+         return false
+      end
+      a = A[i,i]
+   end
+   for i = 1:n
+      for j = 1:m
+         if i == j
+            continue
+         end
+         if !iszero(A[j,i])
+            return false
+         end
+      end
+   end
+   return true
+end
 function test_Matrix_binary_ops_delayed_reduction()
    print("Matrix.binary_ops_delayed_reduction...")
 
@@ -242,6 +265,27 @@ function test_Matrix_hnf_delayed_reduction()
    println("PASS")
 end
 
+function test_Matrix_snf_delayed_reduction()
+   print("Matrix.snf_delayed_reduction...")
+
+   R, x = PolynomialRing(QQ, "x")
+   K, a = NumberField(x^3 + 3x + 1, "a")
+   S = MatrixSpace(K, 6, 6)
+
+   for iter = 1:10
+      A = rand(S, -10:10)
+
+      T, U, K = Generic.snf_kb_with_trafo(A)
+
+      @test is_snf(T)
+      @test isunit(det(U))
+      @test isunit(det(K))
+      @test U*A*K == T
+   end
+
+   println("PASS")
+end
+
 #=
    TODO: Add tests for the following when there are rings that are not fields
          that have delayed reduction
@@ -262,6 +306,7 @@ function test_Matrix()
    test_Matrix_solve_triu_delayed_reduction()
    test_Matrix_charpoly_delayed_reduction()
    test_Matrix_hnf_delayed_reduction()
+   test_Matrix_snf_delayed_reduction()
 
    println("")
 end

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -1,3 +1,21 @@
+function istriu(A::Generic.Mat)
+   m = rows(A)
+   n = cols(A)
+   d = 0
+   for c = 1:n
+      for r = m:-1:1
+         if !iszero(A[r,c])
+            if r < d
+               return false
+            end
+            d = r
+            break
+         end
+      end
+   end
+   return true
+end
+
 function test_Matrix_binary_ops_delayed_reduction()
    print("Matrix.binary_ops_delayed_reduction...")
 
@@ -138,6 +156,92 @@ function test_Matrix_solve_lu_delayed_reduction()
    println("PASS")
 end
 
+function test_Matrix_solve_triu_delayed_reduction()
+   print("Matrix.solve_triu_delayed_reduction...")
+
+   R, x = PolynomialRing(QQ, "x")
+   K, a = NumberField(x^3 + 3x + 1, "a")
+
+   for dim = 0:10
+      S = MatrixSpace(K, dim, dim)
+      U = MatrixSpace(K, dim, rand(1:5))
+
+      M = randmat_triu(S, -100:100)
+      b = rand(U, -100:100)
+
+      x = solve_triu(M, b, false)
+
+      @test M*x == b
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_charpoly_delayed_reduction()
+   print("Matrix.charpoly_delayed_reduction...")
+
+   R, x = PolynomialRing(QQ, "x")
+   K, a = NumberField(x^3 + 3x + 1, "a")
+
+   for dim = 0:5
+      S = MatrixSpace(K, dim, dim)
+      U, x = PolynomialRing(K, "x")
+
+      for i = 1:10
+         M = rand(S, -5:5)
+
+         p1 = charpoly_danilevsky_ff!(U, deepcopy(M))
+         p2 = charpoly_danilevsky!(U, deepcopy(M))
+         p3 = charpoly(U, M)
+
+         @test p1 == p2
+         @test p1 == p3
+      end
+   end
+
+   println("PASS")
+end
+
+function test_Matrix_hnf_delayed_reduction()
+   print("Matrix.hnf_delayed_reduction...")
+
+   R, x = PolynomialRing(QQ, "x")
+   K, a = NumberField(x^3 + 3x + 1, "a")
+   S = MatrixSpace(K, 6, 6)
+   
+   for iter = 1:10
+      A = rand(S, -10:10)
+
+      H, U = hnf_cohen_with_trafo(A)
+
+      @test istriu(H)
+      @test isunit(det(U))
+      @test U*A == H
+   end
+
+   for iter = 1:10
+      A = rand(S, -10:10)
+
+      H, U = hnf_minors_with_trafo(A)
+
+      @test istriu(H)
+      @test isunit(det(U))
+      @test U*A == H
+   end
+
+   for iter = 1:10
+      A = rand(S, -10:10)
+
+      H, U = hnf_kb_with_trafo(A)
+
+      @test istriu(H)
+      @test isunit(det(U))
+      @test U*A == H
+   end
+
+   println("PASS")
+end
+
 #=
    TODO: Add tests for the following when there are rings that are not fields
          that have delayed reduction
@@ -155,6 +259,9 @@ function test_Matrix()
    test_Matrix_minpoly_delayed_reduction()
    test_Matrix_solve_fflu_delayed_reduction()
    test_Matrix_solve_lu_delayed_reduction()
+   test_Matrix_solve_triu_delayed_reduction()
+   test_Matrix_charpoly_delayed_reduction()
+   test_Matrix_hnf_delayed_reduction()
 
    println("")
 end

--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -1,0 +1,45 @@
+function test_Poly_binary_ops_delayed_reduction()
+   print("Poly.binary_ops_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   R, x = PolynomialRing(K, "x")
+
+   for iter = 1:100
+      f = rand(R, 0:10, -10:10)
+      g = rand(R, 0:10, -10:10)
+      h = rand(R, 0:10, -10:10)
+
+      @test f*g == g*f
+      @test f*(g + h) == f*g + f*h
+      @test (f + g)*(f - g) == f*f - g*g
+   end
+
+   println("PASS")
+end
+
+function test_Poly_truncation_delayed_reduction()
+   print("Poly.truncation_delayed_reduction...")
+
+   S, t = PolynomialRing(QQ, "t")
+   K, a = NumberField(t^3 + 3t + 1, "a")
+   R, x = PolynomialRing(K, "x")
+
+   for iter = 1:300
+      f = rand(R, 0:10, -10:10)
+      g = rand(R, 0:10, -10:10)
+      n = rand(0:20)
+
+      @test truncate(f*g, n) == mullow(f, g, n)
+   end
+
+   println("PASS")
+end
+
+function test_Poly()
+   test_Poly_binary_ops_delayed_reduction()
+   test_Poly_truncation_delayed_reduction()
+
+   println("")
+end
+


### PR DESCRIPTION
This adds test code for the generic delayed reduction implemented in AbstractAlgebra. It works by constructing Poly's, MPoly's and Matrix's over Nemo number fields, which support delayed reduction.

Note that the delayed_reduction_fixes patch will have to be applied to AbstractAlgebra before this will pass.

Also note that our polynomial over a number field benchmark now takes half the time with delayed reduction supported. :-)