### PR TITLE
Local field types

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -75,6 +75,8 @@ include("flint/padic.jl")
 
 include("flint/qadic.jl")
 
+include("flint/local_field.jl")
+
 include("flint/fmpq_rel_series.jl")
 
 include("flint/fmpq_abs_series.jl")

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1789,8 +1789,8 @@ end
 ###############################################################################
 
 # Abstract types
-abstract type NonArchimedeanLocalField     <: Field end
-abstract type NonArchimedeanLocalFieldElem <: FieldElem end
+abstract type NonArchLocalField     <: Field end
+abstract type NonArchLocalFieldElem <: FieldElem end
 
 abstract type FlintLocalField     <: NonArchLocalField end
 abstract type FlintLocalFieldElem <: NonArchLocalFieldElem end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1792,13 +1792,13 @@ end
 abstract type NonArchimedeanLocalField     <: Field end
 abstract type NonArchimedeanLocalFieldElem <: FieldElem end
 
-abstract type FlintLocalField     <: NonArchimedeanLocalField end
-abstract type FlintLocalFieldElem <: NonArchimedeanLocalFieldElem end
+abstract type FlintLocalField     <: NonArchLocalField end
+abstract type FlintLocalFieldElem <: NonArchLocalFieldElem end
 
 
 # Alias
-NALocalField     = NonArchimedeanLocalField
-NALocalFieldElem = NonArchimedeanLocalFieldElem
+const NALocalField     = NonArchLocalField
+const NALocalFieldElem = NonArchLocalFieldElem
 
 
 ###############################################################################

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1781,6 +1781,26 @@ function _fq_clear_fn(a::fq)
          (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 end
 
+
+###############################################################################
+#
+#   FlintLocalField / Local field type heirarchy
+#
+###############################################################################
+
+# Abstract types
+abstract type NonArchimedeanLocalField     <: Field end
+abstract type NonArchimedeanLocalFieldElem <: FieldElem end
+
+abstract type FlintLocalField     <: NonArchimedeanLocalField end
+abstract type FlintLocalFieldElem <: NonArchimedeanLocalFieldElem end
+
+
+# Alias
+NALocalField     = NonArchimedeanLocalField
+NALocalFieldElem = NonArchimedeanLocalFieldElem
+
+
 ###############################################################################
 #
 #   FlintPadicField / padic
@@ -1789,7 +1809,7 @@ end
 
 const flint_padic_printing_mode = [:terse, :series, :val_unit]
 
-mutable struct FlintPadicField <: Field
+mutable struct FlintPadicField <: FlintLocalField
    p::Int
    pinv::Float64
    pow::Ptr{Nothing}
@@ -1831,7 +1851,7 @@ function _padic_ctx_clear_fn(a::FlintPadicField)
    ccall((:padic_ctx_clear, :libflint), Nothing, (Ref{FlintPadicField},), a)
 end
 
-mutable struct padic <: FieldElem
+mutable struct padic <: FlintLocalFieldElem
    u :: Int
    v :: Int
    N :: Int
@@ -1855,7 +1875,7 @@ end
 #
 ###############################################################################
 
-mutable struct FlintQadicField <: Field
+mutable struct FlintQadicField <: FlintLocalField
    p::Int
    pinv::Float64
    pow::Ptr{Nothing}
@@ -1900,7 +1920,7 @@ function _qadic_ctx_clear_fn(a::FlintQadicField)
    ccall((:qadic_ctx_clear, :libflint), Nothing, (Ref{FlintQadicField},), a)
 end
 
-mutable struct qadic <: FieldElem
+mutable struct qadic <: FlintLocalFieldElem
    coeffs::Int
    alloc::Int
    length::Int

--- a/src/flint/local_field.jl
+++ b/src/flint/local_field.jl
@@ -1,0 +1,5 @@
+export NonArchimedeanLocalField, NonArchimedeanLocalFieldElem, FlintLocalField, FlintLocalFieldElem, NALocalField, NALocalFieldElem
+
+parent_type(::Type{NALocalFieldElem}) = NALocalField
+
+parent_type(::Type{FlintLocalFieldElem}) = FlintLocalField

--- a/src/flint/local_field.jl
+++ b/src/flint/local_field.jl
@@ -1,4 +1,4 @@
-export NonArchimedeanLocalField, NonArchimedeanLocalFieldElem, FlintLocalField, FlintLocalFieldElem, NALocalField, NALocalFieldElem
+export NonArchLocalField, NonArchLocalFieldElem, FlintLocalField, FlintLocalFieldElem, NALocalField, NALocalFieldElem
 
 parent_type(::Type{NALocalFieldElem}) = NALocalField
 

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -142,7 +142,9 @@ precision(a::qadic) = a.N
 > element is divisible by $p^n$ but not a higher power of $q$ then the function
 > will return $n$.
 """
-valuation(a::qadic) = ccall((:qadic_val, :libflint), Int, (Ref{qadic}, ), a)
+function valuation(a::qadic)
+    iszero(a) ? precision(a) : ccall((:qadic_val, :libflint), Int, (Ref{qadic}, ), a)
+end
 
 @doc Markdown.doc"""
     lift(R::FmpqPolyRing, a::qadic)

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -66,6 +66,8 @@ end
    @test prime(R) == 7
 
    @test valuation(b) == 2
+
+   @test valuation(R(0)) == precision(R(0)) 
 end
 
 @testset "qadic.unary_ops..." begin


### PR DESCRIPTION
Changed type hierarchy from
padic,qadic <: FieldElem <: ...
to
padic,quadic <: FlintLocalFieldElem <: NonArchimedeanLocalFieldElem <: FieldElem
(and on parent types as well.)

Also changed `valuation(a::qadic)` to be consistent with the p-adic valuation function.