### PR TITLE
Conform `nmod` rand function to RNG interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -6,9 +6,9 @@ using Markdown
 
 using InteractiveUtils
 
-if VERSION >= v"0.7.0-"
-   using Libdl
-end
+using Libdl
+
+using Random
 
 import Base: Array, abs, acos, acosh, asin, asinh, atan, atanh,
              bin, ceil, checkbounds, conj, convert, cmp, cos, cosh,
@@ -22,10 +22,6 @@ import Base: Array, abs, acos, acosh, asin, asinh, atan, atanh,
              tan, tanh, trailing_zeros, transpose, truncate,
              typed_hvcat, typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^,
              &, |, <<, >>, ~, <=, >=, <, >, //, /, !=
-
-if VERSION <= v"0.7.0"
-   import Base: atan2, base, contains, nextpow2, prevpow2
-end
 
 import LinearAlgebra: det, norm, nullspace, rank, transpose!, hessenberg, tr,
                       lu, lu!, eigvals

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -362,15 +362,16 @@ end
 #
 ###############################################################################
 
-function rand(R::NmodRing)
-   n = rand(UInt(0):R.n - 1)
+function rand(r::Random.AbstractRNG, R::NmodRing)
+   n = rand(r, UInt(0):R.n - 1)
    return nmod(n, R)
 end
 
-function rand(R::NmodRing, b::UnitRange{Int64})
-   n = rand(b)
+function rand(r::Random.AbstractRNG, R::NmodRing, b::UnitRange{Int64})
+   n = rand(r, b)
    return R(n)
 end
+rand(R::NmodRing, b::UnitRange{Int64}) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -35,7 +35,9 @@ function test_nmod_constructors()
       d = a.data
 
       @test a.data < R.n
-   end 
+   end
+
+   @test isa(rand(Random.GLOBAL_RNG, R), Nemo.nmod)
 
    println("PASS")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 using Nemo
-
-if VERSION < v"0.7.0-DEV.2004"
-   using Base.Test
-else
-   using Test
-end
+using Test
+using Random
 
 include("../test/Nemo-test.jl")
 


### PR DESCRIPTION
The interface requires taking an RNG as the first argument and passing
it down to any interior calls to `rand`. Do that for nmod.