### PR TITLE
docs: use `checkdocs = :none` option in makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ makedocs(
          sitename = "Nemo.jl",
          modules = [Nemo],
          clean = true,
+         checkdocs = :none,
          doctest = false,
          pages    = [
              "index.md",


### PR DESCRIPTION
This was wrongly documented to default to :none, but it doesn't.
This option was the cause of the huge pile of useless garbage
when running `julia docs/make.jl`, which indicates all the
docstrings that are not referenced in the docs.
We are too far from this state (all methods with docstrings
referenced in the docs) for these warnings to be
currently useful.