### PR TITLE
Add `mod(n::Nmod, u::UInt)`

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -672,11 +672,15 @@ end
 function mod(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     if c > 0
-        return ccall((:fmpz_fdiv_ui, :libflint), Int, (Ref{fmpz}, Int), x, c)
+        return Int(ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, c))
     else
-        r = ccall((:fmpz_fdiv_ui, :libflint), Int, (Ref{fmpz}, Int), x, -c)
+        r = ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, -c)
         return r == 0 ? 0 : r + c
     end
+end
+function mod(x::fmpz, c::UInt)
+    c == 0 && throw(DivideError())
+    ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, c)
 end
 
 @doc Markdown.doc"""

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -672,15 +672,15 @@ end
 function mod(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     if c > 0
-        return Int(ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, c))
+        return Int(ccall((:fmpz_fdiv_ui, :libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c))
     else
-        r = ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, -c)
+        r = ccall((:fmpz_fdiv_ui, :libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, -c)
         return r == 0 ? 0 : r + c
     end
 end
 function mod(x::fmpz, c::UInt)
     c == 0 && throw(DivideError())
-    ccall((:fmpz_fdiv_ui, :libflint), Culong, (Ref{fmpz}, Culong), x, c)
+    ccall((:fmpz_fdiv_ui, :libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c)
 end
 
 @doc Markdown.doc"""

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -678,6 +678,12 @@ function mod(x::fmpz, c::Int)
         return r == 0 ? 0 : r + c
     end
 end
+
+@doc Markdown.doc"""
+    mod(x::fmpz, y::UInt)
+> Return the remainder after division of $x$ by $y$. The remainder will be the
+> least nonnegative remainder.
+"""
 function mod(x::fmpz, c::UInt)
     c == 0 && throw(DivideError())
     ccall((:fmpz_fdiv_ui, :libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c)


### PR DESCRIPTION
Also, while we're here, make sure to properly match the C type of the
ccall signature (Culong rather than Int). These can be subtely different
depending on platform giving potentially incorrect results.