### PR TITLE
Add documentation build to the normal travis stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
    include:
-     - stage: "Documentation"
+     - stage: "Test"
        julia: 1.0
        os: linux
        script:


### PR DESCRIPTION
So that documentation is always build and deployed when pushed to the master branch (even if there are errors in one of the jobs. I am looking at you Windows julia 1.0!).