### PR TITLE
Restrict domain of number theoretic functions to N not Z.

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1304,27 +1304,27 @@ end
 @doc Markdown.doc"""
     fibonacci(x::Int)
 >  Return the $x$-th Fibonacci number $F_x$. We define $F_1 = 1$, $F_2 = 1$ and
-> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n > 0$.
+> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. The sequence is defined for
+> all integers.
 """
 function fibonacci(x::Int)
-    x <= 0 && throw(DomainError(x, "Argument must be positive"))
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
-          (Ref{fmpz}, UInt), z, UInt(x))
-    return Int(z)
+          (Ref{fmpz}, UInt), z, UInt(abs(x)))
+    return x < 0 ? ((x & 1) == 0 ? -Int(z) : Int(z)) : Int(z)
 end
 
 @doc Markdown.doc"""
     fibonacci(x::fmpz)
 >  Return the $x$-th Fibonacci number $F_x$. We define $F_1 = 1$, $F_2 = 1$ and
-> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n > 0$.
+> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. The sequence is defined for
+> all integers.
 """
 function fibonacci(x::fmpz)
-    x <= 0 && throw(DomainError(x, "Argument must be positive"))
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
-          (Ref{fmpz}, UInt), z, UInt(x))
-    return z
+          (Ref{fmpz}, UInt), z, UInt(abs(x)))
+    return x < 0 ? ((x & 1) == 0 ? -z : z) : z
 end
 
 @doc Markdown.doc"""

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1304,11 +1304,10 @@ end
 @doc Markdown.doc"""
     fibonacci(x::Int)
 >  Return the $x$-th Fibonacci number $F_x$. We define $F_1 = 1$, $F_2 = 1$ and
-> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n \geq 0$. For
-> convenience, we define $F_0 = 0$.
+> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n > 0$.
 """
 function fibonacci(x::Int)
-    x < 0 && throw(DomainError("Argument must be non-negative: $x"))
+    x <= 0 && throw(DomainError(x, "Argument must be positive"))
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
@@ -1318,11 +1317,10 @@ end
 @doc Markdown.doc"""
     fibonacci(x::fmpz)
 >  Return the $x$-th Fibonacci number $F_x$. We define $F_1 = 1$, $F_2 = 1$ and
-> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n \geq 0$. For
-> convenience, we define $F_0 = 0$.
+> $F_{i + 1} = F_i + F_{i - 1}$ for all $i > 2$. We require $n > 0$.
 """
 function fibonacci(x::fmpz)
-    x < 0 && throw(DomainError("Argument must be non-negative: $x"))
+    x <= 0 && throw(DomainError(x, "Argument must be positive"))
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
@@ -1370,10 +1368,10 @@ end
 @doc Markdown.doc"""
     moebius_mu(x::fmpz)
 > Returns the Moebius mu function of $x$ as an `Int`. The value
-> returned is either $-1$, $0$ or $1$. If $x < 0$ we throw a `DomainError()`.
+> returned is either $-1$, $0$ or $1$. If $x \leq 0$ we throw a `DomainError()`.
 """
 function moebius_mu(x::fmpz)
-   x < 0 && throw(DomainError("Argument must be non-negative: $x"))
+   x <= 0 && throw(DomainError(x, "Argument must be positive"))
    return Int(ccall((:fmpz_moebius_mu, :libflint), Cint,
                     (Ref{fmpz},), x))
 end
@@ -1381,7 +1379,7 @@ end
 @doc Markdown.doc"""
     moebius_mu(x::Int)
 > Returns the Moebius mu function of $x$ as an `Int`. The value
-> returned is either $-1$, $0$ or $1$. If $x < 0$ we throw a `DomainError()`.
+> returned is either $-1$, $0$ or $1$. If $x \leq 0$ we throw a `DomainError()`.
 """
 moebius_mu(x::Int) = moebius_mu(fmpz(x))
 
@@ -1415,10 +1413,11 @@ end
 @doc Markdown.doc"""
     divisor_sigma(x::fmpz, y::Int)
 > Return the value of the sigma function, i.e. $\sum_{0 < d \;| x} d^y$. If
-> $y < 0$ we throw a `DomainError()`.
+> "x \leq 0$ or $y < 0$ we throw a `DomainError()`.
 """
 function divisor_sigma(x::fmpz, y::Int)
-   y < 0 && throw(DomainError("Second argument must be non-negative: $y"))
+   x <= 0 && throw(DomainError(x, "Argument must be positive"))
+   y < 0 && throw(DomainError(y, "Power must be non-negative"))
    z = fmpz()
    ccall((:fmpz_divisor_sigma, :libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
@@ -1428,24 +1427,25 @@ end
 @doc Markdown.doc"""
     divisor_sigma(x::fmpz, y::fmpz)
 > Return the value of the sigma function, i.e. $\sum_{0 < d \;| x} d^y$. If
-> $y < 0$ we throw a `DomainError()`.
+> $x \leq 0$ or $y < 0$ we throw a `DomainError()`.
 """
 divisor_sigma(x::fmpz, y::fmpz) = divisor_sigma(x, Int(y))
 
 @doc Markdown.doc"""
     divisor_sigma(x::Int, y::Int)
 > Return the value of the sigma function, i.e. $\sum_{0 < d \;| x} d^y$. If
-> $y < 0$ we throw a `DomainError()`.
+> $x \leq 0$ or $y < 0$ we throw a `DomainError()`.
 """
 divisor_sigma(x::Int, y::Int) = Int(divisor_sigma(fmpz(x), y))
 
 @doc Markdown.doc"""
     euler_phi(x::fmpz)
 > Return the value of the Euler phi function at $x$, i.e. the number of
-> positive integers up to $x$ (inclusive) that are coprime with $x$.
+> positive integers up to $x$ (inclusive) that are coprime with $x$. An
+> exception is raised if $x \leq 0$. 
 """
 function euler_phi(x::fmpz)
-   x < 0 && throw(DomainError("Argument must be non-negative: $x"))
+   x <= 0 && throw(DomainError(x, "Argument must be positive"))
    z = fmpz()
    ccall((:fmpz_euler_phi, :libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}), z, x)
@@ -1455,7 +1455,8 @@ end
 @doc Markdown.doc"""
     euler_phi(x::Int)
 > Return the value of the Euler phi function at $x$, i.e. the number of
-> positive integers up to $x$ (inclusive) that are coprime with $x$.
+> positive integers up to $x$ (inclusive) that are coprime with $x$. An
+> exception is raised if $x \leq 0$.
 """
 euler_phi(x::Int) = Int(euler_phi(fmpz(x)))
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1311,7 +1311,7 @@ function fibonacci(x::Int)
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(abs(x)))
-    return x < 0 ? ((x & 1) == 0 ? -Int(z) : Int(z)) : Int(z)
+    return x < 0 ? (iseven(x) ? -Int(z) : Int(z)) : Int(z)
 end
 
 @doc Markdown.doc"""
@@ -1324,7 +1324,7 @@ function fibonacci(x::fmpz)
     z = fmpz()
     ccall((:fmpz_fib_ui, :libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(abs(x)))
-    return x < 0 ? ((x & 1) == 0 ? -z : z) : z
+    return x < 0 ? (iseven(x) ? -z : z) : z
 end
 
 @doc Markdown.doc"""

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -537,6 +537,16 @@ end
 
    @test euler_phi(fmpz(12480)) == 3072
 
+   @test fibonacci(2) == 1
+
+   @test fibonacci(0) == 0
+
+   @test fibonacci(-2) == -1
+
+   @test fibonacci(fmpz(2)) == 1
+
+   @test fibonacci(fmpz(-2)) == -1
+
    @test_throws DomainError  euler_phi(-fmpz(12480))
 
    @test remove(fmpz(12), fmpz(2)) == (2, 3)


### PR DESCRIPTION
After consulting many references, I discovered that multiplicative number theoretic functions can either be defined as function on N or functions on Z. However, I can find no source documenting a consistent set of definitions for Z for all standard number theoretic functions. In fact, *every single source* I consulted defines them over N, even if they say they are defining them over Z, and then goes to extreme lengths to ensure they only use the definition over N, e.g. by inserting absolute values every time the function is used.

The problem is particularly severe for Euler's phi function, where phi(0) could be either undefined, 0, 1 or 2, depending on the definition used. And at negative values, there are two common conventions, depending again on the definition.

I strongly suggest that people define the function phi (instead of euler_phi) if they do not mean the multiplicative arithmetic function defined on N.

Similarly, the divisor_sigma function is not defined at 0, since zero has infinitely many divisors. Again, I suggest defining the function sigma (or something else of one's own choosing) if another definition is expected.

For this reason, the current pull request restricts *all* multiplicative arithmetic functions to positive inputs. 

*If* there was a reference that dealt with consistent definitions over Z for all the multiplicative arithmetic functions, and *if* this was widely used, I would/could take a different opinion on this matter. But as it is, it is very clear that a lot of people will be pissed off by any definition we give for these functions at 0 or negative values.