### PR TITLE
fix remaining issues with building the docs

### DIFF
--- a/docs/src/ff_embedding.md
+++ b/docs/src/ff_embedding.md
@@ -52,7 +52,6 @@ julia> z = k4(x2)
 
 ```@docs
 preimage_map(::FqNmodFiniteField, ::FqNmodFiniteField)
-preimage_map(::FinFieldMorphism)
 ```
 
 **Examples**

--- a/docs/src/ff_embedding.md
+++ b/docs/src/ff_embedding.md
@@ -52,6 +52,7 @@ julia> z = k4(x2)
 
 ```@docs
 preimage_map(::FqNmodFiniteField, ::FqNmodFiniteField)
+preimage_map(::FinFieldMorphism)
 ```
 
 **Examples**

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -303,7 +303,7 @@ isprime(::fmpz)
 ```
 
 ```@docs
-isprobabprime(::fmpz)
+isprobable_prime(::fmpz)
 ```
 
 ```@docs
@@ -335,7 +335,7 @@ fibonacci(::fmpz)
 ```
 
 ```@docs
-bell(:fmpz)
+bell(::fmpz)
 bell(::Int)
 ```
 

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -47,7 +47,7 @@ The other residue types in Nemo also implement this functionality.
 
 ```@docs
 gcdx(::nmod, ::nmod)
-gcdx(::ResElem{fmpz}, ::ResElem{fmpz})
+gcdx(::fmpz_mod, ::fmpz_mod)
 ```
 
 **Examples**

--- a/src/embedding/EmbeddingTypes.jl
+++ b/src/embedding/EmbeddingTypes.jl
@@ -65,5 +65,9 @@ function Base.show(io::IO, f::FinFieldPreimage)
     print("Preimage of the morphism from $(domain(f))\nto $(codomain(f))")
 end
 
+@doc Markdown.doc"""
+    preimage_map(f::FinFieldMorphism)
+> Compute the preimage map corresponding to the embedding $f$.
+"""
 preimage_map(f::FinFieldMorphism) = FinFieldPreimage(domain(f), codomain(f),
-                                                 image_fn(f), inverse_fn(f))
+                                                     image_fn(f), inverse_fn(f))


### PR DESCRIPTION
I had to remove the reference to `preimage_map(::FinFieldMorphism)` in the documentation, as the docstring for this method doesn't exist. If someone has a suggestion, I can add it here instead.