### PR TITLE
API suggestion: Make Base.oftype work for Nemo types

### DIFF
--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -435,6 +435,8 @@ function (R::NmodRing)(a::nmod)
    return a
 end
 
+Base.oftype(x::nmod, y::Integer) = x.parent(y)
+
 ###############################################################################
 #
 #   nmod constructor


### PR DESCRIPTION
At the risk of setting off another debate like #619, here's another API convention
I've found useful when writing code that is generic over both Nemo-provided
datatypes and julia datatypes from other libraries. The core problem of course
is that Nemo doesn't encode all there is to know about a type in the type itself
(which is understandable for performance reasons), so idioms like `typeof(x)(y)`,
don't in general work for Nemo types `x` and `y`.  You can generally do `parent(x)(y)`,
but of course `parent` isn't generic with other julia types. We do however have
a generic method that is suitable: `oftype`, which matches the `typeof(x)(y)`
definition as a fallback, but is extensible for this purpose. In this PR, I'm adding
it to `nmod`, which is where I needed it first. Of course if the `parent(x)(y)` pattern
is generic, then it might makes sense to just define:
```
Base.oftype(x::SomeNemoType, y::SomeNemoType) = parent(x)(y)
```
However, I don't know the Nemo type hierarchy well enough to say what
`SomeNemoType` should be or where to put it, so I'm opening this strawman
PR as a proposal, and leave it to you to consider whether you like the idea and
if so where to put it properly.