### PR TITLE
added characteristic of ZZ

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -135,7 +135,7 @@ function deepcopy_internal(a::fmpz, dict::IdDict)
    return z
 end
 
-characteristic(R::FlintIntegerRing) = fmpz(0)
+characteristic(R::FlintIntegerRing) = 0
 
 @doc Markdown.doc"""
     one(R::FlintIntegerRing)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -135,6 +135,8 @@ function deepcopy_internal(a::fmpz, dict::IdDict)
    return z
 end
 
+characteristic(R::FlintIntegerRing) = fmpz(0)
+
 @doc Markdown.doc"""
     one(R::FlintIntegerRing)
 > Return the integer $1$.


### PR DESCRIPTION
This should also repair `characteristic(QQ)`.

I was not sure what the correct return type for `characteristic` is since it is not stated in the Field Interface; I chose `fmpz` following the example set in:
https://github.com/Nemocas/Nemo.jl/blob/e587a905513ed28462da08fbbc29cf4d7fa4be3b/src/flint/gfp_elem.jl#L65-L69