### PR TITLE
delete exp(::RingElem), already defined in AbstractAlgebra

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -1,16 +1,5 @@
 ###############################################################################
 #
-#   Rings.jl : Generic rings
-#
-###############################################################################
-
-function exp(a::T) where {T <: RingElem}
-   a != 0 && error("Exponential of nonzero element")
-   return one(parent(a))
-end
-
-###############################################################################
-#
 #   Generic and specific rings and fields
 #
 ###############################################################################
@@ -104,4 +93,3 @@ include("arb/acb_mat.jl")
 include("Factor.jl")
 
 include("polysubst.jl")
-


### PR DESCRIPTION
This was generating a warning "method definition overwritten".
Original defined at: https://github.com/Nemocas/AbstractAlgebra.jl/blob/b12527c644104eb311fccf9c6d60346c011f7a75/src/Rings.jl#L187