### PR TITLE
fix input/output aliasing in fmpz(2)^1 and fmpz(-1)^3 and fmpz(1)^2

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1147,7 +1147,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{UInt}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
-
+ 
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1167,7 +1167,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Int}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
-
+ 
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1187,7 +1187,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Ref{fmpz}}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
-
+ 
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1388,7 +1388,7 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
       finalizer(_fmpq_mpoly_clear_fn, z)
       return z
    end
-
+   
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Int)
       z = new()
       ccall((:fmpq_mpoly_init, :libflint), Nothing,
@@ -1646,7 +1646,7 @@ mutable struct FqNmodFiniteField <: FinField
          return z
       end
    end
-
+   
    function FqNmodFiniteField(f::gfp_poly, s::Symbol, cached::Bool = true)
       if cached && haskey(FqNmodFiniteFieldIDGFPPol, (parent(f), f, s))
          return FqNmodFiniteFieldIDGFPPol[parent(f), f, s]
@@ -1786,7 +1786,7 @@ mutable struct FqFiniteField <: FinField
          return z
       end
    end
-
+   
    function FqFiniteField(f::gfp_fmpz_poly, s::Symbol, cached::Bool = true)
       if cached && haskey(FqFiniteFieldIDGFPPol, (f, s))
          return FqFiniteFieldIDGFPPol[f, s]
@@ -3259,7 +3259,8 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            fmpz_set!(el, arr[i, j])
+            ccall((:fmpz_set, :libflint), Nothing,
+                  (Ptr{fmpz}, Ref{fmpz}), el, arr[i, j])
          end
       end
       return z
@@ -3274,7 +3275,8 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            fmpz_set!(el, arr[(i-1)*c+j])
+            ccall((:fmpz_set, :libflint), Nothing,
+                  (Ptr{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -3289,7 +3291,8 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            fmpz_set!(el, fmpz(arr[i, j]))
+            ccall((:fmpz_set, :libflint), Nothing,
+                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
          end
       end
       return z
@@ -3304,7 +3307,8 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            fmpz_set!(el, fmpz(arr[(i-1)*c+j]))
+            ccall((:fmpz_set, :libflint), Nothing,
+                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -3318,7 +3322,8 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       GC.@preserve z for i = 1:min(r, c)
          el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                     (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
-         fmpz_set!(el, d)
+         ccall((:fmpz_set, :libflint), Nothing,
+               (Ptr{fmpz}, Ref{fmpz}), el, d)
       end
       return z
    end
@@ -4198,7 +4203,7 @@ mutable struct fq_mat <: MatElem{fq}
    rows::Ptr{Nothing}
    base_ring::FqFiniteField
    view_parent
-
+   
    # used by windows, not finalised!!
    function fq_mat()
       return new()
@@ -4386,7 +4391,7 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
    rows::Ptr{Nothing}
    base_ring::FqNmodFiniteField
    view_parent
-
+   
    # used by windows, not finalised!!
    function fq_nmod_mat()
       return new()
@@ -4563,23 +4568,3 @@ function _rand_ctx_clear_fn(a::rand_ctx)
    ccall((:flint_rand_free, libflint), Cvoid, (Ptr{Cvoid}, ), a.ptr)
    nothing
 end
-
-
-###############################################################################
-#
-#   wrapping of Flint C functions
-#
-###############################################################################
-
-# x is an "output" parameters, a is a constant "input" parameter
-
-const fmpz_t = Ref{fmpz}
-const _fmpz = Union{fmpz, Ptr{fmpz}}
-
-# fmpz
-function fmpz_set!(x::_fmpz, a::fmpz)
-   ccall((:fmpz_set, :libflint), Nothing, (fmpz_t, fmpz_t), x, a)
-   x
-end
-
-fmpz_set(a::fmpz) = fmpz_set!(fmpz(), a)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1147,7 +1147,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{UInt}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1167,7 +1167,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Int}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1187,7 +1187,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Ref{fmpz}}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
- 
+
        ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
@@ -1388,7 +1388,7 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
       finalizer(_fmpq_mpoly_clear_fn, z)
       return z
    end
-   
+
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Int)
       z = new()
       ccall((:fmpq_mpoly_init, :libflint), Nothing,
@@ -1646,7 +1646,7 @@ mutable struct FqNmodFiniteField <: FinField
          return z
       end
    end
-   
+
    function FqNmodFiniteField(f::gfp_poly, s::Symbol, cached::Bool = true)
       if cached && haskey(FqNmodFiniteFieldIDGFPPol, (parent(f), f, s))
          return FqNmodFiniteFieldIDGFPPol[parent(f), f, s]
@@ -1786,7 +1786,7 @@ mutable struct FqFiniteField <: FinField
          return z
       end
    end
-   
+
    function FqFiniteField(f::gfp_fmpz_poly, s::Symbol, cached::Bool = true)
       if cached && haskey(FqFiniteFieldIDGFPPol, (f, s))
          return FqFiniteFieldIDGFPPol[f, s]
@@ -3259,8 +3259,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
-                  (Ptr{fmpz}, Ref{fmpz}), el, arr[i, j])
+            fmpz_set!(el, arr[i, j])
          end
       end
       return z
@@ -3275,8 +3274,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
-                  (Ptr{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
+            fmpz_set!(el, arr[(i-1)*c+j])
          end
       end
       return z
@@ -3291,8 +3289,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
-                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
+            fmpz_set!(el, fmpz(arr[i, j]))
          end
       end
       return z
@@ -3307,8 +3304,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
          for j = 1:c
             el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
-                  (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
+            fmpz_set!(el, fmpz(arr[(i-1)*c+j]))
          end
       end
       return z
@@ -3322,8 +3318,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
       GC.@preserve z for i = 1:min(r, c)
          el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
                     (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
-         ccall((:fmpz_set, :libflint), Nothing,
-               (Ptr{fmpz}, Ref{fmpz}), el, d)
+         fmpz_set!(el, d)
       end
       return z
    end
@@ -4203,7 +4198,7 @@ mutable struct fq_mat <: MatElem{fq}
    rows::Ptr{Nothing}
    base_ring::FqFiniteField
    view_parent
-   
+
    # used by windows, not finalised!!
    function fq_mat()
       return new()
@@ -4391,7 +4386,7 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
    rows::Ptr{Nothing}
    base_ring::FqNmodFiniteField
    view_parent
-   
+
    # used by windows, not finalised!!
    function fq_nmod_mat()
       return new()
@@ -4568,3 +4563,23 @@ function _rand_ctx_clear_fn(a::rand_ctx)
    ccall((:flint_rand_free, libflint), Cvoid, (Ptr{Cvoid}, ), a.ptr)
    nothing
 end
+
+
+###############################################################################
+#
+#   wrapping of Flint C functions
+#
+###############################################################################
+
+# x is an "output" parameters, a is a constant "input" parameter
+
+const fmpz_t = Ref{fmpz}
+const _fmpz = Union{fmpz, Ptr{fmpz}}
+
+# fmpz
+function fmpz_set!(x::_fmpz, a::fmpz)
+   ccall((:fmpz_set, :libflint), Nothing, (fmpz_t, fmpz_t), x, a)
+   x
+end
+
+fmpz_set(a::fmpz) = fmpz_set!(fmpz(), a)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -130,11 +130,7 @@ end
 #
 ###############################################################################
 
-function deepcopy_internal(a::fmpz, dict::IdDict)
-   z = fmpz()
-   ccall((:fmpz_set, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, a)
-   return z
-end
+deepcopy_internal(a::fmpz, dict::IdDict) = fmpz_set(a)
 
 characteristic(R::FlintIntegerRing) = 0
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -527,7 +527,7 @@ function ^(x::fmpz, y::Int)
    elseif x == -1
       isodd(y) ? deepcopy(x) : one(x)
    elseif y < 0
-      throw(DomainError("Exponent must be non-negative: $y"))
+      throw(DomainError(y, "Exponent must be non-negative"))
    elseif y == 1
       deepcopy(x)
    else

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -518,15 +518,19 @@ end
 ###############################################################################
 
 function ^(x::fmpz, y::Int)
-    if isone(x); return x; end
-    if x == -1; return isodd(y) ? x : -x; end
-    if y < 0; throw(DomainError("Exponent must be non-negative: $y")); end
-    if y > typemax(UInt); throw(DomainError("Exponent too large")); end
-    if y == 0; return one(FlintZZ); end
-    if y == 1; return x; end
-    z = fmpz()
-    ccall((:fmpz_pow_ui, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(y))
-    return z
+   if isone(x) || y == 0
+      one(x)
+   elseif x == -1
+      isodd(y) ? fmpz_set(x) : one(x)
+   elseif y < 0
+      throw(DomainError("Exponent must be non-negative: $y"))
+   elseif y == 1
+      fmpz_set(x)
+   else
+      z = fmpz()
+      ccall((:fmpz_pow_ui, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(y))
+      z
+   end
 end
 
 ###############################################################################

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -273,6 +273,15 @@ end
    a = fmpz(-12)
 
    @test a^5 == -248832
+
+   # the result must never alias the input
+   @test a^1 !== a
+
+   a = fmpz(-1)
+   @test a^3 !== a
+
+   a = fmpz(1)
+   @test a^2 !== a
 end
 
 @testset "fmpz.comparison..." begin

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -274,14 +274,35 @@ end
 
    @test a^5 == -248832
 
-   # the result must never alias the input
+   @test a^1 == a
    @test a^1 !== a
 
-   a = fmpz(-1)
-   @test a^3 !== a
+   @test isone(a^0)
+
+   for a in fmpz.(-5:5)
+      for e = -5:-1
+         if a != 1 && a != -1
+            @test_throws DomainError a^e
+         end
+      end
+      @test a^1 == a
+      @test a^1 !== a
+   end
 
    a = fmpz(1)
-   @test a^2 !== a
+   for e = -2:2
+      @test isone(a^e)
+      @test a^e !== a
+   end
+
+   a = fmpz(-1)
+   for e = [-3, -1, 1, 3, 5]
+      @test a^e == a
+      @test a^e !== a
+   end
+   for e = [-2, 0, 2, 4]
+      @test isone(a^e )
+   end
 end
 
 @testset "fmpz.comparison..." begin


### PR DESCRIPTION
According to https://github.com/Nemocas/Nemo.jl/issues/278#issue-262752430. The bug was noticed by @tthsqe12.

Also, this introduces the `fmpz_set!` function, which is a bare wrapper over the flint `fmpz_set` function, to not have to repeat the same `ccall` invocation all over. This imitates [what I did](https://github.com/JuliaLang/julia/blob/1432c5a08531aab153953848e5e8015faed2bb8d/base/gmp.jl#L125) for the `GMP` module (except I didn't make an `Fmpz` module). More such functions can be introduced as needed. Note that I needed `fmpz_set` to make an efficient copy, `deepcopy` of an `fmpz` is about 4 times slower (I will open an issue about that).