### PR TITLE
New mpoly interface fns

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 1.0
-AbstractAlgebra 0.3.1
+AbstractAlgebra 0.3.3

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -799,6 +799,14 @@ function set_exponent_vector!(a::fmpq_mpoly, n::Int, exps::Vector{fmpz})
    return a
 end
 
+# Return j-th coordinate of i-th exponent vector
+function exponent(a::fmpq_mpoly, i::Int, j::Int)
+   (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
+   return ccall((:fmpq_mpoly_get_term_var_exp_ui, :libflint), Int,
+                (Ref{fmpq_mpoly}, Int, Int, Ref{FmpqMPolyRing}),
+                 a, i - 1, j - 1, a.parent)
+end
+
 # Return the coefficient of the term with the given exponent vector
 # Return zero if there is no such term
 function coeff(a::fmpq_mpoly, exps::Vector{UInt})

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -242,6 +242,33 @@ end
 
 ###############################################################################
 #
+#   Multivariable coefficient polynomials
+#
+###############################################################################
+
+function coeff(a::fmpq_mpoly, vars::Vector{Int}, exps::Vector{Int})
+   unique(vars) != vars && error("Variables not unique")
+   length(vars) != length(exps) &&
+       error("Number of variables does not match number of exponents")
+   z = parent(a)()
+   vars = [UInt(i) - 1 for i in vars]
+   for i = 1:length(vars)
+      if vars[i] < 0 || vars[i] >= nvars(parent(a))
+         error("Variable index not in range")
+      end
+      if exps[i] < 0
+         error("Exponent cannot be negative")
+      end
+   end
+   ccall((:fmpq_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+         (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ptr{Int},
+          Ptr{Int}, Int, Ref{FmpqMPolyRing}),
+          z, a, vars, exps, length(vars), a.parent)
+   return z
+end
+
+###############################################################################
+#
 #   String I/O
 #
 ###############################################################################

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -482,6 +482,13 @@ function ==(a::fmpq_mpoly, b::fmpq_mpoly)
                a, b, a.parent))
 end
 
+function Base.isless(a::fmpq_mpoly, b::fmpq_mpoly)
+   (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
+   return ccall((:fmpq_mpoly_cmp, :libflint), Cint,
+               (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
+               a, b, a.parent) < 0
+end
+
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -868,7 +868,33 @@ function sort_terms!(a::fmpq_mpoly)
    ccall((:fmpq_mpoly_sort_terms, :libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return a
-end    
+end
+
+# Return the i-th term of the polynomial, as a polynomial
+function term(a::fmpq_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:fmpq_mpoly_get_term, :libflint), Nothing,
+         (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Return the i-th monomial of the polynomial, as a polynomial
+function monomial(a::fmpq_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:fmpq_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Sets the given polynomial m to the i-th monomial of the polynomial
+function monomial!(m::fmpq_mpoly, a::fmpq_mpoly, i::Int)
+   ccall((:fmpq_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
+          m, a, i - 1, a.parent)
+   return m
+end
 
 ###############################################################################
 #

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -738,6 +738,14 @@ function set_exponent_vector!(a::fmpz_mpoly, n::Int, exps::Vector{fmpz})
    return a
 end
 
+# Return j-th coordinate of i-th exponent vector
+function exponent(a::fmpz_mpoly, i::Int, j::Int)
+   (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
+   return ccall((:fmpz_mpoly_get_term_var_exp_ui, :libflint), Int,
+                (Ref{fmpz_mpoly}, Int, Int, Ref{FmpzMPolyRing}),
+                 a, i - 1, j - 1, a.parent)
+end
+
 # Return the coefficient of the term with the given exponent vector
 # Return zero if there is no such term
 function coeff(a::fmpz_mpoly, exps::Vector{UInt})

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -237,6 +237,33 @@ end
 
 ###############################################################################
 #
+#   Multivariable coefficient polynomials
+#
+###############################################################################
+
+function coeff(a::fmpz_mpoly, vars::Vector{Int}, exps::Vector{Int})
+   unique(vars) != vars && error("Variables not unique")
+   length(vars) != length(exps) &&
+       error("Number of variables does not match number of exponents")
+   z = parent(a)()
+   vars = [UInt(i) - 1 for i in vars]
+   for i = 1:length(vars)
+      if vars[i] < 0 || vars[i] >= nvars(parent(a))
+         error("Variable index not in range")
+      end
+      if exps[i] < 0
+         error("Exponent cannot be negative")
+      end
+   end
+   ccall((:fmpz_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ptr{Int},
+          Ptr{Int}, Int, Ref{FmpzMPolyRing}),
+          z, a, vars, exps, length(vars), a.parent)
+   return z
+end
+
+###############################################################################
+#
 #   String I/O
 #
 ###############################################################################

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -456,6 +456,13 @@ function ==(a::fmpz_mpoly, b::fmpz_mpoly)
                a, b, a.parent))
 end
 
+function Base.isless(a::fmpz_mpoly, b::fmpz_mpoly)
+   (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
+   return ccall((:fmpz_mpoly_cmp, :libflint), Cint,
+               (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
+               a, b, a.parent) < 0
+end
+
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -798,6 +798,32 @@ function sort_terms!(a::fmpz_mpoly)
    return a
 end    
 
+# Return the i-th term of the polynomial, as a polynomial
+function term(a::fmpz_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:fmpz_mpoly_get_term, :libflint), Nothing,
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Return the i-th monomial of the polynomial, as a polynomial
+function monomial(a::fmpz_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:fmpz_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Sets the given polynomial m to the i-th monomial of the polynomial
+function monomial!(m::fmpz_mpoly, a::fmpz_mpoly, i::Int)
+   ccall((:fmpz_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
+          m, a, i - 1, a.parent)
+   return m
+end
+
 ###############################################################################
 #
 #   Promotion rules

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -838,6 +838,32 @@ function sort_terms!(a::nmod_mpoly)
    return a
 end    
 
+# Return the i-th term of the polynomial, as a polynomial
+function term(a::nmod_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:nmod_mpoly_get_term, :libflint), Nothing,
+         (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Return the i-th monomial of the polynomial, as a polynomial
+function monomial(a::nmod_mpoly, i::Int)
+   z = parent(a)()
+   ccall((:nmod_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
+          z, a, i - 1, a.parent)
+   return z
+end
+
+# Sets the given polynomial m to the i-th monomial of the polynomial
+function monomial!(m::nmod_mpoly, a::nmod_mpoly, i::Int)
+   ccall((:nmod_mpoly_get_term_monomial, :libflint), Nothing,
+         (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
+          m, a, i - 1, a.parent)
+   return m
+end
+
 ###############################################################################
 #
 #   Promotion rules

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -779,6 +779,14 @@ function set_exponent_vector!(a::nmod_mpoly, n::Int, exps::Vector{fmpz})
    return a
 end
 
+# Return j-th coordinate of i-th exponent vector
+function exponent(a::nmod_mpoly, i::Int, j::Int)
+   (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
+   return ccall((:nmod_mpoly_get_term_var_exp_ui, :libflint), Int,
+                (Ref{nmod_mpoly}, Int, Int, Ref{NmodMPolyRing}),
+                 a, i - 1, j - 1, a.parent)
+end
+
 # Return the coefficient of the term with the given exponent vector
 # Return zero if there is no such term
 function coeff(a::nmod_mpoly, exps::Vector{UInt})

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -238,6 +238,33 @@ end
 
 ###############################################################################
 #
+#   Multivariable coefficient polynomials
+#
+###############################################################################
+
+function coeff(a::nmod_mpoly, vars::Vector{Int}, exps::Vector{Int})
+   unique(vars) != vars && error("Variables not unique")
+   length(vars) != length(exps) &&
+       error("Number of variables does not match number of exponents")
+   z = parent(a)()
+   vars = [UInt(i) - 1 for i in vars]
+   for i = 1:length(vars)
+      if vars[i] < 0 || vars[i] >= nvars(parent(a))
+         error("Variable index not in range")
+      end
+      if exps[i] < 0
+         error("Exponent cannot be negative")
+      end
+   end
+   ccall((:nmod_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+         (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ptr{Int},
+          Ptr{Int}, Int, Ref{NmodMPolyRing}),
+          z, a, vars, exps, length(vars), a.parent)
+   return z
+end
+
+###############################################################################
+#
 #   String I/O
 #
 ###############################################################################

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -457,6 +457,13 @@ function ==(a::nmod_mpoly, b::nmod_mpoly)
                a, b, a.parent))
 end
 
+function Base.isless(a::nmod_mpoly, b::nmod_mpoly)
+   (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
+   return ccall((:nmod_mpoly_cmp, :libflint), Cint,
+               (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
+               a, b, a.parent) < 0
+end
+
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -644,6 +644,9 @@ function test_fmpq_mpoly_exponents()
         c = coeff(f, v)
 
         @test c == coeff(f, nrand)
+        for ind = 1:length(v)
+           @test v[ind] == exponent(f, nrand, ind)
+        end
      end
 
      for iter in 1:10

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -106,6 +106,14 @@ function test_fmpq_mpoly_manipulation()
       end
       @test f == r
 
+      for i = 1:length(f)
+         i1 = rand(1:length(f))
+         i2 = rand(1:length(f))
+         @test (i1 < i2) == (monomial(f, i1) > monomial(f, i2))
+         @test (i1 > i2) == (monomial(f, i1) < monomial(f, i2))
+         @test (i1 == i2) == (monomial(f, i1) == monomial(f, i2))
+      end
+
       deg = isdegree(ordering(S))
       rev = isreverse(ordering(S))
 

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -147,6 +147,29 @@ function test_fmpq_mpoly_manipulation()
    println("PASS")
 end
 
+function test_fmpq_mpoly_multivariate_coeff()
+   print("fmpq_mpoly.multivariate_coeff...")
+
+   R = FlintQQ
+
+   for ord in Nemo.flint_orderings
+      S, (x, y, z) = PolynomialRing(R, ["x", "y", "z"]; ordering=ord)
+
+      f = -8*x^5*y^3*z^5+9*x^5*y^2*z^3-8*x^4*y^5*z^4-10*x^4*y^3*z^2+8*x^3*y^2*z-10*x*y^3*
+z^4-4*x*y-10*x*z^2+8*y^2*z^5-9*y^2*z^3
+
+      @test coeff(f, [1], [1]) == -10*y^3*z^4-4*y-10*z^2
+      @test coeff(f, [2, 3], [3, 2]) == -10*x^4
+      @test coeff(f, [1, 3], [4, 5]) == 0
+
+      @test coeff(f, [x], [1]) == -10*y^3*z^4-4*y-10*z^2
+      @test coeff(f, [y, z], [3, 2]) == -10*x^4
+      @test coeff(f, [x, z], [4, 5]) == 0
+   end
+
+   println("PASS")
+end
+
 function test_fmpq_mpoly_unary_ops()
    print("fmpq_mpoly.unary_ops...")
 
@@ -654,6 +677,7 @@ end
 function test_fmpq_mpoly()
    test_fmpq_mpoly_constructors()
    test_fmpq_mpoly_manipulation()
+   test_fmpq_mpoly_multivariate_coeff()
    test_fmpq_mpoly_unary_ops()
    test_fmpq_mpoly_binary_ops()
    test_fmpq_mpoly_adhoc_binary()

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -96,6 +96,16 @@ function test_fmpq_mpoly_manipulation()
         @test f == sum((coeff(f, i) * S(fmpq[1], [Nemo.exponent_vector_fmpz(f, i)])  for i in 1:length(f)))
       end
 
+      r = S()
+      m = S()
+      for i = 1:length(f)
+         m = monomial!(m, f, i)
+         @test m == monomial(f, i)
+         @test term(f, i) == coeff(f, i)*monomial(f, i)
+         r += coeff(f, i)*monomial(f, i)
+      end
+      @test f == r
+
       deg = isdegree(ordering(S))
       rev = isreverse(ordering(S))
 

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -635,6 +635,9 @@ function test_fmpz_mpoly_exponents()
         c = coeff(f, v)
 
         @test c == coeff(f, nrand)
+        for ind = 1:length(v)
+           @test v[ind] == exponent(f, nrand, ind)
+        end
      end
 
      for iter in 1:10

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -106,6 +106,14 @@ function test_fmpz_mpoly_manipulation()
       end
       @test f == r
 
+      for i = 1:length(f)
+         i1 = rand(1:length(f))
+         i2 = rand(1:length(f))
+         @test (i1 < i2) == (monomial(f, i1) > monomial(f, i2))
+         @test (i1 > i2) == (monomial(f, i1) < monomial(f, i2))
+         @test (i1 == i2) == (monomial(f, i1) == monomial(f, i2))
+      end
+
       deg = isdegree(ordering(S))
       rev = isreverse(ordering(S))
 

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -147,6 +147,28 @@ function test_fmpz_mpoly_manipulation()
    println("PASS")
 end
 
+function test_fmpz_mpoly_multivariate_coeff()
+   print("fmpz_mpoly.multivariate_coeff...")
+
+   R = FlintZZ
+   
+   for ord in Nemo.flint_orderings
+      S, (x, y, z) = PolynomialRing(R, ["x", "y", "z"]; ordering=ord)
+
+      f = -8*x^5*y^3*z^5+9*x^5*y^2*z^3-8*x^4*y^5*z^4-10*x^4*y^3*z^2+8*x^3*y^2*z-10*x*y^3*z^4-4*x*y-10*x*z^2+8*y^2*z^5-9*y^2*z^3
+
+      @test coeff(f, [1], [1]) == -10*y^3*z^4-4*y-10*z^2
+      @test coeff(f, [2, 3], [3, 2]) == -10*x^4
+      @test coeff(f, [1, 3], [4, 5]) == 0
+
+      @test coeff(f, [x], [1]) == -10*y^3*z^4-4*y-10*z^2
+      @test coeff(f, [y, z], [3, 2]) == -10*x^4
+      @test coeff(f, [x, z], [4, 5]) == 0
+   end
+
+   println("PASS")
+end
+
 function test_fmpz_mpoly_unary_ops()
    print("fmpz_mpoly.unary_ops...")
 
@@ -646,6 +668,7 @@ end
 function test_fmpz_mpoly()
    test_fmpz_mpoly_constructors()
    test_fmpz_mpoly_manipulation()
+   test_fmpz_mpoly_multivariate_coeff()
    test_fmpz_mpoly_unary_ops()
    test_fmpz_mpoly_binary_ops()
    test_fmpz_mpoly_adhoc_binary()

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -96,6 +96,16 @@ function test_fmpz_mpoly_manipulation()
         @test f == sum((coeff(f, i) * S(fmpz[1], [Nemo.exponent_vector_fmpz(f, i)])  for i in 1:length(f)))
       end
 
+      r = S()
+      m = S()
+      for i = 1:length(f)
+         m = monomial!(m, f, i)
+         @test m == monomial(f, i)
+         @test term(f, i) == coeff(f, i)*monomial(f, i)
+         r += coeff(f, i)*monomial(f, i)
+      end
+      @test f == r
+
       deg = isdegree(ordering(S))
       rev = isreverse(ordering(S))
 

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -100,6 +100,14 @@ function test_nmod_mpoly_manipulation()
       end
       @test f == r
 
+      for i = 1:length(f)
+         i1 = rand(1:length(f))
+         i2 = rand(1:length(f))
+         @test (i1 < i2) == (monomial(f, i1) > monomial(f, i2))
+         @test (i1 > i2) == (monomial(f, i1) < monomial(f, i2))
+         @test (i1 == i2) == (monomial(f, i1) == monomial(f, i2))
+      end
+
       f = rand(S, 1:5, 0:100)
 
       if length(f) > 0

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -162,6 +162,28 @@ function test_nmod_mpoly_manipulation()
    println("PASS")
 end
 
+function test_nmod_mpoly_multivariate_coeff()
+   print("nmod_mpoly.multivariate_coeff...")
+
+   R = ResidueRing(FlintZZ, 23)
+
+   for ord in Nemo.flint_orderings
+      S, (x, y, z) = PolynomialRing(R, ["x", "y", "z"]; ordering=ord)
+
+      f = 15*x^5*y^3*z^5+9*x^5*y^2*z^3+15*x^4*y^5*z^4+13*x^4*y^3*z^2+8*x^3*y^2*z+13*x*y^3*z^4+19*x*y+13*x*z^2+8*y^2*z^5+14*y^2*z^3
+
+      @test coeff(f, [1], [1]) == 13*y^3*z^4+19*y+13*z^2
+      @test coeff(f, [2, 3], [3, 2]) == 13*x^4
+      @test coeff(f, [1, 3], [4, 5]) == 0
+
+      @test coeff(f, [x], [1]) == 13*y^3*z^4+19*y+13*z^2
+      @test coeff(f, [y, z], [3, 2]) == 13*x^4
+      @test coeff(f, [x, z], [4, 5]) == 0
+   end
+
+   println("PASS")
+end
+
 function test_nmod_mpoly_unary_ops()
    print("nmod_mpoly.unary_ops...")
 
@@ -668,6 +690,7 @@ end
 function test_nmod_mpoly()
    test_nmod_mpoly_constructors()
    test_nmod_mpoly_manipulation()
+   test_nmod_mpoly_multivariate_coeff()
    test_nmod_mpoly_unary_ops()
    test_nmod_mpoly_binary_ops()
    test_nmod_mpoly_adhoc_binary()

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -90,6 +90,16 @@ function test_nmod_mpoly_manipulation()
          @test isa(coeff(f, i), elem_type(R))
       end
 
+      r = S()
+      m = S()
+      for i = 1:length(f)
+         m = monomial!(m, f, i)
+         @test m == monomial(f, i)
+         @test term(f, i) == coeff(f, i)*monomial(f, i)
+         r += coeff(f, i)*monomial(f, i)
+      end
+      @test f == r
+
       f = rand(S, 1:5, 0:100)
 
       if length(f) > 0

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -657,6 +657,9 @@ function test_nmod_mpoly_exponents()
         c = coeff(f, v)
 
         @test c == coeff(f, nrand)
+        for ind = 1:length(v)
+           @test v[ind] == exponent(f, nrand, ind)
+        end
      end
 
      for iter in 1:10


### PR DESCRIPTION
This, and the accompanying AbstractAlgebra PR add a bunch of functionality @fieker wants.

* exponent(f, i, j) to get the j-th component of the i-th exponent vector efficiently
* monomial(f, i), monomial!(m, f, i), term(f, i) to get the i-th monomial/term of a polynomial
* comparison of monomials (can be combined with monomial! for efficient comparison)

It also adds:

* coeff(f, [x, z], [2, 0]) to return the (multivariate) coefficient of x^2*z^0 in the multivariate f

This PR depends on the AbstractAlgebra one.