### PR TITLE
fix a couple documentation issues with `Fac`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,9 @@
-using Documenter, Nemo
+using Documenter, Nemo, AbstractAlgebra
 
 makedocs(
          format   = :html,
          sitename = "Nemo.jl",
-         modules = [Nemo],
+         modules = [Nemo, AbstractAlgebra],
          clean = true,
          checkdocs = :none,
          doctest = false,

--- a/docs/src/factor.md
+++ b/docs/src/factor.md
@@ -41,8 +41,8 @@ then `for (p, e) in a` will iterate through all pairs `(p, e)`, where `p` is a
 factor and `e` the corresponding exponent.
 
 ```@docs
-in(a::fmpz, ::Fac{fmpz})
-getindex(::Fac{fmpz}, fmpz)
+in(::fmpz, ::Fac{fmpz})
+getindex(::Fac{fmpz}, ::fmpz)
 length(::Fac{fmpz})
 unit(::Fac{fmpz})
 ```


### PR DESCRIPTION
There was a small typo, but the main point here is to import docstrings which are defined in `AbstractAlgebra`, by adding this module to the `modules` list in `makedocs`. 