### PR TITLE
implement similar(mat, ring, r, c)

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "~0.19"
-AbstractAlgebra = "^0.5.0"
+AbstractAlgebra = "^0.6.0"

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -15,15 +15,9 @@ export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
 #
 ###############################################################################
 
-function similar(x::acb_mat)
-   z = acb_mat(nrows(x), ncols(x))
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::acb_mat, r::Int, c::Int)
+function similar(x::acb_mat, R::AcbField, r::Int, c::Int)
    z = acb_mat(r, c)
-   z.base_ring = x.base_ring
+   z.base_ring = R
    return z
 end
 

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -15,15 +15,9 @@ export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
 #
 ###############################################################################
 
-function similar(x::arb_mat)
-   z = arb_mat(nrows(x), ncols(x))
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::arb_mat, r::Int, c::Int)
+function similar(x::arb_mat, R::ArbField, r::Int, c::Int)
    z = arb_mat(r, c)
-   z.base_ring = x.base_ring
+   z.base_ring = R
    return z
 end
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -37,15 +37,9 @@ end
 #
 ###############################################################################
 
-function similar(x::fmpq_mat)
-   z = fmpq_mat(nrows(x), ncols(x))
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::fmpq_mat, r::Int, c::Int)
+function similar(x::fmpq_mat, R::FlintRationalField, r::Int, c::Int)
    z = fmpq_mat(r, c)
-   z.base_ring = x.base_ring
+   z.base_ring = R
    return z
 end
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -43,15 +43,9 @@ end
 #
 ###############################################################################
 
-function similar(x::fmpz_mat)
-   z = fmpz_mat(nrows(x), ncols(x))
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::fmpz_mat, r::Int, c::Int)
+function similar(x::fmpz_mat, R::FlintIntegerRing, r::Int, c::Int)
    z = fmpz_mat(r, c)
-   z.base_ring = x.base_ring
+   z.base_ring = R
    return z
 end
 

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -37,13 +37,8 @@ end
 #
 ###############################################################################
 
-function similar(x::fq_mat)
-   z = fq_mat(nrows(x), ncols(x), base_ring(x))
-   return z
-end
-
-function similar(x::fq_mat, r::Int, c::Int)
-   z = fq_mat(r, c, base_ring(x))
+function similar(x::fq_mat, R::FqFiniteField, r::Int, c::Int)
+   z = fq_mat(r, c, R)
    return z
 end
 

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -42,8 +42,8 @@ function similar(x::fq_nmod_mat)
    return z
 end
 
-function similar(x::fq_nmod_mat, r::Int, c::Int)
-   z = fq_nmod_mat(r, c, base_ring(x))
+function similar(x::fq_nmod_mat, R::FqNmodFiniteField, r::Int, c::Int)
+   z = fq_nmod_mat(r, c, R)
    return z
 end
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -24,15 +24,9 @@ dense_matrix_type(::Type{gfp_elem}) = gfp_mat
 #
 ###############################################################################
 
-function similar(x::gfp_mat)
-   z = gfp_mat(nrows(x), ncols(x), x.n)
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::gfp_mat, r::Int, c::Int)
-   z = gfp_mat(r, c, x.n)
-   z.base_ring = x.base_ring
+function similar(x::gfp_mat, R::GaloisField, r::Int, c::Int)
+   z = gfp_mat(r, c, R.n)
+   z.base_ring = R
    return z
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -37,15 +37,9 @@ end
 #
 ###############################################################################
 
-function similar(x::nmod_mat)
-   z = nmod_mat(nrows(x), ncols(x), x.n)
-   z.base_ring = x.base_ring
-   return z
-end
-
-function similar(x::nmod_mat, r::Int, c::Int)
-   z = nmod_mat(r, c, x.n)
-   z.base_ring = x.base_ring
+function similar(x::nmod_mat, R::NmodRing, r::Int, c::Int)
+   z = nmod_mat(r, c, R.n)
+   z.base_ring = R
    return z
 end
 

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -98,6 +98,29 @@ function test_acb_mat_constructors()
    println("PASS")
 end
 
+function test_acb_mat_similar()
+   print("acb_mat.similar...")
+
+   S = MatrixSpace(CC, 3, 3)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa acb_mat
+   @test size(t) == size(s)
+   t = similar(s, CC)
+   @test t isa acb_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa acb_mat
+   @test size(t) == (2, 3)
+   t = similar(s, CC, 2, 3)
+   @test t isa acb_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_acb_mat_printing()
    print("acb_mat.printing...")
 
@@ -513,6 +536,7 @@ end
 
 function test_acb_mat()
    test_acb_mat_constructors()
+   test_acb_mat_similar()
    test_acb_mat_printing()
    test_acb_mat_manipulation()
    test_acb_mat_unary_ops()

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -97,6 +97,29 @@ function test_arb_mat_constructors()
    println("PASS")
 end
 
+function test_arb_mat_similar()
+   print("arb_mat.similar...")
+
+   S = MatrixSpace(RR, 3, 3)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa arb_mat
+   @test size(t) == size(s)
+   t = similar(s, RR)
+   @test t isa arb_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa arb_mat
+   @test size(t) == (2, 3)
+   t = similar(s, RR, 2, 3)
+   @test t isa arb_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_arb_mat_printing()
    print("arb_mat.printing...")
 
@@ -454,6 +477,7 @@ end
 
 function test_arb_mat()
    test_arb_mat_constructors()
+   test_arb_mat_similar()
    test_arb_mat_printing()
    test_arb_mat_manipulation()
    test_arb_mat_unary_ops()

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -123,6 +123,29 @@ function test_fmpq_mat_constructors()
    println("PASS")
 end
 
+function test_fmpq_mat_similar()
+   print("fmpq_mat.similar...")
+
+   S = MatrixSpace(QQ, 3, 3)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa fmpq_mat
+   @test size(t) == size(s)
+   t = similar(s, QQ)
+   @test t isa fmpq_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa fmpq_mat
+   @test size(t) == (2, 3)
+   t = similar(s, QQ, 2, 3)
+   @test t isa fmpq_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_fmpq_mat_printing()
    print("fmpq_mat.printing...")
 
@@ -645,6 +668,7 @@ end
 
 function test_fmpq_mat()
    test_fmpq_mat_constructors()
+   test_fmpq_mat_similar()
    test_fmpq_mat_printing()
    test_fmpq_mat_manipulation()
    test_fmpq_mat_view()

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -79,6 +79,29 @@ function test_fmpz_mat_constructors()
    println("PASS")
 end
 
+function test_fmpz_mat_similar()
+   print("fmpz_mat.similar...")
+
+   S = MatrixSpace(FlintZZ, 3, 3)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa fmpz_mat
+   @test size(t) == size(s)
+   t = similar(s, FlintZZ)
+   @test t isa fmpz_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa fmpz_mat
+   @test size(t) == (2, 3)
+   t = similar(s, FlintZZ, 2, 3)
+   @test t isa fmpz_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_fmpz_mat_printing()
    print("fmpz_mat.printing...")
 
@@ -704,6 +727,7 @@ end
 
 function test_fmpz_mat()
    test_fmpz_mat_constructors()
+   test_fmpz_mat_similar()
    test_fmpz_mat_printing()
    test_fmpz_mat_convert()
    test_fmpz_mat_manipulation()

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -182,6 +182,30 @@ function test_fq_mat_constructors()
   println("PASS")
 end
 
+function test_fq_mat_similar()
+   print("fq_mat.similar...")
+
+   F9, b = FiniteField(fmpz(3), 2, "b")
+   S = MatrixSpace(F9, 3, 3)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa fq_mat
+   @test size(t) == size(s)
+   t = similar(s, F9)
+   @test t isa fq_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa fq_mat
+   @test size(t) == (2, 3)
+   t = similar(s, F9, 2, 3)
+   @test t isa fq_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_fq_mat_printing()
   print("fq_mat.printing...")
 
@@ -786,6 +810,7 @@ end
 
 function test_fq_mat()
   test_fq_mat_constructors()
+  test_fq_mat_similar()
   test_fq_mat_printing()
   test_fq_mat_manipulation()
   test_fq_mat_unary_ops()

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -182,6 +182,30 @@ function test_fq_nmod_mat_constructors()
   println("PASS")
 end
 
+function test_fq_nmod_mat_similar()
+   print("fq_nmod_mat.similar...")
+
+   F9, b = FiniteField(3, 2, "b")
+   S = FqNmodMatSpace(F9, 2, 2)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa fq_nmod_mat
+   @test size(t) == size(s)
+   t = similar(s, F9)
+   @test t isa fq_nmod_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa fq_nmod_mat
+   @test size(t) == (2, 3)
+   t = similar(s, F9, 2, 3)
+   @test t isa fq_nmod_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_fq_nmod_mat_printing()
   print("fq_nmod_mat.printing...")
 
@@ -786,6 +810,7 @@ end
 
 function test_fq_nmod_mat()
   test_fq_nmod_mat_constructors()
+  test_fq_nmod_mat_similar()
   test_fq_nmod_mat_printing()
   test_fq_nmod_mat_manipulation()
   test_fq_nmod_mat_unary_ops()

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -186,6 +186,30 @@ function test_gfp_mat_constructors()
   println("PASS")
 end
 
+function test_gfp_mat_similar()
+   print("gfp_mat.similar...")
+
+   Z13 = GF(13)
+   S = GFPMatSpace(Z13, 2, 2)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa gfp_mat
+   @test size(t) == size(s)
+   t = similar(s, Z13)
+   @test t isa gfp_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa gfp_mat
+   @test size(t) == (2, 3)
+   t = similar(s, Z13, 2, 3)
+   @test t isa gfp_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_gfp_mat_printing()
   print("gfp_mat.printing...")
 
@@ -883,6 +907,7 @@ end
 
 function test_gfp_mat()
   test_gfp_mat_constructors()
+  test_gfp_mat_similar()
   test_gfp_mat_printing()
   test_gfp_mat_manipulation()
   test_gfp_mat_unary_ops()

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -186,6 +186,30 @@ function test_nmod_mat_constructors()
   println("PASS")
 end
 
+function test_nmod_mat_similar()
+   print("nmod_mat.similar...")
+
+   Z13 = ResidueRing(ZZ, 13)
+   S = NmodMatSpace(Z13, 2, 2)
+   s = S(fmpz(3))
+
+   t = similar(s)
+   @test t isa nmod_mat
+   @test size(t) == size(s)
+   t = similar(s, Z13)
+   @test t isa nmod_mat
+   @test size(t) == size(s)
+
+   t = similar(s, 2, 3)
+   @test t isa nmod_mat
+   @test size(t) == (2, 3)
+   t = similar(s, Z13, 2, 3)
+   @test t isa nmod_mat
+   @test size(t) == (2, 3)
+
+   println("PASS")
+end
+
 function test_nmod_mat_printing()
   print("nmod_mat.printing...")
 
@@ -884,6 +908,7 @@ end
 
 function test_nmod_mat()
   test_nmod_mat_constructors()
+  test_nmod_mat_similar()
   test_nmod_mat_printing()
   test_nmod_mat_manipulation()
   test_nmod_mat_unary_ops()


### PR DESCRIPTION
This is the entry point for the API defining
similar and zero methods.

This fixes for example `z = zero_matrix(ZZ, 2, 2); zero(z)` which now gives an `fmpz_mat` instead of `AbstractAlgebra.Generic.MatSpaceElem{fmpz}` (this fixes an actual test failure, e.g. the function `test_fq_mat_charpoly()`).

This is WIP, tests are yet to be added, but I checked locally that it doesn't break anything. A new release of `AbstractAlgebra` is needed before merging this.
I will then make a follow-up PR to extend this behavior within Nemo matrix types, e.g. with
```
function similar(x::fmpz_mat, R::FlintRationalField, r::Int, c::Int)
       z = fmpq_mat(r, c)
       z.base_ring = R
       return z
   end
```
we will also get `zero(z, FlintQQ)` return a `fmpq_mat`.