### PR TITLE
specialize zero for Nemo matrices

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -39,7 +39,7 @@ end
 
 ###############################################################################
 #
-#   Similar
+#   similar & zero
 #
 ###############################################################################
 
@@ -48,6 +48,19 @@ function similar(::MatElem, R::FlintIntegerRing, r::Int, c::Int)
    z.base_ring = R
    return z
 end
+
+const MatrixRing = Union{FlintIntegerRing,
+                         FlintRationalField,
+                         NmodRing,
+                         GaloisField,
+                         FqNmodFiniteField,
+                         FqFiniteField,
+                         ArbField,
+                         AcbField,
+                         }
+
+# Nemo matrices are always initialized to zero
+zero(x::MatElem, R::MatrixRing, r::Int, c::Int) = similar(x, R, r, c)
 
 ###############################################################################
 #

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -75,39 +75,45 @@
    @test !(a in keys(Dict(b => 1)))
 end
 
-@testset "fmpz_mat.similar..." begin
+@testset "fmpz_mat.$sim_zero..." for sim_zero in (similar, zero)
    S = MatrixSpace(FlintZZ, 3, 3)
    s = S(fmpz(3))
 
-   t = similar(s)
+   t = sim_zero(s)
    @test t isa fmpz_mat
    @test size(t) == size(s)
+   @test iszero(t)
 
-   t = similar(s, 2, 3)
+   t = sim_zero(s, 2, 3)
    @test t isa fmpz_mat
    @test size(t) == (2, 3)
+   @test iszero(t)
 
    for (R, M) in ring_to_mat
-      t = similar(s, R)
+      t = sim_zero(s, R)
       @test t isa M
       @test size(t) == size(s)
+      @test iszero(t)
 
-      t = similar(s, R, 2, 3)
+      t = sim_zero(s, R, 2, 3)
       @test t isa M
       @test size(t) == (2, 3)
+      @test iszero(t)
    end
 
    # test that similar also creates Nemo matrices when the input is not
    for s in (matrix(Nemo.AbstractAlgebra.ZZ, zeros(Int, 3, 3)),
              matrix(Nemo.AbstractAlgebra.QQ, zeros(Int, 3, 3)))
       for (R, M) in ring_to_mat
-         t = similar(s, R)
+         t = sim_zero(s, R)
          @test t isa M
          @test size(t) == size(s)
+         @test iszero(t)
 
-         t = similar(s, R, 2, 3)
+         t = sim_zero(s, R, 2, 3)
          @test t isa M
          @test size(t) == (2, 3)
+         @test iszero(t)
       end
    end
 end


### PR DESCRIPTION
Currently this only specializes the general method `zero(mat, ring, r, c)` but with https://github.com/Nemocas/AbstractAlgebra.jl/pull/436 this will be sufficient.