### PR TITLE
disable the greeting banner when loaded from Oscar

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -257,21 +257,15 @@ function __init__()
    ccall((:flint_set_abort, libflint), Nothing,
          (Ptr{Nothing},), @cfunction(flint_abort, Nothing, ()))
 
-   if isinteractive()
-       oscar_loading = haskey(Base.package_locks,
-                              Base.PkgId(Base.UUID("f1435218-dba5-11e9-1e4d-f1a5fab5fc13"),
-                                         "Oscar"))
+   if isinteractive() &&
+         !any(x -> x.name in ("Hecke", "Oscar"), keys(Base.package_locks)) &&
+         get(ENV, "NEMO_PRINT_BANNER", "true") != "false"
 
-       print_banner = oscar_loading ? "false" :
-                                      get(ENV, "NEMO_PRINT_BANNER", "true")
-
-       if print_banner == "true"
-          println("")
-          println("Welcome to Nemo version $(version())")
-          println("")
-          println("Nemo comes with absolutely no warranty whatsoever")
-          println("")
-       end
+      println("")
+      println("Welcome to Nemo version $(version())")
+      println("")
+      println("Nemo comes with absolutely no warranty whatsoever")
+      println("")
    end
 
   t = create_accessors(AnticNumberField, Dict, get_handle())

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -257,11 +257,20 @@ function __init__()
    ccall((:flint_set_abort, libflint), Nothing,
          (Ptr{Nothing},), @cfunction(flint_abort, Nothing, ()))
 
-   println("")
-   println("Welcome to Nemo version $(version())")
-   println("")
-   println("Nemo comes with absolutely no warranty whatsoever")
-   println("")
+   oscar_loading = haskey(Base.package_locks,
+                          Base.PkgId(Base.UUID("f1435218-dba5-11e9-1e4d-f1a5fab5fc13"),
+                                     "Oscar"))
+
+   print_banner = oscar_loading ? "false" :
+                                  get(ENV, "NEMO_PRINT_BANNER", "true")
+
+   if print_banner == "true"
+      println("")
+      println("Welcome to Nemo version $(version())")
+      println("")
+      println("Nemo comes with absolutely no warranty whatsoever")
+      println("")
+   end
 
   t = create_accessors(AnticNumberField, Dict, get_handle())
 

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -257,19 +257,21 @@ function __init__()
    ccall((:flint_set_abort, libflint), Nothing,
          (Ptr{Nothing},), @cfunction(flint_abort, Nothing, ()))
 
-   oscar_loading = haskey(Base.package_locks,
-                          Base.PkgId(Base.UUID("f1435218-dba5-11e9-1e4d-f1a5fab5fc13"),
-                                     "Oscar"))
+   if isinteractive()
+       oscar_loading = haskey(Base.package_locks,
+                              Base.PkgId(Base.UUID("f1435218-dba5-11e9-1e4d-f1a5fab5fc13"),
+                                         "Oscar"))
 
-   print_banner = oscar_loading ? "false" :
-                                  get(ENV, "NEMO_PRINT_BANNER", "true")
+       print_banner = oscar_loading ? "false" :
+                                      get(ENV, "NEMO_PRINT_BANNER", "true")
 
-   if print_banner == "true"
-      println("")
-      println("Welcome to Nemo version $(version())")
-      println("")
-      println("Nemo comes with absolutely no warranty whatsoever")
-      println("")
+       if print_banner == "true"
+          println("")
+          println("Welcome to Nemo version $(version())")
+          println("")
+          println("Nemo comes with absolutely no warranty whatsoever")
+          println("")
+       end
    end
 
   t = create_accessors(AnticNumberField, Dict, get_handle())


### PR DESCRIPTION
This is a hack, hoping that a better solution appears someday. The same can be replicated in other packages (Hecke, Polymake, I can make PR there is requested).

The idea is to look inside the `Base.package_locks` internal dict to see if `Oscar`'s loading has been initiated when `Nemo` is loading. In other words, `Nemo` will load before `Oscar`, but while loading, `Nemo` can know whether `Oscar` is about to be loaded afterwards.

In addition to `Oscar`, we can manually add a check for other packages, e.g. `Hecke`, unfortunately there is no way for packages to "register" into a "no-print-banner hook". So this PR also gives an escape hatch, by checking an environment variable (`"NEMO_PRINT_BANNER"`), which can be set by end-user.