### PR TITLE
finalize fmpz only when necessary (WIP)

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -14,50 +14,51 @@ mutable struct FlintIntegerRing <: Ring
 end
 
 const FlintZZ = FlintIntegerRing()
+using Base.GMP: Limb, BITS_PER_LIMB
+const HIGH_BIT = 1 << (BITS_PER_LIMB-2)
 
 mutable struct fmpz <: RingElem
-    d::Int
+   d::Int
 
-    function fmpz()
-        z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
-        finalizer(_fmpz_clear_fn, z)
-        return z
-    end
+   function fmpz()
+      z = new(0)
+      return z
+   end
 
-    function fmpz(x::Int)
-        z = new()
-        ccall((:fmpz_init_set_si, :libflint), Nothing, (Ref{fmpz}, Int), z, x)
-        finalizer(_fmpz_clear_fn, z)
-        return z
-    end
+   function fmpz(x::Int)
+      z = new()
+      ccall((:fmpz_init_set_si, :libflint), Nothing, (Ref{fmpz}, Int), z, x)
+      maybe_finalizer(z)
+   end
 
-    function fmpz(x::UInt)
-        z = new()
-        ccall((:fmpz_init_set_ui, :libflint), Nothing, (Ref{fmpz}, UInt), z, x)
-        finalizer(_fmpz_clear_fn, z)
-        return z
-    end
+   function fmpz(x::UInt)
+      z = new()
+      ccall((:fmpz_init_set_ui, :libflint), Nothing, (Ref{fmpz}, UInt), z, x)
+      maybe_finalizer(z)
+   end
 
-    function fmpz(x::BigInt)
-        z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
-        ccall((:fmpz_set_mpz, :libflint), Nothing, (Ref{fmpz}, Ref{BigInt}), z, x)
-        finalizer(_fmpz_clear_fn, z)
-        return z
-    end
+   function fmpz(x::BigInt)
+      z = new(0)
+      ccall((:fmpz_set_mpz, :libflint), Nothing, (Ref{fmpz}, Ref{BigInt}), z, x)
+      maybe_finalizer(z)
+   end
 
-    function fmpz(x::Float64)
-        !isinteger(x) && throw(InexactError())
-        z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
-        ccall((:fmpz_set_d, :libflint), Nothing, (Ref{fmpz}, Cdouble), z, x)
-        finalizer(_fmpz_clear_fn, z)
-        return z
-    end
+   function fmpz(x::Float64)
+      !isinteger(x) && throw(InexactError())
+      z = new()
+      ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
+      ccall((:fmpz_set_d, :libflint), Nothing, (Ref{fmpz}, Cdouble), z, x)
+      finalizer(_fmpz_clear_fn, z)
+      return z
+   end
 
-    fmpz(x::fmpz) = x
+   fmpz(x::fmpz) = x
 end
+
+
+coeff_is_mpz(d::Int)  = (HIGH_BIT & x)   != 0
+coeff_is_mpz(x::fmpz) = (HIGH_BIT & x.d) != 0
+@inline maybe_finalizer(x::fmpz) = (coeff_is_mpz(x) && finalizer(_fmpz_clear_fn, x); x)
 
 function _fmpz_clear_fn(a::fmpz)
    ccall((:fmpz_clear, :libflint), Nothing, (Ref{fmpz},), a)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -630,6 +630,7 @@ function <<(x::fmpz, c::Int)
     z = fmpz()
     ccall((:fmpz_mul_2exp, :libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
+    maybe_finalizer(z)
     return z
 end
 
@@ -1541,8 +1542,11 @@ end
 > Note that this function modifies its input in-place.
 """
 function combit!(x::fmpz, c::Int)
-    c < 0 && throw(DomainError("Second argument must be non-negative: $c"))
-    ccall((:fmpz_combit, :libflint), Nothing, (Ref{fmpz}, Int), x, c)
+   c < 0 && throw(DomainError("Second argument must be non-negative: $c"))
+   hasfinalizer = coeff_is_mpz(x)
+   ccall((:fmpz_combit, :libflint), Nothing, (Ref{fmpz}, Int), x, c)
+   !hasfinalizer && maybe_finalizer(x)
+   nothing
 end
 
 ###############################################################################

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -272,14 +272,14 @@ end
 
 for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
                  (:&, :and), (:|, :or), (:xor, :xor))
-    @eval begin
-        function ($fJ)(x::fmpz, y::fmpz)
-            z = fmpz()
-            ccall(($(string(:fmpz_, fC)), :libflint), Nothing,
-                  (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
-            return z
-        end
-    end
+   @eval begin
+      function ($fJ)(x::fmpz, y::fmpz)
+         z = fmpz()
+         ccall(($(string(:fmpz_, fC)), :libflint), Nothing,
+               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
+         maybe_finalizer(z)
+      end
+   end
 end
 
 # Metaprogram to define functions fdiv, cdiv, tdiv, div, mod


### PR DESCRIPTION
Adding a `finalizer` to an object in Julia is costly. `fmpz` objects need only one when they represent non-small integers. So after each construction of an `fmpz`, we can attach a finalizer only conditionally. The drawback is that this means after each `ccall` to a flint library function, we have to remember to check for that, whereas now this has to be taken care of only in the (inner) constructors.

Preliminary simple benchmarks seem to indicate that for example for addition and substraction, there is a speed-up of about 40% or 50%. 

This is WIP, finishing this PR would mean adding this `maybe_finalizer` function after all `ccall` invocations in the code-base (like is done for `+` etc. here).