### PR TITLE
Trivial embedding fail in Nemo

### DIFF
--- a/docs/src/ff_embedding.md
+++ b/docs/src/ff_embedding.md
@@ -48,7 +48,7 @@ julia> z = k4(x2)
 6*x4^3+5*x4^2+9*x4+17
 ```
 
-### Computed the preimage of an embedding
+### Computing the preimage of an embedding
 
 ```@docs
 preimage_map(::FqNmodFiniteField, ::FqNmodFiniteField)

--- a/src/embedding/embedding.jl
+++ b/src/embedding/embedding.jl
@@ -8,7 +8,7 @@ export embed, preimage, preimage_map
 
 ################################################################################
 #
-#  Over/Sub fields
+#   Over/Sub fields
 #
 ################################################################################
 
@@ -55,7 +55,7 @@ end
 
 ################################################################################
 #
-#  Root Finding (of a splitting polynomial, internal use only)
+#   Root Finding (of a splitting polynomial, internal use only)
 #
 ################################################################################
 
@@ -63,7 +63,7 @@ any_root(x::PolyElem) = -coeff(linear_factor(x), 0)
 
 ################################################################################
 #
-#  Minimal polynomial of the generator
+#   Minimal polynomial of the generator
 #
 ################################################################################
 
@@ -129,7 +129,7 @@ end
 
 ################################################################################
 #
-#  Embedding 
+#   Embedding
 #
 ################################################################################
 
@@ -353,11 +353,19 @@ end
 """
 function embed(k::T, K::T) where T <: FinField
 
-    # If k == K we return the identity
+    degree(K) % degree(k) != 0 && error("Embedding impossible")
+
+    # Special cases of k == K or degree(k) == 1
 
     if k == K
         identity(x) = x
         morph = FinFieldMorphism(k, k, identity, identity)
+        return morph
+
+    elseif degree(k) == 1
+        f(x) = K(coeff(x, 0))
+        finv(y) = k(coeff(y, 0))
+        morph = FinFieldMorphism(k, K, f, finv)
         return morph
     end
 
@@ -399,7 +407,7 @@ end
 
 ################################################################################
 #
-#   Sections
+#   Preimage map
 #
 ################################################################################
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -458,7 +458,7 @@ function (a::FqNmodFiniteField)(b::fq_nmod)
         return f(b)
     else
         dk % da != 0 && error("Coercion impossible")
-        f = preimage_map(k, a)
+        f = preimage_map(a, k)
         return f(b)
     end
 end
@@ -485,7 +485,7 @@ end
 
 ################################################################################
 #
-#  FqNmodFiniteField Modulus
+#   FqNmodFiniteField Modulus
 #
 ################################################################################
 

--- a/test/flint/fq_nmod_embed-test.jl
+++ b/test/flint/fq_nmod_embed-test.jl
@@ -1,12 +1,13 @@
 @testset "fq_nmod_embed.embed..." begin
 
-    for i in 1:100
+    for i in 1:10
 
         p = rand(2:997)
         while !isprime(p)
             p = rand(2:997)
         end
 
+        k1, x1 = FiniteField(p, 1, "x1")
         k2, x2 = FiniteField(p, 2, "x2")
         k3, x3 = FiniteField(p, 3, "x3")
         k4, x4 = FiniteField(p, 4, "x4")
@@ -39,14 +40,22 @@
                  (k2, k24),
                  (k2, k4),
                  (k4, k24),
+                 (k1, k3),
+                 (k1, k4),
+                 (k1, k6),
+                 (k1, k16),
+                 (k1, k12),
+                 (k1, k9),
                  (k4, k8)])
 
         f = Dict()
+        # Compute embeddings in a random order
         while !isempty(S)
             k, K = pop!(S, rand(S))
             f[(k, K)] = embed(k, K)
         end
 
+        # Check that the embeddings are compatible
         @test f[k6, k18](f[k3, k6](x3)) == f[k3, k18](x3)
         @test f[k8, k16](f[k2, k8](x2)) == f[k2, k16](x2)
         @test f[k12, k24](f[k6, k12](x6)) == f[k6, k24](x6)
@@ -64,6 +73,31 @@
         @test f[k8, k24](f[k4, k8](x4)) == f[k4, k24](x4)
         @test f[k4, k8](f[k2, k4](x2)) == f[k2, k8](x2)
         @test f[k4, k16](f[k2, k4](x2)) == f[k2, k16](x2)
+        @test f[k4, k16](f[k1, k4](x1)) == f[k1, k16](x1)
+        @test f[k3, k9](f[k1, k3](x1)) == f[k1, k9](x1)
+        @test f[k6, k12](f[k1, k6](x1)) == f[k1, k12](x1)
     end
-    println("PASS")
+end
+
+@testset "fq_nmod_embed.preimage_map..." begin
+
+    for i in 1:10
+
+        p = rand(2:997)
+        while !isprime(p)
+            p = rand(2:997)
+        end
+
+        a, b = rand(1:5), rand(1:5)
+        ka, xa = FiniteField(p, a, "xa")
+        kab, xab = FiniteField(p, a*b, "xab")
+
+        f = preimage_map(ka, kab)
+        g = embed(ka, kab)
+
+        for j in 1:20
+            x = rand(ka)
+            @test f(g(x)) == x
+        end
+    end
 end


### PR DESCRIPTION
As noticed by @tmagnuss in #670, asking for a trivial embedding in Nemo results in a segfault. 

In fact, trivial embeddings are not implemented in flint.

I added a test to check if the degree of the embedded finite field was 1, I also corrected a stupid bug and some typos.

Tell me if it is the way you want to handle it!