### PR TITLE
tests: fix matrix printing

### DIFF
--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -3,7 +3,7 @@ RR = ArbField(64)
 
 function test_acb_mat_constructors()
    print("acb_mat.constructors...")
- 
+
    S = MatrixSpace(CC, 3, 3)
    R = MatrixSpace(ZZ, 3, 3)
 
@@ -100,11 +100,12 @@ end
 
 function test_acb_mat_printing()
    print("acb_mat.printing...")
- 
+
    S = MatrixSpace(CC, 3, 3)
    f = S(fmpz(3))
 
-   @test string(f) == "[3.0000000000000000000 + i*0 0 + i*0 0 + i*0]\n[0 + i*0 3.0000000000000000000 + i*0 0 + i*0]\n[0 + i*0 0 + i*0 3.0000000000000000000 + i*0]"
+   # test that default Julia printing is not used
+   @test !occursin(string(typeof(f)), string(f))
 
    println("PASS")
 end
@@ -269,11 +270,11 @@ function test_acb_mat_comparison()
    @test A == A
 
    @test A != B
-   
+
    @test overlaps(A, C)
 
    @test contains(C, A)
-   
+
    println("PASS")
 end
 
@@ -290,7 +291,7 @@ function test_acb_mat_adhoc_comparison()
 
    @test contains(A, B)
    @test contains(A, C)
-   
+
    @test S(12) == 12
    @test 12 == S(12)
    @test S(5) == fmpz(5)
@@ -313,7 +314,7 @@ function test_acb_mat_predicates()
    A = onei(CC) * A
 
    @test !isreal(A)
-   
+
    println("PASS")
 end
 

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -2,7 +2,7 @@ RR = ArbField(64)
 
 function test_arb_mat_constructors()
    print("arb_mat.constructors...")
- 
+
    S = MatrixSpace(RR, 3, 3)
    R = MatrixSpace(ZZ, 3, 3)
 
@@ -41,7 +41,7 @@ function test_arb_mat_constructors()
    o = S([1.0 2.0 3.0; 1.0 1.0 1.0; 2.0 3.1 4.1])
 
    @test isa(o, MatElem)
-   
+
    p = S(BigFloat[1.0 2.0 3.0; 1.0 1.0 1.0; 2.0 3.1 4.1])
 
    @test isa(p, MatElem)
@@ -99,11 +99,12 @@ end
 
 function test_arb_mat_printing()
    print("arb_mat.printing...")
- 
+
    S = MatrixSpace(RR, 3, 3)
    f = S(fmpz(3))
 
-   @test string(f) == "[3.0000000000000000000 0 0]\n[0 3.0000000000000000000 0]\n[0 0 3.0000000000000000000]"
+   # test that default Julia printing is not used
+   @test !occursin(string(typeof(f)), string(f))
 
    println("PASS")
 end
@@ -223,7 +224,7 @@ function test_arb_mat_adhoc_binary()
 
    @test contains(q*A, C*q)
    @test contains(A*q, C*q)
- 
+
    println("PASS")
 end
 
@@ -262,11 +263,11 @@ function test_arb_mat_comparison()
    @test A == A
 
    @test A != B
-   
+
    @test overlaps(A, C)
 
    @test contains(C, A)
-   
+
    println("PASS")
 end
 
@@ -283,7 +284,7 @@ function test_arb_mat_adhoc_comparison()
 
    @test contains(A, B)
    @test contains(A, C)
-   
+
    @test S(12) == 12
    @test 12 == S(12)
    @test S(5) == fmpz(5)

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -1,6 +1,6 @@
 function test_fmpq_mat_constructors()
    print("fmpq_mat.constructors...")
- 
+
    S = MatrixSpace(QQ, 3, 3)
 
    @test elem_type(S) == fmpq_mat
@@ -19,9 +19,9 @@ function test_fmpq_mat_constructors()
    g = S(2)
 
    @test isa(g, MatElem)
-   
+
    h = S(fmpz(5))
-   
+
    @test isa(h, MatElem)
 
    k = S([fmpq(2) 3 5; 1 4 7; 9 6 3])
@@ -101,7 +101,7 @@ function test_fmpq_mat_constructors()
       @test_throws ErrorConstrDimMismatch matrix(FlintQQ, 2, 2, map(T, arr2))
       @test_throws ErrorConstrDimMismatch matrix(FlintQQ, 2, 4, map(T, arr2))
    end
-   
+
    M3 = zero_matrix(FlintQQ, 2, 3)
 
    @test isa(M3, fmpq_mat)
@@ -125,10 +125,11 @@ end
 
 function test_fmpq_mat_printing()
    print("fmpq_mat.printing...")
- 
+
    a = MatrixSpace(QQ, 2, 2)(1)
-   
-   @test string(a) == "[1 0]\n[0 1]"
+
+  # test that default Julia printing is not used
+  @test !occursin(string(typeof(a)), string(a))
 
    println("PASS")
 end
@@ -285,7 +286,7 @@ function test_fmpq_mat_adhoc_binary()
    @test fmpq(3)*A == A*fmpq(3)
    @test (3//1)*A == A*fmpq(3)
    @test (BigInt(3)//1)*A == A*fmpq(3)
-  
+
    println("PASS")
 end
 
@@ -373,7 +374,7 @@ function test_fmpq_mat_adhoc_exact_division()
    @test divexact(3*A, BigInt(3)) == A
    @test divexact(3*A, 3//1) == A
    @test divexact(3*A, BigInt(3)//1) == A
-   
+
    println("PASS")
 end
 
@@ -397,7 +398,7 @@ function test_fmpq_mat_tr()
    S = MatrixSpace(QQ, 3, 3)
 
    A = S([fmpq(2) 3 5; 1 4 7; 9 6 3])
- 
+
    @test tr(A) == 9
 
    println("PASS")
@@ -470,15 +471,15 @@ function test_fmpq_mat_inversion()
    A = S([fmpq(2) 3 5; 1 4 7; 9 2 2])
    B = S([-6 4 1; 61 (-41) (-9); -34 23 5])
    C = S([fmpq(3) 1 2; 1 5 1; 4 8 0])
-   
+
    @test inv(inv(A)) == A
 
    @test inv(A) == B
 
    @test inv(A)*A == one(S)
-   
+
    @test inv(C)*C == one(S)
-   
+
    @test C*inv(C) == one(S)
 
    println("PASS")
@@ -491,7 +492,7 @@ function test_fmpq_mat_exact_division()
 
    A = S([fmpq(2) 3 5; 1 4 7; 9 2 2])
    B = S([2 3 4; 7 9 1; 5 4 5])
- 
+
    @test divexact(B*A, A) == B
 
    println("PASS")
@@ -503,7 +504,7 @@ function test_fmpq_mat_det()
    S = MatrixSpace(QQ, 3, 3)
 
    A = S([fmpq(2) 3 5; 1 4 7; 19 3 7])
-   
+
    @test det(A) == 27
 
    println("PASS")
@@ -515,9 +516,9 @@ function test_fmpq_mat_hilbert()
    S = MatrixSpace(QQ, 4, 4)
 
    c4 = fmpz(2)^2*fmpz(3)
-   
+
    c8 = fmpz(2)^6*fmpz(3)^5*fmpz(4)^4*fmpz(5)^3*fmpz(6)^2*fmpz(7)
-   
+
    @test det(hilbert(S)) == c4^4//c8
 
    println("PASS")
@@ -530,7 +531,7 @@ function test_fmpq_mat_nullspace()
    T = MatrixSpace(QQ, 3, 1)
 
    A = S([fmpq(2) 3 5; 1 4 7; 4 1 1])
-   
+
    @test nullspace(A) == (1, T([fmpq(1, 5); fmpq(-9, 5); fmpq(1)]))
 
    r, N = nullspace(A)
@@ -546,7 +547,7 @@ function test_fmpq_mat_rank()
    S = MatrixSpace(QQ, 3, 3)
 
    A = S([fmpq(2) 3 5; 1 4 7; 4 1 1])
-   
+
    @test rank(A) == 2
 
    println("PASS")
@@ -558,7 +559,7 @@ function test_fmpq_mat_rref()
    S = MatrixSpace(QQ, 3, 3)
 
    A = S([fmpq(2) 3 5; 1 4 7; 4 1 1])
-   
+
    @test rref(A) == (2, S([1 0 fmpq(-1, 5); 0 1 fmpq(9, 5); 0 0 0]))
 
    println("PASS")
@@ -570,7 +571,7 @@ function test_fmpq_mat_solve()
    S = MatrixSpace(QQ, 3, 3)
 
    A = S([fmpq(2) 3 5; 1 4 7; 9 2 2])
-   
+
    T = MatrixSpace(QQ, 3, 1)
 
    B = T([fmpq(4), 5, 7])
@@ -584,7 +585,7 @@ function test_fmpq_mat_solve()
    Y = solve_dixon(A, B)
 
    @test X == Y
-   
+
    println("PASS")
 end
 
@@ -610,9 +611,9 @@ function test_fmpq_mat_charpoly()
 
    S = MatrixSpace(QQ, 3, 3)
    R, x = PolynomialRing(QQ, "x")
-   
+
    A = S([fmpq(2) 3 5; 1 4 7; 9 6 3])
-   
+
    @test charpoly(R, A) == x^3 - 9*x^2 - 64*x + 30
 
    println("PASS")
@@ -624,7 +625,7 @@ function test_fmpq_mat_minpoly()
    S = MatrixSpace(QQ, 10, 10)
    R, x = PolynomialRing(QQ, "x")
    M = S()
-   
+
    for i in 1:5
       for j in 1:5
          r = rand(-10:10)
@@ -632,13 +633,13 @@ function test_fmpq_mat_minpoly()
          M[5 + i, 5 + j] = r
       end
    end
-   
+
    for i in 1:5
       similarity!(M, rand(1:10), fmpq(rand(-3:3)))
    end
-   
+
    @test degree(minpoly(R, M)) == 5
-   
+
    println("PASS")
 end
 

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -85,7 +85,8 @@ function test_fmpz_mat_printing()
    S = MatrixSpace(FlintZZ, 3, 3)
    f = S(fmpz(3))
 
-   @test string(f) == "[3 0 0]\n[0 3 0]\n[0 0 3]"
+   # test that default Julia printing is not used
+   @test !occursin(string(typeof(f)), string(f))
 
    println("PASS")
 end

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -14,7 +14,7 @@ function test_fq_mat_constructors()
   print("fq_mat.constructors...")
 
   F4, a = FiniteField(fmpz(2), 2, "a")
-  F9, b = FiniteField(fmpz(3), 2, "b") 
+  F9, b = FiniteField(fmpz(3), 2, "b")
 
   R = FqMatSpace(F4, 2, 2)
 
@@ -190,7 +190,8 @@ function test_fq_mat_printing()
 
   a = R(1)
 
-  @test string(a) == "[1 0]\n[0 1]"
+  # test that default Julia printing is not used
+  @test !occursin(string(typeof(a)), string(a))
 
   println("PASS")
 end
@@ -475,7 +476,7 @@ function test_fq_mat_row_echelon_form()
   c = a*transpose(a)
 
   r, d = rref(a)
-  
+
   @test d == R([ 1 0 0 8; 0 1 0 15; 0 0 1 16])
   @test r == 3
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -14,7 +14,7 @@ function test_fq_nmod_mat_constructors()
   print("fq_nmod_mat.constructors...")
 
   F4, a = FlintFiniteField(2, 2, "a")
-  F9, b = FlintFiniteField(3, 2, "b") 
+  F9, b = FlintFiniteField(3, 2, "b")
 
   R = FqNmodMatSpace(F4, 2, 2)
 
@@ -190,7 +190,8 @@ function test_fq_nmod_mat_printing()
 
   a = R(1)
 
-  @test string(a) == "[1 0]\n[0 1]"
+  # test that default Julia printing is not used
+  @test !occursin(string(typeof(a)), string(a))
 
   println("PASS")
 end

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -194,7 +194,8 @@ function test_gfp_mat_printing()
 
   a = R(1)
 
-  @test string(a) == "[1 0]\n[0 1]"
+  # test that default Julia printing is not used
+  @test !occursin(string(typeof(a)), string(a))
 
   println("PASS")
 end

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -194,7 +194,8 @@ function test_nmod_mat_printing()
 
   a = R(1)
 
-  @test string(a) == "[1 0]\n[0 1]"
+  # test that default Julia printing is not used
+  @test !occursin(string(typeof(a)), string(a))
 
   println("PASS")
 end


### PR DESCRIPTION
Closes #618.
This test that printing doesn't error out and that (thanks to @thofma's [suggestion](https://github.com/Nemocas/Nemo.jl/issues/618#issuecomment-530395692)) the matrix type doesn't appear in the output, which would suggest that the default Julia printing funbction for structs is used.