### PR TITLE
FiniteField from a poly: check that base ring is a field

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1147,7 +1147,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{UInt}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1167,7 +1167,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Int}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1187,7 +1187,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Ref{fmpz}}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1388,7 +1388,7 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
       finalizer(_fmpq_mpoly_clear_fn, z)
       return z
    end
-   
+
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Int)
       z = new()
       ccall((:fmpq_mpoly_init, :libflint), Nothing,
@@ -1629,7 +1629,9 @@ mutable struct FqNmodFiniteField <: FinField
       end
    end
 
-   function FqNmodFiniteField(f::nmod_poly, s::Symbol, cached::Bool = true)
+   function FqNmodFiniteField(f::nmod_poly, s::Symbol, cached::Bool = true; check::Bool = true)
+      check && !isprime(modulus(f)) &&
+         throw(DomainError(base_ring(f), "the base ring of the polynomial must be a field"))
       if cached && haskey(FqNmodFiniteFieldIDNmodPol, (parent(f), f, s))
          return FqNmodFiniteFieldIDNmodPol[parent(f), f, s]
       else
@@ -1646,8 +1648,9 @@ mutable struct FqNmodFiniteField <: FinField
          return z
       end
    end
-   
-   function FqNmodFiniteField(f::gfp_poly, s::Symbol, cached::Bool = true)
+
+   function FqNmodFiniteField(f::gfp_poly, s::Symbol, cached::Bool = true; check::Bool=true)
+      # check ignored
       if cached && haskey(FqNmodFiniteFieldIDGFPPol, (parent(f), f, s))
          return FqNmodFiniteFieldIDGFPPol[parent(f), f, s]
       else
@@ -1771,7 +1774,9 @@ mutable struct FqFiniteField <: FinField
       end
    end
 
-   function FqFiniteField(f::fmpz_mod_poly, s::Symbol, cached::Bool = true)
+   function FqFiniteField(f::fmpz_mod_poly, s::Symbol, cached::Bool = true; check::Bool = true)
+      check && !isprobable_prime(modulus(f)) &&
+         throw(DomainError(base_ring(f), "the base ring of the polynomial must be a field"))
       if cached && haskey(FqFiniteFieldIDFmpzPol, (f, s))
          return FqFiniteFieldIDFmpzPol[f, s]
       else
@@ -1786,8 +1791,9 @@ mutable struct FqFiniteField <: FinField
          return z
       end
    end
-   
-   function FqFiniteField(f::gfp_fmpz_poly, s::Symbol, cached::Bool = true)
+
+   function FqFiniteField(f::gfp_fmpz_poly, s::Symbol, cached::Bool = true; check::Bool = true)
+      # check ignored
       if cached && haskey(FqFiniteFieldIDGFPPol, (f, s))
          return FqFiniteFieldIDGFPPol[f, s]
       else
@@ -4203,7 +4209,7 @@ mutable struct fq_mat <: MatElem{fq}
    rows::Ptr{Nothing}
    base_ring::FqFiniteField
    view_parent
-   
+
    # used by windows, not finalised!!
    function fq_mat()
       return new()
@@ -4391,7 +4397,7 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
    rows::Ptr{Nothing}
    base_ring::FqNmodFiniteField
    view_parent
-   
+
    # used by windows, not finalised!!
    function fq_nmod_mat()
       return new()

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -581,25 +581,27 @@ function FlintFiniteField(char::Integer, deg::Int, s::AbstractString; cached = t
 end
 
 @doc Markdown.doc"""
-    FlintFiniteField(pol::fmpz_mod_poly, s::AbstractString; cached = true)
+    FlintFiniteField(pol::fmpz_mod_poly, s::AbstractString; cached = true, check = true)
 > Returns a tuple $S, x$ consisting of a finite field parent object $S$ and
 > generator $x$ for the finite field over $F_p$ defined by the given
 > polynomial, i.e. $\mathbb{F}_p[t]/(pol)$. The characteristic is specified by
 > the modulus of `pol`. The polynomial is required to be irreducible, but this
-> is not checked. The string $s$ is used to designate how the finite field
+> is not checked. The base ring of the polynomial is required to be a field, which
+> is checked by default. Use `check = false` to disable the check.
+> The string $s$ is used to designate how the finite field
 > generator will be printed. The generator will not be multiplicative in
 > general.
 """
-function FlintFiniteField(pol::fmpz_mod_poly, s::AbstractString; cached = true)
+function FlintFiniteField(pol::fmpz_mod_poly, s::AbstractString; cached = true, check::Bool=true)
    S = Symbol(s)
-   parent_obj = FqFiniteField(pol, S, cached)
+   parent_obj = FqFiniteField(pol, S, cached, check=check)
 
    return parent_obj, gen(parent_obj)
 end
 
-function FlintFiniteField(pol::gfp_fmpz_poly, s::AbstractString; cached = true)
+function FlintFiniteField(pol::gfp_fmpz_poly, s::AbstractString; cached = true, check::Bool=true)
    S = Symbol(s)
-   parent_obj = FqFiniteField(pol, S, cached)
+   parent_obj = FqFiniteField(pol, S, cached, check=check)
 
    return parent_obj, gen(parent_obj)
 end

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -476,9 +476,9 @@ function FlintFiniteField(char::Int, deg::Int, s::AbstractString; cached = true)
    return parent_obj, gen(parent_obj)
 end
 
-function FlintFiniteField(pol::Zmodn_poly, s::AbstractString; cached = true)
+function FlintFiniteField(pol::Zmodn_poly, s::AbstractString; cached = true, check::Bool=true)
    S = Symbol(s)
-   parent_obj = FqNmodFiniteField(pol, S, cached)
+   parent_obj = FqNmodFiniteField(pol, S, cached, check=check)
 
    return parent_obj, gen(parent_obj)
 end

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -33,6 +33,13 @@
    d = R(c)
 
    @test isa(d, fq)
+
+   # check for primality
+   T3, z3 = FiniteField(yy^2 + 1, "z", check=false)
+   @test isa(T2, FqFiniteField)
+   Syyy, yyy = PolynomialRing(ResidueRing(FlintZZ, ZZ(4)), "y")
+   @test yyy isa fmpz_mod_poly
+   @test_throws DomainError FiniteField(yyy^2+1, "z")
 end
 
 @testset "fq.printing..." begin

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -33,6 +33,13 @@
    d = R(c)
 
    @test isa(d, fq_nmod)
+
+   # check for primality
+   T3, z3 = FiniteField(yy^2 + 1, "z", check=false)
+   @test isa(T2, FqNmodFiniteField)
+   Syyy, yyy = PolynomialRing(ResidueRing(FlintZZ, 4), "y")
+   @test yyy isa nmod_poly
+   @test_throws DomainError FiniteField(yyy^2+1, "z")
 end
 
 @testset "fq_nmod.printing..." begin


### PR DESCRIPTION
The check can be bypassed with a check=false keyword argument.
Without a check, the result of calling FiniteField with a
non-field base ring ~~leads~~ can lead to to a segfault.

Fixes #667. Doc should still be added, and do the same for `fmpz_mod_poly`.