### PR TITLE
Add missing base_ring functions (needed by AbstractAlgebra generics).

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -37,6 +37,8 @@ nvars(a::FmpqMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, :libflint), Int,
 
 base_ring(a::FmpqMPolyRing) = a.base_ring
 
+base_ring(f::fmpq_mpoly) = f.parent.base_ring
+
 function ordering(a::FmpqMPolyRing)
    b = ccall((:fmpq_mpoly_ctx_ord, :libflint), Cint, (Ref{FmpqMPolyRing}, ), a)
    return flint_orderings[b + 1]

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -32,6 +32,8 @@ nvars(a::FmpzMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, :libflint), Int,
 
 base_ring(a::FmpzMPolyRing) = a.base_ring
 
+base_ring(f::fmpz_mpoly) = f.parent.base_ring
+
 function ordering(a::FmpzMPolyRing)
    b = ccall((:fmpz_mpoly_ctx_ord, :libflint), Cint, (Ref{FmpzMPolyRing}, ), a)
    return flint_orderings[b + 1]

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -31,6 +31,8 @@ nvars(a::NmodMPolyRing) = a.nvars
 
 base_ring(a::NmodMPolyRing) = a.base_ring
 
+base_ring(f::nmod_mpoly) = f.parent.base_ring
+
 function ordering(a::NmodMPolyRing)
 b = a.ord
 #   b = ccall((:nmod_mpoly_ctx_ord, :libflint), Cint, (Ref{NmodMPolyRing}, ), a)


### PR DESCRIPTION
Simply adds a few missing functions that the generic code really needs to exist.