### PR TITLE
Add fmpz_mod module

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ if !issource_build
     # This has to be in sync with the corresponding commit in the source build below (for flint, arb, antic)
     "https://github.com/JuliaPackaging/Yggdrasil/releases/download/GMP-v6.1.2-1/build_GMP.v6.1.2.jl",
     "https://github.com/JuliaPackaging/Yggdrasil/releases/download/MPFR-v4.0.2-1/build_MPFR.v4.0.2.jl",
-    "https://github.com/thofma/Flint2Builder/releases/download/c58523/build_libflint.v0.0.0-c5852387025bf144f32c0593f0ecc906c81266f1.jl",
+    "https://github.com/thofma/Flint2Builder/releases/download/88e468/build_libflint.v0.0.0-88e468ec621222784bcabe8191a3d63340ea9c56.jl",
     "https://github.com/thofma/ArbBuilder/releases/download/6c3738-v2/build_libarb.v0.0.0-6c3738555d00b8b8b24a1f5e0065ef787432513c.jl",
     "https://github.com/thofma/AnticBuilder/releases/download/364f97-v2/build_libantic.v0.0.0-364f97edd9b6af537787113cf910f16d7bbc48a3.jl"
    ]
@@ -64,7 +64,7 @@ else
   @show YASM_VERSION = "1.3.0"
   @show MPIR_VERSION = "3.0.0-90740d8fdf03b941b55723b449831c52fd7f51ca"
   @show MPFR_VERSION = "4.0.0"
-  @show FLINT_VERSION = "c5852387025bf144f32c0593f0ecc906c81266f1"
+  @show FLINT_VERSION = "88e468ec621222784bcabe8191a3d63340ea9c56"
   @show ARB_VERSION = "6c3738555d00b8b8b24a1f5e0065ef787432513c"
   @show ANTIC_VERSION = "364f97edd9b6af537787113cf910f16d7bbc48a3"
 

--- a/docs/src/gfp.md
+++ b/docs/src/gfp.md
@@ -6,13 +6,14 @@ CurrentModule = Nemo
 
 Nemo allows the creation of Galois fields of the form $\mathbb{Z}/p\mathbb{Z}$ for a
 prime $p$. Note that these are not the same as finite fields of degree 1, as Conway
-polynomials are not used.
+polynomials are not used and no generator is given.
 
 For convenience, the following constructors are provided.
 
 ```julia
 GF(n::UInt)
 GF(n::Int)
+GF(n::fmpz)
 ```
 
 For example, one can create the Galois field of characteristic $7$ as follows.
@@ -27,13 +28,16 @@ Elements of the field are then created in the usual way.
 a = R(3)
 ```
 
-Elements of Galois fields have type `gfp_elem`, and the type of the parent objects is
-`GaloisField`.
+Elements of Galois fields have type `gfp_elem` when $p$ is given to the
+constructor as an `Int` or `UInt`, and of type `gfp_fmpz_elem` if $p$ is
+given as an `fmpz`, and the type of the parent objects is
+`GaloisField` or `GaloisFmpzField` respectively.
 
 The modulus $p$ of an element of a Galois field is stored in its parent object.
 
-The `gfp_elem` type belong to the abstract type `FinFieldElem` and the
-`GaloisField` parent object type belongs to the abstract type `FinField`.
+The `gfp_elem` and `gfp_fmpz_elem` types belong to the abstract type
+`FinFieldElem` and the `GaloisField` and `GaloisFmpzField` parent object types
+belong to the abstract type `FinField`.
 
 ## Galois field functionality
 
@@ -51,10 +55,12 @@ Below we describe the functionality that is provided in addition to this interfa
 
 ```@docs
 characteristic(::GaloisField)
+characteristic(::GaloisFmpzField)
 ```
 
 ```@docs
 order(::GaloisField)
+order(::GaloisFmpzField)
 ```
 
 **Examples**

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -22,7 +22,8 @@ Nemo are given in the following table.
 Base ring                   | Library            | Element type    | Parent type
 ----------------------------|--------------------|-----------------|--------------------
 Generic ring $R$            | AbstractAlgebra.jl | `Generic.Res{T}`| `Generic.ResRing{T}`
-$\mathbb{Z}$                | Flint              | `nmod`          | `NmodRing`
+$\mathbb{Z}$ (Int modulus)  | Flint              | `nmod`          | `NmodRing`
+$\mathbb{Z}$ (ZZ modulus)   | Flint              | `fmpz_mod`      | `FmpzModRing`
 
 The modulus $a$ of a residue ring is stored in its parent object.
 

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -18,6 +18,8 @@ include("flint/fmpz_mod.jl")
 
 include("flint/gfp_elem.jl")
 
+include("flint/gfp_fmpz_elem.jl")
+
 include("flint/fmpz_mod_poly.jl")
 
 include("flint/gfp_fmpz_poly.jl")

--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -14,9 +14,9 @@ include("flint/gfp_poly.jl")
 
 include("flint/nmod.jl")
 
-include("flint/gfp_elem.jl")
-
 include("flint/fmpz_mod.jl")
+
+include("flint/gfp_elem.jl")
 
 include("flint/fmpz_mod_poly.jl")
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@
 
 rand(x::Union{GaloisField,FinField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
 
-rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing}, v) =
+rand(x::Union{AnticNumberField,GaloisField,NmodRing,FmpzModRing,FlintIntegerRing}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@
 
 rand(x::Union{GaloisField,FinField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
 
-rand(x::Union{AnticNumberField,GaloisField,NmodRing,FmpzModRing,FlintIntegerRing}, v) =
+rand(x::Union{AnticNumberField,GaloisField,NmodRing,FmpzModRing,FlintIntegerRing,GaloisFmpzField}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -420,6 +420,54 @@ end
 
 ###############################################################################
 #
+#   FmpzModRing / fmpz_mod
+#
+###############################################################################
+
+mutable struct fmpz_mod_ctx_struct
+   n::Int # fmpz_t
+   add_fxn::Ptr{Nothing}
+   sub_fxn::Ptr{Nothing}
+   mul_fxn::Ptr{Nothing}
+   n2::UInt
+   ninv::UInt
+   norm::UInt
+   n_limbs::Tuple{UInt, UInt, UInt}
+   ninv_limbs::Tuple{UInt, UInt, UInt}
+
+   function fmpz_mod_ctx_struct()
+      return new()
+   end
+end
+
+mutable struct FmpzModRing <: Ring
+   n::fmpz
+   ninv::fmpz_mod_ctx_struct
+
+   function FmpzModRing(n::fmpz, cached::Bool=true)
+      if cached && haskey(FmpzModRingID, n)
+         return FmpzModRingID[n]
+      else
+         ninv = fmpz_mod_ctx_struct()
+         ccall((:fmpz_mod_ctx_init, :libflint), Nothing, (Ref{fmpz_mod_ctx_struct}, Ref{fmpz}), ninv, n)
+         z = new(n, ninv)
+         if cached
+            FmpzModRingID[n] = z
+         end
+         return z
+      end
+   end
+end
+
+const FmpzModRingID = Dict{fmpz, FmpzModRing}()
+
+struct fmpz_mod <: ResElem{fmpz}
+   data::fmpz
+   parent::FmpzModRing
+end
+
+###############################################################################
+#
 #   NmodPolyRing / nmod_poly
 #
 ###############################################################################

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -132,7 +132,7 @@ function +(x::fmpz_mod, y::fmpz_mod)
    R = parent(x)
    n = modulus(R)
    d = x.data + y.data - n
-   if d > x.data
+   if d < 0
       return fmpz_mod(d + n, R)
    else
       return fmpz_mod(d, R)
@@ -144,7 +144,7 @@ function -(x::fmpz_mod, y::fmpz_mod)
    R = parent(x)
    n = modulus(R)
    d = x.data - y.data
-   if d > x.data
+   if d < 0
       return fmpz_mod(d + n, R)
    else
       return fmpz_mod(d, R)

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -6,19 +6,412 @@
 
 ###############################################################################
 #
+#   Type and parent object methods
+#
+###############################################################################
+
+parent_type(::Type{fmpz_mod}) = FmpzModRing
+
+elem_type(::Type{FmpzModRing}) = fmpz_mod
+
+base_ring(a::FmpzModRing) = Union{}
+
+base_ring(a::fmpz_mod) = Union{}
+
+parent(a::fmpz_mod) = a.parent
+
+function check_parent(a::fmpz_mod, b::fmpz_mod)
+   a.parent != b.parent && error("Operations on distinct residue rings not supported")
+end
+
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
+
+function Base.hash(a::fmpz_mod, h::UInt)
+   b = 0x2fbb6980039a0fec%UInt
+   return xor(xor(hash(a.data), h), b)
+end
+
+function zero(R::FmpzModRing)
+   return fmpz_mod(fmpz(0), R)
+end
+
+function one(R::FmpzModRing)
+   if R.n == 1
+      return fmpz_mod(fmpz(0), R)
+   else
+      return fmpz_mod(fmpz(1), R)
+   end
+end
+
+iszero(a::fmpz_mod) = a.data == 0
+
+isone(a::fmpz_mod) = a.parent.n == 1 ? a.data == 0 : a.data == 1
+
+isunit(a::fmpz_mod) = a.parent.n == 1 ? a.data == 0 : gcd(a.data, a.parent.n) == 1
+
+modulus(R::FmpzModRing) = R.n
+
+function deepcopy_internal(a::fmpz_mod, dict::IdDict)
+   R = parent(a)
+   return fmpz_mod(deepcopy(a.data), R)
+end
+
+###############################################################################
+#
+#   Canonicalisation
+#
+###############################################################################
+
+function canonical_unit(x::fmpz_mod)
+  # the simple return x does not work
+  #  - if x == 0, this is not a unit
+  #  - if R is not a field....
+  if iszero(x)
+    return parent(x)(0)
+  end
+  g = gcd(modulus(x), data(x))
+  u = divexact(data(x), g)
+  a, b = ppio(modulus(x), u)
+  if isone(a)
+    r = u
+  elseif isone(b)
+    r = b
+  else
+    r = crt(fmpz(1), a, u, b)
+  end
+  return parent(x)(r)
+end
+
+###############################################################################
+#
+#   AbstractString I/O
+#
+###############################################################################
+
+function show(io::IO, R::FmpzModRing)
+   print(io, "Integers modulo ", R.n)
+end
+
+function show(io::IO, a::fmpz_mod)
+   print(io, a.data)
+end
+
+needs_parentheses(x::fmpz_mod) = false
+
+displayed_with_minus_in_front(x::fmpz_mod) = false
+
+show_minus_one(::Type{fmpz_mod}) = true
+
+###############################################################################
+#
+#   Unary operations
+#
+###############################################################################
+
+function -(x::fmpz_mod)
+   if x.data == 0
+      return deepcopy(x)
+   else
+      R = parent(x)
+      return fmpz_mod(R.n - x.data, R)
+   end
+end
+
+###############################################################################
+#
+#   Binary operations
+#
+###############################################################################
+
+function +(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   R = parent(x)
+   n = modulus(R)
+   d = x.data + y.data - n
+   if d > x.data
+      return fmpz_mod(d + n, R)
+   else
+      return fmpz_mod(d, R)
+   end
+end
+
+function -(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   R = parent(x)
+   n = modulus(R)
+   d = x.data - y.data
+   if d > x.data
+      return fmpz_mod(d + n, R)
+   else
+      return fmpz_mod(d, R)
+   end
+end
+
+function *(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   R = parent(x)
+   d = fmpz()
+   ccall((:fmpz_mod_mul, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+             d, x.data, y.data, R.ninv)
+   return fmpz_mod(d, R)
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::Integer, y::fmpz_mod)
+   R = parent(y)
+   return R(x*y.data)
+end
+
+*(x::fmpz_mod, y::Integer) = y*x
+
++(x::fmpz_mod, y::Integer) = x + parent(x)(y)
+
++(x::Integer, y::fmpz_mod) = y + x
+
+-(x::fmpz_mod, y::Integer) = x - parent(x)(y)
+
+-(x::Integer, y::fmpz_mod) = parent(y)(x) - y
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(x::fmpz_mod, y::Int)
+   R = parent(x)
+   if y < 0
+      x = inv(x)
+      y = -y
+   end
+   d = fmpz()
+   ccall((:fmpz_mod_pow_ui, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, UInt, Ref{fmpz_mod_ctx_struct}),
+             d, x.data, y, R.ninv)
+   return fmpz_mod(d, R)
+end
+
+
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
+
+function ==(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   return x.data == y.data
+end
+
+###############################################################################
+#
+#   Ad hoc comparison
+#
+###############################################################################
+
+==(x::fmpz_mod, y::Integer) = x == parent(x)(y)
+
+==(x::Integer, y::fmpz_mod) = parent(y)(x) == y
+
+==(x::fmpz_mod, y::fmpz) = x == parent(x)(y)
+
+==(x::fmpz, y::fmpz_mod) = parent(y)(x) == y
+
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
+
+function inv(x::fmpz_mod)
+   R = parent(x)
+   (iszero(x) && R.n != 1) && throw(DivideError())
+   if R.n == 1
+      return deepcopy(x)
+   end
+   s = fmpz()
+   g = fmpz()
+   ccall((:fmpz_gcdinv, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+            g, s, x.data, R.n)
+   g != 1 && error("Impossible inverse in ", R)
+   return fmpz_mod(s, R)
+end
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   fl, q = divides(x, y)
+   if !fl
+     error("Impossible inverse in ", parent(x))
+   end
+   return q
+end
+
+function divides(a::fmpz_mod, b::fmpz_mod)
+   check_parent(a, b)
+   if iszero(a)
+      return true, a
+   end
+   A = data(a)
+   B = data(b)
+   R = parent(a)
+   m = modulus(R)
+   gb = gcd(B, m)
+   q, r = divrem(A, gb)
+   if !iszero(r)
+      return false, b
+   end
+   ub = divexact(B, gb)
+   b1 = fmpz()
+   ccall((:fmpz_invmod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+           b1, ub, divexact(m, gb))
+   rr = R(q)*b1
+   return true, rr
+end
+
+###############################################################################
+#
 #   GCD
 #
 ###############################################################################
 
+function gcd(x::fmpz_mod, y::fmpz_mod)
+   check_parent(x, y)
+   R = parent(x)
+   d = gcd(gcd(x.data, R.n), y.data)
+   if d == R.n
+      return fmpz_mod(0, R)
+   else
+      return fmpz_mod(d, R)
+   end
+end
+
 @doc Markdown.doc"""
-    gcdx(a::ResElem{fmpz}, b::ResElem{fmpz})
+    gcdx(a::fmpz_mod, b::fmpz_mod)
 > Compute the extended gcd with the Euclidean structure inherited from
 > $\mathbb{Z}$.
 """
-function gcdx(a::ResElem{fmpz}, b::ResElem{fmpz})
-  m = modulus(a)
-  R = parent(a)
-  g, u, v = gcdx(fmpz(a.data), fmpz(b.data))
-  G, U, V = gcdx(g, fmpz(m))
-  return R(G), R(U)*R(u), R(U)*R(v)
+function gcdx(a::fmpz_mod, b::fmpz_mod)
+   m = modulus(a)
+   R = parent(a)
+   g, u, v = gcdx(a.data, b.data)
+   G, U, V = gcdx(g, m)
+   return R(G), R(U)*R(u), R(U)*R(v)
 end
+
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
+
+function zero!(z::fmpz_mod)
+   ccall((:fmpz_set_ui, :libflint), Nothing,
+		(Ref{fmpz}, UInt), z.data, UInt(0))
+   return z
+end
+
+function mul!(z::fmpz_mod, x::fmpz_mod, y::fmpz_mod)
+   R = parent(z)
+   ccall((:fmpz_mod_mul, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+	      z.data, x.data, y.data, R.ninv)
+   return z
+end
+
+function addeq!(z::fmpz_mod, x::fmpz_mod)
+   R = parent(z)
+   ccall((:fmpz_mod_add, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+	    z.data, z.data, x.data, R.ninv)
+   return z
+end
+
+function add!(z::fmpz_mod, x::fmpz_mod, y::fmpz_mod)
+   R = parent(z)
+   ccall((:fmpz_mod_add, :libflint), Nothing,
+	(Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+	   z.data, x.data, y.data, R.ninv)
+   return z
+end
+
+###############################################################################
+#
+#   Random functions
+#
+###############################################################################
+
+function rand(r::Random.AbstractRNG, R::FmpzModRing)
+   n = rand(r, BigInt(0):BigInt(R.n) - 1)
+   return fmpz_mod(fmpz(n), R)
+end
+
+function rand(r::Random.AbstractRNG, R::FmpzModRing, b::UnitRange{Int})
+   n = rand(r, b)
+   return R(n)
+end
+
+###############################################################################
+#
+#   Promotions
+#
+###############################################################################
+
+promote_rule(::Type{fmpz_mod}, ::Type{T}) where T <: Integer = fmpz_mod
+
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
+
+function (R::FmpzModRing)()
+   return fmpz_mod(fmpz(0), R)
+end
+
+function (R::FmpzModRing)(a::Integer)
+   n = R.n
+   d = fmpz(a)%n
+   if d < 0
+      d += n
+   end
+   return fmpz_mod(d, R)
+end
+
+function (R::FmpzModRing)(a::fmpz)
+   d = fmpz()
+   ccall((:fmpz_mod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+             d, a, R.n)
+   return fmpz_mod(d, R)
+end
+
+function (R::FmpzModRing)(a::fmpz_mod)
+   return a
+end
+
+###############################################################################
+#
+#   fmpz_mod constructor
+#
+###############################################################################
+
+function ResidueRing(R::FlintIntegerRing, n::fmpz; cached::Bool=true)
+   n <= 0 && throw(DomainError("Modulus must be non-negative: $n"))
+   return FmpzModRing(n, cached)
+end
+

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -272,6 +272,7 @@ end
 
 function divexact(x::gfp_elem, y::gfp_elem)
    check_parent(x, y)
+   y == 0 && throw(DivideError())
    R = parent(x)
    yinv = ccall((:n_invmod, :libflint), UInt, (UInt, UInt),
            y.data, R.n)
@@ -394,7 +395,7 @@ end
 
 ###############################################################################
 #
-#   gfp_elem constructor
+#   GF constructor
 #
 ###############################################################################
 
@@ -411,24 +412,3 @@ function GF(n::UInt; cached::Bool=true)
    return GaloisField(un, cached)
 end
 
-function GF(n::fmpz; cached::Bool=true)
-   return ResidueField(FlintZZ, n, cached = cached)
-end
-
-################################################################################
-#
-#   Characteristic & order
-#
-################################################################################
-
-@doc Markdown.doc"""
-    characteristic(F::Generic.ResField{fmpz}) -> fmpz
-> Return the characteristic of the given Galois field.
-"""
-characteristic(F::Generic.ResField{fmpz}) = modulus(F)
-
-@doc Markdown.doc"""
-    order(F::Generic.ResField{fmpz})-> fmpz
-> Return the order, i.e. the number of elements in, the given Galois field.
-"""
-order(F::Generic.ResField{fmpz}) = modulus(F)

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -1,0 +1,378 @@
+###############################################################################
+#
+#   gfp_fmpz_elem.jl : Galois fields Z/pZ (large n)
+#
+###############################################################################
+
+###############################################################################
+#
+#   Type and parent object methods
+#
+###############################################################################
+
+parent_type(::Type{gfp_fmpz_elem}) = GaloisFmpzField
+
+elem_type(::Type{GaloisFmpzField}) = gfp_fmpz_elem
+
+base_ring(a::GaloisFmpzField) = Union{}
+
+base_ring(a::gfp_fmpz_elem) = Union{}
+
+parent(a::gfp_fmpz_elem) = a.parent
+
+function check_parent(a::gfp_fmpz_elem, b::gfp_fmpz_elem)
+   a.parent != b.parent && error("Operations on distinct residue rings not supported")
+end
+
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
+
+function Base.hash(a::gfp_fmpz_elem, h::UInt)
+   b = 0x6b61d2959976f517%UInt
+   return xor(xor(hash(a.data), h), b)
+end
+
+iszero(a::gfp_fmpz_elem) = a.data == 0                                                        
+
+isone(a::gfp_fmpz_elem) = a.data == 1
+
+function zero(R::GaloisFmpzField)
+   return gfp_fmpz_elem(fmpz(0), R)
+end
+
+function one(R::GaloisFmpzField)
+   if R.n == 1
+      return gfp_fmpz_elem(fmpz(0), R)
+   else
+      return gfp_fmpz_elem(fmpz(1), R)
+   end
+end
+
+isunit(a::gfp_fmpz_elem) = a.data != 0
+
+modulus(R::GaloisFmpzField) = R.n
+
+@doc Markdown.doc"""
+    characteristic(F::GaloisFmpzField)
+> Return the characteristic of the given Galois field.
+"""
+characteristic(F::GaloisFmpzField) = modulus(F)
+
+@doc Markdown.doc"""
+    order(F::GaloisFmpzField)
+> Return the order, i.e. the number of elements in, the given Galois field.
+"""
+order(F::GaloisFmpzField) = modulus(F)
+
+function deepcopy_internal(a::gfp_fmpz_elem, dict::IdDict)
+   R = parent(a)
+   return gfp_fmpz_elem(deepcopy(a.data), R)
+end
+
+###############################################################################
+#
+#   Canonicalisation
+#
+###############################################################################
+
+canonical_unit(x::gfp_fmpz_elem) = x
+
+###############################################################################
+#
+#   AbstractString I/O
+#
+###############################################################################
+
+function show(io::IO, R::GaloisFmpzField)
+   print(io, "Galois field with characteristic ", R.n)
+end
+
+function show(io::IO, a::gfp_fmpz_elem)
+   print(io, a.data)
+end
+
+needs_parentheses(x::gfp_fmpz_elem) = false
+
+displayed_with_minus_in_front(x::gfp_fmpz_elem) = false
+
+show_minus_one(::Type{gfp_fmpz_elem}) = true
+
+###############################################################################
+#
+#   Unary operations
+#
+###############################################################################
+
+function -(x::gfp_fmpz_elem)
+   if x.data == 0
+      return deepcopy(x)
+   else
+      R = parent(x)
+      return gfp_fmpz_elem(R.n - x.data, R)
+   end
+end
+
+###############################################################################
+#
+#   Binary operations
+#
+###############################################################################
+
+function +(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   check_parent(x, y)
+   R = parent(x)
+   n = modulus(R)
+   d = x.data + y.data - n
+   if d < 0
+      return gfp_fmpz_elem(d + n, R)
+   else
+      return gfp_fmpz_elem(d, R)
+   end
+end
+
+function -(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   check_parent(x, y)
+   R = parent(x)
+   n = modulus(R)
+   d = x.data - y.data
+   if d < 0
+      return gfp_fmpz_elem(d + n, R)
+   else
+      return gfp_fmpz_elem(d, R)
+   end
+end
+
+function *(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   check_parent(x, y)
+   R = parent(x)
+   d = fmpz()
+   ccall((:fmpz_mod_mul, :libflint), Nothing,
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+				                d, x.data, y.data, R.ninv)
+   return gfp_fmpz_elem(d, R)
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::Integer, y::gfp_fmpz_elem)
+   R = parent(y)
+   return R(x*y.data)
+end
+
+*(x::gfp_fmpz_elem, y::Integer) = y*x
+
+*(x::gfp_fmpz_elem, y::fmpz) = x*parent(x)(y)
+
+*(x::fmpz, y::gfp_fmpz_elem) = y*x
+
++(x::gfp_fmpz_elem, y::Integer) = x + parent(x)(y)
+
++(x::Integer, y::gfp_fmpz_elem) = y + x
+
++(x::gfp_fmpz_elem, y::fmpz) = x + parent(x)(y)
+
++(x::fmpz, y::gfp_fmpz_elem) = y + x
+
+-(x::gfp_fmpz_elem, y::Integer) = x - parent(x)(y)
+
+-(x::Integer, y::gfp_fmpz_elem) = parent(y)(x) - y
+
+-(x::gfp_fmpz_elem, y::fmpz) = x - parent(x)(y)
+
+-(x::fmpz, y::gfp_fmpz_elem) = parent(y)(x) - y
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(x::gfp_fmpz_elem, y::Int)
+   R = parent(x)
+   if y < 0
+      x = inv(x)
+      y = -y
+   end
+   d = fmpz()
+   ccall((:fmpz_mod_pow_ui, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, UInt, Ref{fmpz_mod_ctx_struct}),
+						 d, x.data, y, R.ninv)
+   return gfp_fmpz_elem(d, R)
+end
+
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
+
+function ==(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   check_parent(x, y)
+   return x.data == y.data
+end
+
+###############################################################################
+#
+#   Ad hoc comparison
+#
+###############################################################################
+
+==(x::gfp_fmpz_elem, y::Integer) = x == parent(x)(y)
+
+==(x::Integer, y::gfp_fmpz_elem) = parent(y)(x) == y
+
+==(x::gfp_fmpz_elem, y::fmpz) = x == parent(x)(y)
+
+==(x::fmpz, y::gfp_fmpz_elem) = parent(y)(x) == y
+
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
+
+function inv(x::gfp_fmpz_elem)
+   R = parent(x)
+   iszero(x) && throw(DivideError())
+   s = fmpz()
+   g = fmpz()
+   ccall((:fmpz_gcdinv, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+					         g, s, x.data, R.n)
+   return gfp_fmpz_elem(s, R)
+end
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   check_parent(x, y)
+   iszero(y) && throw(DivideError())
+   return x*inv(y)
+end
+
+function divides(a::gfp_fmpz_elem, b::gfp_fmpz_elem)
+   check_parent(x, y)
+   if iszero(a)
+      return true, a
+   end
+   if iszero(b)
+      return false, a
+   end
+   return true, divexact(a, b)
+end
+
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
+
+function zero!(z::gfp_fmpz_elem)
+   ccall((:fmpz_set_ui, :libflint), Nothing,
+	 (Ref{fmpz}, UInt), z.data, UInt(0))
+   return z
+end
+
+function mul!(z::gfp_fmpz_elem, x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   R = parent(z)
+   ccall((:fmpz_mod_mul, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+					   z.data, x.data, y.data, R.ninv)
+   return z
+end
+
+function addeq!(z::gfp_fmpz_elem, x::gfp_fmpz_elem)
+   R = parent(z)
+   ccall((:fmpz_mod_add, :libflint), Nothing,
+         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+		                          z.data, z.data, x.data, R.ninv)
+   return z
+end
+
+function add!(z::gfp_fmpz_elem, x::gfp_fmpz_elem, y::gfp_fmpz_elem)
+   R = parent(z)
+   ccall((:fmpz_mod_add, :libflint), Nothing,
+	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+					 z.data, x.data, y.data, R.ninv)
+   return z
+end
+
+###############################################################################
+#
+#   Random functions
+#
+###############################################################################
+
+function rand(r::Random.AbstractRNG, R::GaloisFmpzField)
+   n = rand(r, BigInt(0):BigInt(R.n) - 1)
+   return gfp_fmpz_elem(fmpz(n), R)
+end
+
+function rand(r::Random.AbstractRNG, R::GaloisFmpzField, b::UnitRange{Int})
+   n = rand(r, b)
+   return R(n)
+end
+
+###############################################################################
+#
+#   Promotions
+#
+###############################################################################
+
+function promote_rule(::Type{gfp_fmpz_elem}, ::Type{T}) where T <: Integer
+   return gfp_fmpz_elem
+end
+
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
+
+function (R::GaloisFmpzField)()
+   return gfp_fmpz_elem(fmpz(0), R)
+end
+
+function (R::GaloisFmpzField)(a::Integer)
+   n = R.n
+   d = fmpz(a)%n
+   if d < 0
+      d += n
+   end
+   return gfp_fmpz_elem(d, R)
+end
+
+function (R::GaloisFmpzField)(a::fmpz)
+   d = fmpz()
+   ccall((:fmpz_mod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+				              d, a, R.n)
+   return gfp_fmpz_elem(d, R)
+end
+
+function (R::GaloisFmpzField)(a::gfp_fmpz_elem)
+   return a
+end
+
+###############################################################################
+#
+#   GF constructor
+#
+###############################################################################
+
+function GF(n::fmpz; cached::Bool=true)
+   (n <= 0) && throw(DomainError("Characteristic must be positive: $n"))
+   !isprobable_prime(n) && throw(DomainError("Characteristic must be prime: $n"))
+   return GaloisFmpzField(n, cached)
+end
+

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -43,12 +43,12 @@ end
 
 *(x::Integer, y::gfp_fmpz_poly) = y*x
 
-function *(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
+function *(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   (base_ring(x) != parent(y)) && error("Must have same parent")
   return x*y.data
 end
 
-*(x::Generic.ResF{fmpz}, y::gfp_fmpz_poly) = y*x
+*(x::gfp_fmpz_elem, y::gfp_fmpz_poly) = y*x
 
 function +(x::gfp_fmpz_poly, y::Int)
   z = parent(x)()
@@ -72,12 +72,12 @@ end
 
 +(x::Integer, y::gfp_fmpz_poly) = fmpz(y) + x 
 
-function +(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
+function +(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   (base_ring(x) != parent(y)) && error("Elements must have same parent")
   return x + y.data
 end
 
-+(x::Generic.ResF{fmpz}, y::gfp_fmpz_poly) = y + x
++(x::gfp_fmpz_elem, y::gfp_fmpz_poly) = y + x
 
 function -(x::gfp_fmpz_poly, y::Int)
   z = parent(x)()
@@ -111,12 +111,12 @@ end
 
 -(x::Integer, y::gfp_fmpz_poly) = fmpz(x) - y
 
-function -(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
+function -(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   (base_ring(x) != parent(y)) && error("Elements must have same parent")
   return x - y.data
 end
 
-function -(x::Generic.ResF{fmpz}, y::gfp_fmpz_poly)
+function -(x::gfp_fmpz_elem, y::gfp_fmpz_poly)
    (parent(x) != base_ring(y)) && error("Elements must have same parent")
    return x.data - y
 end
@@ -127,7 +127,7 @@ end
 #
 ################################################################################
 
-function ==(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
+function ==(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   base_ring(x) != parent(y) && error("Incompatible base rings in comparison")
   if length(x) > 1
      return false
@@ -141,7 +141,7 @@ function ==(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
   end 
 end
 
-==(x::Generic.ResF{fmpz}, y::gfp_fmpz_poly) = y == x
+==(x::gfp_fmpz_elem, y::gfp_fmpz_poly) = y == x
 
 ################################################################################
 #
@@ -149,7 +149,7 @@ end
 #
 ################################################################################
 
-function divexact(x::gfp_fmpz_poly, y::Generic.ResF{fmpz})
+function divexact(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   base_ring(x) != parent(y) && error("Elements must have same parent")
   iszero(y) && throw(DivideError())
   q = parent(x)()
@@ -167,7 +167,7 @@ end
 
 function integral(x::gfp_fmpz_poly)
    len = length(x)
-   v = Vector{Generic.ResF{fmpz}}(undef, len + 1)
+   v = Vector{gfp_fmpz_elem}(undef, len + 1)
    v[1] = zero(base_ring(x))
    for i = 1:len
       v[i + 1] = divexact(coeff(x, i - 1), base_ring(x)(i))
@@ -307,7 +307,7 @@ end
 #
 ################################################################################
 
-setcoeff!(x::gfp_fmpz_poly, n::Int, y::Generic.ResF{fmpz}) = setcoeff!(x, n, y.data)
+setcoeff!(x::gfp_fmpz_poly, n::Int, y::gfp_fmpz_elem) = setcoeff!(x, n, y.data)
 
 ################################################################################
 #
@@ -315,7 +315,7 @@ setcoeff!(x::gfp_fmpz_poly, n::Int, y::Generic.ResF{fmpz}) = setcoeff!(x, n, y.d
 #
 ################################################################################
 
-promote_rule(::Type{gfp_fmpz_poly}, ::Type{Generic.ResF{fmpz}}) = gfp_fmpz_poly
+promote_rule(::Type{gfp_fmpz_poly}, ::Type{gfp_fmpz_elem}) = gfp_fmpz_poly
 
 ###############################################################################
 #
@@ -323,7 +323,7 @@ promote_rule(::Type{gfp_fmpz_poly}, ::Type{Generic.ResF{fmpz}}) = gfp_fmpz_poly
 #
 ###############################################################################
 
-function (f::gfp_fmpz_poly)(a::Generic.ResF{fmpz})
+function (f::gfp_fmpz_poly)(a::gfp_fmpz_elem)
    if parent(a) != base_ring(f)
       return subst(f, a)
    end
@@ -354,7 +354,7 @@ function (R::GFPFmpzPolyRing)(x::Integer)
   return z
 end
 
-function (R::GFPFmpzPolyRing)(x::Generic.ResF{fmpz})
+function (R::GFPFmpzPolyRing)(x::gfp_fmpz_elem)
   base_ring(R) != parent(x) && error("Wrong parents")
   z = gfp_fmpz_poly(R.n, x.data)
   z.parent = R
@@ -367,7 +367,7 @@ function (R::GFPFmpzPolyRing)(arr::Array{fmpz, 1})
   return z
 end
 
-function (R::GFPFmpzPolyRing)(arr::Array{Generic.ResF{fmpz}, 1})
+function (R::GFPFmpzPolyRing)(arr::Array{gfp_fmpz_elem, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
@@ -395,7 +395,7 @@ end
 #
 ################################################################################
 
-function PolynomialRing(R::Generic.ResField{fmpz}, s::AbstractString; cached=true)
+function PolynomialRing(R::GaloisFmpzField, s::AbstractString; cached=true)
    parent_obj = GFPFmpzPolyRing(R, Symbol(s), cached)
 
    return parent_obj, parent_obj([R(0), R(1)])

--- a/test/Fields-test.jl
+++ b/test/Fields-test.jl
@@ -1,5 +1,6 @@
 include("flint/fmpq-test.jl")
 include("flint/gfp-test.jl")
+include("flint/gfp_fmpz-test.jl")
 include("flint/fq-test.jl")
 include("flint/fq_nmod-test.jl")
 include("flint/fq_nmod_embed-test.jl")

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -1,11 +1,406 @@
-@testset "fmpz_mod.gcdx..." begin
+@testset "fmpz_mod.constructors..." begin
+   R = ResidueRing(ZZ, ZZ(13))
+
+   @test_throws DomainError ResidueRing(ZZ, -ZZ(13))
+
+   @test elem_type(R) == Nemo.fmpz_mod
+   @test elem_type(Nemo.FmpzModRing) == Nemo.fmpz_mod
+   @test parent_type(Nemo.fmpz_mod) == Nemo.FmpzModRing
+
+   @test isa(R, Nemo.FmpzModRing)
+
+   @test isa(R(), Nemo.fmpz_mod)
+
+   @test isa(R(11), Nemo.fmpz_mod)
+
+   a = R(11)
+
+   @test isa(R(a), Nemo.fmpz_mod)
+
+   for i = 1:1000
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      a = R(rand(Int))
+      d = a.data
+
+      @test a.data < R.n
+   end
+
+   for i = 1:1000
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      a = R(rand(Int))
+      d = a.data
+
+      @test a.data < R.n
+   end
+end
+
+@testset "fmpz_mod.rand..." begin
+   R = ResidueRing(ZZ, ZZ(13))
+   @test rand(R) isa Nemo.fmpz_mod
+   @test rand(R, 1:9) isa Nemo.fmpz_mod
+   Random.seed!(rng, 0)
+   s = rand(rng, R)
+   @test s isa Nemo.fmpz_mod
+   t = rand(rng, R, 1:9)
+   @test t isa Nemo.fmpz_mod
+   Random.seed!(rng, 0)
+   @test s == rand(rng, R)
+   @test t == rand(rng, R, 1:9)
+end
+
+@testset "fmpz_mod.printing..." begin
+   R = ResidueRing(ZZ, ZZ(13))
+
+   @test string(R(3)) == "3"
+   @test string(R()) == "0"
+end
+
+@testset "fmpz_mod.manipulation..." begin
+   R = ResidueRing(ZZ, ZZ(13))
+
+   @test iszero(zero(R))
+
+   @test modulus(R) == UInt(13)
+
+   @test !isunit(R())
+   @test isunit(R(3))
+
+   @test deepcopy(R(3)) == R(3)
+
+   R1 = ResidueRing(ZZ, ZZ(13))
+
+   @test R === R1
+
+   S = ResidueRing(ZZ, ZZ(1))
+
+   @test iszero(zero(S))
+
+   @test modulus(S) == UInt(1)
+
+   @test isunit(S())
+end
+
+@testset "fmpz_mod.unary_ops..." begin
    for i = 1:100
-      n = rand(1:24)
-      R = ResidueRing(ZZ, ZZ(n))
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
 
       for iter = 1:100
-         a = rand(R, 0:n-1)
-         b = rand(R, 0:n-1)
+         a = rand(R)
+
+         @test a == -(-a)
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         @test a == -(-a)
+      end
+   end
+end
+
+@testset "fmpz_mod.binary_ops..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a1 = rand(R)
+         a2 = rand(R)
+         a3 = rand(R)
+
+         @test a1 + a2 == a2 + a1
+         @test a1 - a2 == -(a2 - a1)
+         @test a1 + R() == a1
+         @test a1 + (a2 + a3) == (a1 + a2) + a3
+         @test a1*(a2 + a3) == a1*a2 + a1*a3
+         @test a1*a2 == a2*a1
+         @test a1*R(1) == a1
+         @test R(1)*a1 == a1
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a1 = rand(R)
+         a2 = rand(R)
+         a3 = rand(R)
+
+         @test a1 + a2 == a2 + a1
+         @test a1 - a2 == -(a2 - a1)
+         @test a1 + R() == a1
+         @test a1 + (a2 + a3) == (a1 + a2) + a3
+         @test a1*(a2 + a3) == a1*a2 + a1*a3
+         @test a1*a2 == a2*a1
+         @test a1*R(1) == a1
+         @test R(1)*a1 == a1
+      end
+   end
+end
+
+@testset "fmpz_mod.adhoc_binary..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         c1 = rand(0:100)
+         c2 = rand(0:100)
+         d1 = rand(BigInt(0):BigInt(100))
+         d2 = rand(BigInt(0):BigInt(100))
+
+         @test a + c1 == c1 + a
+         @test a + d1 == d1 + a
+         @test a - c1 == -(c1 - a)
+         @test a - d1 == -(d1 - a)
+         @test a*c1 == c1*a
+         @test a*d1 == d1*a
+         @test a*c1 + a*c2 == a*(c1 + c2)
+         @test a*d1 + a*d2 == a*(d1 + d2)
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         c1 = rand(Int)
+         c2 = rand(Int)
+         d1 = rand(BigInt(0):BigInt(100))
+         d2 = rand(BigInt(0):BigInt(100))
+
+         @test a + c1 == c1 + a
+         @test a + d1 == d1 + a
+         @test a - c1 == -(c1 - a)
+         @test a - d1 == -(d1 - a)
+         @test a*c1 == c1*a
+         @test a*d1 == d1*a
+         @test a*c1 + a*c2 == a*(widen(c1) + widen(c2))
+         @test a*d1 + a*d2 == a*(d1 + d2)
+      end
+   end
+end
+
+@testset "fmpz_mod.powering..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a = R(1)
+
+         r = rand(R)
+
+         for n = 0:20
+            @test r == 0 || a == r^n
+
+            a *= r
+         end
+      end
+
+      for iter = 1:100
+         a = R(1)
+
+         r = rand(R)
+         while !isunit(r)
+            r = rand(R)
+         end
+
+         rinv = r == 0 ? R(0) : inv(r)
+
+         for n = 0:20
+            @test r == 0 || a == r^(-n)
+
+            a *= rinv
+         end
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a = R(1)
+
+         r = rand(R)
+
+         for n = 0:20
+            @test r == 0 || a == r^n
+
+            a *= r
+         end
+      end
+
+      for iter = 1:100
+         a = R(1)
+
+         r = rand(R)
+         while !isunit(r)
+            r = rand(R)
+         end
+
+         rinv = r == 0 ? R(0) : inv(r)
+
+         for n = 0:20
+            @test r == 0 || a == r^(-n)
+
+            a *= rinv
+         end
+      end
+   end
+end
+
+@testset "fmpz_mod.comparison..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         @test (modulus(R) == 1 && a == a + 1) || a != a + 1
+
+         c = rand(0:100)
+         d = rand(BigInt(0):BigInt(100))
+
+         @test R(c) == R(c)
+         @test R(d) == R(d)
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         @test (modulus(R) == 1 && a == a + 1) || a != a + 1
+
+         c = rand(Int)
+         d = rand(BigInt(0):BigInt(100))
+
+         @test R(c) == R(c)
+         @test R(d) == R(d)
+      end
+   end
+end
+
+@testset "fmpz_mod.adhoc_comparison..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         c = rand(0:100)
+         d = rand(BigInt(0):BigInt(100))
+
+         @test R(c) == c
+         @test c == R(c)
+         @test R(d) == d
+         @test d == R(d)
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         c = rand(Int)
+         d = rand(BigInt(0):BigInt(100))
+
+         @test R(c) == c
+         @test c == R(c)
+         @test R(d) == d
+         @test d == R(d)
+      end
+   end
+end
+
+@testset "fmpz_mod.inversion..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         @test !isunit(a) || inv(inv(a)) == a
+
+         @test !isunit(a) || a*inv(a) == one(R)
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a = rand(R)
+
+         @test !isunit(a) || inv(inv(a)) == a
+
+         @test !isunit(a) || a*inv(a) == one(R)
+      end
+   end
+end
+
+@testset "fmpz_mod.exact_division..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a1 = rand(R)
+         a2 = rand(R)
+         a2 += Int(a2 == 0) # still works mod 1
+         p = a1*a2
+
+         q = divexact(p, a2)
+
+         @test q*a2 == p
+      end
+   end
+
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:56987432569869432769438752)))
+
+      for iter = 1:100
+         a1 = rand(R)
+         a2 = rand(R)
+         a2 += Int(a2 == 0) # still works mod 1
+         p = a1*a2
+
+         q = divexact(p, a2)
+
+         @test q*a2 == p
+      end
+   end
+end
+
+@testset "fmpz_mod.gcd..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+         b = rand(R)
+         c = rand(R)
+
+         @test gcd(c*a, c*b) == R(gcd(c.data*gcd(a, b).data, R.n))
+      end
+   end
+end
+
+@testset "fmpz_mod.gcdx..." begin
+   for i = 1:100
+      R = ResidueRing(ZZ, ZZ(rand(1:24)))
+
+      for iter = 1:100
+         a = rand(R)
+         b = rand(R)
 
          g, s, t = gcdx(a, b)
 

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -1,27 +1,26 @@
-@testset "gfp.constructors..." begin
-   R = GF(13)
+@testset "gfp_fmpz.constructors..." begin
+   R = GF(ZZ(13))
 
-   @test_throws DomainError GF(-13)
+   @test_throws DomainError GF(-ZZ(13))
 
-   @test elem_type(R) == Nemo.gfp_elem
-   @test elem_type(Nemo.GaloisField) == Nemo.gfp_elem
-   @test parent_type(Nemo.gfp_elem) == Nemo.GaloisField
+   @test elem_type(R) == Nemo.gfp_fmpz_elem
+   @test elem_type(Nemo.GaloisFmpzField) == Nemo.gfp_fmpz_elem
+   @test parent_type(Nemo.gfp_fmpz_elem) == Nemo.GaloisFmpzField
 
-   @test isa(R, Nemo.GaloisField)
+   @test isa(R, Nemo.GaloisFmpzField)
 
-   @test isa(R(), Nemo.gfp_elem)
+   @test isa(R(), Nemo.gfp_fmpz_elem)
 
-   @test isa(R(11), Nemo.gfp_elem)
+   @test isa(R(11), Nemo.gfp_fmpz_elem)
 
    a = R(11)
 
-   @test isa(R(a), Nemo.gfp_elem)
+   @test isa(R(a), Nemo.gfp_fmpz_elem)
 
    for i = 1:1000
-      p = rand(UInt(1):typemax(UInt))
-
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          a = R(rand(Int))
          d = a.data
@@ -33,7 +32,7 @@
    for i = 1:1000
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          a = R(rand(Int))
          d = a.data
@@ -42,38 +41,46 @@
       end
    end
 
-   S = GF(17)
-   T = GF(17)
+   S = GF(ZZ(17))
+   T = GF(ZZ(17))
    @test T === S
 
-   S = GF(19, cached = false)
-   T = GF(19, cached = false)
+   S = GF(ZZ(19), cached = false)
+   T = GF(ZZ(19), cached = false)
+   @test !(S === T)
+
+   S = GF(fmpz(17))
+   T = GF(fmpz(17))
+   @test T === S
+
+   S = GF(fmpz(19), cached = false)
+   T = GF(fmpz(19), cached = false)
    @test !(S === T)
 end
 
-@testset "gfp.rand..." begin
-   R = GF(13)
-   @test rand(R) isa Nemo.gfp_elem
-   @test rand(R, 1:9) isa Nemo.gfp_elem
+@testset "gfp_fmpz.rand..." begin
+   R = GF(ZZ(13))
+   @test rand(R) isa Nemo.gfp_fmpz_elem
+   @test rand(R, 1:9) isa Nemo.gfp_fmpz_elem
    Random.seed!(rng, 0)
    s = rand(rng, R)
-   @test s isa Nemo.gfp_elem
+   @test s isa Nemo.gfp_fmpz_elem
    t = rand(rng, R, 1:9)
-   @test t isa Nemo.gfp_elem
+   @test t isa Nemo.gfp_fmpz_elem
    Random.seed!(rng, 0)
    @test s == rand(rng, R)
    @test t == rand(rng, R, 1:9)
 end
 
-@testset "gfp.printing..." begin
-   R = GF(13)
+@testset "gfp_fmpz.printing..." begin
+   R = GF(ZZ(13))
 
    @test string(R(3)) == "3"
    @test string(R()) == "0"
 end
 
-@testset "gfp.manipulation..." begin
-   R = GF(13)
+@testset "gfp_fmpz.manipulation..." begin
+   R = GF(ZZ(13))
 
    @test iszero(zero(R))
 
@@ -84,18 +91,18 @@ end
 
    @test deepcopy(R(3)) == R(3)
 
-   R1 = GF(13)
+   R1 = GF(ZZ(13))
 
    @test R === R1
 end
 
-@testset "gfp.unary_ops..." begin
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+@testset "gfp_fmpz.unary_ops..." begin
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
-         for iter = 1:100
+         for iter = 1:1000
             a = rand(R)
 
             @test a == -(-a)
@@ -106,7 +113,7 @@ end
    for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -117,11 +124,11 @@ end
    end
 end
 
-@testset "gfp.binary_ops..." begin
+@testset "gfp_fmpz.binary_ops..." begin
    for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a1 = rand(R)
@@ -140,10 +147,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a1 = rand(R)
@@ -163,11 +170,11 @@ end
    end
 end
 
-@testset "gfp.adhoc_binary..." begin
+@testset "gfp_fmpz.adhoc_binary..." begin
    for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -189,10 +196,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -215,11 +222,11 @@ end
    end
 end
 
-@testset "gfp.powering..." begin
+@testset "gfp_fmpz.powering..." begin
   for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = R(1)
@@ -252,10 +259,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = R(1)
@@ -289,11 +296,11 @@ end
    end
 end
 
-@testset "gfp.comparison..." begin
+@testset "gfp_fmpz.comparison..." begin
   for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -309,10 +316,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -329,11 +336,11 @@ end
    end
 end
 
-@testset "gfp.adhoc_comparison..." begin
+@testset "gfp_fmpz.adhoc_comparison..." begin
   for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             c = rand(0:100)
@@ -347,10 +354,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             c = rand(Int)
@@ -365,11 +372,11 @@ end
    end
 end
 
-@testset "gfp.inversion..." begin
+@testset "gfp_fmpz.inversion..." begin
   for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -381,10 +388,10 @@ end
       end
    end
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a = rand(R)
@@ -397,11 +404,11 @@ end
    end
 end
 
-@testset "gfp.exact_division..." begin
+@testset "gfp_fmpz.exact_division..." begin
   for i = 1:100
       p = rand(1:24)
       if Nemo.isprime(ZZ(p))
-         R = GF(p)
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a1 = rand(R)
@@ -417,10 +424,10 @@ end
    end
 
 
-   for i = 1:100
-      p = rand(UInt(1):typemax(UInt))
-      if Nemo.isprime(ZZ(p))
-         R = GF(p)
+   for i = 1:1000
+      p = rand(BigInt(1):BigInt(4273673264873254848326487))*6 + 1
+      if Nemo.isprobable_prime(ZZ(p))
+         R = GF(ZZ(p))
 
          for iter = 1:100
             a1 = rand(R)

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -8,7 +8,7 @@
 
    @test typeof(S) <: GFPFmpzPolyRing
 
-   @test isa(x, PolyElem{Generic.ResF{fmpz}})
+   @test isa(x, PolyElem{Nemo.gfp_fmpz_elem})
 
    f = x^3 + 2x^2 + x + 1
 


### PR DESCRIPTION
This adds an fmpz_mod module based on Flint.

Tests pass, but require the latest version of Flint in which a minor bug is fixed.

Currently fmpz_mod_poly still works with Generic.Res{fmpz}'s rather than the new fmpz_mod's. I can switch that over and add it to this PR if preferred. Or we can do this step by step.