### PR TITLE
Speed up nmod/gfp_mat and bring in line with fmpz_mod_mat.

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3407,33 +3407,24 @@ mutable struct nmod_mat <: MatElem{nmod}
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
+      arr = Base.transpose(arr)
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        setindex_raw!(z, mod(arr[i, j], n), i, j)
       end
     end
     return z
   end
 
-  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1}, transpose::Bool = false)
+  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r,c = c,r
-    else
-      se = set_entry!
-    end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        setindex_raw!(z, mod(arr[(i - 1) * c + j], n), i, j)
       end
     end
     return z
@@ -3445,33 +3436,31 @@ mutable struct nmod_mat <: MatElem{nmod}
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r,c = c,r
-    else
-      se = set_entry!
+       arr = Base.transpose(arr)
     end
+    t = fmpz()
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        ccall((:fmpz_mod_ui, :libflint), Nothing,
+	      (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[i, j], n)
+	setindex_raw!(z, t, i, j)
       end
     end
     return z
   end
 
-  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1}, transpose::Bool = false)
+  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r,c = c,r
-    else
-      se = set_entry!
-    end
+    t = fmpz()
+    n = fmpz(n)
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        ccall((:fmpz_mod_ui, :libflint), Nothing,
+              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[(i - 1) * c + j], n)
+        setindex!(z, t, i, j)
       end
     end
     return z
@@ -3482,9 +3471,9 @@ mutable struct nmod_mat <: MatElem{nmod}
     return nmod_mat(r, c, n, arr_fmpz, transpose)
   end
 
-  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{T, 1}, transpose::Bool = false) where {T <: Integer}
+  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{T, 1}) where {T <: Integer}
     arr_fmpz = map(fmpz, arr)
-    return nmod_mat(r, c, n, arr_fmpz, transpose)
+    return nmod_mat(r, c, n, arr_fmpz)
   end
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{nmod, 2}, transpose::Bool = false)
@@ -3493,33 +3482,24 @@ mutable struct nmod_mat <: MatElem{nmod}
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r,c = c,r
-    else
-      se = set_entry!
+      arr = Base.transpose(arr)
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        setindex_raw!(z, arr[i, j].data, i, j) # no reduction necessary
       end
     end
     return z
   end
 
-  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{nmod, 1}, transpose::Bool = false)
+  function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{nmod, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
-    end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        setindex_raw!(z, arr[(i - 1) * c + j].data, i, j) # no reduction necessary
       end
     end
     return z
@@ -3756,33 +3736,24 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
+      arr = Base.transpose(arr)
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        setindex_raw!(z, mod(arr[i, j], n), i, j)
       end
     end
     return z
   end
 
-  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1}, transpose::Bool = false)
+  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
-    end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        setindex_raw!(z, mod(arr[(i - 1) * c + j], n), i, j)
       end
     end
     return z
@@ -3794,33 +3765,30 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
+       arr = Base.transpose(arr)
     end
+    t = fmpz()
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        ccall((:fmpz_mod_ui, :libflint), Nothing,
+              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[i, j], n)
+        setindex_raw!(z, t, i, j)
       end
     end
     return z
   end
 
-  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1}, transpose::Bool = false)
+  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
-    end
+    t = fmpz()
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        ccall((:fmpz_mod_ui, :libflint), Nothing,
+              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[(i - 1) * c + j], n)
+        setindex!(z, t, i, j)
       end
     end
     return z
@@ -3831,9 +3799,9 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
     return gfp_mat(r, c, n, arr_fmpz, transpose)
   end
 
-  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{T, 1}, transpose::Bool = false) where {T <: Integer}
+  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{T, 1}) where {T <: Integer}
     arr_fmpz = map(fmpz, arr)
-    return gfp_mat(r, c, n, arr_fmpz, transpose)
+    return gfp_mat(r, c, n, arr_fmpz)
   end
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{gfp_elem, 2}, transpose::Bool = false)
@@ -3842,33 +3810,24 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
+      arr = Base.transpose(arr)
     end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[i, j])
+        setindex_raw!(z, arr[i, j].data, i, j) # no reduction necessary
       end
     end
     return z
   end
 
-  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{gfp_elem, 1}, transpose::Bool = false)
+  function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{gfp_elem, 1})
     z = new()
     ccall((:nmod_mat_init, :libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
-    if transpose
-      se = set_entry_t!
-      r, c = c, r
-    else
-      se = set_entry!
-    end
     for i = 1:r
       for j = 1:c
-        se(z, i, j, arr[(i - 1) * c + j])
+        setindex_raw!(z, arr[(i - 1) * c + j].data, i, j) # no reduction necessary
       end
     end
     return z

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -312,7 +312,7 @@ end
 end
 
 @testset "nmod_mat.binary_ops..." begin
-  Z17 = ResidueRing(ZZ,17)
+  Z17 = ResidueRing(ZZ, 17)
 
   R = MatrixSpace(Z17, 3, 4)
 


### PR DESCRIPTION
* Rename set_entry functions to setindex_raw as per fmpz_mod_mat
* Remove set_entry_t functions and use Julia's lazy transpose
* Use Flint's fmpz_mod_ui (faster)
* Remove multiple reductions mod n and only reduce mod n when necessary
* Remove transpose option from 1-d arrays as per fmpz_mod_mat
* Change argument order to match fmpz_mod_mat and Julia (and to make it consistent)

The stuff that has been removed is supposed to be internal stuff. However, this is actually a breaking change because of precisely one call to set_entry in misc2 in Hecke. It can be changed to setindex_raw! and the last argument is moved to the second place.

Closes #672 