### PR TITLE
remove undefined export symbols

### DIFF
--- a/src/Factor.jl
+++ b/src/Factor.jl
@@ -1,4 +1,4 @@
-export Fac, unit, factors
+export Fac, unit
 
 ################################################################################
 #
@@ -9,4 +9,3 @@ export Fac, unit, factors
 Base.in(b::Integer, a::Fac{fmpz}) = Base.in(fmpz(b), a)
 
 Base.getindex(a::Fac{fmpz}, b::Integer) = getindex(a, fmpz(b))
-

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export zero, one, deepcopy, -, transpose, +, *, &, ==, !=, strongequal,
+export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
        overlaps, contains, inv, divexact, charpoly, det, lu, lu!, solve,
        solve!, solve_lu_precomp, solve_lu_precomp!, swap_rows, swap_rows!,
        bound_inf_norm, isreal, eigvals, eigvals_simple
@@ -995,7 +995,7 @@ end
 > has only simple eigenvalues.
 >
 > The algorithm used can be changed by setting the `alg` keyword to
-> `:vdhoeven_mourrain` or `:rump`. 
+> `:vdhoeven_mourrain` or `:rump`.
 >
 > This function is experimental.
 """

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -14,7 +14,7 @@ export ball, radius, midpoint, contains, contains_zero,
        contains_nonpositive, convert, iszero,
        isnonzero, isexact, isint, ispositive, isfinite,
        isnonnegative, isnegative, isnonpositive, add!, mul!,
-       sub!, div!, strongequal, prec, overlaps, unique_integer,
+       sub!, div!, prec, overlaps, unique_integer,
        accuracy_bits, trim, ldexp, setunion, setintersection,
        const_pi, const_e, const_log2, const_log10, const_euler,
        const_catalan, const_khinchin, const_glaisher,
@@ -1796,7 +1796,7 @@ numpart(n::Int, r::ArbField) = numpart(fmpz(n), r)
 > (using LLL). The entries are first scaled by the given number of bits before
 > truncating to integers for use in LLL. This function can be used to find linear
 > dependence between a list of real numbers. The algorithm is heuristic only and
-> returns an array of Nemo integers representing the linear combination.  
+> returns an array of Nemo integers representing the linear combination.
 """
 function lindep(A::Array{arb, 1}, bits::Int)
   bits < 0 && throw(DomainError("Number of bits must be non-negative: $bits"))

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-export zero, one, deepcopy, -, transpose, +, *, &, ==, !=, strongequal,
+export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
        overlaps, contains, inv, divexact, charpoly, det, lu, lu!, solve,
        solve!, solve_lu_precomp, solve_lu_precomp!, swap_rows, swap_rows!,
        bound_inf_norm

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -32,7 +32,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 export fmpz, FlintZZ, FlintIntegerRing, parent, show, convert, hash, fac, bell,
-       binom, isprime, fdiv, cdiv, tdiv, div, rem, mod, gcd, xgcd, lcm, invmod,
+       binom, isprime, fdiv, cdiv, tdiv, div, rem, mod, gcd, lcm, invmod,
        powmod, abs, divrem, isqrt, popcount, prevpow2, nextpow2, ndigits, dec,
        bin, oct, hex, base, one, zero, divexact, fits, sign, nbits, deepcopy,
        tdivpow2, fdivpow2, cdivpow2, flog, clog, cmpabs, clrbit!, setbit!,
@@ -40,7 +40,7 @@ export fmpz, FlintZZ, FlintIntegerRing, parent, show, convert, hash, fac, bell,
        gcdinv, isprobabprime, issquare, jacobi, remove, root, size, isqrtrem,
        sqrtmod, trailing_zeros, sigma, eulerphi, fib, moebiusmu, primorial,
        risingfac, numpart, canonical_unit, needs_parentheses, displayed_with_minus_in_front,
-       show_minus_one, parseint, addeq!, mul!, isunit, isequal,
+       show_minus_one, addeq!, mul!, isunit, isequal,
        iszero, rand
 
 ###############################################################################

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -4,14 +4,14 @@
 #
 ###############################################################################
 
-export fmpz_mat, FmpzMatSpace, getindex, getindex!, setindex!, rows, cols,
+export fmpz_mat, FmpzMatSpace, getindex, getindex!, setindex!,
        charpoly, det, det_divisor, det_given_divisor, gram, hadamard,
        ishadamard, hnf, ishnf, hnf_with_transform, hnf_modular, lll, lll!,
        lll_ctx, lll_gram, lll_gram!, lll_with_transform,
        lll_gram_with_transform, lll_with_removal, lll_with_removal_transform,
        nullspace, rank, rref, reduce_mod, similar, snf, snf_diagonal, issnf,
        solve, solve_rational, cansolve, cansolve_with_nullspace, solve_dixon,
-       tr, transpose, content, hcat, vcat, addmul!, zero!, window, pseudo_inv,
+       tr, transpose, content, hcat, vcat, addmul!, zero!, pseudo_inv,
        hnf_modular_eldiv, nullspace_right_rational
 
 ###############################################################################

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-export fq_mat, FqMatSpace, getindex, setindex!, set_entry!, deepcopy, rows,
-       cols, parent, base_ring, zero, one, transpose,
+export fq_mat, FqMatSpace, getindex, setindex!, set_entry!, deepcopy,
+       parent, base_ring, zero, one, transpose,
        transpose!, rref, rref!, tr, det, rank, inv, solve, lu,
        sub, hcat, vcat, Array, lift, lift!, MatrixSpace, check_parent,
        howell_form, howell_form!, strong_echelon_form, strong_echelon_form!

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-export fq_nmod_mat, FqNmodMatSpace, getindex, setindex!, set_entry!, deepcopy, rows,
-       cols, parent, base_ring, zero, one, show, transpose,
+export fq_nmod_mat, FqNmodMatSpace, getindex, setindex!, set_entry!, deepcopy,
+       parent, base_ring, zero, one, show, transpose,
        transpose!, rref, rref!, tr, det, rank, inv, solve,
        sub, hcat, vcat, Array, lift, lift!, MatrixSpace, check_parent,
        howell_form, howell_form!, strong_echelon_form, strong_echelon_form!

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-export nmod_mat, NmodMatSpace, getindex, setindex!, set_entry!, deepcopy, rows,
-       cols, parent, base_ring, zero, one, transpose,
+export nmod_mat, NmodMatSpace, getindex, setindex!, set_entry!, deepcopy,
+       parent, base_ring, zero, one, transpose,
        transpose!, rref, rref!, tr, det, rank, inv, solve, lu,
        sub, hcat, vcat, Array, lift, lift!, MatrixSpace, check_parent,
        howell_form, howell_form!, strong_echelon_form, strong_echelon_form!

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -4,13 +4,13 @@
 #
 ################################################################################
 
-export NmodPolyRing, nmod_poly, parent, base_ring, elem_type, length, zero, 
+export NmodPolyRing, nmod_poly, parent, base_ring, elem_type, length, zero,
        one, gen, isgen, iszero, var, deepcopy, show, truncate, mullow, reverse,
-       shift_left, shift_right, divexact, divrem, rem, gcd, xgcd, resultant,
+       shift_left, shift_right, divexact, divrem, rem, gcd, resultant,
        evaluate, derivative, compose, interpolate, inflate, deflate, lift,
        isirreducible, issquarefree, factor, factor_squarefree,
        factor_distinct_deg, factor_shape, setcoeff!, canonical_unit,
-       add!, sub!, mul!, call, PolynomialRing, check_parent, gcdx, mod,
+       add!, sub!, mul!, PolynomialRing, check_parent, gcdx, mod,
        invmod, gcdinv, mulmod, powmod, zero!, one!
 
 ################################################################################
@@ -162,7 +162,7 @@ end
 function +(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_add, :libflint), Nothing, 
+  ccall((:nmod_poly_add, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -170,7 +170,7 @@ end
 function -(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_sub, :libflint), Nothing, 
+  ccall((:nmod_poly_sub, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -178,7 +178,7 @@ end
 function *(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_mul, :libflint), Nothing, 
+  ccall((:nmod_poly_mul, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -244,7 +244,7 @@ end
 
 +(x::T, y::Integer) where T <: Zmodn_poly = x + fmpz(y)
 
-+(x::Integer, y::T) where T <: Zmodn_poly = y + x 
++(x::Integer, y::T) where T <: Zmodn_poly = y + x
 
 function +(x::nmod_poly, y::nmod)
   (base_ring(x) != parent(y)) && error("Elements must have same parent")
@@ -323,13 +323,13 @@ function ==(x::nmod_poly, y::nmod)
   base_ring(x) != parent(y) && error("Incompatible base rings in comparison")
   if length(x) > 1
     return false
-  elseif length(x) == 1 
-    u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt, 
+  elseif length(x) == 1
+    u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
             (Ref{nmod_poly}, Int), x, 0)
     return u == y
   else
     return iszero(y)
-  end 
+  end
 end
 
 ==(x::nmod, y::nmod_poly) = y == x
@@ -407,7 +407,7 @@ function divexact(x::nmod_poly, y::nmod_poly)
   iszero(y) && throw(DivideError())
   !lead_isunit(y) && error("Impossible inverse in divexact")
   z = parent(x)()
-  ccall((:nmod_poly_div, :libflint), Nothing, 
+  ccall((:nmod_poly_div, :libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}), z, x, y)
   return z
 end
@@ -471,7 +471,7 @@ end
 
 function rem(x::nmod_poly, y::nmod_poly)
   check_parent(x,y)
-  iszero(y) && throw(DivideError()) 
+  iszero(y) && throw(DivideError())
   !lead_isunit(y) && error("Impossible inverse in rem")
   z = parent(x)()
   ccall((:nmod_poly_rem, :libflint), Nothing,
@@ -483,7 +483,7 @@ mod(x::T, y::T) where T <: Zmodn_poly = rem(x, y)
 
 ################################################################################
 #
-#  GCD 
+#  GCD
 #
 ################################################################################
 
@@ -494,7 +494,7 @@ function gcd(x::nmod_poly, y::nmod_poly)
   ccall((:nmod_poly_gcd, :libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}), z, x, y)
   return z
-end 
+end
 
 function gcdx(x::nmod_poly, y::nmod_poly)
   check_parent(x,y)
@@ -518,7 +518,7 @@ function gcdinv(x::nmod_poly, y::nmod_poly)
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}),
           g, s, x, y)
   return g,s
-end 
+end
 
 ################################################################################
 #
@@ -529,7 +529,7 @@ end
 function invmod(x::T, y::T) where T <: Zmodn_poly
   length(y) == 0 && error("Second argument must not be 0")
   check_parent(x,y)
-  if length(y) == 1 
+  if length(y) == 1
     return parent(x)(inv(eval(x, coeff(y, 0))))
   end
   z = parent(x)()
@@ -680,7 +680,7 @@ function deflate(x::T, n::Int) where T <: Zmodn_poly
           (Ref{T}, Ref{T}, UInt), z, x, UInt(n))
   return z
 end
- 
+
 ################################################################################
 #
 #  Lifting
@@ -888,7 +888,7 @@ end
 ################################################################################
 
 function zero!(x::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_zero, :libflint), Nothing, 
+  ccall((:nmod_poly_zero, :libflint), Nothing,
                    (Ref{T},), x)
   return x
 end
@@ -899,56 +899,56 @@ function one!(a::T) where T <: Zmodn_poly
 end
 
 function fit!(x::T, n::Int) where T <: Zmodn_poly
-  ccall((:nmod_poly_fit_length, :libflint), Nothing, 
+  ccall((:nmod_poly_fit_length, :libflint), Nothing,
                    (Ref{T}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(x::T, n::Int, y::UInt) where T <: Zmodn_poly
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing, 
+  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::T, n::Int, y::Int) where T <: Zmodn_poly
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing, 
+  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, mod(y, x.mod_n))
   return x
 end
-  
+
 function setcoeff!(x::T, n::Int, y::fmpz) where T <: Zmodn_poly
   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, x.mod_n)
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing, 
+  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, r)
   return x
 end
-  
+
 setcoeff!(x::T, n::Int, y::Integer) where T <: Zmodn_poly = setcoeff!(x, n, fmpz(y))
-  
+
 setcoeff!(x::nmod_poly, n::Int, y::nmod) = setcoeff!(x, n, y.data)
 
 function add!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_add, :libflint), Nothing, 
+  ccall((:nmod_poly_add, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
-  return z        
+  return z
 end
 
 function addeq!(z::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_add, :libflint), Nothing, 
+  ccall((:nmod_poly_add, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, z, y)
-  return z        
+  return z
 end
 
 function sub!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_sub, :libflint), Nothing, 
+  ccall((:nmod_poly_sub, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
-  return z        
+  return z
 end
 
 function mul!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_mul, :libflint), Nothing, 
+  ccall((:nmod_poly_mul, :libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
-  return z        
+  return z
 end
 
 function mul!(z::T, x::T, y::UInt) where T <: Zmodn_poly
@@ -1062,6 +1062,6 @@ end
 
 function PolynomialRing(R::NmodRing, s::AbstractString; cached=true)
    parent_obj = NmodPolyRing(R, Symbol(s), cached)
-   
+
    return parent_obj, parent_obj([R(0), R(1)])
 end


### PR DESCRIPTION
These were exported but not defined:
factors, strongequal, xgcd, parseint, rows, cols, window, call.