### PR TITLE
Test divides of integers where second argument is zero #687.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "^0.7.0"
+AbstractAlgebra = "^0.8.0"
 BinaryProvider = "0.4, 0.5"
 julia = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "~0.19"
-AbstractAlgebra = "^0.7.0"
+AbstractAlgebra = "^0.8.0"

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -137,6 +137,13 @@ end
    @test divexact(fmpz(24), fmpz(12)) == 2
 end
 
+@testset "fmpz.divides..." begin
+   flag, q = divides(fmpz(12), fmpz(0))
+   @test flag == false
+   @test divides(fmpz(12), fmpz(6)) == (true, fmpz(2))
+   @test divides(fmpz(0), fmpz(0)) == (true, fmpz(0))
+end
+
 @testset "fmpz.gcd_lcm..." begin
    a = fmpz(12)
    b = fmpz(26)


### PR DESCRIPTION
This will fail until PR #527 is merged in AbstractAlgebra and a new release is made. It's only test code to ensure the fix works.

Closes #687 