### PR TITLE
Raise DivideError on divide by zero.

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -395,6 +395,7 @@ isless(a::fmpq, b::Rational{T}) where {T <: Integer} = isless(a, fmpq(b))
 ###############################################################################
 
 function ^(a::fmpq, b::Int)
+   iszero(a) && b < 0 && throw(DivideError())
    temp = fmpq()
    ccall((:fmpq_pow_si, :libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), temp, a, b)
@@ -450,7 +451,7 @@ function Base.sqrt(a::fmpq)
 
 function inv(a::fmpq)
     if iszero(a)
-      throw(error("Element not invertible"))
+       throw(error("Element not invertible"))
     end
     z = fmpq()
     ccall((:fmpq_inv, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
@@ -492,11 +493,17 @@ function divexact(a::fmpq, b::fmpz)
    return z
 end
 
-divexact(a::fmpz, b::fmpq) = inv(b)*a
+function divexact(a::fmpz, b::fmpq)
+   iszero(b) && throw(DivideError())
+   return inv(b)*a
+end
 
 divexact(a::fmpq, b::Integer) = divexact(a, fmpz(b))
 
-divexact(a::Integer, b::fmpq) = inv(b)*a
+function divexact(a::Integer, b::fmpq)
+   iszero(b) && throw(DivideError())
+   return inv(b)*a
+end
 
 divexact(a::fmpq, b::Rational{T}) where {T <: Integer} = divexact(a, fmpq(b))
 

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -270,6 +270,8 @@ end
    a = -fmpz(2)//3
 
    @test a^(-12) == fmpz(531441)//4096
+
+   @test_throws DivideError fmpq(0)^-1
 end
 
 @testset "fmpq.inversion..." begin
@@ -314,6 +316,10 @@ end
    @test_throws DivideError divexact(a, 0//1)
 
    @test_throws DivideError divexact(a, ZZ(0))
+
+   @test_throws DivideError(12, QQ(0))
+
+   @test_throws DivideError(ZZ(12), QQ(0))
 end
 
 @testset "fmpq.modular_arithmetic..." begin

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -317,9 +317,9 @@ end
 
    @test_throws DivideError divexact(a, ZZ(0))
 
-   @test_throws DivideError(12, QQ(0))
+   @test_throws DivideError divexact(12, QQ(0))
 
-   @test_throws DivideError(ZZ(12), QQ(0))
+   @test_throws DivideError divexact(ZZ(12), QQ(0))
 end
 
 @testset "fmpq.modular_arithmetic..." begin


### PR DESCRIPTION
Goes some way towards addressing point 2 of https://github.com/Nemocas/Nemo.jl/issues/775