### PR TITLE
replace ccall(.. :lib...) by a ccall with the path

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -36,7 +36,7 @@ mutable struct AnticNumberField <: SimpleNumField{fmpq}
       if !cached
          nf = new()
          nf.pol = pol
-         ccall((:nf_init, :libantic), Nothing, 
+         ccall((:nf_init, libantic), Nothing, 
             (Ref{AnticNumberField}, Ref{fmpq_poly}), nf, pol)
          finalizer(_AnticNumberField_clear_fn, nf)
          nf.S = s
@@ -48,7 +48,7 @@ mutable struct AnticNumberField <: SimpleNumField{fmpq}
          else
             nf = new()
             nf.pol = pol
-            ccall((:nf_init, :libantic), Nothing, 
+            ccall((:nf_init, libantic), Nothing, 
                (Ref{AnticNumberField}, Ref{fmpq_poly}), nf, pol)
             finalizer(_AnticNumberField_clear_fn, nf)
             nf.S = s
@@ -63,7 +63,7 @@ mutable struct AnticNumberField <: SimpleNumField{fmpq}
 end
 
 function _AnticNumberField_clear_fn(a::AnticNumberField)
-   ccall((:nf_clear, :libantic), Nothing, (Ref{AnticNumberField},), a)
+   ccall((:nf_clear, libantic), Nothing, (Ref{AnticNumberField},), a)
 end
 
 mutable struct nf_elem <: SimpleNumFieldElem{fmpq}
@@ -75,7 +75,7 @@ mutable struct nf_elem <: SimpleNumFieldElem{fmpq}
 
    function nf_elem(p::AnticNumberField)
       r = new()
-      ccall((:nf_elem_init, :libantic), Nothing, 
+      ccall((:nf_elem_init, libantic), Nothing, 
             (Ref{nf_elem}, Ref{AnticNumberField}), r, p)
       r.parent = p
       finalizer(_nf_elem_clear_fn, r)
@@ -84,9 +84,9 @@ mutable struct nf_elem <: SimpleNumFieldElem{fmpq}
 
    function nf_elem(p::AnticNumberField, a::nf_elem)
       r = new()
-      ccall((:nf_elem_init, :libantic), Nothing, 
+      ccall((:nf_elem_init, libantic), Nothing, 
             (Ref{nf_elem}, Ref{AnticNumberField}), r, p)
-      ccall((:nf_elem_set, :libantic), Nothing,
+      ccall((:nf_elem_set, libantic), Nothing,
             (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}), r, a, p)
       r.parent = p
       finalizer(_nf_elem_clear_fn, r)
@@ -95,6 +95,6 @@ mutable struct nf_elem <: SimpleNumFieldElem{fmpq}
 end
 
 function _nf_elem_clear_fn(a::nf_elem)
-   ccall((:nf_elem_clear, :libantic), Nothing, 
+   ccall((:nf_elem_clear, libantic), Nothing, 
          (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -95,14 +95,14 @@ end
 function coeff(x::nf_elem, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = fmpq()
-   ccall((:nf_elem_get_coeff_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_get_coeff_fmpq, libantic), Nothing,
      (Ref{fmpq}, Ref{nf_elem}, Int, Ref{AnticNumberField}), z, x, n, parent(x))
    return z
 end
 
 function num_coeff!(z::fmpz, x::nf_elem, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
-   ccall((:nf_elem_get_coeff_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_get_coeff_fmpz, libantic), Nothing,
      (Ref{fmpz}, Ref{nf_elem}, Int, Ref{AnticNumberField}), z, x, n, parent(x))
    return z
 end
@@ -113,7 +113,7 @@ end
 """
 function gen(a::AnticNumberField)
    r = nf_elem(a)
-   ccall((:nf_elem_gen, :libantic), Nothing,
+   ccall((:nf_elem_gen, libantic), Nothing,
          (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
@@ -124,7 +124,7 @@ end
 """
 function one(a::AnticNumberField)
    r = nf_elem(a)
-   ccall((:nf_elem_one, :libantic), Nothing,
+   ccall((:nf_elem_one, libantic), Nothing,
          (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
@@ -135,7 +135,7 @@ end
 """
 function zero(a::AnticNumberField)
    r = nf_elem(a)
-   ccall((:nf_elem_zero, :libantic), Nothing,
+   ccall((:nf_elem_zero, libantic), Nothing,
          (Ref{nf_elem}, Ref{AnticNumberField}), r, a)
    return r
 end
@@ -146,7 +146,7 @@ end
 > number field, otherwise return `false`.
 """
 function isgen(a::nf_elem)
-   return ccall((:nf_elem_is_gen, :libantic), Bool,
+   return ccall((:nf_elem_is_gen, libantic), Bool,
                 (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
@@ -156,7 +156,7 @@ end
 > identity of the number field, i.e. one, otherwise return `false`.
 """
 function isone(a::nf_elem)
-   return ccall((:nf_elem_is_one, :libantic), Bool,
+   return ccall((:nf_elem_is_one, libantic), Bool,
                 (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
@@ -166,7 +166,7 @@ end
 > identity of the number field, i.e. zero, otherwise return `false`.
 """
 function iszero(a::nf_elem)
-   return ccall((:nf_elem_is_zero, :libantic), Bool,
+   return ccall((:nf_elem_is_zero, libantic), Bool,
                 (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
 end
 
@@ -183,7 +183,7 @@ isunit(a::nf_elem) = !iszero(a)
 > return `false`.
 """
 function isinteger(a::nf_elem)
-   b = ccall((:nf_elem_is_integer, :libantic), Cint,
+   b = ccall((:nf_elem_is_integer, libantic), Cint,
              (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
    return Bool(b)
 end
@@ -194,7 +194,7 @@ end
 > otherwise `false`.
 """
 function isrational(a::nf_elem)
-   b = ccall((:nf_elem_is_rational, :libantic), Cint,
+   b = ccall((:nf_elem_is_rational, libantic), Cint,
              (Ref{nf_elem}, Ref{AnticNumberField}), a, a.parent)
    return Bool(b)
 end
@@ -206,7 +206,7 @@ end
 """
 function denominator(a::nf_elem)
    z = fmpz()
-   ccall((:nf_elem_get_den, :libantic), Nothing,
+   ccall((:nf_elem_get_den, libantic), Nothing,
          (Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
          z, a, a.parent)
    return z
@@ -216,14 +216,14 @@ function elem_from_mat_row(a::AnticNumberField, b::fmpz_mat, i::Int, d::fmpz)
    Generic._checkbounds(nrows(b), i) || throw(BoundsError())
    ncols(b) == degree(a) || error("Wrong number of columns")
    z = a()
-   ccall((:nf_elem_set_fmpz_mat_row, :libantic), Nothing,
+   ccall((:nf_elem_set_fmpz_mat_row, libantic), Nothing,
         (Ref{nf_elem}, Ref{fmpz_mat}, Int, Ref{fmpz}, Ref{AnticNumberField}),
         z, b, i - 1, d, a)
    return z
 end
 
 function elem_to_mat_row!(a::fmpz_mat, i::Int, d::fmpz, b::nf_elem)
-   ccall((:nf_elem_get_fmpz_mat_row, :libantic), Nothing,
+   ccall((:nf_elem_get_fmpz_mat_row, libantic), Nothing,
          (Ref{fmpz_mat}, Int, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
          a, i - 1, d, b, b.parent)
    nothing
@@ -301,11 +301,11 @@ function show(io::IO, a::AnticNumberField)
 end
 
 function show(io::IO, x::nf_elem)
-   cstr = ccall((:nf_elem_get_str_pretty, :libantic), Ptr{UInt8},
+   cstr = ccall((:nf_elem_get_str_pretty, libantic), Ptr{UInt8},
                 (Ref{nf_elem}, Ptr{UInt8}, Ref{AnticNumberField}),
                  x, string(var(parent(x))), parent(x))
    s = unsafe_string(cstr)
-   ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+   ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
 
    s = replace(s, "/" => "//")
 
@@ -327,7 +327,7 @@ canonical_unit(x::nf_elem) = x
 
 function -(a::nf_elem)
    r = a.parent()
-   ccall((:nf_elem_neg, :libantic), Nothing,
+   ccall((:nf_elem_neg, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, a.parent)
    return r
@@ -342,7 +342,7 @@ end
 function +(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
-   ccall((:nf_elem_add, :libantic), Nothing,
+   ccall((:nf_elem_add, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -351,7 +351,7 @@ end
 function -(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
-   ccall((:nf_elem_sub, :libantic), Nothing,
+   ccall((:nf_elem_sub, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -360,7 +360,7 @@ end
 function *(a::nf_elem, b::nf_elem)
    check_parent(a, b)
    r = a.parent()
-   ccall((:nf_elem_mul, :libantic), Nothing,
+   ccall((:nf_elem_mul, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -374,7 +374,7 @@ end
 
 function +(a::nf_elem, b::Int)
    r = a.parent()
-   ccall((:nf_elem_add_si, :libantic), Nothing,
+   ccall((:nf_elem_add_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -382,7 +382,7 @@ end
 
 function +(a::nf_elem, b::fmpz)
    r = a.parent()
-   ccall((:nf_elem_add_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_add_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -390,7 +390,7 @@ end
 
 function +(a::nf_elem, b::fmpq)
    r = a.parent()
-   ccall((:nf_elem_add_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_add_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -398,7 +398,7 @@ end
 
 function -(a::nf_elem, b::Int)
    r = a.parent()
-   ccall((:nf_elem_sub_si, :libantic), Nothing,
+   ccall((:nf_elem_sub_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -406,7 +406,7 @@ end
 
 function -(a::nf_elem, b::fmpz)
    r = a.parent()
-   ccall((:nf_elem_sub_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_sub_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -414,7 +414,7 @@ end
 
 function -(a::nf_elem, b::fmpq)
    r = a.parent()
-   ccall((:nf_elem_sub_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_sub_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -422,7 +422,7 @@ end
 
 function -(a::Int, b::nf_elem)
    r = b.parent()
-   ccall((:nf_elem_si_sub, :libantic), Nothing,
+   ccall((:nf_elem_si_sub, libantic), Nothing,
          (Ref{nf_elem}, Int, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, b.parent)
    return r
@@ -430,7 +430,7 @@ end
 
 function -(a::fmpz, b::nf_elem)
    r = b.parent()
-   ccall((:nf_elem_fmpz_sub, :libantic), Nothing,
+   ccall((:nf_elem_fmpz_sub, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, b.parent)
    return r
@@ -438,7 +438,7 @@ end
 
 function -(a::fmpq, b::nf_elem)
    r = b.parent()
-   ccall((:nf_elem_fmpq_sub, :libantic), Nothing,
+   ccall((:nf_elem_fmpq_sub, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, b.parent)
    return r
@@ -464,7 +464,7 @@ end
 
 function *(a::nf_elem, b::Int)
    r = a.parent()
-   ccall((:nf_elem_scalar_mul_si, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -472,7 +472,7 @@ end
 
 function *(a::nf_elem, b::fmpz)
    r = a.parent()
-   ccall((:nf_elem_scalar_mul_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -480,7 +480,7 @@ end
 
 function *(a::nf_elem, b::fmpq)
    r = a.parent()
-   ccall((:nf_elem_scalar_mul_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -526,7 +526,7 @@ end
 
 function ^(a::nf_elem, n::Int)
    r = a.parent()
-   ccall((:nf_elem_pow, :libantic), Nothing,
+   ccall((:nf_elem_pow, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          r, a, abs(n), a.parent)
    if n < 0
@@ -543,7 +543,7 @@ end
 
 function ==(a::nf_elem, b::nf_elem)
    check_parent(a, b)
-   return ccall((:nf_elem_equal, :libantic), Bool,
+   return ccall((:nf_elem_equal, libantic), Bool,
            (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}), a, b, a.parent)
 end
 
@@ -554,28 +554,28 @@ end
 ###############################################################################
 
 function ==(a::nf_elem, b::fmpz)
-   b = ccall((:nf_elem_equal_fmpz, :libantic), Cint,
+   b = ccall((:nf_elem_equal_fmpz, libantic), Cint,
              (Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
               a, b, a.parent)
    return Bool(b)
 end
 
 function ==(a::nf_elem, b::fmpq)
-   b = ccall((:nf_elem_equal_fmpq, :libantic), Cint,
+   b = ccall((:nf_elem_equal_fmpq, libantic), Cint,
              (Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
               a, b, a.parent)
    return Bool(b)
 end
 
 function ==(a::nf_elem, b::Int)
-   b = ccall((:nf_elem_equal_si, :libantic), Cint,
+   b = ccall((:nf_elem_equal_si, libantic), Cint,
              (Ref{nf_elem}, Int, Ref{AnticNumberField}),
               a, b, a.parent)
    return Bool(b)
 end
 
 function ==(a::nf_elem, b::UInt)
-   b = ccall((:nf_elem_equal_ui, :libantic), Cint,
+   b = ccall((:nf_elem_equal_ui, libantic), Cint,
              (Ref{nf_elem}, UInt, Ref{AnticNumberField}),
               a, b, a.parent)
    return Bool(b)
@@ -610,7 +610,7 @@ end
 function inv(a::nf_elem)
    iszero(a) && throw(DivideError())
    r = a.parent()
-   ccall((:nf_elem_inv, :libantic), Nothing,
+   ccall((:nf_elem_inv, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, a.parent)
    return r
@@ -626,7 +626,7 @@ function divexact(a::nf_elem, b::nf_elem)
    iszero(b) && throw(DivideError())
    check_parent(a, b)
    r = a.parent()
-   ccall((:nf_elem_div, :libantic), Nothing,
+   ccall((:nf_elem_div, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -641,7 +641,7 @@ end
 function divexact(a::nf_elem, b::Int)
    b == 0 && throw(DivideError())
    r = a.parent()
-   ccall((:nf_elem_scalar_div_si, :libantic), Nothing,
+   ccall((:nf_elem_scalar_div_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -650,7 +650,7 @@ end
 function divexact(a::nf_elem, b::fmpz)
    iszero(b) && throw(DivideError())
    r = a.parent()
-   ccall((:nf_elem_scalar_div_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_scalar_div_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -661,7 +661,7 @@ divexact(a::nf_elem, b::Integer) = divexact(a, fmpz(b))
 function divexact(a::nf_elem, b::fmpq)
    iszero(b) && throw(DivideError())
    r = a.parent()
-   ccall((:nf_elem_scalar_div_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_scalar_div_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          r, a, b, a.parent)
    return r
@@ -707,7 +707,7 @@ end
 """
 function norm(a::nf_elem)
    z = fmpq()
-   ccall((:nf_elem_norm, :libantic), Nothing,
+   ccall((:nf_elem_norm, libantic), Nothing,
          (Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
          z, a, a.parent)
    return z
@@ -719,7 +719,7 @@ end
 """
 function tr(a::nf_elem)
    z = fmpq()
-   ccall((:nf_elem_trace, :libantic), Nothing,
+   ccall((:nf_elem_trace, libantic), Nothing,
          (Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
          z, a, a.parent)
    return z
@@ -735,7 +735,7 @@ function representation_matrix(a::nf_elem)
   K = parent(a)
   z = fmpq_mat(degree(K), degree(K))
   z.base_ring = FlintQQ
-  ccall((:nf_elem_rep_mat, :libantic), Nothing,
+  ccall((:nf_elem_rep_mat, libantic), Nothing,
         (Ref{fmpq_mat}, Ref{nf_elem}, Ref{AnticNumberField}), z, a, K)
   return z
 end
@@ -752,7 +752,7 @@ function representation_matrix_q(a::nf_elem)
   z = fmpz_mat(degree(K), degree(K))
   z.base_ring = FlintZZ
   d = fmpz()
-  ccall((:nf_elem_rep_mat_fmpz_mat_den, :libantic), Nothing,
+  ccall((:nf_elem_rep_mat_fmpz_mat_den, libantic), Nothing,
         (Ref{fmpz_mat}, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
         z, d, a, K)
   return z, d
@@ -765,13 +765,13 @@ end
 ###############################################################################
 
 function zero!(a::nf_elem)
-   ccall((:nf_elem_zero, :libantic), Nothing,
+   ccall((:nf_elem_zero, libantic), Nothing,
          (Ref{nf_elem}, Ref{AnticNumberField}), a, parent(a))
    return a
 end
 
 function mul!(z::nf_elem, x::nf_elem, y::nf_elem)
-   ccall((:nf_elem_mul, :libantic), Nothing,
+   ccall((:nf_elem_mul, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
                                                   z, x, y, parent(x))
    return z
@@ -786,21 +786,21 @@ end
 > eliminates associated garbage collection.
 """
 function mul_red!(z::nf_elem, x::nf_elem, y::nf_elem, red::Bool)
-   ccall((:nf_elem_mul_red, :libantic), Nothing,
+   ccall((:nf_elem_mul_red, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}, Cint),
                                                 z, x, y, parent(x), red)
    return z
 end
 
 function addeq!(z::nf_elem, x::nf_elem)
-   ccall((:nf_elem_add, :libantic), Nothing,
+   ccall((:nf_elem_add, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
                                                   z, z, x, parent(x))
    return z
 end
 
 function add!(a::nf_elem, b::nf_elem, c::nf_elem)
-   ccall((:nf_elem_add, :libantic), Nothing,
+   ccall((:nf_elem_add, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{nf_elem}, Ref{AnticNumberField}),
          a, b, c, a.parent)
   return a
@@ -814,7 +814,7 @@ end
 > functions automatically reduce their outputs.
 """
 function reduce!(x::nf_elem)
-   ccall((:nf_elem_reduce, :libantic), Nothing,
+   ccall((:nf_elem_reduce, libantic), Nothing,
          (Ref{nf_elem}, Ref{AnticNumberField}), x, parent(x))
    return x
 end
@@ -826,21 +826,21 @@ end
 ###############################################################################
 
 function add!(c::nf_elem, a::nf_elem, b::fmpq)
-   ccall((:nf_elem_add_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_add_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::fmpz)
-   ccall((:nf_elem_add_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_add_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function add!(c::nf_elem, a::nf_elem, b::Int)
-   ccall((:nf_elem_add_si, :libantic), Nothing,
+   ccall((:nf_elem_add_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
@@ -849,21 +849,21 @@ end
 add!(c::nf_elem, a::nf_elem, b::Integer) = add!(c, a, fmpz(b))
 
 function sub!(c::nf_elem, a::nf_elem, b::fmpq)
-   ccall((:nf_elem_sub_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_sub_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::fmpz)
-   ccall((:nf_elem_sub_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_sub_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::nf_elem, b::Int)
-   ccall((:nf_elem_sub_si, :libantic), Nothing,
+   ccall((:nf_elem_sub_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
@@ -872,21 +872,21 @@ end
 sub!(c::nf_elem, a::nf_elem, b::Integer) = sub!(c, a, fmpz(b))
 
 function sub!(c::nf_elem, a::fmpq, b::nf_elem)
-   ccall((:nf_elem_fmpq_sub, :libantic), Nothing,
+   ccall((:nf_elem_fmpq_sub, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpq}, Ref{nf_elem}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::fmpz, b::nf_elem)
-   ccall((:nf_elem_fmpz_sub, :libantic), Nothing,
+   ccall((:nf_elem_fmpz_sub, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpz}, Ref{nf_elem}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function sub!(c::nf_elem, a::Int, b::nf_elem)
-   ccall((:nf_elem_si_sub, :libantic), Nothing,
+   ccall((:nf_elem_si_sub, libantic), Nothing,
          (Ref{nf_elem}, Int, Ref{nf_elem}, Ref{AnticNumberField}),
          c, a, b, b.parent)
    return c
@@ -895,21 +895,21 @@ end
 sub!(c::nf_elem, a::Integer, b::nf_elem) = sub!(c, fmpz(a), b)
 
 function mul!(c::nf_elem, a::nf_elem, b::fmpq)
-   ccall((:nf_elem_scalar_mul_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::fmpz)
-   ccall((:nf_elem_scalar_mul_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
 end
 
 function mul!(c::nf_elem, a::nf_elem, b::Int)
-   ccall((:nf_elem_scalar_mul_si, :libantic), Nothing,
+   ccall((:nf_elem_scalar_mul_si, libantic), Nothing,
          (Ref{nf_elem}, Ref{nf_elem}, Int, Ref{AnticNumberField}),
          c, a, b, a.parent)
    return c
@@ -1073,7 +1073,7 @@ promote_rule(::Type{nf_elem}, ::Type{fmpq_poly}) = nf_elem
 """
 function (a::AnticNumberField)()
    z = nf_elem(a)
-   ccall((:nf_elem_set_si, :libantic), Nothing,
+   ccall((:nf_elem_set_si, libantic), Nothing,
          (Ref{nf_elem}, Int, Ref{AnticNumberField}), z, 0, a)
    return z
 end
@@ -1085,7 +1085,7 @@ end
 """
 function (a::AnticNumberField)(c::Int)
    z = nf_elem(a)
-   ccall((:nf_elem_set_si, :libantic), Nothing,
+   ccall((:nf_elem_set_si, libantic), Nothing,
          (Ref{nf_elem}, Int, Ref{AnticNumberField}), z, c, a)
    return z
 end
@@ -1094,14 +1094,14 @@ end
 
 function (a::AnticNumberField)(c::fmpz)
    z = nf_elem(a)
-   ccall((:nf_elem_set_fmpz, :libantic), Nothing,
+   ccall((:nf_elem_set_fmpz, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpz}, Ref{AnticNumberField}), z, c, a)
    return z
 end
 
 function (a::AnticNumberField)(c::fmpq)
    z = nf_elem(a)
-   ccall((:nf_elem_set_fmpq, :libantic), Nothing,
+   ccall((:nf_elem_set_fmpq, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpq}, Ref{AnticNumberField}), z, c, a)
    return z
 end
@@ -1119,7 +1119,7 @@ function (a::AnticNumberField)(pol::fmpq_poly)
    if length(pol) >= length(a.pol)
       pol = mod(pol, a.pol)
    end
-   ccall((:nf_elem_set_fmpq_poly, :libantic), Nothing,
+   ccall((:nf_elem_set_fmpq_poly, libantic), Nothing,
          (Ref{nf_elem}, Ref{fmpq_poly}, Ref{AnticNumberField}), z, pol, a)
    return z
 end
@@ -1127,7 +1127,7 @@ end
 function (a::FmpqPolyRing)(b::nf_elem)
    parent(parent(b).pol) != a && error("Cannot coerce from number field to polynomial ring")
    r = a()
-   ccall((:nf_elem_get_fmpq_poly, :libantic), Nothing,
+   ccall((:nf_elem_get_fmpq_poly, libantic), Nothing,
          (Ref{fmpq_poly}, Ref{nf_elem}, Ref{AnticNumberField}), r, b, parent(b))
    return r
 end

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -104,7 +104,7 @@ mutable struct arb <: FieldElem
 
   function arb()
     z = new()
-    ccall((:arb_init, :libarb), Nothing, (Ref{arb}, ), z)
+    ccall((:arb_init, libarb), Nothing, (Ref{arb}, ), z)
     finalizer(_arb_clear_fn, z)
     return z
   end
@@ -112,7 +112,7 @@ mutable struct arb <: FieldElem
   function arb(x::Union{Int, UInt, Float64, fmpz, fmpq,
                         BigFloat, AbstractString, arb}, p::Int)
     z = new()
-    ccall((:arb_init, :libarb), Nothing, (Ref{arb}, ), z)
+    ccall((:arb_init, libarb), Nothing, (Ref{arb}, ), z)
     _arb_set(z, x, p)
     finalizer(_arb_clear_fn, z)
     return z
@@ -120,7 +120,7 @@ mutable struct arb <: FieldElem
 
   function arb(x::Union{Int, UInt, Float64, fmpz, BigFloat, arb})
     z = new()
-    ccall((:arb_init, :libarb), Nothing, (Ref{arb}, ), z)
+    ccall((:arb_init, libarb), Nothing, (Ref{arb}, ), z)
     _arb_set(z, x)
     finalizer(_arb_clear_fn, z)
     return z
@@ -128,24 +128,24 @@ mutable struct arb <: FieldElem
 
   function arb(mid::arb, rad::arb)
     z = new()
-    ccall((:arb_init, :libarb), Nothing, (Ref{arb}, ), z)
-    ccall((:arb_set, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, mid)
-    ccall((:arb_add_error, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, rad)
+    ccall((:arb_init, libarb), Nothing, (Ref{arb}, ), z)
+    ccall((:arb_set, libarb), Nothing, (Ref{arb}, Ref{arb}), z, mid)
+    ccall((:arb_add_error, libarb), Nothing, (Ref{arb}, Ref{arb}), z, rad)
     finalizer(_arb_clear_fn, z)
     return z
   end
 
   #function arb(x::arf)
   #  z = new()
-  #  ccall((:arb_init, :libarb), Nothing, (Ref{arb}, ), z)
-  #  ccall((:arb_set_arf, :libarb), Nothing, (Ref{arb}, Ptr{arf}), z, x)
+  #  ccall((:arb_init, libarb), Nothing, (Ref{arb}, ), z)
+  #  ccall((:arb_set_arf, libarb), Nothing, (Ref{arb}, Ptr{arf}), z, x)
   #  finalizer(_arb_clear_fn, z)
   #  return z
   #end
 end
 
 function _arb_clear_fn(x::arb)
-  ccall((:arb_clear, :libarb), Nothing, (Ref{arb}, ), x)
+  ccall((:arb_clear, libarb), Nothing, (Ref{arb}, ), x)
 end
 
 ################################################################################
@@ -192,14 +192,14 @@ mutable struct acb <: FieldElem
 
   function acb()
     z = new()
-    ccall((:acb_init, :libarb), Nothing, (Ref{acb}, ), z)
+    ccall((:acb_init, libarb), Nothing, (Ref{acb}, ), z)
     finalizer(_acb_clear_fn, z)
     return z
   end
 
   function acb(x::Union{Int, UInt, Float64, fmpz, BigFloat, arb, acb})
     z = new()
-    ccall((:acb_init, :libarb), Nothing, (Ref{acb}, ), z)
+    ccall((:acb_init, libarb), Nothing, (Ref{acb}, ), z)
     _acb_set(z, x)
     finalizer(_acb_clear_fn, z)
     return z
@@ -208,7 +208,7 @@ mutable struct acb <: FieldElem
   function acb(x::Union{Int, UInt, Float64, fmpz, fmpq,
                         BigFloat, arb, acb, AbstractString}, p::Int)
     z = new()
-    ccall((:acb_init, :libarb), Nothing, (Ref{acb}, ), z)
+    ccall((:acb_init, libarb), Nothing, (Ref{acb}, ), z)
     _acb_set(z, x, p)
     finalizer(_acb_clear_fn, z)
     return z
@@ -216,7 +216,7 @@ mutable struct acb <: FieldElem
 
   #function acb{T <: Union{Int, UInt, Float64, fmpz, BigFloat, arb}}(x::T, y::T)
   #  z = new()
-  #  ccall((:acb_init, :libarb), Nothing, (Ref{acb}, ), z)
+  #  ccall((:acb_init, libarb), Nothing, (Ref{acb}, ), z)
   #  _acb_set(z, x, y)
   #  finalizer(_acb_clear_fn, z)
   #  return z
@@ -224,7 +224,7 @@ mutable struct acb <: FieldElem
 
   function acb(x::T, y::T, p::Int) where {T <: Union{Int, UInt, Float64, fmpz, fmpq, BigFloat, AbstractString, arb}}
     z = new()
-    ccall((:acb_init, :libarb), Nothing, (Ref{acb}, ), z)
+    ccall((:acb_init, libarb), Nothing, (Ref{acb}, ), z)
     _acb_set(z, x, y, p)
     finalizer(_acb_clear_fn, z)
     return z
@@ -232,7 +232,7 @@ mutable struct acb <: FieldElem
 end
 
 function _acb_clear_fn(x::acb)
-  ccall((:acb_clear, :libarb), Nothing, (Ref{acb}, ), x)
+  ccall((:acb_clear, libarb), Nothing, (Ref{acb}, ), x)
 end
 
 mutable struct acb_calc_integrate_opts
@@ -249,7 +249,7 @@ mutable struct acb_calc_integrate_opts
 
   function acb_calc_integrate_opts()
     opts = new()
-    ccall((:acb_calc_integrate_opt_init, :libarb),
+    ccall((:acb_calc_integrate_opt_init, libarb),
       Nothing, (Ref{acb_calc_integrate_opts}, ), opts)
     return opts
   end
@@ -288,15 +288,15 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly()
     z = new()
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
     finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function arb_poly(x::arb, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
-    ccall((:arb_poly_set_coeff_arb, :libarb), Nothing,
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set_coeff_arb, libarb), Nothing,
                 (Ref{arb_poly}, Int, Ref{arb}), z, 0, x)
     finalizer(_arb_poly_clear_fn, z)
     return z
@@ -304,9 +304,9 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly(x::Array{arb, 1}, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
     for i = 1:length(x)
-        ccall((:arb_poly_set_coeff_arb, :libarb), Nothing,
+        ccall((:arb_poly_set_coeff_arb, libarb), Nothing,
                 (Ref{arb_poly}, Int, Ref{arb}), z, i - 1, x[i])
     end
     finalizer(_arb_poly_clear_fn, z)
@@ -315,16 +315,16 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly(x::arb_poly)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
-    ccall((:arb_poly_set, :libarb), Nothing, (Ref{arb_poly}, Ref{arb_poly}), z, x)
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set, libarb), Nothing, (Ref{arb_poly}, Ref{arb_poly}), z, x)
     finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function arb_poly(x::arb_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
-    ccall((:arb_poly_set_round, :libarb), Nothing,
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set_round, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, p)
     finalizer(_arb_poly_clear_fn, z)
     return z
@@ -332,8 +332,8 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly(x::fmpz_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
-    ccall((:arb_poly_set_fmpz_poly, :libarb), Nothing,
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set_fmpz_poly, libarb), Nothing,
                 (Ref{arb_poly}, Ref{fmpz_poly}, Int), z, x, p)
     finalizer(_arb_poly_clear_fn, z)
     return z
@@ -341,8 +341,8 @@ mutable struct arb_poly <: PolyElem{arb}
 
   function arb_poly(x::fmpq_poly, p::Int)
     z = new() 
-    ccall((:arb_poly_init, :libarb), Nothing, (Ref{arb_poly}, ), z)
-    ccall((:arb_poly_set_fmpq_poly, :libarb), Nothing,
+    ccall((:arb_poly_init, libarb), Nothing, (Ref{arb_poly}, ), z)
+    ccall((:arb_poly_set_fmpq_poly, libarb), Nothing,
                 (Ref{arb_poly}, Ref{fmpq_poly}, Int), z, x, p)
     finalizer(_arb_poly_clear_fn, z)
     return z
@@ -350,7 +350,7 @@ mutable struct arb_poly <: PolyElem{arb}
 end
 
 function _arb_poly_clear_fn(x::arb_poly)
-  ccall((:arb_poly_clear, :libarb), Nothing, (Ref{arb_poly}, ), x)
+  ccall((:arb_poly_clear, libarb), Nothing, (Ref{arb_poly}, ), x)
 end
 
 parent(x::arb_poly) = x.parent
@@ -396,15 +396,15 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly()
     z = new()
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
     finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function acb_poly(x::acb, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set_coeff_acb, :libarb), Nothing,
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set_coeff_acb, libarb), Nothing,
                 (Ref{acb_poly}, Int, Ref{acb}), z, 0, x)
     finalizer(_acb_poly_clear_fn, z)
     return z
@@ -412,9 +412,9 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::Array{acb, 1}, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
     for i = 1:length(x)
-        ccall((:acb_poly_set_coeff_acb, :libarb), Nothing,
+        ccall((:acb_poly_set_coeff_acb, libarb), Nothing,
                 (Ref{acb_poly}, Int, Ref{acb}), z, i - 1, x[i])
     end
     finalizer(_acb_poly_clear_fn, z)
@@ -423,18 +423,18 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::acb_poly)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set, :libarb), Nothing, (Ref{acb_poly}, Ref{acb_poly}), z, x)
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set, libarb), Nothing, (Ref{acb_poly}, Ref{acb_poly}), z, x)
     finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function acb_poly(x::arb_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set_arb_poly, :libarb), Nothing,
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set_arb_poly, libarb), Nothing,
                 (Ref{acb_poly}, Ref{arb_poly}, Int), z, x, p)
-    ccall((:acb_poly_set_round, :libarb), Nothing,
+    ccall((:acb_poly_set_round, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, z, p)
     finalizer(_acb_poly_clear_fn, z)
     return z
@@ -442,8 +442,8 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::acb_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set_round, :libarb), Nothing,
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set_round, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, p)
     finalizer(_acb_poly_clear_fn, z)
     return z
@@ -451,8 +451,8 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::fmpz_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set_fmpz_poly, :libarb), Nothing,
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set_fmpz_poly, libarb), Nothing,
                 (Ref{acb_poly}, Ref{fmpz_poly}, Int), z, x, p)
     finalizer(_acb_poly_clear_fn, z)
     return z
@@ -460,8 +460,8 @@ mutable struct acb_poly <: PolyElem{acb}
 
   function acb_poly(x::fmpq_poly, p::Int)
     z = new() 
-    ccall((:acb_poly_init, :libarb), Nothing, (Ref{acb_poly}, ), z)
-    ccall((:acb_poly_set_fmpq_poly, :libarb), Nothing,
+    ccall((:acb_poly_init, libarb), Nothing, (Ref{acb_poly}, ), z)
+    ccall((:acb_poly_set_fmpq_poly, libarb), Nothing,
                 (Ref{acb_poly}, Ref{fmpq_poly}, Int), z, x, p)
     finalizer(_acb_poly_clear_fn, z)
     return z
@@ -469,7 +469,7 @@ mutable struct acb_poly <: PolyElem{acb}
 end
 
 function _acb_poly_clear_fn(x::acb_poly)
-  ccall((:acb_poly_clear, :libarb), Nothing, (Ref{acb_poly}, ), x)
+  ccall((:acb_poly_clear, libarb), Nothing, (Ref{acb_poly}, ), x)
 end
 
 parent(x::acb_poly) = x.parent
@@ -517,16 +517,16 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(r::Int, c::Int)
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing, (Ref{arb_mat}, Int, Int), z, r, c)
+    ccall((:arb_mat_init, libarb), Nothing, (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(_arb_mat_clear_fn, z)
     return z
   end
 
   function arb_mat(a::fmpz_mat)
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing,
+    ccall((:arb_mat_init, libarb), Nothing,
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:arb_mat_set_fmpz_mat, :libarb), Nothing,
+    ccall((:arb_mat_set_fmpz_mat, libarb), Nothing,
                 (Ref{arb_mat}, Ref{fmpz_mat}), z, a)
     finalizer(_arb_mat_clear_fn, z)
     return z
@@ -534,9 +534,9 @@ mutable struct arb_mat <: MatElem{arb}
   
   function arb_mat(a::fmpz_mat, prec::Int)
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing,
+    ccall((:arb_mat_init, libarb), Nothing,
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:arb_mat_set_round_fmpz_mat, :libarb), Nothing,
+    ccall((:arb_mat_set_round_fmpz_mat, libarb), Nothing,
                 (Ref{arb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
     finalizer(_arb_mat_clear_fn, z)
     return z
@@ -544,12 +544,12 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}) where {T <: Union{Int, UInt, fmpz, Float64, BigFloat, arb}}
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing, 
+    ccall((:arb_mat_init, libarb), Nothing, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(_arb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+        el = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[i, j])
       end
@@ -559,12 +559,12 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}) where {T <: Union{Int, UInt, fmpz, Float64, BigFloat, arb}}
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing, 
+    ccall((:arb_mat_init, libarb), Nothing, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(_arb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+        el = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         Nemo._arb_set(el, arr[(i-1)*c+j])
       end
@@ -574,12 +574,12 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing, 
+    ccall((:arb_mat_init, libarb), Nothing, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(_arb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+        el = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[i, j], prec)
       end
@@ -589,12 +589,12 @@ mutable struct arb_mat <: MatElem{arb}
      
   function arb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString}}
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing, 
+    ccall((:arb_mat_init, libarb), Nothing, 
                 (Ref{arb_mat}, Int, Int), z, r, c)
     finalizer(_arb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+        el = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                     (Ref{arb_mat}, Int, Int), z, i - 1, j - 1)
         _arb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -604,9 +604,9 @@ mutable struct arb_mat <: MatElem{arb}
 
   function arb_mat(a::fmpq_mat, prec::Int)
     z = new()
-    ccall((:arb_mat_init, :libarb), Nothing,
+    ccall((:arb_mat_init, libarb), Nothing,
                 (Ref{arb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:arb_mat_set_fmpq_mat, :libarb), Nothing,
+    ccall((:arb_mat_set_fmpq_mat, libarb), Nothing,
                 (Ref{arb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
     finalizer(_arb_mat_clear_fn, z)
     return z
@@ -614,7 +614,7 @@ mutable struct arb_mat <: MatElem{arb}
 end
 
 function _arb_mat_clear_fn(x::arb_mat)
-  ccall((:arb_mat_clear, :libarb), Nothing, (Ref{arb_mat}, ), x)
+  ccall((:arb_mat_clear, libarb), Nothing, (Ref{arb_mat}, ), x)
 end
 
 ################################################################################
@@ -652,16 +652,16 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, (Ref{acb_mat}, Int, Int), z, r, c)
+    ccall((:acb_mat_init, libarb), Nothing, (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function acb_mat(a::fmpz_mat)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing,
+    ccall((:acb_mat_init, libarb), Nothing,
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:acb_mat_set_fmpz_mat, :libarb), Nothing,
+    ccall((:acb_mat_set_fmpz_mat, libarb), Nothing,
                 (Ref{acb_mat}, Ref{fmpz_mat}), z, a)
     finalizer(_acb_mat_clear_fn, z)
     return z
@@ -669,9 +669,9 @@ mutable struct acb_mat <: MatElem{acb}
   
   function acb_mat(a::fmpz_mat, prec::Int)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing,
+    ccall((:acb_mat_init, libarb), Nothing,
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:acb_mat_set_round_fmpz_mat, :libarb), Nothing,
+    ccall((:acb_mat_set_round_fmpz_mat, libarb), Nothing,
                 (Ref{acb_mat}, Ref{fmpz_mat}, Int), z, a, prec)
     finalizer(_acb_mat_clear_fn, z)
     return z
@@ -679,9 +679,9 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(a::arb_mat)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing,
+    ccall((:acb_mat_init, libarb), Nothing,
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:acb_mat_set_arb_mat, :libarb), Nothing,
+    ccall((:acb_mat_set_arb_mat, libarb), Nothing,
                 (Ref{acb_mat}, Ref{arb_mat}), z, a)
     finalizer(_acb_mat_clear_fn, z)
     return z
@@ -689,9 +689,9 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(a::arb_mat, prec::Int)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing,
+    ccall((:acb_mat_init, libarb), Nothing,
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:acb_mat_set_round_arb_mat, :libarb), Nothing,
+    ccall((:acb_mat_set_round_arb_mat, libarb), Nothing,
                 (Ref{acb_mat}, Ref{arb_mat}, Int), z, a, prec)
     finalizer(_acb_mat_clear_fn, z)
     return z
@@ -699,12 +699,12 @@ mutable struct acb_mat <: MatElem{acb}
    
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}) where {T <: Union{Int, UInt, Float64, fmpz}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
@@ -714,12 +714,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}) where {T <: Union{BigFloat, acb, arb}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j])
       end
@@ -729,12 +729,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}) where {T <: Union{Int, UInt, Float64, fmpz}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
@@ -744,12 +744,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}) where {T <: Union{BigFloat, acb, arb}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j])
       end
@@ -759,12 +759,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
@@ -774,12 +774,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 2}, prec::Int) where {T <: Union{BigFloat, arb, AbstractString, acb}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j], prec)
       end
@@ -789,12 +789,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}, prec::Int) where {T <: Union{Int, UInt, fmpz, fmpq, Float64}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -804,12 +804,12 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(r::Int, c::Int, arr::AbstractArray{T, 1}, prec::Int) where {T <: Union{BigFloat, arb, AbstractString, acb}}
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j], prec)
       end
@@ -820,12 +820,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::AbstractArray{Tuple{T, T}, 2}, prec::Int) where {T <: Union{Int, UInt, Float64, fmpz}}
 
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
@@ -836,12 +836,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::AbstractArray{Tuple{T, T}, 2}, prec::Int) where {T <: Union{fmpq, BigFloat, arb, AbstractString}}
 
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
       end
@@ -852,12 +852,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::AbstractArray{Tuple{T, T}, 1}, prec::Int) where {T <: Union{Int, UInt, Float64, fmpz}}
 
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
@@ -868,12 +868,12 @@ mutable struct acb_mat <: MatElem{acb}
   function acb_mat(r::Int, c::Int, arr::AbstractArray{Tuple{T, T}, 1}, prec::Int) where {T <: Union{fmpq, BigFloat, arb, AbstractString}}
 
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing, 
+    ccall((:acb_mat_init, libarb), Nothing, 
                 (Ref{acb_mat}, Int, Int), z, r, c)
     finalizer(_acb_mat_clear_fn, z)
     GC.@preserve z for i = 1:r
       for j = 1:c
-        el = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+        el = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                     (Ref{acb_mat}, Int, Int), z, i - 1, j - 1)
         _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
@@ -883,9 +883,9 @@ mutable struct acb_mat <: MatElem{acb}
 
   function acb_mat(a::fmpq_mat, prec::Int)
     z = new()
-    ccall((:acb_mat_init, :libarb), Nothing,
+    ccall((:acb_mat_init, libarb), Nothing,
                 (Ref{acb_mat}, Int, Int), z, a.r, a.c)
-    ccall((:acb_mat_set_fmpq_mat, :libarb), Nothing,
+    ccall((:acb_mat_set_fmpq_mat, libarb), Nothing,
                 (Ref{acb_mat}, Ref{fmpq_mat}, Int), z, a, prec)
     finalizer(_acb_mat_clear_fn, z)
     return z
@@ -893,6 +893,6 @@ mutable struct acb_mat <: MatElem{acb}
 end
 
 function _acb_mat_clear_fn(x::acb_mat)
-  ccall((:acb_mat_clear, :libarb), Nothing, (Ref{acb_mat}, ), x)
+  ccall((:acb_mat_clear, libarb), Nothing, (Ref{acb_mat}, ), x)
 end
 

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -73,7 +73,7 @@ end
 """
 function one(r::AcbField)
   z = acb()
-  ccall((:acb_one, :libarb), Nothing, (Ref{acb}, ), z)
+  ccall((:acb_one, libarb), Nothing, (Ref{acb}, ), z)
   z.parent = r
   return z
 end
@@ -84,7 +84,7 @@ end
 """
 function onei(r::AcbField)
   z = acb()
-  ccall((:acb_onei, :libarb), Nothing, (Ref{acb}, ), z)
+  ccall((:acb_onei, libarb), Nothing, (Ref{acb}, ), z)
   z.parent = r
   return z
 end
@@ -96,12 +96,12 @@ end
 """
 function accuracy_bits(x::acb)
   # bug in acb.h: rel_accuracy_bits is not in the library
-  return -ccall((:acb_rel_error_bits, :libarb), Int, (Ref{acb},), x)
+  return -ccall((:acb_rel_error_bits, libarb), Int, (Ref{acb},), x)
 end
 
 function deepcopy_internal(a::acb, dict::IdDict)
   b = parent(a)()
-  ccall((:acb_set, :libarb), Nothing, (Ref{acb}, Ref{acb}), b, a)
+  ccall((:acb_set, libarb), Nothing, (Ref{acb}, Ref{acb}), b, a)
   return b
 end
 
@@ -126,13 +126,13 @@ characteristic(::AcbField) = 0
 
 function convert(::Type{ComplexF64}, x::acb)
     GC.@preserve x begin
-      re = ccall((:acb_real_ptr, :libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
-      im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
-      t = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), re)
-      u = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ptr{arb}, ), im)
+      re = ccall((:acb_real_ptr, libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
+      im = ccall((:acb_imag_ptr, libarb), Ptr{arb_struct}, (Ref{acb}, ), x)
+      t = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ptr{arb}, ), re)
+      u = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ptr{arb}, ), im)
       # 4 == round to nearest
-      v = ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
-      w = ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), u, 4)
+      v = ccall((:arf_get_d, libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
+      w = ccall((:arf_get_d, libarb), Float64, (Ptr{arf_struct}, Int), u, 4)
     end
     return complex(v, w)
 end
@@ -149,7 +149,7 @@ end
 """
 function real(x::acb)
   z = arb()
-  ccall((:acb_get_real, :libarb), Nothing, (Ref{arb}, Ref{acb}), z, x)
+  ccall((:acb_get_real, libarb), Nothing, (Ref{arb}, Ref{acb}), z, x)
   z.parent = ArbField(parent(x).prec)
   return z
 end
@@ -160,7 +160,7 @@ end
 """
 function imag(x::acb)
   z = arb()
-  ccall((:acb_get_imag, :libarb), Nothing, (Ref{arb}, Ref{acb}), z, x)
+  ccall((:acb_get_imag, libarb), Nothing, (Ref{arb}, Ref{acb}), z, x)
   z.parent = ArbField(parent(x).prec)
   return z
 end
@@ -195,7 +195,7 @@ show_minus_one(::Type{acb}) = true
 
 function -(x::acb)
   z = parent(x)()
-  ccall((:acb_neg, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
+  ccall((:acb_neg, libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
   return z
 end
 
@@ -211,7 +211,7 @@ for (s,f) in ((:+,"acb_add"), (:*,"acb_mul"), (://, "acb_div"), (:-,"acb_sub"), 
   @eval begin
     function ($s)(x::acb, y::acb)
       z = parent(x)()
-      ccall(($f, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+      ccall(($f, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
                            z, x, y, parent(x).prec)
       return z
     end
@@ -223,7 +223,7 @@ for (f,s) in ((:+, "add"), (:-, "sub"), (:*, "mul"), (://, "div"), (:^, "pow"))
 
     function ($f)(x::acb, y::UInt)
       z = parent(x)()
-      ccall(($("acb_"*s*"_ui"), :libarb), Nothing,
+      ccall(($("acb_"*s*"_ui"), libarb), Nothing,
                   (Ref{acb}, Ref{acb}, UInt, Int),
                   z, x, y, parent(x).prec)
       return z
@@ -231,14 +231,14 @@ for (f,s) in ((:+, "add"), (:-, "sub"), (:*, "mul"), (://, "div"), (:^, "pow"))
 
     function ($f)(x::acb, y::Int)
       z = parent(x)()
-      ccall(($("acb_"*s*"_si"), :libarb), Nothing,
+      ccall(($("acb_"*s*"_si"), libarb), Nothing,
       (Ref{acb}, Ref{acb}, Int, Int), z, x, y, parent(x).prec)
       return z
     end
 
     function ($f)(x::acb, y::fmpz)
       z = parent(x)()
-      ccall(($("acb_"*s*"_fmpz"), :libarb), Nothing,
+      ccall(($("acb_"*s*"_fmpz"), libarb), Nothing,
                   (Ref{acb}, Ref{acb}, Ref{fmpz}, Int),
                   z, x, y, parent(x).prec)
       return z
@@ -246,7 +246,7 @@ for (f,s) in ((:+, "add"), (:-, "sub"), (:*, "mul"), (://, "div"), (:^, "pow"))
 
     function ($f)(x::acb, y::arb)
       z = parent(x)()
-      ccall(($("acb_"*s*"_arb"), :libarb), Nothing,
+      ccall(($("acb_"*s*"_arb"), libarb), Nothing,
                   (Ref{acb}, Ref{acb}, Ref{arb}, Int),
                   z, x, y, parent(x).prec)
       return z
@@ -278,29 +278,29 @@ end
 
 function -(x::UInt, y::acb)
   z = parent(y)()
-  ccall((:acb_sub_ui, :libarb), Nothing, (Ref{acb}, Ref{acb}, UInt, Int), z, y, x, parent(y).prec)
-  ccall((:acb_neg, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
+  ccall((:acb_sub_ui, libarb), Nothing, (Ref{acb}, Ref{acb}, UInt, Int), z, y, x, parent(y).prec)
+  ccall((:acb_neg, libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
   return z
 end
 
 function -(x::Int, y::acb)
   z = parent(y)()
-  ccall((:acb_sub_si, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int, Int), z, y, x, parent(y).prec)
-  ccall((:acb_neg, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
+  ccall((:acb_sub_si, libarb), Nothing, (Ref{acb}, Ref{acb}, Int, Int), z, y, x, parent(y).prec)
+  ccall((:acb_neg, libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
   return z
 end
 
 function -(x::fmpz, y::acb)
   z = parent(y)()
-  ccall((:acb_sub_fmpz, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{fmpz}, Int), z, y, x, parent(y).prec)
-  ccall((:acb_neg, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
+  ccall((:acb_sub_fmpz, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{fmpz}, Int), z, y, x, parent(y).prec)
+  ccall((:acb_neg, libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
   return z
 end
 
 function -(x::arb, y::acb)
   z = parent(y)()
-  ccall((:acb_sub_arb, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{arb}, Int), z, y, x, parent(y).prec)
-  ccall((:acb_neg, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
+  ccall((:acb_sub_arb, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{arb}, Int), z, y, x, parent(y).prec)
+  ccall((:acb_neg, libarb), Nothing, (Ref{acb}, Ref{acb}), z, z)
   return z
 end
 
@@ -411,17 +411,17 @@ divexact(x::acb, y::Rational{T}) where {T <: Integer} = x // y
 > and imaginary parts have the same midpoints and radii.
 """
 function isequal(x::acb, y::acb)
-  r = ccall((:acb_equal, :libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
+  r = ccall((:acb_equal, libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
   return Bool(r)
 end
 
 function ==(x::acb, y::acb)
-  r = ccall((:acb_eq, :libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
+  r = ccall((:acb_eq, libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
   return Bool(r)
 end
 
 function !=(x::acb, y::acb)
-  r = ccall((:acb_ne, :libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
+  r = ccall((:acb_ne, libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
   return Bool(r)
 end
 
@@ -464,7 +464,7 @@ end
 > otherwise return `false`.
 """
 function overlaps(x::acb, y::acb)
-  r = ccall((:acb_overlaps, :libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
+  r = ccall((:acb_overlaps, libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
   return Bool(r)
 end
 
@@ -474,7 +474,7 @@ end
 > `false`.
 """
 function contains(x::acb, y::acb)
-  r = ccall((:acb_contains, :libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
+  r = ccall((:acb_contains, libarb), Cint, (Ref{acb}, Ref{acb}), x, y)
   return Bool(r)
 end
 
@@ -484,7 +484,7 @@ end
 > return `false`.
 """
 function contains(x::acb, y::fmpq)
-  r = ccall((:acb_contains_fmpq, :libarb), Cint, (Ref{acb}, Ref{fmpq}), x, y)
+  r = ccall((:acb_contains_fmpq, libarb), Cint, (Ref{acb}, Ref{fmpq}), x, y)
   return Bool(r)
 end
 
@@ -494,13 +494,13 @@ end
 > return `false`.
 """
 function contains(x::acb, y::fmpz)
-  r = ccall((:acb_contains_fmpz, :libarb), Cint, (Ref{acb}, Ref{fmpz}), x, y)
+  r = ccall((:acb_contains_fmpz, libarb), Cint, (Ref{acb}, Ref{fmpz}), x, y)
   return Bool(r)
 end
 
 function contains(x::acb, y::Int)
   v = fmpz(y)
-  r = ccall((:acb_contains_fmpz, :libarb), Cint, (Ref{acb}, Ref{fmpz}), x, v)
+  r = ccall((:acb_contains_fmpz, libarb), Cint, (Ref{acb}, Ref{fmpz}), x, v)
   return Bool(r)
 end
 
@@ -523,7 +523,7 @@ contains(x::acb, y::Rational{T}) where {T <: Integer} = contains(x, fmpz(y))
 > Returns `true` if the box $x$ contains zero, otherwise return `false`.
 """
 function contains_zero(x::acb)
-   return Bool(ccall((:acb_contains_zero, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_contains_zero, libarb), Cint, (Ref{acb},), x))
 end
 
 ################################################################################
@@ -541,7 +541,7 @@ end
 > Return `true` if $x$ is certainly zero, otherwise return `false`.
 """
 function iszero(x::acb)
-   return Bool(ccall((:acb_is_zero, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_zero, libarb), Cint, (Ref{acb},), x))
 end
 
 @doc Markdown.doc"""
@@ -549,7 +549,7 @@ end
 > Return `true` if $x$ is certainly zero, otherwise return `false`.
 """
 function isone(x::acb)
-   return Bool(ccall((:acb_is_one, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_one, libarb), Cint, (Ref{acb},), x))
 end
 
 @doc Markdown.doc"""
@@ -558,7 +558,7 @@ end
 > midpoint and radius, otherwise return `false`.
 """
 function isfinite(x::acb)
-   return Bool(ccall((:acb_is_finite, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_finite, libarb), Cint, (Ref{acb},), x))
 end
 
 @doc Markdown.doc"""
@@ -567,7 +567,7 @@ end
 > zero radius, otherwise return `false`.
 """
 function isexact(x::acb)
-   return Bool(ccall((:acb_is_exact, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_exact, libarb), Cint, (Ref{acb},), x))
 end
 
 @doc Markdown.doc"""
@@ -575,7 +575,7 @@ end
 > Return `true` if $x$ is an exact integer, otherwise return `false`.
 """
 function isint(x::acb)
-   return Bool(ccall((:acb_is_int, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_int, libarb), Cint, (Ref{acb},), x))
 end
 
 @doc Markdown.doc"""
@@ -584,7 +584,7 @@ end
 > otherwise return `false`.
 """
 function isreal(x::acb)
-   return Bool(ccall((:acb_is_real, :libarb), Cint, (Ref{acb},), x))
+   return Bool(ccall((:acb_is_real, libarb), Cint, (Ref{acb},), x))
 end
 
 isnegative(x::acb) = isreal(x) && isnegative(real(x))
@@ -601,7 +601,7 @@ isnegative(x::acb) = isreal(x) && isnegative(real(x))
 """
 function abs(x::acb)
   z = arb()
-  ccall((:acb_abs, :libarb), Nothing,
+  ccall((:acb_abs, libarb), Nothing,
                 (Ref{arb}, Ref{acb}, Int), z, x, parent(x).prec)
   z.parent = ArbField(parent(x).prec)
   return z
@@ -619,7 +619,7 @@ end
 """
 function inv(x::acb)
   z = parent(x)()
-  ccall((:acb_inv, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+  ccall((:acb_inv, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
   return z
 end
 
@@ -635,7 +635,7 @@ end
 """
 function ldexp(x::acb, y::Int)
   z = parent(x)()
-  ccall((:acb_mul_2exp_si, :libarb), Nothing,
+  ccall((:acb_mul_2exp_si, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Int), z, x, y)
   return z
 end
@@ -646,7 +646,7 @@ end
 """
 function ldexp(x::acb, y::fmpz)
   z = parent(x)()
-  ccall((:acb_mul_2exp_fmpz, :libarb), Nothing,
+  ccall((:acb_mul_2exp_fmpz, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -664,7 +664,7 @@ end
 """
 function trim(x::acb)
   z = parent(x)()
-  ccall((:acb_trim, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
+  ccall((:acb_trim, libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
   return z
 end
 
@@ -677,7 +677,7 @@ end
 """
 function unique_integer(x::acb)
   z = fmpz()
-  unique = ccall((:acb_get_unique_fmpz, :libarb), Int,
+  unique = ccall((:acb_get_unique_fmpz, libarb), Int,
     (Ref{fmpz}, Ref{acb}), z, x)
   return (unique != 0, z)
 end
@@ -688,7 +688,7 @@ end
 """
 function conj(x::acb)
   z = parent(x)()
-  ccall((:acb_conj, :libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
+  ccall((:acb_conj, libarb), Nothing, (Ref{acb}, Ref{acb}), z, x)
   return z
 end
 
@@ -699,7 +699,7 @@ end
 """
 function angle(x::acb)
   z = arb()
-  ccall((:acb_arg, :libarb), Nothing,
+  ccall((:acb_arg, libarb), Nothing,
                 (Ref{arb}, Ref{acb}, Int), z, x, parent(x).prec)
   z.parent = ArbField(parent(x).prec)
   return z
@@ -717,7 +717,7 @@ end
 """
 function const_pi(r::AcbField)
   z = r()
-  ccall((:acb_const_pi, :libarb), Nothing, (Ref{acb}, Int), z, prec(r))
+  ccall((:acb_const_pi, libarb), Nothing, (Ref{acb}, Int), z, prec(r))
   return z
 end
 
@@ -735,7 +735,7 @@ end
 """
 function Base.sqrt(x::acb)
    z = parent(x)()
-   ccall((:acb_sqrt, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_sqrt, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -745,7 +745,7 @@ end
 """
 function rsqrt(x::acb)
    z = parent(x)()
-   ccall((:acb_rsqrt, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_rsqrt, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -756,7 +756,7 @@ end
 """
 function log(x::acb)
    z = parent(x)()
-   ccall((:acb_log, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_log, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -766,7 +766,7 @@ end
 """
 function log1p(x::acb)
    z = parent(x)()
-   ccall((:acb_log1p, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_log1p, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -776,7 +776,7 @@ end
 """
 function Base.exp(x::acb)
    z = parent(x)()
-   ccall((:acb_exp, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_exp, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -786,7 +786,7 @@ end
 """
 function exppii(x::acb)
    z = parent(x)()
-   ccall((:acb_exp_pi_i, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_exp_pi_i, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -796,7 +796,7 @@ end
 """
 function sin(x::acb)
    z = parent(x)()
-   ccall((:acb_sin, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_sin, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -806,7 +806,7 @@ end
 """
 function cos(x::acb)
    z = parent(x)()
-   ccall((:acb_cos, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_cos, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -816,7 +816,7 @@ end
 """
 function tan(x::acb)
    z = parent(x)()
-   ccall((:acb_tan, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_tan, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -826,7 +826,7 @@ end
 """
 function cot(x::acb)
    z = parent(x)()
-   ccall((:acb_cot, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_cot, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -836,7 +836,7 @@ end
 """
 function sinpi(x::acb)
    z = parent(x)()
-   ccall((:acb_sin_pi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_sin_pi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -846,7 +846,7 @@ end
 """
 function cospi(x::acb)
    z = parent(x)()
-   ccall((:acb_cos_pi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_cos_pi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -856,7 +856,7 @@ end
 """
 function tanpi(x::acb)
    z = parent(x)()
-   ccall((:acb_tan_pi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_tan_pi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -866,7 +866,7 @@ end
 """
 function cotpi(x::acb)
    z = parent(x)()
-   ccall((:acb_cot_pi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_cot_pi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -876,7 +876,7 @@ end
 """
 function sinh(x::acb)
    z = parent(x)()
-   ccall((:acb_sinh, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_sinh, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -886,7 +886,7 @@ end
 """
 function cosh(x::acb)
    z = parent(x)()
-   ccall((:acb_cosh, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_cosh, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -896,7 +896,7 @@ end
 """
 function tanh(x::acb)
    z = parent(x)()
-   ccall((:acb_tanh, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_tanh, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -906,7 +906,7 @@ end
 """
 function coth(x::acb)
    z = parent(x)()
-   ccall((:acb_coth, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_coth, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -916,7 +916,7 @@ end
 """
 function atan(x::acb)
    z = parent(x)()
-   ccall((:acb_atan, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_atan, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -926,7 +926,7 @@ end
 """
 function logsinpi(x::acb)
    z = parent(x)()
-   ccall((:acb_log_sin_pi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_log_sin_pi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -936,7 +936,7 @@ end
 """
 function gamma(x::acb)
    z = parent(x)()
-   ccall((:acb_gamma, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_gamma, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -946,7 +946,7 @@ end
 """
 function rgamma(x::acb)
    z = parent(x)()
-   ccall((:acb_rgamma, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_rgamma, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -956,7 +956,7 @@ end
 """
 function lgamma(x::acb)
    z = parent(x)()
-   ccall((:acb_lgamma, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_lgamma, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -967,7 +967,7 @@ end
 """
 function digamma(x::acb)
    z = parent(x)()
-   ccall((:acb_digamma, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_digamma, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -977,7 +977,7 @@ end
 """
 function zeta(x::acb)
    z = parent(x)()
-   ccall((:acb_zeta, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_zeta, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -987,7 +987,7 @@ end
 """
 function barnesg(x::acb)
    z = parent(x)()
-   ccall((:acb_barnes_g, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_barnes_g, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -997,7 +997,7 @@ end
 """
 function logbarnesg(x::acb)
    z = parent(x)()
-   ccall((:acb_log_barnes_g, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_log_barnes_g, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1007,7 +1007,7 @@ end
 """
 function agm(x::acb)
    z = parent(x)()
-   ccall((:acb_agm1, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_agm1, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1017,7 +1017,7 @@ end
 """
 function erf(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_erf, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_erf, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1027,7 +1027,7 @@ end
 """
 function erfi(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_erfi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_erfi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1037,7 +1037,7 @@ end
 """
 function erfc(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_erfc, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_erfc, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1047,7 +1047,7 @@ end
 """
 function ei(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_ei, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_ei, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1057,7 +1057,7 @@ end
 """
 function si(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_si, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_si, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1067,7 +1067,7 @@ end
 """
 function ci(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_ci, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_ci, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1077,7 +1077,7 @@ end
 """
 function shi(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_shi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_shi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1087,7 +1087,7 @@ end
 """
 function chi(x::acb)
    z = parent(x)()
-   ccall((:acb_hypgeom_chi, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_hypgeom_chi, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1097,7 +1097,7 @@ end
 """
 function modeta(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_eta, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_eta, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1141,7 +1141,7 @@ end
 """
 function modj(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_j, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_j, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1151,7 +1151,7 @@ end
 """
 function modlambda(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_lambda, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_lambda, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1161,7 +1161,7 @@ end
 """
 function moddelta(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_delta, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_delta, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1171,7 +1171,7 @@ end
 """
 function ellipk(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_elliptic_k, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_elliptic_k, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1181,7 +1181,7 @@ end
 """
 function ellipe(x::acb)
    z = parent(x)()
-   ccall((:acb_modular_elliptic_e, :libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
+   ccall((:acb_modular_elliptic_e, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1192,7 +1192,7 @@ end
 function sincos(x::acb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:acb_sin_cos, :libarb), Nothing,
+  ccall((:acb_sin_cos, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1204,7 +1204,7 @@ end
 function sincospi(x::acb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:acb_sin_cos_pi, :libarb), Nothing,
+  ccall((:acb_sin_cos_pi, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1216,7 +1216,7 @@ end
 function sinhcosh(x::acb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:acb_sinh_cosh, :libarb), Nothing,
+  ccall((:acb_sinh_cosh, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1227,7 +1227,7 @@ end
 """
 function zeta(s::acb, a::acb)
   z = parent(s)()
-  ccall((:acb_hurwitz_zeta, :libarb), Nothing,
+  ccall((:acb_hurwitz_zeta, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, s, a, parent(s).prec)
   return z
 end
@@ -1238,14 +1238,14 @@ end
 """
 function polygamma(s::acb, a::acb)
   z = parent(s)()
-  ccall((:acb_polygamma, :libarb), Nothing,
+  ccall((:acb_polygamma, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, s, a, parent(s).prec)
   return z
 end
 
 function risingfac(x::acb, n::UInt)
   z = parent(x)()
-  ccall((:acb_rising_ui, :libarb), Nothing,
+  ccall((:acb_rising_ui, libarb), Nothing,
               (Ref{acb}, Ref{acb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
@@ -1262,7 +1262,7 @@ end
 function risingfac2(x::acb, n::UInt)
   z = parent(x)()
   w = parent(x)()
-  ccall((:acb_rising2_ui, :libarb), Nothing,
+  ccall((:acb_rising2_ui, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, UInt, Int), z, w, x, n, parent(x).prec)
   return (z, w)
 end
@@ -1283,7 +1283,7 @@ end
 """
 function polylog(s::acb, a::acb)
   z = parent(s)()
-  ccall((:acb_polylog, :libarb), Nothing,
+  ccall((:acb_polylog, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, s, a, parent(s).prec)
   return z
 end
@@ -1294,7 +1294,7 @@ end
 """
 function polylog(s::Int, a::acb)
   z = parent(a)()
-  ccall((:acb_polylog_si, :libarb), Nothing,
+  ccall((:acb_polylog_si, libarb), Nothing,
               (Ref{acb}, Int, Ref{acb}, Int), z, s, a, parent(a).prec)
   return z
 end
@@ -1305,7 +1305,7 @@ end
 """
 function li(x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_li, :libarb), Nothing,
+  ccall((:acb_hypgeom_li, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Int, Int), z, x, 0, parent(x).prec)
   return z
 end
@@ -1316,7 +1316,7 @@ end
 """
 function lioffset(x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_li, :libarb), Nothing,
+  ccall((:acb_hypgeom_li, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Int, Int), z, x, 1, parent(x).prec)
   return z
 end
@@ -1327,7 +1327,7 @@ end
 """
 function expint(s::acb, x::acb)
   z = parent(s)()
-  ccall((:acb_hypgeom_expint, :libarb), Nothing,
+  ccall((:acb_hypgeom_expint, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, s, x, parent(s).prec)
   return z
 end
@@ -1338,7 +1338,7 @@ end
 """
 function gamma(s::acb, x::acb)
   z = parent(s)()
-  ccall((:acb_hypgeom_gamma_upper, :libarb), Nothing,
+  ccall((:acb_hypgeom_gamma_upper, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 0, parent(s).prec)
   return z
 end
@@ -1349,7 +1349,7 @@ end
 """
 function besselj(nu::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_bessel_j, :libarb), Nothing,
+  ccall((:acb_hypgeom_bessel_j, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, nu, x, parent(x).prec)
   return z
 end
@@ -1360,7 +1360,7 @@ end
 """
 function bessely(nu::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_bessel_y, :libarb), Nothing,
+  ccall((:acb_hypgeom_bessel_y, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, nu, x, parent(x).prec)
   return z
 end
@@ -1371,7 +1371,7 @@ end
 """
 function besseli(nu::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_bessel_i, :libarb), Nothing,
+  ccall((:acb_hypgeom_bessel_i, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, nu, x, parent(x).prec)
   return z
 end
@@ -1382,7 +1382,7 @@ end
 """
 function besselk(nu::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_bessel_k, :libarb), Nothing,
+  ccall((:acb_hypgeom_bessel_k, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, nu, x, parent(x).prec)
   return z
 end
@@ -1393,7 +1393,7 @@ end
 """
 function hyp1f1(a::acb, b::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_m, :libarb), Nothing,
+  ccall((:acb_hypgeom_m, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, a, b, x, 0, parent(x).prec)
   return z
 end
@@ -1405,7 +1405,7 @@ end
 """
 function hyp1f1r(a::acb, b::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_m, :libarb), Nothing,
+  ccall((:acb_hypgeom_m, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, a, b, x, 1, parent(x).prec)
   return z
 end
@@ -1416,7 +1416,7 @@ end
 """
 function hyperu(a::acb, b::acb, x::acb)
   z = parent(x)()
-  ccall((:acb_hypgeom_u, :libarb), Nothing,
+  ccall((:acb_hypgeom_u, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Int), z, a, b, x, parent(x).prec)
   return z
 end
@@ -1427,7 +1427,7 @@ end
 """
 function hyp2f1(a::acb, b::acb, c::acb, x::acb; flags=0)
   z = parent(x)()
-  ccall((:acb_hypgeom_2f1, :libarb), Nothing,
+  ccall((:acb_hypgeom_2f1, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, a, b, c, x, flags, parent(x).prec)
   return z
 end
@@ -1442,7 +1442,7 @@ function jtheta(z::acb, tau::acb)
   t2 = parent(z)()
   t3 = parent(z)()
   t4 = parent(z)()
-  ccall((:acb_modular_theta, :libarb), Nothing,
+  ccall((:acb_modular_theta, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Ref{acb}, Int),
                 t1, t2, t3, t4, z, tau, parent(z).prec)
   return (t1, t2, t3, t4)
@@ -1454,7 +1454,7 @@ end
 """
 function ellipwp(z::acb, tau::acb)
   r = parent(z)()
-  ccall((:acb_modular_elliptic_p, :libarb), Nothing,
+  ccall((:acb_modular_elliptic_p, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), r, z, tau, parent(z).prec)
   return r
 end
@@ -1535,36 +1535,36 @@ end
 ################################################################################
 
 function zero!(z::acb)
-   ccall((:acb_zero, :libarb), Nothing, (Ref{acb},), z)
+   ccall((:acb_zero, libarb), Nothing, (Ref{acb},), z)
    return z
 end
 
 function add!(z::acb, x::acb, y::acb)
-  ccall((:acb_add, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+  ccall((:acb_add, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
          z, x, y, parent(z).prec)
   return z
 end
 
 function addeq!(z::acb, y::acb)
-  ccall((:acb_add, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+  ccall((:acb_add, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
          z, z, y, parent(z).prec)
   return z
 end
 
 function sub!(z::acb, x::acb, y::acb)
-  ccall((:acb_sub, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+  ccall((:acb_sub, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
         z, x, y, parent(z).prec)
   return z
 end
 
 function mul!(z::acb, x::acb, y::acb)
-  ccall((:acb_mul, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+  ccall((:acb_mul, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
         z, x, y, parent(z).prec)
   return z
 end
 
 function div!(z::acb, x::acb, y::acb)
-  ccall((:acb_div, :libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
+  ccall((:acb_div, libarb), Nothing, (Ref{acb}, Ref{acb}, Ref{acb}, Int),
         z, x, y, parent(z).prec)
   return z
 end
@@ -1580,12 +1580,12 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ptr{acb}, Ptr{acb}))
                 ("acb_set_d", Float64))
     @eval begin
       function _acb_set(x::($typeofx), y::($t))
-        ccall(($f, :libarb), Nothing, (($passtoc), ($t)), x, y)
+        ccall(($f, libarb), Nothing, (($passtoc), ($t)), x, y)
       end
 
       function _acb_set(x::($typeofx), y::($t), p::Int)
         _acb_set(x, y)
-        ccall((:acb_set_round, :libarb), Nothing,
+        ccall((:acb_set_round, libarb), Nothing,
                     (($passtoc), ($passtoc), Int), x, x, p)
       end
     end
@@ -1593,88 +1593,88 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ptr{acb}, Ptr{acb}))
 
   @eval begin
     function _acb_set(x::($typeofx), y::fmpz)
-      ccall((:acb_set_fmpz, :libarb), Nothing, (($passtoc), Ref{fmpz}), x, y)
+      ccall((:acb_set_fmpz, libarb), Nothing, (($passtoc), Ref{fmpz}), x, y)
     end
 
     function _acb_set(x::($typeofx), y::fmpz, p::Int)
-      ccall((:acb_set_round_fmpz, :libarb), Nothing,
+      ccall((:acb_set_round_fmpz, libarb), Nothing,
                   (($passtoc), Ref{fmpz}, Int), x, y, p)
     end
 
     function _acb_set(x::($typeofx), y::fmpq, p::Int)
-      ccall((:acb_set_fmpq, :libarb), Nothing,
+      ccall((:acb_set_fmpq, libarb), Nothing,
                   (($passtoc), Ref{fmpq}, Int), x, y, p)
     end
 
     function _acb_set(x::($typeofx), y::arb)
-      ccall((:acb_set_arb, :libarb), Nothing, (($passtoc), Ref{arb}), x, y)
+      ccall((:acb_set_arb, libarb), Nothing, (($passtoc), Ref{arb}), x, y)
     end
 
     function _acb_set(x::($typeofx), y::arb, p::Int)
       _acb_set(x, y)
-      ccall((:acb_set_round, :libarb), Nothing,
+      ccall((:acb_set_round, libarb), Nothing,
                   (($passtoc), ($passtoc), Int), x, x, p)
     end
 
     function _acb_set(x::($typeofx), y::acb)
-      ccall((:acb_set, :libarb), Nothing, (($passtoc), Ref{acb}), x, y)
+      ccall((:acb_set, libarb), Nothing, (($passtoc), Ref{acb}), x, y)
     end
 
     function _acb_set(x::($typeofx), y::acb, p::Int)
-      ccall((:acb_set_round, :libarb), Nothing,
+      ccall((:acb_set_round, libarb), Nothing,
                   (($passtoc), Ref{acb}, Int), x, y, p)
     end
 
     function _acb_set(x::($typeofx), y::AbstractString, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Nothing, (Ptr{arb}, ), i)
+      i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, libarb), Nothing, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::BigFloat)
-      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y)
-      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Nothing, (Ptr{arb}, ), i)
+      i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, libarb), Nothing, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::BigFloat, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
-      ccall((:arb_zero, :libarb), Nothing, (Ptr{arb}, ), i)
+      i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
+      ccall((:arb_zero, libarb), Nothing, (Ptr{arb}, ), i)
     end
 
     function _acb_set(x::($typeofx), y::Int, z::Int, p::Int)
-      ccall((:acb_set_si_si, :libarb), Nothing,
+      ccall((:acb_set_si_si, libarb), Nothing,
                   (($passtoc), Int, Int), x, y, z)
-      ccall((:acb_set_round, :libarb), Nothing,
+      ccall((:acb_set_round, libarb), Nothing,
                   (($passtoc), ($passtoc), Int), x, x, p)
     end
 
     function _acb_set(x::($typeofx), y::arb, z::arb)
-      ccall((:acb_set_arb_arb, :libarb), Nothing,
+      ccall((:acb_set_arb_arb, libarb), Nothing,
                   (($passtoc), Ref{arb}, Ref{arb}), x, y, z)
     end
 
     function _acb_set(x::($typeofx), y::arb, z::arb, p::Int)
       _acb_set(x, y, z)
-      ccall((:acb_set_round, :libarb), Nothing,
+      ccall((:acb_set_round, libarb), Nothing,
                   (($passtoc), ($passtoc), Int), x, x, p)
     end
 
     function _acb_set(x::($typeofx), y::fmpq, z::fmpq, p::Int)
-      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(i, z, p)
     end
 
     function _acb_set(x::($typeofx), y::T, z::T, p::Int) where {T <: AbstractString}
-      r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(r, y, p)
-      i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+      i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
       _arb_set(i, z, p)
     end
 
@@ -1683,16 +1683,16 @@ for (typeofx, passtoc) in ((acb, Ref{acb}), (Ptr{acb}, Ptr{acb}))
   for T in (Float64, BigFloat, UInt, fmpz)
     @eval begin
       function _acb_set(x::($typeofx), y::($T), z::($T))
-        r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+        r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(r, y)
-        i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+        i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(i, z)
       end
 
       function _acb_set(x::($typeofx), y::($T), z::($T), p::Int)
-        r = ccall((:acb_real_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+        r = ccall((:acb_real_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(r, y, p)
-        i = ccall((:acb_imag_ptr, :libarb), Ptr{arb}, (($passtoc), ), x)
+        i = ccall((:acb_imag_ptr, libarb), Ptr{arb}, (($passtoc), ), x)
         _arb_set(i, z, p)
       end
     end

--- a/src/arb/acb_calc.jl
+++ b/src/arb/acb_calc.jl
@@ -3,7 +3,7 @@ function acb_calc_func_wrap(res::Ptr{acb}, x::Ptr{acb}, param::Ptr{Nothing}, ord
     xx.parent = AcbField(prec)
     F = unsafe_pointer_to_objref(param)
     w = F(xx)
-    ccall((:acb_set, :libarb), Ptr{Nothing}, (Ptr{acb}, Ref{acb}), res, w)
+    ccall((:acb_set, libarb), Ptr{Nothing}, (Ptr{acb}, Ref{acb}), res, w)
     return zero(Cint)
 end
 
@@ -40,7 +40,7 @@ function integrate(C::AcbField, F, a, b;
    end
 
    ctol = mag_struct(0, 0)
-   ccall((:mag_init, :libarb), Nothing, (Ref{mag_struct},), ctol)
+   ccall((:mag_init, libarb), Nothing, (Ref{mag_struct},), ctol)
 
    if abs_tol === -1.0
       ccall((:mag_set_ui_2exp_si, libarb), Nothing, (Ref{mag_struct}, UInt, Int), ctol, 1, -prec(C))
@@ -54,7 +54,7 @@ function integrate(C::AcbField, F, a, b;
 
    res = C()
 
-   status = ccall((:acb_calc_integrate, :libarb), UInt,
+   status = ccall((:acb_calc_integrate, libarb), UInt,
                   (Ref{acb},                       #res
                    Ptr{Nothing},                      #func
                    Any,                            #params
@@ -66,7 +66,7 @@ function integrate(C::AcbField, F, a, b;
                    Int),
       res, acb_calc_func_wrap_c(), F, lower, upper, cgoal, ctol, opts, prec(C))
 
-   ccall((:mag_clear, :libarb), Nothing, (Ref{mag_struct},), ctol)
+   ccall((:mag_clear, libarb), Nothing, (Ref{mag_struct},), ctol)
 
    if status == ARB_CALC_SUCCESS
       nothing

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -52,9 +52,9 @@ end
 
 function getindex!(z::acb, x::acb_mat, r::Int, c::Int)
   GC.@preserve x begin
-    v = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+    v = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                 (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
-    ccall((:acb_set, :libarb), Nothing, (Ref{acb}, Ptr{acb}), z, v)
+    ccall((:acb_set, libarb), Nothing, (Ref{acb}, Ptr{acb}), z, v)
   end
   return z
 end
@@ -64,9 +64,9 @@ end
 
   z = base_ring(x)()
   GC.@preserve x begin
-     v = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+     v = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
-     ccall((:acb_set, :libarb), Nothing, (Ref{acb}, Ptr{acb}), z, v)
+     ccall((:acb_set, libarb), Nothing, (Ref{acb}, Ptr{acb}), z, v)
   end
   return z
 end
@@ -77,7 +77,7 @@ for T in [Integer, Float64, fmpz, fmpq, arb, BigFloat, acb, AbstractString]
          @boundscheck Generic._checkbounds(x, r, c)
 
          GC.@preserve x begin
-            z = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+            z = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                       (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
             _acb_set(z, y, prec(base_ring(x)))
          end
@@ -95,7 +95,7 @@ for T in [Integer, Float64, fmpz, fmpq, arb, BigFloat, AbstractString]
          @boundscheck Generic._checkbounds(x, r, c)
 
          GC.@preserve x begin
-            z = ccall((:acb_mat_entry_ptr, :libarb), Ptr{acb},
+            z = ccall((:acb_mat_entry_ptr, libarb), Ptr{acb},
                       (Ref{acb_mat}, Int, Int), x, r - 1, c - 1)
             _acb_set(z, y[1], y[2], prec(base_ring(x)))
          end
@@ -110,7 +110,7 @@ zero(x::AcbMatSpace) = x()
 
 function one(x::AcbMatSpace)
   z = x()
-  ccall((:acb_mat_one, :libarb), Nothing, (Ref{acb_mat}, ), z)
+  ccall((:acb_mat_one, libarb), Nothing, (Ref{acb_mat}, ), z)
   return z
 end
 
@@ -124,7 +124,7 @@ ncols(a::AcbMatSpace) = a.ncols
 
 function deepcopy_internal(x::acb_mat, dict::IdDict)
   z = similar(x)
-  ccall((:acb_mat_set, :libarb), Nothing, (Ref{acb_mat}, Ref{acb_mat}), z, x)
+  ccall((:acb_mat_set, libarb), Nothing, (Ref{acb_mat}, Ref{acb_mat}), z, x)
   return z
 end
 
@@ -136,7 +136,7 @@ end
 
 function -(x::acb_mat)
   z = similar(x)
-  ccall((:acb_mat_neg, :libarb), Nothing, (Ref{acb_mat}, Ref{acb_mat}), z, x)
+  ccall((:acb_mat_neg, libarb), Nothing, (Ref{acb_mat}, Ref{acb_mat}), z, x)
   return z
 end
 
@@ -148,7 +148,7 @@ end
 
 function transpose(x::acb_mat)
   z = similar(x, ncols(x), nrows(x))
-  ccall((:acb_mat_transpose, :libarb), Nothing,
+  ccall((:acb_mat_transpose, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}), z, x)
   return z
 end
@@ -162,7 +162,7 @@ end
 function +(x::acb_mat, y::acb_mat)
   check_parent(x, y)
   z = similar(x)
-  ccall((:acb_mat_add, :libarb), Nothing,
+  ccall((:acb_mat_add, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -171,7 +171,7 @@ end
 function -(x::acb_mat, y::acb_mat)
   check_parent(x, y)
   z = similar(x)
-  ccall((:acb_mat_sub, :libarb), Nothing,
+  ccall((:acb_mat_sub, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -180,7 +180,7 @@ end
 function *(x::acb_mat, y::acb_mat)
   ncols(x) != nrows(y) && error("Matrices have wrong dimensions")
   z = similar(x, nrows(x), ncols(y))
-  ccall((:acb_mat_mul, :libarb), Nothing,
+  ccall((:acb_mat_mul, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -195,7 +195,7 @@ end
 function ^(x::acb_mat, y::UInt)
   nrows(x) != ncols(x) && error("Matrix must be square")
   z = similar(x)
-  ccall((:acb_mat_pow_ui, :libarb), Nothing,
+  ccall((:acb_mat_pow_ui, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, UInt, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -203,7 +203,7 @@ end
 
 function *(x::acb_mat, y::Int)
   z = similar(x)
-  ccall((:acb_mat_scalar_mul_si, :libarb), Nothing,
+  ccall((:acb_mat_scalar_mul_si, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Int, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -213,7 +213,7 @@ end
 
 function *(x::acb_mat, y::fmpz)
   z = similar(x)
-  ccall((:acb_mat_scalar_mul_fmpz, :libarb), Nothing,
+  ccall((:acb_mat_scalar_mul_fmpz, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{fmpz}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -223,7 +223,7 @@ end
 
 function *(x::acb_mat, y::arb)
   z = similar(x)
-  ccall((:acb_mat_scalar_mul_arb, :libarb), Nothing,
+  ccall((:acb_mat_scalar_mul_arb, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{arb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -233,7 +233,7 @@ end
 
 function *(x::acb_mat, y::acb)
   z = similar(x)
-  ccall((:acb_mat_scalar_mul_acb, :libarb), Nothing,
+  ccall((:acb_mat_scalar_mul_acb, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -329,7 +329,7 @@ end
 """
 function ldexp(x::acb_mat, y::Int)
   z = similar(x)
-  ccall((:acb_mat_scalar_mul_2exp_si, :libarb), Nothing,
+  ccall((:acb_mat_scalar_mul_2exp_si, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Int), z, x, y)
   return z
 end
@@ -346,7 +346,7 @@ end
 > i.e. if all matrix entries have the same midpoints and radii.
 """
 function isequal(x::acb_mat, y::acb_mat)
-  r = ccall((:acb_mat_equal, :libarb), Cint,
+  r = ccall((:acb_mat_equal, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}), x, y)
   return Bool(r)
 end
@@ -354,12 +354,12 @@ end
 function ==(x::acb_mat, y::acb_mat)
   fl = check_parent(x, y, false)
   !fl && return false
-  r = ccall((:acb_mat_eq, :libarb), Cint, (Ref{acb_mat}, Ref{acb_mat}), x, y)
+  r = ccall((:acb_mat_eq, libarb), Cint, (Ref{acb_mat}, Ref{acb_mat}), x, y)
   return Bool(r)
 end
 
 function !=(x::acb_mat, y::acb_mat)
-  r = ccall((:acb_mat_ne, :libarb), Cint, (Ref{acb_mat}, Ref{acb_mat}), x, y)
+  r = ccall((:acb_mat_ne, libarb), Cint, (Ref{acb_mat}, Ref{acb_mat}), x, y)
   return Bool(r)
 end
 
@@ -369,7 +369,7 @@ end
 > $y$, otherwise return `false`.
 """
 function overlaps(x::acb_mat, y::acb_mat)
-  r = ccall((:acb_mat_overlaps, :libarb), Cint,
+  r = ccall((:acb_mat_overlaps, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}), x, y)
   return Bool(r)
 end
@@ -380,7 +380,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::acb_mat, y::acb_mat)
-  r = ccall((:acb_mat_contains, :libarb), Cint,
+  r = ccall((:acb_mat_contains, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}), x, y)
   return Bool(r)
 end
@@ -397,7 +397,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::acb_mat, y::fmpz_mat)
-  r = ccall((:acb_mat_contains_fmpz_mat, :libarb), Cint,
+  r = ccall((:acb_mat_contains_fmpz_mat, libarb), Cint,
               (Ref{acb_mat}, Ref{fmpz_mat}), x, y)
   return Bool(r)
 end
@@ -408,7 +408,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::acb_mat, y::fmpq_mat)
-  r = ccall((:acb_mat_contains_fmpq_mat, :libarb), Cint,
+  r = ccall((:acb_mat_contains_fmpq_mat, libarb), Cint,
               (Ref{acb_mat}, Ref{fmpq_mat}), x, y)
   return Bool(r)
 end
@@ -432,7 +432,7 @@ end
 > Returns whether every entry of $x$ has vanishing imaginary part.
 """
 isreal(x::acb_mat) =
-            Bool(ccall((:acb_mat_is_real, :libarb), Cint, (Ref{acb_mat}, ), x))
+            Bool(ccall((:acb_mat_is_real, libarb), Cint, (Ref{acb_mat}, ), x))
 
 ###############################################################################
 #
@@ -449,7 +449,7 @@ isreal(x::acb_mat) =
 function inv(x::acb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = similar(x)
-  r = ccall((:acb_mat_inv, :libarb), Cint,
+  r = ccall((:acb_mat_inv, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}, Int), z, x, prec(base_ring(x)))
   Bool(r) ? (return z) : error("Matrix cannot be inverted numerically")
 end
@@ -474,7 +474,7 @@ end
 function divexact(x::acb_mat, y::Int)
   y == 0 && throw(DivideError())
   z = similar(x)
-  ccall((:acb_mat_scalar_div_si, :libarb), Nothing,
+  ccall((:acb_mat_scalar_div_si, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Int, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -482,7 +482,7 @@ end
 
 function divexact(x::acb_mat, y::fmpz)
   z = similar(x)
-  ccall((:acb_mat_scalar_div_fmpz, :libarb), Nothing,
+  ccall((:acb_mat_scalar_div_fmpz, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{fmpz}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -490,7 +490,7 @@ end
 
 function divexact(x::acb_mat, y::arb)
   z = similar(x)
-  ccall((:acb_mat_scalar_div_arb, :libarb), Nothing,
+  ccall((:acb_mat_scalar_div_arb, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{arb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -498,7 +498,7 @@ end
 
 function divexact(x::acb_mat, y::acb)
   z = similar(x)
-  ccall((:acb_mat_scalar_div_acb, :libarb), Nothing,
+  ccall((:acb_mat_scalar_div_acb, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -521,7 +521,7 @@ divexact(x::acb_mat, y::Rational{T}) where T <: Union{Int, BigInt} = divexact(x,
 function charpoly(x::AcbPolyRing, y::acb_mat)
   base_ring(x) != base_ring(y) && error("Base rings must coincide")
   z = x()
-  ccall((:acb_mat_charpoly, :libarb), Nothing,
+  ccall((:acb_mat_charpoly, libarb), Nothing,
               (Ref{acb_poly}, Ref{acb_mat}, Int), z, y, prec(base_ring(y)))
   return z
 end
@@ -535,7 +535,7 @@ end
 function det(x::acb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = base_ring(x)()
-  ccall((:acb_mat_det, :libarb), Nothing,
+  ccall((:acb_mat_det, libarb), Nothing,
               (Ref{acb}, Ref{acb_mat}, Int), z, x, prec(base_ring(x)))
   return z
 end
@@ -553,7 +553,7 @@ end
 function Base.exp(x::acb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = similar(x)
-  ccall((:acb_mat_exp, :libarb), Nothing,
+  ccall((:acb_mat_exp, libarb), Nothing,
               (Ref{acb_mat}, Ref{acb_mat}, Int), z, x, prec(base_ring(x)))
   return z
 end
@@ -566,7 +566,7 @@ end
 
 function lu!(P::Generic.Perm, x::acb_mat)
   P.d .-= 1
-  r = ccall((:acb_mat_lu, :libarb), Cint,
+  r = ccall((:acb_mat_lu, libarb), Cint,
               (Ptr{Int}, Ref{acb_mat}, Ref{acb_mat}, Int),
               P.d, x, x, prec(base_ring(x)))
   r == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
@@ -599,7 +599,7 @@ function lu(P::Generic.Perm, x::acb_mat)
 end
 
 function solve!(z::acb_mat, x::acb_mat, y::acb_mat)
-  r = ccall((:acb_mat_solve, :libarb), Cint,
+  r = ccall((:acb_mat_solve, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   r == 0 && error("Matrix cannot be inverted numerically")
@@ -616,7 +616,7 @@ end
 
 function solve_lu_precomp!(z::acb_mat, P::Generic.Perm, LU::acb_mat, y::acb_mat)
   Q = inv(P)
-  ccall((:acb_mat_solve_lu_precomp, :libarb), Nothing,
+  ccall((:acb_mat_solve_lu_precomp, libarb), Nothing,
               (Ref{acb_mat}, Ptr{Int}, Ref{acb_mat}, Ref{acb_mat}, Int),
               z, Q.d .- 1, LU, y, prec(base_ring(LU)))
   nothing
@@ -644,7 +644,7 @@ function swap_rows(x::acb_mat, i::Int, j::Int)
 end
 
 function swap_rows!(x::acb_mat, i::Int, j::Int)
-  ccall((:acb_mat_swap_rows, :libarb), Nothing,
+  ccall((:acb_mat_swap_rows, libarb), Nothing,
               (Ref{acb_mat}, Ptr{Nothing}, Int, Int),
               x, C_NULL, i - 1, j - 1)
 end
@@ -663,13 +663,13 @@ end
 function bound_inf_norm(x::acb_mat)
   z = arb()
   GC.@preserve x z begin
-     t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
-     ccall((:acb_mat_bound_inf_norm, :libarb), Nothing,
+     t = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
+     ccall((:acb_mat_bound_inf_norm, libarb), Nothing,
                  (Ptr{mag_struct}, Ref{acb_mat}), t, x)
-     s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
-     ccall((:arf_set_mag, :libarb), Nothing,
+     s = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+     ccall((:arf_set_mag, libarb), Nothing,
                  (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
-     ccall((:mag_zero, :libarb), Nothing,
+     ccall((:mag_zero, libarb), Nothing,
                  (Ptr{mag_struct},), t)
   end
   return ArbField(prec(base_ring(x)))(z)
@@ -685,7 +685,7 @@ for (s,f) in (("add!","acb_mat_add"), ("mul!","acb_mat_mul"),
               ("sub!","acb_mat_sub"))
   @eval begin
     function ($(Symbol(s)))(z::acb_mat, x::acb_mat, y::acb_mat)
-      ccall(($f, :libarb), Nothing,
+      ccall(($f, libarb), Nothing,
                   (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),
                   z, x, y, prec(base_ring(x)))
       return z
@@ -864,7 +864,7 @@ function identity_matrix(R::AcbField, n::Int)
      error("dimension must not be negative")
    end
    z = acb_mat(n, n)
-   ccall((:acb_mat_one, :libarb), Nothing, (Ref{acb_mat}, ), z)
+   ccall((:acb_mat_one, libarb), Nothing, (Ref{acb_mat}, ), z)
    z.base_ring = R
    return z
 end
@@ -901,7 +901,7 @@ promote_rule(::Type{acb_mat}, ::Type{arb_mat}) = acb_mat
 
 function __approx_eig_qr!(v::Ptr{acb_struct}, R::acb_mat, A::acb_mat)
   n = nrows(A)
-  ccall((:acb_mat_approx_eig_qr, :libarb), Cint,
+  ccall((:acb_mat_approx_eig_qr, libarb), Cint,
         (Ptr{acb_struct}, Ptr{Nothing}, Ref{acb_mat},
         Ref{acb_mat}, Ptr{Nothing}, Int, Int),
         v, C_NULL, R, A, C_NULL, 0, prec(parent(A)))
@@ -924,7 +924,7 @@ function _eig_multiple(A::acb_mat, check::Bool = true)
   v_approx = acb_vec(n)
   R = zero_matrix(base_ring(A), n, n)
   __approx_eig_qr!(v, R, A)
-  b = ccall((:acb_mat_eig_multiple, :libarb), Cint,
+  b = ccall((:acb_mat_eig_multiple, libarb), Cint,
             (Ptr{acb_struct}, Ref{acb_mat}, Ptr{acb_struct}, Ref{acb_mat}, Int),
              v_approx, A, v, R, prec(base_ring(A)))
   check && b == 0 && throw(error("Could not isolate eigenvalues of matrix $A"))
@@ -958,17 +958,17 @@ function _eig_simple(A::acb_mat; check::Bool = true, alg = :default)
   R = zero_matrix(base_ring(A), n, n)
   __approx_eig_qr!(v, Rapprox, A)
   if alg == :vdhoeven_mourrain
-      b = ccall((:acb_mat_eig_simple_vdhoeven_mourrain, :libarb), Cint,
+      b = ccall((:acb_mat_eig_simple_vdhoeven_mourrain, libarb), Cint,
                 (Ptr{acb_struct}, Ref{acb_mat}, Ref{acb_mat},
                  Ref{acb_mat}, Ptr{acb_struct}, Ref{acb_mat}, Int),
                  v_approx, L, R, A, v, Rapprox, prec(base_ring(A)))
   elseif alg == :rump
-      b = ccall((:acb_mat_eig_simple_rump, :libarb), Cint,
+      b = ccall((:acb_mat_eig_simple_rump, libarb), Cint,
                 (Ptr{acb_struct}, Ref{acb_mat}, Ref{acb_mat},
                  Ref{acb_mat}, Ptr{acb_struct}, Ref{acb_mat}, Int),
                  v_approx, L, R, A, v, Rapprox, prec(base_ring(A)))
   elseif alg == :default
-      b = ccall((:acb_mat_eig_simple, :libarb), Cint,
+      b = ccall((:acb_mat_eig_simple, libarb), Cint,
                 (Ptr{acb_struct}, Ref{acb_mat}, Ref{acb_mat},
                  Ref{acb_mat}, Ptr{acb_struct}, Ref{acb_mat}, Int),
                  v_approx, L, R, A, v, Rapprox, prec(base_ring(A)))

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -19,10 +19,10 @@ parent_type(::Type{acb_poly}) = AcbPolyRing
 
 elem_type(::Type{AcbPolyRing}) = acb_poly
 
-length(x::acb_poly) = ccall((:acb_poly_length, :libarb), Int,
+length(x::acb_poly) = ccall((:acb_poly_length, libarb), Int,
                                    (Ref{acb_poly},), x)
 
-set_length!(x::acb_poly, n::Int) = ccall((:_acb_poly_set_length, :libarb), Nothing,
+set_length!(x::acb_poly, n::Int) = ccall((:_acb_poly_set_length, libarb), Nothing,
                                    (Ref{acb_poly}, Int), x, n)
 
 degree(x::acb_poly) = length(x) - 1
@@ -30,7 +30,7 @@ degree(x::acb_poly) = length(x) - 1
 function coeff(a::acb_poly, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = parent(a).base_ring()
-  ccall((:acb_poly_get_coeff_acb, :libarb), Nothing,
+  ccall((:acb_poly_get_coeff_acb, libarb), Nothing,
               (Ref{acb}, Ref{acb_poly}, Int), t, a, n)
   return t
 end
@@ -41,7 +41,7 @@ one(a::AcbPolyRing) = a(1)
 
 function gen(a::AcbPolyRing)
    z = acb_poly()
-   ccall((:acb_poly_set_coeff_si, :libarb), Nothing,
+   ccall((:acb_poly_set_coeff_si, libarb), Nothing,
         (Ref{acb_poly}, Int, Int), z, 1, 1)
    z.parent = a
    return z
@@ -102,7 +102,7 @@ end
 ###############################################################################
 
 function isequal(x::acb_poly, y::acb_poly)
-   return ccall((:acb_poly_equal, :libarb), Bool,
+   return ccall((:acb_poly_equal, libarb), Bool,
                                       (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
@@ -112,7 +112,7 @@ end
 > of $y$, otherwise return `false`.
 """
 function overlaps(x::acb_poly, y::acb_poly)
-   return ccall((:acb_poly_overlaps, :libarb), Bool,
+   return ccall((:acb_poly_overlaps, libarb), Bool,
                                       (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
@@ -122,7 +122,7 @@ end
 > coefficient boxes of $y$, otherwise return `false`.
 """
 function contains(x::acb_poly, y::acb_poly)
-   return ccall((:acb_poly_contains, :libarb), Bool,
+   return ccall((:acb_poly_contains, libarb), Bool,
                                       (Ref{acb_poly}, Ref{acb_poly}), x, y)
 end
 
@@ -132,7 +132,7 @@ end
 > exact coefficients of $y$, otherwise return `false`.
 """
 function contains(x::acb_poly, y::fmpz_poly)
-   return ccall((:acb_poly_contains_fmpz_poly, :libarb), Bool,
+   return ccall((:acb_poly_contains_fmpz_poly, libarb), Bool,
                                       (Ref{acb_poly}, Ref{fmpz_poly}), x, y)
 end
 
@@ -142,7 +142,7 @@ end
 > exact coefficients of $y$, otherwise return `false`.
 """
 function contains(x::acb_poly, y::fmpq_poly)
-   return ccall((:acb_poly_contains_fmpq_poly, :libarb), Bool,
+   return ccall((:acb_poly_contains_fmpq_poly, libarb), Bool,
                                       (Ref{acb_poly}, Ref{fmpq_poly}), x, y)
 end
 
@@ -175,7 +175,7 @@ end
 """
 function unique_integer(x::acb_poly)
   z = FmpzPolyRing(var(parent(x)))()
-  unique = ccall((:acb_poly_get_unique_fmpz_poly, :libarb), Int,
+  unique = ccall((:acb_poly_get_unique_fmpz_poly, libarb), Int,
     (Ref{fmpz_poly}, Ref{acb_poly}), z, x)
   return (unique != 0, z)
 end
@@ -186,7 +186,7 @@ end
 > imaginary parts.
 """
 function isreal(x::acb_poly)
-  return ccall((:acb_poly_is_real, :libarb), Cint, (Ref{acb_poly}, ), x) != 0
+  return ccall((:acb_poly_is_real, libarb), Cint, (Ref{acb_poly}, ), x) != 0
 end
 
 ###############################################################################
@@ -198,7 +198,7 @@ end
 function shift_left(x::acb_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:acb_poly_shift_left, :libarb), Nothing,
+   ccall((:acb_poly_shift_left, libarb), Nothing,
       (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
    return z
 end
@@ -206,7 +206,7 @@ end
 function shift_right(x::acb_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:acb_poly_shift_right, :libarb), Nothing,
+   ccall((:acb_poly_shift_right, libarb), Nothing,
        (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
    return z
 end
@@ -219,7 +219,7 @@ end
 
 function -(x::acb_poly)
   z = parent(x)()
-  ccall((:acb_poly_neg, :libarb), Nothing, (Ref{acb_poly}, Ref{acb_poly}), z, x)
+  ccall((:acb_poly_neg, libarb), Nothing, (Ref{acb_poly}, Ref{acb_poly}), z, x)
   return z
 end
 
@@ -231,7 +231,7 @@ end
 
 function +(x::acb_poly, y::acb_poly)
   z = parent(x)()
-  ccall((:acb_poly_add, :libarb), Nothing,
+  ccall((:acb_poly_add, libarb), Nothing,
               (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -239,7 +239,7 @@ end
 
 function *(x::acb_poly, y::acb_poly)
   z = parent(x)()
-  ccall((:acb_poly_mul, :libarb), Nothing,
+  ccall((:acb_poly_mul, libarb), Nothing,
               (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -247,7 +247,7 @@ end
 
 function -(x::acb_poly, y::acb_poly)
   z = parent(x)()
-  ccall((:acb_poly_sub, :libarb), Nothing,
+  ccall((:acb_poly_sub, libarb), Nothing,
               (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -256,7 +256,7 @@ end
 function ^(x::acb_poly, y::Int)
   y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
   z = parent(x)()
-  ccall((:acb_poly_pow_ui, :libarb), Nothing,
+  ccall((:acb_poly_pow_ui, libarb), Nothing,
               (Ref{acb_poly}, Ref{acb_poly}, UInt, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -324,7 +324,7 @@ function divrem(x::acb_poly, y::acb_poly)
    iszero(y) && throw(DivideError())
    q = parent(x)()
    r = parent(x)()
-   if (ccall((:acb_poly_divrem, :libarb), Int,
+   if (ccall((:acb_poly_divrem, libarb), Int,
          (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
                q, r, x, y, prec(parent(x))) == 1)
       return (q, r)
@@ -354,7 +354,7 @@ function truncate(a::acb_poly, n::Int)
    end
    # todo: implement set_trunc in arb
    z = deepcopy(a)
-   ccall((:acb_poly_truncate, :libarb), Nothing,
+   ccall((:acb_poly_truncate, libarb), Nothing,
                 (Ref{acb_poly}, Int), z, n)
    return z
 end
@@ -362,7 +362,7 @@ end
 function mullow(x::acb_poly, y::acb_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:acb_poly_mullow, :libarb), Nothing,
+   ccall((:acb_poly_mullow, libarb), Nothing,
          (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int, Int),
             z, x, y, n, prec(parent(x)))
    return z
@@ -377,7 +377,7 @@ end
 #function reverse(x::acb_poly, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:acb_poly_reverse, :libarb), Nothing,
+#   ccall((:acb_poly_reverse, libarb), Nothing,
 #                (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, len)
 #   return z
 #end
@@ -390,7 +390,7 @@ end
 
 function evaluate(x::acb_poly, y::acb)
    z = parent(y)()
-   ccall((:acb_poly_evaluate, :libarb), Nothing,
+   ccall((:acb_poly_evaluate, libarb), Nothing,
                 (Ref{acb}, Ref{acb_poly}, Ref{acb}, Int),
                 z, x, y, prec(parent(y)))
    return z
@@ -404,7 +404,7 @@ end
 function evaluate2(x::acb_poly, y::acb)
    z = parent(y)()
    w = parent(y)()
-   ccall((:acb_poly_evaluate2, :libarb), Nothing,
+   ccall((:acb_poly_evaluate2, libarb), Nothing,
                 (Ref{acb}, Ref{acb}, Ref{acb_poly}, Ref{acb}, Int),
                 z, w, x, y, prec(parent(y)))
    return z, w
@@ -471,7 +471,7 @@ end
 
 function compose(x::acb_poly, y::acb_poly)
    z = parent(x)()
-   ccall((:acb_poly_compose, :libarb), Nothing,
+   ccall((:acb_poly_compose, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
                 z, x, y, prec(parent(x)))
    return z
@@ -485,14 +485,14 @@ end
 
 function derivative(x::acb_poly)
    z = parent(x)()
-   ccall((:acb_poly_derivative, :libarb), Nothing,
+   ccall((:acb_poly_derivative, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
 function integral(x::acb_poly)
    z = parent(x)()
-   ccall((:acb_poly_integral, :libarb), Nothing,
+   ccall((:acb_poly_integral, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
@@ -504,13 +504,13 @@ end
 ###############################################################################
 
 function acb_vec(n::Int)
-   return ccall((:_acb_vec_init, :libarb), Ptr{acb_struct}, (Int,), n)
+   return ccall((:_acb_vec_init, libarb), Ptr{acb_struct}, (Int,), n)
 end
 
 function acb_vec(b::Array{acb, 1})
-   v = ccall((:_acb_vec_init, :libarb), Ptr{acb_struct}, (Int,), length(b))
+   v = ccall((:_acb_vec_init, libarb), Ptr{acb_struct}, (Int,), length(b))
    for i=1:length(b)
-       ccall((:acb_set, :libarb), Nothing, (Ptr{acb_struct}, Ref{acb}),
+       ccall((:acb_set, libarb), Nothing, (Ptr{acb_struct}, Ref{acb}),
            v + (i-1)*sizeof(acb_struct), b[i])
    end
    return v
@@ -520,14 +520,14 @@ function array(R::AcbField, v::Ptr{acb_struct}, n::Int)
    r = Vector{acb}(undef, n)
    for i=1:n
        r[i] = R()
-       ccall((:acb_set, :libarb), Nothing, (Ref{acb}, Ptr{acb_struct}),
+       ccall((:acb_set, libarb), Nothing, (Ref{acb}, Ptr{acb_struct}),
            r[i], v + (i-1)*sizeof(acb_struct))
    end
    return r
 end
 
 function acb_vec_clear(v::Ptr{acb_struct}, n::Int)
-   ccall((:_acb_vec_clear, :libarb), Nothing, (Ptr{acb_struct}, Int), v, n)
+   ccall((:_acb_vec_clear, libarb), Nothing, (Ptr{acb_struct}, Int), v, n)
 end
 
 @doc Markdown.doc"""
@@ -537,7 +537,7 @@ end
 function from_roots(R::AcbPolyRing, b::Array{acb, 1})
    z = R()
    tmp = acb_vec(b)
-   ccall((:acb_poly_product_roots, :libarb), Nothing,
+   ccall((:acb_poly_product_roots, libarb), Nothing,
                 (Ref{acb_poly}, Ptr{acb_struct}, Int, Int), z, tmp, length(b), prec(R))
    acb_vec_clear(tmp, length(b))
    return z
@@ -549,7 +549,7 @@ end
 
 function evaluate_fast(x::acb_poly, b::Array{acb, 1})
    tmp = acb_vec(b)
-   ccall((:acb_poly_evaluate_vec_fast, :libarb), Nothing,
+   ccall((:acb_poly_evaluate_vec_fast, libarb), Nothing,
                 (Ptr{acb_struct}, Ref{acb_poly}, Ptr{acb_struct}, Int, Int),
             tmp, x, tmp, length(b), prec(parent(x)))
    res = array(base_ring(parent(x)), tmp, length(b))
@@ -562,7 +562,7 @@ function interpolate_newton(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{acb, 1}
    z = R()
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
-   ccall((:acb_poly_interpolate_newton, :libarb), Nothing,
+   ccall((:acb_poly_interpolate_newton, libarb), Nothing,
                 (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
@@ -575,7 +575,7 @@ function interpolate_barycentric(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{ac
    z = R()
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
-   ccall((:acb_poly_interpolate_barycentric, :libarb), Nothing,
+   ccall((:acb_poly_interpolate_barycentric, libarb), Nothing,
                 (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
@@ -588,7 +588,7 @@ function interpolate_fast(R::AcbPolyRing, xs::Array{acb, 1}, ys::Array{acb, 1})
    z = R()
    xsv = acb_vec(xs)
    ysv = acb_vec(ys)
-   ccall((:acb_poly_interpolate_fast, :libarb), Nothing,
+   ccall((:acb_poly_interpolate_fast, libarb), Nothing,
                 (Ref{acb_poly}, Ptr{acb_struct}, Ptr{acb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    acb_vec_clear(xsv, length(xs))
@@ -643,7 +643,7 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
     while true
         in_roots = (wp == initial_prec) ? C_NULL : roots
         step_max_iter = (max_iter >= 1) ? max_iter : min(max(deg, 32), wp)
-        isolated = ccall((:acb_poly_find_roots, :libarb), Int,
+        isolated = ccall((:acb_poly_find_roots, libarb), Int,
             (Ptr{acb_struct}, Ref{acb_poly}, Ptr{acb_struct}, Int, Int),
                 roots, x, in_roots, step_max_iter, wp)
 
@@ -653,21 +653,21 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
             ok = true
             if target > 0
                 for i = 0 : deg-1
-                    re = ccall((:acb_real_ptr, :libarb), Ptr{arb_struct},
+                    re = ccall((:acb_real_ptr, libarb), Ptr{arb_struct},
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
-                    im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct},
+                    im = ccall((:acb_imag_ptr, libarb), Ptr{arb_struct},
                         (Ptr{acb}, ), roots + i * sizeof(acb_struct))
-                    t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), re)
-                    u = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ptr{arb}, ), im)
-                    ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
+                    t = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ptr{arb}, ), re)
+                    u = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ptr{arb}, ), im)
+                    ok = ok && (ccall((:mag_cmp_2exp_si, libarb), Cint,
                         (Ptr{mag_struct}, Int), t, -target) <= 0)
-                    ok = ok && (ccall((:mag_cmp_2exp_si, :libarb), Cint,
+                    ok = ok && (ccall((:mag_cmp_2exp_si, libarb), Cint,
                         (Ptr{mag_struct}, Int), u, -target) <= 0)
                 end
             end
 
             if isreal(x)
-                real_ok = ccall((:acb_poly_validate_real_roots, :libarb),
+                real_ok = ccall((:acb_poly_validate_real_roots, libarb),
                     Bool, (Ptr{acb_struct}, Ref{acb_poly}, Int), roots, x, wp)
 
                 if isolate_real && !real_ok
@@ -676,10 +676,10 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
 
                 if real_ok
                     for i = 0 : deg - 1
-                        im = ccall((:acb_imag_ptr, :libarb), Ptr{arb_struct},
+                        im = ccall((:acb_imag_ptr, libarb), Ptr{arb_struct},
                             (Ptr{acb}, ), roots + i * sizeof(acb_struct))
-                        if ccall((:arb_contains_zero, :libarb), Bool, (Ptr{arb_struct}, ), im)
-                            ccall((:arb_zero, :libarb), Nothing, (Ptr{arb_struct}, ), im)
+                        if ccall((:arb_contains_zero, libarb), Bool, (Ptr{arb_struct}, ), im)
+                            ccall((:arb_zero, libarb), Nothing, (Ptr{arb_struct}, ), im)
                         end
                     end
                 end
@@ -696,7 +696,7 @@ function roots(x::acb_poly; target=0, isolate_real=false, initial_prec=0, max_pr
     end
 
     if isolated == deg
-        ccall((:_acb_vec_sort_pretty, :libarb), Nothing,
+        ccall((:_acb_vec_sort_pretty, libarb), Nothing,
             (Ptr{acb_struct}, Int), roots, deg)
         res = array(base_ring(parent(x)), roots, deg)
     end
@@ -725,14 +725,14 @@ function roots_upper_bound(x::acb_poly)
    z = ArbField(prec(base_ring(x)))()
    p = prec(base_ring(x))
    GC.@preserve x z begin
-      t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
-      ccall((:acb_poly_root_bound_fujiwara, :libarb), Nothing,
+      t = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
+      ccall((:acb_poly_root_bound_fujiwara, libarb), Nothing,
             (Ptr{mag_struct}, Ref{acb_poly}), t, x)
-      s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
-      ccall((:arf_set_mag, :libarb), Nothing, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
-      ccall((:arf_set_round, :libarb), Nothing,
+      s = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+      ccall((:arf_set_mag, libarb), Nothing, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+      ccall((:arf_set_round, libarb), Nothing,
             (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
-      ccall((:mag_zero, :libarb), Nothing, (Ptr{mag_struct},), t)
+      ccall((:mag_zero, libarb), Nothing, (Ptr{mag_struct},), t)
    end
    return z
 end
@@ -744,44 +744,44 @@ end
 ###############################################################################
 
 function zero!(z::acb_poly)
-   ccall((:acb_poly_zero, :libarb), Nothing, (Ref{acb_poly},), z)
+   ccall((:acb_poly_zero, libarb), Nothing, (Ref{acb_poly},), z)
    return z
 end
 
 function fit!(z::acb_poly, n::Int)
-   ccall((:acb_poly_fit_length, :libarb), Nothing,
+   ccall((:acb_poly_fit_length, libarb), Nothing,
                     (Ref{acb_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::fmpz)
-   ccall((:acb_poly_set_coeff_fmpz, :libarb), Nothing,
+   ccall((:acb_poly_set_coeff_fmpz, libarb), Nothing,
                     (Ref{acb_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::acb_poly, n::Int, x::acb)
-   ccall((:acb_poly_set_coeff_acb, :libarb), Nothing,
+   ccall((:acb_poly_set_coeff_acb, libarb), Nothing,
                     (Ref{acb_poly}, Int, Ref{acb}), z, n, x)
    return z
 end
 
 function mul!(z::acb_poly, x::acb_poly, y::acb_poly)
-   ccall((:acb_poly_mul, :libarb), Nothing,
+   ccall((:acb_poly_mul, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
                     z, x, y, prec(parent(z)))
    return z
 end
 
 function addeq!(z::acb_poly, x::acb_poly)
-   ccall((:acb_poly_add, :libarb), Nothing,
+   ccall((:acb_poly_add, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
                     z, z, x, prec(parent(z)))
    return z
 end
 
 function add!(z::acb_poly, x::acb_poly, y::acb_poly)
-   ccall((:acb_poly_add, :libarb), Nothing,
+   ccall((:acb_poly_add, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
                     z, x, y, prec(parent(z)))
    return z

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -79,12 +79,12 @@ one(R::ArbField) = R(1)
 > `typemax(Int)` and `-typemax(Int)`.
 """
 function accuracy_bits(x::arb)
-  return ccall((:arb_rel_accuracy_bits, :libarb), Int, (Ref{arb},), x)
+  return ccall((:arb_rel_accuracy_bits, libarb), Int, (Ref{arb},), x)
 end
 
 function deepcopy_internal(a::arb, dict::IdDict)
   b = parent(a)()
-  ccall((:arb_set, :libarb), Nothing, (Ref{arb}, Ref{arb}), b, a)
+  ccall((:arb_set, libarb), Nothing, (Ref{arb}, Ref{arb}), b, a)
   return b
 end
 
@@ -112,9 +112,9 @@ characteristic(::ArbField) = 0
 """
 function Float64(x::arb)
    GC.@preserve x begin
-      t = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), x)
+      t = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), x)
       # 4 == round to nearest
-      d = ccall((:arf_get_d, :libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
+      d = ccall((:arf_get_d, libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
    end
    return d
 end
@@ -141,10 +141,10 @@ end
 
 function show(io::IO, x::arb)
   d = ceil(parent(x).prec * 0.30102999566398119521)
-  cstr = ccall((:arb_get_str, :libarb), Ptr{UInt8}, (Ref{arb}, Int, UInt),
+  cstr = ccall((:arb_get_str, libarb), Ptr{UInt8}, (Ref{arb}, Int, UInt),
                                                   x, Int(d), UInt(0))
   print(io, unsafe_string(cstr))
-  ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+  ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
 end
 
 needs_parentheses(x::arb) = false
@@ -163,12 +163,12 @@ show_minus_one(::Type{arb}) = true
 > otherwise return `false`.
 """
 function overlaps(x::arb, y::arb)
-  r = ccall((:arb_overlaps, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
+  r = ccall((:arb_overlaps, libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
 #function contains(x::arb, y::arf)
-#  r = ccall((:arb_contains_arf, :libarb), Cint, (Ref{arb}, Ref{arf}), x, y)
+#  r = ccall((:arb_contains_arf, libarb), Cint, (Ref{arb}, Ref{arf}), x, y)
 #  return Bool(r)
 #end
 
@@ -178,7 +178,7 @@ end
 > return `false`.
 """
 function contains(x::arb, y::fmpq)
-  r = ccall((:arb_contains_fmpq, :libarb), Cint, (Ref{arb}, Ref{fmpq}), x, y)
+  r = ccall((:arb_contains_fmpq, libarb), Cint, (Ref{arb}, Ref{fmpq}), x, y)
   return Bool(r)
 end
 
@@ -188,12 +188,12 @@ end
 > return `false`.
 """
 function contains(x::arb, y::fmpz)
-  r = ccall((:arb_contains_fmpz, :libarb), Cint, (Ref{arb}, Ref{fmpz}), x, y)
+  r = ccall((:arb_contains_fmpz, libarb), Cint, (Ref{arb}, Ref{fmpz}), x, y)
   return Bool(r)
 end
 
 function contains(x::arb, y::Int)
-  r = ccall((:arb_contains_si, :libarb), Cint, (Ref{arb}, Int), x, y)
+  r = ccall((:arb_contains_si, libarb), Cint, (Ref{arb}, Int), x, y)
   return Bool(r)
 end
 
@@ -217,7 +217,7 @@ contains(x::arb, y::Rational{T}) where {T <: Integer} = contains(x, fmpq(y))
 > otherwise return `false`.
 """
 function contains(x::arb, y::BigFloat)
-  r = ccall((:arb_contains_mpfr, :libarb), Cint,
+  r = ccall((:arb_contains_mpfr, libarb), Cint,
               (Ref{arb}, Ref{BigFloat}), x, y)
   return Bool(r)
 end
@@ -228,7 +228,7 @@ end
 > `false`.
 """
 function contains(x::arb, y::arb)
-  r = ccall((:arb_contains, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
+  r = ccall((:arb_contains, libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
@@ -237,7 +237,7 @@ end
 > Returns `true` if the ball $x$ contains zero, otherwise return `false`.
 """
 function contains_zero(x::arb)
-   r = ccall((:arb_contains_zero, :libarb), Cint, (Ref{arb}, ), x)
+   r = ccall((:arb_contains_zero, libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -247,7 +247,7 @@ end
 > `false`.
 """
 function contains_negative(x::arb)
-   r = ccall((:arb_contains_negative, :libarb), Cint, (Ref{arb}, ), x)
+   r = ccall((:arb_contains_negative, libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -257,7 +257,7 @@ end
 > `false`.
 """
 function contains_positive(x::arb)
-   r = ccall((:arb_contains_positive, :libarb), Cint, (Ref{arb}, ), x)
+   r = ccall((:arb_contains_positive, libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -267,7 +267,7 @@ end
 > return `false`.
 """
 function contains_nonnegative(x::arb)
-   r = ccall((:arb_contains_nonnegative, :libarb), Cint, (Ref{arb}, ), x)
+   r = ccall((:arb_contains_nonnegative, libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -277,7 +277,7 @@ end
 > return `false`.
 """
 function contains_nonpositive(x::arb)
-   r = ccall((:arb_contains_nonpositive, :libarb), Cint, (Ref{arb}, ), x)
+   r = ccall((:arb_contains_nonpositive, libarb), Cint, (Ref{arb}, ), x)
    return Bool(r)
 end
 
@@ -293,32 +293,32 @@ end
 > same midpoints and radii.
 """
 function isequal(x::arb, y::arb)
-  r = ccall((:arb_equal, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
+  r = ccall((:arb_equal, libarb), Cint, (Ref{arb}, Ref{arb}), x, y)
   return Bool(r)
 end
 
 function ==(x::arb, y::arb)
-    return Bool(ccall((:arb_eq, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_eq, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function !=(x::arb, y::arb)
-    return Bool(ccall((:arb_ne, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_ne, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function >(x::arb, y::arb)
-    return Bool(ccall((:arb_gt, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_gt, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function >=(x::arb, y::arb)
-    return Bool(ccall((:arb_ge, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_ge, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function <(x::arb, y::arb)
-    return Bool(ccall((:arb_lt, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_lt, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 function <=(x::arb, y::arb)
-    return Bool(ccall((:arb_le, :libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
+    return Bool(ccall((:arb_le, libarb), Cint, (Ref{arb}, Ref{arb}), x, y))
 end
 
 ==(x::arb, y::Int) = x == arb(y)
@@ -435,7 +435,7 @@ end
 > Return `true` if $x$ is certainly zero, otherwise return `false`.
 """
 function iszero(x::arb)
-   return Bool(ccall((:arb_is_zero, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_zero, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -444,7 +444,7 @@ end
 > `false`.
 """
 function isnonzero(x::arb)
-   return Bool(ccall((:arb_is_nonzero, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_nonzero, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -453,7 +453,7 @@ end
 > `false`.
 """
 function isone(x::arb)
-   return Bool(ccall((:arb_is_one, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_one, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -462,7 +462,7 @@ end
 > otherwise return `false`.
 """
 function isfinite(x::arb)
-   return Bool(ccall((:arb_is_finite, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_finite, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -471,7 +471,7 @@ end
 > `false`.
 """
 function isexact(x::arb)
-   return Bool(ccall((:arb_is_exact, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_exact, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -479,7 +479,7 @@ end
 > Return `true` if $x$ is an exact integer, otherwise return `false`.
 """
 function isint(x::arb)
-   return Bool(ccall((:arb_is_int, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_int, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -487,7 +487,7 @@ end
 > Return `true` if $x$ is certainly positive, otherwise return `false`.
 """
 function ispositive(x::arb)
-   return Bool(ccall((:arb_is_positive, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_positive, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -495,7 +495,7 @@ end
 > Return `true` if $x$ is certainly nonnegative, otherwise return `false`.
 """
 function isnonnegative(x::arb)
-   return Bool(ccall((:arb_is_nonnegative, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_nonnegative, libarb), Cint, (Ref{arb},), x))
 end
 
 @doc Markdown.doc"""
@@ -503,7 +503,7 @@ end
 > Return `true` if $x$ is certainly negative, otherwise return `false`.
 """
 function isnegative(x::arb)
-   return Bool(ccall((:arb_is_negative, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_negative, libarb), Cint, (Ref{arb},), x))
 end
 
 # TODO: return true if printed without brackets and x is negative
@@ -516,7 +516,7 @@ end
 > Return `true` if $x$ is certainly nonpositive, otherwise return `false`.
 """
 function isnonpositive(x::arb)
-   return Bool(ccall((:arb_is_nonpositive, :libarb), Cint, (Ref{arb},), x))
+   return Bool(ccall((:arb_is_nonpositive, libarb), Cint, (Ref{arb},), x))
 end
 
 ################################################################################
@@ -542,7 +542,7 @@ end
 """
 function radius(x::arb)
   z = parent(x)()
-  ccall((:arb_get_rad_arb, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
+  ccall((:arb_get_rad_arb, libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -552,7 +552,7 @@ end
 """
 function midpoint(x::arb)
   z = parent(x)()
-  ccall((:arb_get_mid_arb, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
+  ccall((:arb_get_mid_arb, libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -564,7 +564,7 @@ end
 
 function -(x::arb)
   z = parent(x)()
-  ccall((:arb_neg, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
+  ccall((:arb_neg, libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -578,7 +578,7 @@ for (s,f) in ((:+,"arb_add"), (:*,"arb_mul"), (://, "arb_div"), (:-,"arb_sub"))
   @eval begin
     function ($s)(x::arb, y::arb)
       z = parent(x)()
-      ccall(($f, :libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+      ccall(($f, libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
                            z, x, y, parent(x).prec)
       return z
     end
@@ -589,7 +589,7 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
   @eval begin
     #function ($f)(x::arb, y::arf)
     #  z = parent(x)()
-    #  ccall(($("arb_"*s*"_arf"), :libarb), Nothing,
+    #  ccall(($("arb_"*s*"_arf"), libarb), Nothing,
     #              (Ref{arb}, Ref{arb}, Ref{arf}, Int),
     #              z, x, y, parent(x).prec)
     #  return z
@@ -599,7 +599,7 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
 
     function ($f)(x::arb, y::UInt)
       z = parent(x)()
-      ccall(($("arb_"*s*"_ui"), :libarb), Nothing,
+      ccall(($("arb_"*s*"_ui"), libarb), Nothing,
                   (Ref{arb}, Ref{arb}, UInt, Int),
                   z, x, y, parent(x).prec)
       return z
@@ -609,7 +609,7 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
 
     function ($f)(x::arb, y::Int)
       z = parent(x)()
-      ccall(($("arb_"*s*"_si"), :libarb), Nothing,
+      ccall(($("arb_"*s*"_si"), libarb), Nothing,
       (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
       return z
     end
@@ -618,7 +618,7 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
 
     function ($f)(x::arb, y::fmpz)
       z = parent(x)()
-      ccall(($("arb_"*s*"_fmpz"), :libarb), Nothing,
+      ccall(($("arb_"*s*"_fmpz"), libarb), Nothing,
                   (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
                   z, x, y, parent(x).prec)
       return z
@@ -630,7 +630,7 @@ end
 
 #function -(x::arb, y::arf)
 #  z = parent(x)()
-#  ccall((:arb_sub_arf, :libarb), Nothing,
+#  ccall((:arb_sub_arf, libarb), Nothing,
 #              (Ref{arb}, Ref{arb}, Ref{arf}, Int), z, x, y, parent(x).prec)
 #  return z
 #end
@@ -639,7 +639,7 @@ end
 
 function -(x::arb, y::UInt)
   z = parent(x)()
-  ccall((:arb_sub_ui, :libarb), Nothing,
+  ccall((:arb_sub_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -648,7 +648,7 @@ end
 
 function -(x::arb, y::Int)
   z = parent(x)()
-  ccall((:arb_sub_si, :libarb), Nothing,
+  ccall((:arb_sub_si, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -657,7 +657,7 @@ end
 
 function -(x::arb, y::fmpz)
   z = parent(x)()
-  ccall((:arb_sub_fmpz, :libarb), Nothing,
+  ccall((:arb_sub_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
               z, x, y, parent(x).prec)
   return z
@@ -683,28 +683,28 @@ end
 
 #function //(x::arb, y::arf)
 #  z = parent(x)()
-#  ccall((:arb_div_arf, :libarb), Nothing,
+#  ccall((:arb_div_arf, libarb), Nothing,
 #              (Ref{arb}, Ref{arb}, Ref{arf}, Int), z, x, y, parent(x).prec)
 #  return z
 #end
 
 function //(x::arb, y::UInt)
   z = parent(x)()
-  ccall((:arb_div_ui, :libarb), Nothing,
+  ccall((:arb_div_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function //(x::arb, y::Int)
   z = parent(x)()
-  ccall((:arb_div_si, :libarb), Nothing,
+  ccall((:arb_div_si, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Int, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function //(x::arb, y::fmpz)
   z = parent(x)()
-  ccall((:arb_div_fmpz, :libarb), Nothing,
+  ccall((:arb_div_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
               z, x, y, parent(x).prec)
   return z
@@ -712,7 +712,7 @@ end
 
 function //(x::UInt, y::arb)
   z = parent(y)()
-  ccall((:arb_ui_div, :libarb), Nothing,
+  ccall((:arb_ui_div, libarb), Nothing,
               (Ref{arb}, UInt, Ref{arb}, Int), z, x, y, parent(y).prec)
   return z
 end
@@ -720,7 +720,7 @@ end
 function //(x::Int, y::arb)
   z = parent(y)()
   t = arb(x)
-  ccall((:arb_div, :libarb), Nothing,
+  ccall((:arb_div, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, t, y, parent(y).prec)
   return z
 end
@@ -728,21 +728,21 @@ end
 function //(x::fmpz, y::arb)
   z = parent(y)()
   t = arb(x)
-  ccall((:arb_div, :libarb), Nothing,
+  ccall((:arb_div, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, t, y, parent(y).prec)
   return z
 end
 
 function ^(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_pow, :libarb), Nothing,
+  ccall((:arb_pow, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function ^(x::arb, y::fmpz)
   z = parent(x)()
-  ccall((:arb_pow_fmpz, :libarb), Nothing,
+  ccall((:arb_pow_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{fmpz}, Int),
               z, x, y, parent(x).prec)
   return z
@@ -752,14 +752,14 @@ end
 
 function ^(x::arb, y::UInt)
   z = parent(x)()
-  ccall((:arb_pow_ui, :libarb), Nothing,
+  ccall((:arb_pow_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function ^(x::arb, y::fmpq)
   z = parent(x)()
-  ccall((:arb_pow_fmpq, :libarb), Nothing,
+  ccall((:arb_pow_fmpq, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{fmpq}, Int),
               z, x, y, parent(x).prec)
   return z
@@ -844,7 +844,7 @@ divexact(x::arb, y::Rational{T}) where {T <: Integer} = x // y
 """
 function abs(x::arb)
   z = parent(x)()
-  ccall((:arb_abs, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
+  ccall((:arb_abs, libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -860,7 +860,7 @@ end
 """
 function inv(x::arb)
   z = parent(x)()
-  ccall((:arb_inv, :libarb), Nothing,
+  ccall((:arb_inv, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
   return parent(x)(z)
 end
@@ -877,7 +877,7 @@ end
 """
 function ldexp(x::arb, y::Int)
   z = parent(x)()
-  ccall((:arb_mul_2exp_si, :libarb), Nothing,
+  ccall((:arb_mul_2exp_si, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Int), z, x, y)
   return z
 end
@@ -888,7 +888,7 @@ end
 """
 function ldexp(x::arb, y::fmpz)
   z = parent(x)()
-  ccall((:arb_mul_2exp_fmpz, :libarb), Nothing,
+  ccall((:arb_mul_2exp_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -906,7 +906,7 @@ end
 """
 function trim(x::arb)
   z = parent(x)()
-  ccall((:arb_trim, :libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
+  ccall((:arb_trim, libarb), Nothing, (Ref{arb}, Ref{arb}), z, x)
   return z
 end
 
@@ -919,7 +919,7 @@ end
 """
 function unique_integer(x::arb)
   z = fmpz()
-  unique = ccall((:arb_get_unique_fmpz, :libarb), Int,
+  unique = ccall((:arb_get_unique_fmpz, libarb), Int,
     (Ref{fmpz}, Ref{arb}), z, x)
   return (unique != 0, z)
 end
@@ -943,7 +943,7 @@ end
 """
 function setunion(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_union, :libarb), Nothing,
+  ccall((:arb_union, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -955,7 +955,7 @@ end
 """
 function setintersection(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_intersection, :libarb), Nothing,
+  ccall((:arb_intersection, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -972,7 +972,7 @@ end
 """
 function const_pi(r::ArbField)
   z = r()
-  ccall((:arb_const_pi, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_pi, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -982,7 +982,7 @@ end
 """
 function const_e(r::ArbField)
   z = r()
-  ccall((:arb_const_e, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_e, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -992,7 +992,7 @@ end
 """
 function const_log2(r::ArbField)
   z = r()
-  ccall((:arb_const_log2, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_log2, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1002,7 +1002,7 @@ end
 """
 function const_log10(r::ArbField)
   z = r()
-  ccall((:arb_const_log10, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_log10, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1012,7 +1012,7 @@ end
 """
 function const_euler(r::ArbField)
   z = r()
-  ccall((:arb_const_euler, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_euler, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1022,7 +1022,7 @@ end
 """
 function const_catalan(r::ArbField)
   z = r()
-  ccall((:arb_const_catalan, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_catalan, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1032,7 +1032,7 @@ end
 """
 function const_khinchin(r::ArbField)
   z = r()
-  ccall((:arb_const_khinchin, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_khinchin, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1042,7 +1042,7 @@ end
 """
 function const_glaisher(r::ArbField)
   z = r()
-  ccall((:arb_const_glaisher, :libarb), Nothing, (Ref{arb}, Int), z, prec(r))
+  ccall((:arb_const_glaisher, libarb), Nothing, (Ref{arb}, Int), z, prec(r))
   return z
 end
 
@@ -1061,7 +1061,7 @@ end
 """
 function floor(x::arb)
    z = parent(x)()
-   ccall((:arb_floor, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_floor, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1072,7 +1072,7 @@ end
 """
 function ceil(x::arb)
    z = parent(x)()
-   ccall((:arb_ceil, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_ceil, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1082,7 +1082,7 @@ end
 """
 function Base.sqrt(x::arb)
    z = parent(x)()
-   ccall((:arb_sqrt, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sqrt, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1092,7 +1092,7 @@ end
 """
 function rsqrt(x::arb)
    z = parent(x)()
-   ccall((:arb_rsqrt, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_rsqrt, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1102,7 +1102,7 @@ end
 """
 function sqrt1pm1(x::arb)
    z = parent(x)()
-   ccall((:arb_sqrt1pm1, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sqrt1pm1, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1113,7 +1113,7 @@ end
 """
 function sqrtpos(x::arb)
    z = parent(x)()
-   ccall((:arb_sqrtpos, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sqrtpos, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1124,7 +1124,7 @@ end
 """
 function log(x::arb)
    z = parent(x)()
-   ccall((:arb_log, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_log, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1134,7 +1134,7 @@ end
 """
 function log1p(x::arb)
    z = parent(x)()
-   ccall((:arb_log1p, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_log1p, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1144,7 +1144,7 @@ end
 """
 function Base.exp(x::arb)
    z = parent(x)()
-   ccall((:arb_exp, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_exp, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1154,7 +1154,7 @@ end
 """
 function expm1(x::arb)
    z = parent(x)()
-   ccall((:arb_expm1, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_expm1, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1164,7 +1164,7 @@ end
 """
 function sin(x::arb)
    z = parent(x)()
-   ccall((:arb_sin, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sin, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1174,7 +1174,7 @@ end
 """
 function cos(x::arb)
    z = parent(x)()
-   ccall((:arb_cos, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_cos, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1184,7 +1184,7 @@ end
 """
 function sinpi(x::arb)
    z = parent(x)()
-   ccall((:arb_sin_pi, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sin_pi, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1194,7 +1194,7 @@ end
 """
 function cospi(x::arb)
    z = parent(x)()
-   ccall((:arb_cos_pi, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_cos_pi, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1204,7 +1204,7 @@ end
 """
 function tan(x::arb)
    z = parent(x)()
-   ccall((:arb_tan, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_tan, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1214,7 +1214,7 @@ end
 """
 function cot(x::arb)
    z = parent(x)()
-   ccall((:arb_cot, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_cot, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1224,7 +1224,7 @@ end
 """
 function tanpi(x::arb)
    z = parent(x)()
-   ccall((:arb_tan_pi, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_tan_pi, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1234,7 +1234,7 @@ end
 """
 function cotpi(x::arb)
    z = parent(x)()
-   ccall((:arb_cot_pi, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_cot_pi, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1244,7 +1244,7 @@ end
 """
 function sinh(x::arb)
    z = parent(x)()
-   ccall((:arb_sinh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_sinh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1254,7 +1254,7 @@ end
 """
 function cosh(x::arb)
    z = parent(x)()
-   ccall((:arb_cosh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_cosh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1264,7 +1264,7 @@ end
 """
 function tanh(x::arb)
    z = parent(x)()
-   ccall((:arb_tanh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_tanh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1274,7 +1274,7 @@ end
 """
 function coth(x::arb)
    z = parent(x)()
-   ccall((:arb_coth, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_coth, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1284,7 +1284,7 @@ end
 """
 function atan(x::arb)
    z = parent(x)()
-   ccall((:arb_atan, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_atan, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1294,7 +1294,7 @@ end
 """
 function asin(x::arb)
    z = parent(x)()
-   ccall((:arb_asin, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_asin, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1304,7 +1304,7 @@ end
 """
 function acos(x::arb)
    z = parent(x)()
-   ccall((:arb_acos, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_acos, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1314,7 +1314,7 @@ end
 """
 function atanh(x::arb)
    z = parent(x)()
-   ccall((:arb_atanh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_atanh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1324,7 +1324,7 @@ end
 """
 function asinh(x::arb)
    z = parent(x)()
-   ccall((:arb_asinh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_asinh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1334,7 +1334,7 @@ end
 """
 function acosh(x::arb)
    z = parent(x)()
-   ccall((:arb_acosh, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_acosh, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1344,7 +1344,7 @@ end
 """
 function gamma(x::arb)
    z = parent(x)()
-   ccall((:arb_gamma, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_gamma, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1354,7 +1354,7 @@ end
 """
 function lgamma(x::arb)
    z = parent(x)()
-   ccall((:arb_lgamma, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_lgamma, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1364,7 +1364,7 @@ end
 """
 function rgamma(x::arb)
    z = parent(x)()
-   ccall((:arb_rgamma, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_rgamma, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1375,7 +1375,7 @@ end
 """
 function digamma(x::arb)
    z = parent(x)()
-   ccall((:arb_digamma, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_digamma, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1385,7 +1385,7 @@ end
 """
 function zeta(x::arb)
    z = parent(x)()
-   ccall((:arb_zeta, :libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
+   ccall((:arb_zeta, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
 
@@ -1396,7 +1396,7 @@ end
 function sincos(x::arb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:arb_sin_cos, :libarb), Nothing,
+  ccall((:arb_sin_cos, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1408,7 +1408,7 @@ end
 function sincospi(x::arb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:arb_sin_cos_pi, :libarb), Nothing,
+  ccall((:arb_sin_cos_pi, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1419,7 +1419,7 @@ end
 """
 function sinpi(x::fmpq, r::ArbField)
   z = r()
-  ccall((:arb_sin_pi_fmpq, :libarb), Nothing,
+  ccall((:arb_sin_pi_fmpq, libarb), Nothing,
         (Ref{arb}, Ref{fmpq}, Int), z, x, prec(r))
   return z
 end
@@ -1430,7 +1430,7 @@ end
 """
 function cospi(x::fmpq, r::ArbField)
   z = r()
-  ccall((:arb_cos_pi_fmpq, :libarb), Nothing,
+  ccall((:arb_cos_pi_fmpq, libarb), Nothing,
         (Ref{arb}, Ref{fmpq}, Int), z, x, prec(r))
   return z
 end
@@ -1443,7 +1443,7 @@ end
 function sincospi(x::fmpq, r::ArbField)
   s = r()
   c = r()
-  ccall((:arb_sin_cos_pi_fmpq, :libarb), Nothing,
+  ccall((:arb_sin_cos_pi_fmpq, libarb), Nothing,
         (Ref{arb}, Ref{arb}, Ref{fmpq}, Int), s, c, x, prec(r))
   return (s, c)
 end
@@ -1455,7 +1455,7 @@ end
 function sinhcosh(x::arb)
   s = parent(x)()
   c = parent(x)()
-  ccall((:arb_sinh_cosh, :libarb), Nothing,
+  ccall((:arb_sinh_cosh, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), s, c, x, parent(x).prec)
   return (s, c)
 end
@@ -1466,7 +1466,7 @@ end
 """
 function atan2(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_atan2, :libarb), Nothing,
+  ccall((:arb_atan2, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -1477,7 +1477,7 @@ end
 """
 function agm(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_agm, :libarb), Nothing,
+  ccall((:arb_agm, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
@@ -1488,7 +1488,7 @@ end
 """
 function zeta(s::arb, a::arb)
   z = parent(s)()
-  ccall((:arb_hurwitz_zeta, :libarb), Nothing,
+  ccall((:arb_hurwitz_zeta, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, s, a, parent(s).prec)
   return z
 end
@@ -1499,14 +1499,14 @@ end
 """
 function hypot(x::arb, y::arb)
   z = parent(x)()
-  ccall((:arb_hypot, :libarb), Nothing,
+  ccall((:arb_hypot, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, x, y, parent(x).prec)
   return z
 end
 
 function root(x::arb, n::UInt)
   z = parent(x)()
-  ccall((:arb_root, :libarb), Nothing,
+  ccall((:arb_root, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
@@ -1528,7 +1528,7 @@ fac(x::arb) = gamma(x+1)
 
 function fac(n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_fac_ui, :libarb), Nothing, (Ref{arb}, UInt, Int), z, n, r.prec)
+  ccall((:arb_fac_ui, libarb), Nothing, (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
 
@@ -1544,7 +1544,7 @@ fac(n::Int, r::ArbField) = n < 0 ? fac(r(n)) : fac(UInt(n), r)
 """
 function binom(x::arb, n::UInt)
   z = parent(x)()
-  ccall((:arb_bin_ui, :libarb), Nothing,
+  ccall((:arb_bin_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
@@ -1555,7 +1555,7 @@ end
 """
 function binom(n::UInt, k::UInt, r::ArbField)
   z = r()
-  ccall((:arb_bin_uiui, :libarb), Nothing,
+  ccall((:arb_bin_uiui, libarb), Nothing,
               (Ref{arb}, UInt, UInt, Int), z, n, k, r.prec)
   return z
 end
@@ -1566,14 +1566,14 @@ end
 """
 function fib(n::fmpz, r::ArbField)
   z = r()
-  ccall((:arb_fib_fmpz, :libarb), Nothing,
+  ccall((:arb_fib_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
 
 function fib(n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_fib_ui, :libarb), Nothing,
+  ccall((:arb_fib_ui, libarb), Nothing,
               (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
@@ -1590,7 +1590,7 @@ fib(n::Int, r::ArbField) = n >= 0 ? fib(UInt(n), r) : fib(fmpz(n), r)
 """
 function gamma(x::fmpz, r::ArbField)
   z = r()
-  ccall((:arb_gamma_fmpz, :libarb), Nothing,
+  ccall((:arb_gamma_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{fmpz}, Int), z, x, r.prec)
   return z
 end
@@ -1601,7 +1601,7 @@ end
 """
 function gamma(x::fmpq, r::ArbField)
   z = r()
-  ccall((:arb_gamma_fmpq, :libarb), Nothing,
+  ccall((:arb_gamma_fmpq, libarb), Nothing,
               (Ref{arb}, Ref{fmpq}, Int), z, x, r.prec)
   return z
 end
@@ -1609,7 +1609,7 @@ end
 
 function zeta(n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_zeta_ui, :libarb), Nothing,
+  ccall((:arb_zeta_ui, libarb), Nothing,
               (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
@@ -1623,7 +1623,7 @@ zeta(n::Int, r::ArbField) = n >= 0 ? zeta(UInt(n), r) : zeta(r(n))
 
 function bernoulli(n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_bernoulli_ui, :libarb), Nothing,
+  ccall((:arb_bernoulli_ui, libarb), Nothing,
               (Ref{arb}, UInt, Int), z, n, r.prec)
   return z
 end
@@ -1636,7 +1636,7 @@ bernoulli(n::Int, r::ArbField) = n >= 0 ? bernoulli(UInt(n), r) : throw(DomainEr
 
 function risingfac(x::arb, n::UInt)
   z = parent(x)()
-  ccall((:arb_rising_ui, :libarb), Nothing,
+  ccall((:arb_rising_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Int), z, x, n, parent(x).prec)
   return z
 end
@@ -1649,7 +1649,7 @@ risingfac(x::arb, n::Int) = n < 0 ? throw(DomainError(n, "Index must be non-nega
 
 function risingfac(x::fmpq, n::UInt, r::ArbField)
   z = r()
-  ccall((:arb_rising_fmpq_ui, :libarb), Nothing,
+  ccall((:arb_rising_fmpq_ui, libarb), Nothing,
               (Ref{arb}, Ref{fmpq}, UInt, Int), z, x, n, r.prec)
   return z
 end
@@ -1664,7 +1664,7 @@ risingfac(x::fmpq, n::Int, r::ArbField) = n < 0 ? throw(DomainError(n, "Index mu
 function risingfac2(x::arb, n::UInt)
   z = parent(x)()
   w = parent(x)()
-  ccall((:arb_rising2_ui, :libarb), Nothing,
+  ccall((:arb_rising2_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, UInt, Int), z, w, x, n, parent(x).prec)
   return (z, w)
 end
@@ -1682,7 +1682,7 @@ risingfac2(x::arb, n::Int) = n < 0 ? throw(DomainError(n, "Index must be non-neg
 """
 function polylog(s::arb, a::arb)
   z = parent(s)()
-  ccall((:arb_polylog, :libarb), Nothing,
+  ccall((:arb_polylog, libarb), Nothing,
               (Ref{arb}, Ref{arb}, Ref{arb}, Int), z, s, a, parent(s).prec)
   return z
 end
@@ -1693,21 +1693,21 @@ end
 """
 function polylog(s::Int, a::arb)
   z = parent(a)()
-  ccall((:arb_polylog_si, :libarb), Nothing,
+  ccall((:arb_polylog_si, libarb), Nothing,
               (Ref{arb}, Int, Ref{arb}, Int), z, s, a, parent(a).prec)
   return z
 end
 
 function chebyshev_t(n::UInt, x::arb)
   z = parent(x)()
-  ccall((:arb_chebyshev_t_ui, :libarb), Nothing,
+  ccall((:arb_chebyshev_t_ui, libarb), Nothing,
               (Ref{arb}, UInt, Ref{arb}, Int), z, n, x, parent(x).prec)
   return z
 end
 
 function chebyshev_u(n::UInt, x::arb)
   z = parent(x)()
-  ccall((:arb_chebyshev_u_ui, :libarb), Nothing,
+  ccall((:arb_chebyshev_u_ui, libarb), Nothing,
               (Ref{arb}, UInt, Ref{arb}, Int), z, n, x, parent(x).prec)
   return z
 end
@@ -1715,7 +1715,7 @@ end
 function chebyshev_t2(n::UInt, x::arb)
   z = parent(x)()
   w = parent(x)()
-  ccall((:arb_chebyshev_t2_ui, :libarb), Nothing,
+  ccall((:arb_chebyshev_t2_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Ref{arb}, Int), z, w, n, x, parent(x).prec)
   return z, w
 end
@@ -1723,7 +1723,7 @@ end
 function chebyshev_u2(n::UInt, x::arb)
   z = parent(x)()
   w = parent(x)()
-  ccall((:arb_chebyshev_u2_ui, :libarb), Nothing,
+  ccall((:arb_chebyshev_u2_ui, libarb), Nothing,
               (Ref{arb}, Ref{arb}, UInt, Ref{arb}, Int), z, w, n, x, parent(x).prec)
   return z, w
 end
@@ -1758,7 +1758,7 @@ chebyshev_u2(n::Int, x::arb) = n < 0 ? throw(DomainError(n, "Index must be non-n
 """
 function bell(n::fmpz, r::ArbField)
   z = r()
-  ccall((:arb_bell_fmpz, :libarb), Nothing,
+  ccall((:arb_bell_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
@@ -1775,7 +1775,7 @@ bell(n::Int, r::ArbField) = bell(fmpz(n), r)
 """
 function numpart(n::fmpz, r::ArbField)
   z = r()
-  ccall((:arb_partitions_fmpz, :libarb), Nothing,
+  ccall((:arb_partitions_fmpz, libarb), Nothing,
               (Ref{arb}, Ref{fmpz}, Int), z, n, r.prec)
   return z
 end
@@ -1821,7 +1821,7 @@ end
 ################################################################################
 
 function zero!(z::arb)
-   ccall((:arb_zero, :libarb), Nothing, (Ref{arb},), z)
+   ccall((:arb_zero, libarb), Nothing, (Ref{arb},), z)
    return z
 end
 
@@ -1829,7 +1829,7 @@ for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
               ("sub!","arb_sub"))
   @eval begin
     function ($(Symbol(s)))(z::arb, x::arb, y::arb)
-      ccall(($f, :libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+      ccall(($f, libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
                            z, x, y, parent(x).prec)
       return z
     end
@@ -1837,7 +1837,7 @@ for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
 end
 
 function addeq!(z::arb, x::arb)
-    ccall((:arb_add, :libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
+    ccall((:arb_add, libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{arb}, Int),
                            z, z, x, parent(x).prec)
     return z
 end
@@ -1853,12 +1853,12 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
                 ("arb_set_d", Float64))
     @eval begin
       function _arb_set(x::($typeofx), y::($t))
-        ccall(($f, :libarb), Nothing, (($passtoc), ($t)), x, y)
+        ccall(($f, libarb), Nothing, (($passtoc), ($t)), x, y)
       end
 
       function _arb_set(x::($typeofx), y::($t), p::Int)
         _arb_set(x, y)
-        ccall((:arb_set_round, :libarb), Nothing,
+        ccall((:arb_set_round, libarb), Nothing,
                     (($passtoc), ($passtoc), Int), x, x, p)
       end
     end
@@ -1866,52 +1866,52 @@ for (typeofx, passtoc) in ((arb, Ref{arb}), (Ptr{arb}, Ptr{arb}))
 
   @eval begin
     function _arb_set(x::($typeofx), y::fmpz)
-      ccall((:arb_set_fmpz, :libarb), Nothing, (($passtoc), Ref{fmpz}), x, y)
+      ccall((:arb_set_fmpz, libarb), Nothing, (($passtoc), Ref{fmpz}), x, y)
     end
 
     function _arb_set(x::($typeofx), y::fmpz, p::Int)
-      ccall((:arb_set_round_fmpz, :libarb), Nothing,
+      ccall((:arb_set_round_fmpz, libarb), Nothing,
                   (($passtoc), Ref{fmpz}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::fmpq, p::Int)
-      ccall((:arb_set_fmpq, :libarb), Nothing,
+      ccall((:arb_set_fmpq, libarb), Nothing,
                   (($passtoc), Ref{fmpq}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::arb)
-      ccall((:arb_set, :libarb), Nothing, (($passtoc), Ref{arb}), x, y)
+      ccall((:arb_set, libarb), Nothing, (($passtoc), Ref{arb}), x, y)
     end
 
     function _arb_set(x::($typeofx), y::arb, p::Int)
-      ccall((:arb_set_round, :libarb), Nothing,
+      ccall((:arb_set_round, libarb), Nothing,
                   (($passtoc), Ref{arb}, Int), x, y, p)
     end
 
     function _arb_set(x::($typeofx), y::AbstractString, p::Int)
       s = string(y)
-      err = ccall((:arb_set_str, :libarb), Int32,
+      err = ccall((:arb_set_str, libarb), Int32,
                   (($passtoc), Ptr{UInt8}, Int), x, s, p)
       err == 0 || error("Invalid real string: $(repr(s))")
     end
 
     function _arb_set(x::($typeofx), y::BigFloat)
-      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct},
+      m = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct},
                   (($passtoc), ), x)
-      r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct},
+      r = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct},
                   (($passtoc), ), x)
-      ccall((:arf_set_mpfr, :libarb), Nothing,
+      ccall((:arf_set_mpfr, libarb), Nothing,
                   (Ptr{arf_struct}, Ref{BigFloat}), m, y)
-      ccall((:mag_zero, :libarb), Nothing, (Ptr{mag_struct}, ), r)
+      ccall((:mag_zero, libarb), Nothing, (Ptr{mag_struct}, ), r)
     end
 
     function _arb_set(x::($typeofx), y::BigFloat, p::Int)
-      m = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (($passtoc), ), x)
-      r = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (($passtoc), ), x)
-      ccall((:arf_set_mpfr, :libarb), Nothing,
+      m = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (($passtoc), ), x)
+      r = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (($passtoc), ), x)
+      ccall((:arf_set_mpfr, libarb), Nothing,
                   (Ptr{arf_struct}, Ref{BigFloat}), m, y)
-      ccall((:mag_zero, :libarb), Nothing, (Ptr{mag_struct}, ), r)
-      ccall((:arb_set_round, :libarb), Nothing,
+      ccall((:mag_zero, libarb), Nothing, (Ptr{mag_struct}, ), r)
+      ccall((:arb_set_round, libarb), Nothing,
                   (($passtoc), ($passtoc), Int), x, x, p)
     end
   end

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -52,9 +52,9 @@ end
 
 function getindex!(z::arb, x::arb_mat, r::Int, c::Int)
   GC.@preserve x begin
-     v = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+     v = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                  (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
-     ccall((:arb_set, :libarb), Nothing, (Ref{arb}, Ptr{arb}), z, v)
+     ccall((:arb_set, libarb), Nothing, (Ref{arb}, Ptr{arb}), z, v)
   end
   return z
 end
@@ -64,9 +64,9 @@ end
 
   z = base_ring(x)()
   GC.@preserve x begin
-     v = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+     v = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                  (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
-     ccall((:arb_set, :libarb), Nothing, (Ref{arb}, Ptr{arb}), z, v)
+     ccall((:arb_set, libarb), Nothing, (Ref{arb}, Ptr{arb}), z, v)
   end
   return z
 end
@@ -77,7 +77,7 @@ for T in [Int, UInt, fmpz, fmpq, Float64, BigFloat, arb, AbstractString]
          @boundscheck Generic._checkbounds(x, r, c)
 
          GC.@preserve x begin
-            z = ccall((:arb_mat_entry_ptr, :libarb), Ptr{arb},
+            z = ccall((:arb_mat_entry_ptr, libarb), Ptr{arb},
                       (Ref{arb_mat}, Int, Int), x, r - 1, c - 1)
             Nemo._arb_set(z, y, prec(base_ring(x)))
          end
@@ -97,7 +97,7 @@ zero(a::ArbMatSpace) = a()
 
 function one(x::ArbMatSpace)
   z = x()
-  ccall((:arb_mat_one, :libarb), Nothing, (Ref{arb_mat}, ), z)
+  ccall((:arb_mat_one, libarb), Nothing, (Ref{arb_mat}, ), z)
   return z
 end
 
@@ -111,7 +111,7 @@ ncols(a::ArbMatSpace) = a.ncols
 
 function deepcopy_internal(x::arb_mat, dict::IdDict)
   z = arb_mat(nrows(x), ncols(x))
-  ccall((:arb_mat_set, :libarb), Nothing, (Ref{arb_mat}, Ref{arb_mat}), z, x)
+  ccall((:arb_mat_set, libarb), Nothing, (Ref{arb_mat}, Ref{arb_mat}), z, x)
   z.base_ring = x.base_ring
   return z
 end
@@ -124,7 +124,7 @@ end
 
 function -(x::arb_mat)
   z = similar(x)
-  ccall((:arb_mat_neg, :libarb), Nothing, (Ref{arb_mat}, Ref{arb_mat}), z, x)
+  ccall((:arb_mat_neg, libarb), Nothing, (Ref{arb_mat}, Ref{arb_mat}), z, x)
   return z
 end
 
@@ -136,7 +136,7 @@ end
 
 function transpose(x::arb_mat)
   z = similar(x, ncols(x), nrows(x))
-  ccall((:arb_mat_transpose, :libarb), Nothing,
+  ccall((:arb_mat_transpose, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}), z, x)
   return z
 end
@@ -150,7 +150,7 @@ end
 function +(x::arb_mat, y::arb_mat)
   check_parent(x, y)
   z = similar(x)
-  ccall((:arb_mat_add, :libarb), Nothing,
+  ccall((:arb_mat_add, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -159,7 +159,7 @@ end
 function -(x::arb_mat, y::arb_mat)
   check_parent(x, y)
   z = similar(x)
-  ccall((:arb_mat_sub, :libarb), Nothing,
+  ccall((:arb_mat_sub, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -168,7 +168,7 @@ end
 function *(x::arb_mat, y::arb_mat)
   ncols(x) != nrows(y) && error("Matrices have wrong dimensions")
   z = similar(x, nrows(x), ncols(y))
-  ccall((:arb_mat_mul, :libarb), Nothing,
+  ccall((:arb_mat_mul, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -183,7 +183,7 @@ end
 function ^(x::arb_mat, y::UInt)
   nrows(x) != ncols(x) && error("Matrix must be square")
   z = similar(x)
-  ccall((:arb_mat_pow_ui, :libarb), Nothing,
+  ccall((:arb_mat_pow_ui, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, UInt, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -191,7 +191,7 @@ end
 
 function *(x::arb_mat, y::Int)
   z = similar(x)
-  ccall((:arb_mat_scalar_mul_si, :libarb), Nothing,
+  ccall((:arb_mat_scalar_mul_si, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Int, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -205,7 +205,7 @@ end
 
 function *(x::arb_mat, y::fmpz)
   z = similar(x)
-  ccall((:arb_mat_scalar_mul_fmpz, :libarb), Nothing,
+  ccall((:arb_mat_scalar_mul_fmpz, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{fmpz}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -215,7 +215,7 @@ end
 
 function *(x::arb_mat, y::arb)
   z = similar(x)
-  ccall((:arb_mat_scalar_mul_arb, :libarb), Nothing,
+  ccall((:arb_mat_scalar_mul_arb, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -291,7 +291,7 @@ end
 """
 function ldexp(x::arb_mat, y::Int)
   z = similar(x)
-  ccall((:arb_mat_scalar_mul_2exp_si, :libarb), Nothing,
+  ccall((:arb_mat_scalar_mul_2exp_si, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Int), z, x, y)
   return z
 end
@@ -308,7 +308,7 @@ end
 > i.e. if all matrix entries have the same midpoints and radii.
 """
 function isequal(x::arb_mat, y::arb_mat)
-  r = ccall((:arb_mat_equal, :libarb), Cint,
+  r = ccall((:arb_mat_equal, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}), x, y)
   return Bool(r)
 end
@@ -316,12 +316,12 @@ end
 function ==(x::arb_mat, y::arb_mat)
   fl = check_parent(x, y, false)
   !fl && return false
-  r = ccall((:arb_mat_eq, :libarb), Cint, (Ref{arb_mat}, Ref{arb_mat}), x, y)
+  r = ccall((:arb_mat_eq, libarb), Cint, (Ref{arb_mat}, Ref{arb_mat}), x, y)
   return Bool(r)
 end
 
 function !=(x::arb_mat, y::arb_mat)
-  r = ccall((:arb_mat_ne, :libarb), Cint, (Ref{arb_mat}, Ref{arb_mat}), x, y)
+  r = ccall((:arb_mat_ne, libarb), Cint, (Ref{arb_mat}, Ref{arb_mat}), x, y)
   return Bool(r)
 end
 
@@ -331,7 +331,7 @@ end
 > $y$, otherwise return `false`.
 """
 function overlaps(x::arb_mat, y::arb_mat)
-  r = ccall((:arb_mat_overlaps, :libarb), Cint,
+  r = ccall((:arb_mat_overlaps, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}), x, y)
   return Bool(r)
 end
@@ -342,7 +342,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::arb_mat, y::arb_mat)
-  r = ccall((:arb_mat_contains, :libarb), Cint,
+  r = ccall((:arb_mat_contains, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}), x, y)
   return Bool(r)
 end
@@ -359,7 +359,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::arb_mat, y::fmpz_mat)
-  r = ccall((:arb_mat_contains_fmpz_mat, :libarb), Cint,
+  r = ccall((:arb_mat_contains_fmpz_mat, libarb), Cint,
               (Ref{arb_mat}, Ref{fmpz_mat}), x, y)
   return Bool(r)
 end
@@ -371,7 +371,7 @@ end
 > $y$, otherwise return `false`.
 """
 function contains(x::arb_mat, y::fmpq_mat)
-  r = ccall((:arb_mat_contains_fmpq_mat, :libarb), Cint,
+  r = ccall((:arb_mat_contains_fmpq_mat, libarb), Cint,
               (Ref{arb_mat}, Ref{fmpq_mat}), x, y)
   return Bool(r)
 end
@@ -403,7 +403,7 @@ end
 function inv(x::arb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = similar(x)
-  r = ccall((:arb_mat_inv, :libarb), Cint,
+  r = ccall((:arb_mat_inv, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}, Int), z, x, prec(base_ring(x)))
   Bool(r) ? (return z) : error("Matrix cannot be inverted numerically")
 end
@@ -428,7 +428,7 @@ end
 function divexact(x::arb_mat, y::Int)
   y == 0 && throw(DivideError())
   z = similar(x)
-  ccall((:arb_mat_scalar_div_si, :libarb), Nothing,
+  ccall((:arb_mat_scalar_div_si, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Int, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -436,7 +436,7 @@ end
 
 function divexact(x::arb_mat, y::fmpz)
   z = similar(x)
-  ccall((:arb_mat_scalar_div_fmpz, :libarb), Nothing,
+  ccall((:arb_mat_scalar_div_fmpz, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{fmpz}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -444,7 +444,7 @@ end
 
 function divexact(x::arb_mat, y::arb)
   z = similar(x)
-  ccall((:arb_mat_scalar_div_arb, :libarb), Nothing,
+  ccall((:arb_mat_scalar_div_arb, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb}, Int),
               z, x, y, prec(base_ring(x)))
   return z
@@ -459,7 +459,7 @@ end
 function charpoly(x::ArbPolyRing, y::arb_mat)
   base_ring(y) != base_ring(x) && error("Base rings must coincide")
   z = x()
-  ccall((:arb_mat_charpoly, :libarb), Nothing,
+  ccall((:arb_mat_charpoly, libarb), Nothing,
               (Ref{arb_poly}, Ref{arb_mat}, Int), z, y, prec(base_ring(y)))
   return z
 end
@@ -473,7 +473,7 @@ end
 function det(x::arb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = base_ring(x)()
-  ccall((:arb_mat_det, :libarb), Nothing,
+  ccall((:arb_mat_det, libarb), Nothing,
               (Ref{arb}, Ref{arb_mat}, Int), z, x, prec(base_ring(x)))
   return z
 end
@@ -491,7 +491,7 @@ end
 function Base.exp(x::arb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   z = similar(x)
-  ccall((:arb_mat_exp, :libarb), Nothing,
+  ccall((:arb_mat_exp, libarb), Nothing,
               (Ref{arb_mat}, Ref{arb_mat}, Int), z, x, prec(base_ring(x)))
   return z
 end
@@ -506,7 +506,7 @@ function lu!(P::Generic.Perm, x::arb_mat)
   ncols(x) != nrows(x) && error("Matrix must be square")
   parent(P).n != nrows(x) && error("Permutation does not match matrix")
   P.d .-= 1
-  r = ccall((:arb_mat_lu, :libarb), Cint,
+  r = ccall((:arb_mat_lu, libarb), Cint,
               (Ptr{Int}, Ref{arb_mat}, Ref{arb_mat}, Int),
               P.d, x, x, prec(base_ring(x)))
   r == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
@@ -538,7 +538,7 @@ function lu(x::arb_mat, P = PermGroup(nrows(x)))
 end
 
 function solve!(z::arb_mat, x::arb_mat, y::arb_mat)
-  r = ccall((:arb_mat_solve, :libarb), Cint,
+  r = ccall((:arb_mat_solve, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
               z, x, y, prec(base_ring(x)))
   r == 0 && error("Matrix cannot be inverted numerically")
@@ -555,7 +555,7 @@ end
 
 function solve_lu_precomp!(z::arb_mat, P::Generic.Perm, LU::arb_mat, y::arb_mat)
   Q = inv(P)
-  ccall((:arb_mat_solve_lu_precomp, :libarb), Nothing,
+  ccall((:arb_mat_solve_lu_precomp, libarb), Nothing,
               (Ref{arb_mat}, Ptr{Int}, Ref{arb_mat}, Ref{arb_mat}, Int),
               z, Q.d .- 1, LU, y, prec(base_ring(LU)))
   nothing
@@ -583,7 +583,7 @@ function swap_rows(x::arb_mat, i::Int, j::Int)
 end
 
 function swap_rows!(x::arb_mat, i::Int, j::Int)
-  ccall((:arb_mat_swap_rows, :libarb), Nothing,
+  ccall((:arb_mat_swap_rows, libarb), Nothing,
               (Ref{arb_mat}, Ptr{Nothing}, Int, Int),
               x, C_NULL, i - 1, j - 1)
 end
@@ -602,13 +602,13 @@ end
 function bound_inf_norm(x::arb_mat)
   z = arb()
   GC.@preserve x z begin
-     t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
-     ccall((:arb_mat_bound_inf_norm, :libarb), Nothing,
+     t = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
+     ccall((:arb_mat_bound_inf_norm, libarb), Nothing,
                  (Ptr{mag_struct}, Ref{arb_mat}), t, x)
-     s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
-     ccall((:arf_set_mag, :libarb), Nothing,
+     s = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+     ccall((:arf_set_mag, libarb), Nothing,
                  (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
-     ccall((:mag_zero, :libarb), Nothing,
+     ccall((:mag_zero, libarb), Nothing,
                  (Ptr{mag_struct},), t)
   end
   return base_ring(x)(z)
@@ -624,7 +624,7 @@ for (s,f) in (("add!","arb_mat_add"), ("mul!","arb_mat_mul"),
               ("sub!","arb_mat_sub"))
   @eval begin
     function ($(Symbol(s)))(z::arb_mat, x::arb_mat, y::arb_mat)
-      ccall(($f, :libarb), Nothing,
+      ccall(($f, libarb), Nothing,
                   (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
                   z, x, y, prec(base_ring(x)))
       return z
@@ -748,7 +748,7 @@ function identity_matrix(R::ArbField, n::Int)
      error("dimension must not be negative")
    end
    z = arb_mat(n, n)
-   ccall((:arb_mat_one, :libarb), Nothing, (Ref{arb_mat}, ), z)
+   ccall((:arb_mat_one, libarb), Nothing, (Ref{arb_mat}, ), z)
    z.base_ring = R
    return z
 end

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -19,10 +19,10 @@ parent_type(::Type{arb_poly}) = ArbPolyRing
 
 elem_type(::Type{ArbPolyRing}) = arb_poly
 
-length(x::arb_poly) = ccall((:arb_poly_length, :libarb), Int,
+length(x::arb_poly) = ccall((:arb_poly_length, libarb), Int,
                                    (Ref{arb_poly},), x)
 
-set_length!(x::arb_poly, n::Int) = ccall((:_arb_poly_set_length, :libarb), Nothing,
+set_length!(x::arb_poly, n::Int) = ccall((:_arb_poly_set_length, libarb), Nothing,
                                    (Ref{arb_poly}, Int), x, n)
 
 degree(x::arb_poly) = length(x) - 1
@@ -30,7 +30,7 @@ degree(x::arb_poly) = length(x) - 1
 function coeff(a::arb_poly, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = parent(a).base_ring()
-  ccall((:arb_poly_get_coeff_arb, :libarb), Nothing,
+  ccall((:arb_poly_get_coeff_arb, libarb), Nothing,
               (Ref{arb}, Ref{arb_poly}, Int), t, a, n)
   return t
 end
@@ -41,7 +41,7 @@ one(a::ArbPolyRing) = a(1)
 
 function gen(a::ArbPolyRing)
    z = arb_poly()
-   ccall((:arb_poly_set_coeff_si, :libarb), Nothing,
+   ccall((:arb_poly_set_coeff_si, libarb), Nothing,
         (Ref{arb_poly}, Int, Int), z, 1, 1)
    z.parent = a
    return z
@@ -88,7 +88,7 @@ end
 ###############################################################################
 
 function isequal(x::arb_poly, y::arb_poly)
-   return ccall((:arb_poly_equal, :libarb), Bool,
+   return ccall((:arb_poly_equal, libarb), Bool,
                                       (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
@@ -98,7 +98,7 @@ end
 > of $y$, otherwise return `false`.
 """
 function overlaps(x::arb_poly, y::arb_poly)
-   return ccall((:arb_poly_overlaps, :libarb), Bool,
+   return ccall((:arb_poly_overlaps, libarb), Bool,
                                       (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
@@ -108,7 +108,7 @@ end
 > coefficient balls of $y$, otherwise return `false`.
 """
 function contains(x::arb_poly, y::arb_poly)
-   return ccall((:arb_poly_contains, :libarb), Bool,
+   return ccall((:arb_poly_contains, libarb), Bool,
                                       (Ref{arb_poly}, Ref{arb_poly}), x, y)
 end
 
@@ -118,7 +118,7 @@ end
 > exact coefficients of $y$, otherwise return `false`.
 """
 function contains(x::arb_poly, y::fmpz_poly)
-   return ccall((:arb_poly_contains_fmpz_poly, :libarb), Bool,
+   return ccall((:arb_poly_contains_fmpz_poly, libarb), Bool,
                                       (Ref{arb_poly}, Ref{fmpz_poly}), x, y)
 end
 
@@ -128,7 +128,7 @@ end
 > exact coefficients of $y$, otherwise return `false`.
 """
 function contains(x::arb_poly, y::fmpq_poly)
-   return ccall((:arb_poly_contains_fmpq_poly, :libarb), Bool,
+   return ccall((:arb_poly_contains_fmpq_poly, libarb), Bool,
                                       (Ref{arb_poly}, Ref{fmpq_poly}), x, y)
 end
 
@@ -161,7 +161,7 @@ end
 """
 function unique_integer(x::arb_poly)
   z = FmpzPolyRing(var(parent(x)))()
-  unique = ccall((:arb_poly_get_unique_fmpz_poly, :libarb), Int,
+  unique = ccall((:arb_poly_get_unique_fmpz_poly, libarb), Int,
     (Ref{fmpz_poly}, Ref{arb_poly}), z, x)
   return (unique != 0, z)
 end
@@ -175,7 +175,7 @@ end
 function shift_left(x::arb_poly, len::Int)
   len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:arb_poly_shift_left, :libarb), Nothing,
+   ccall((:arb_poly_shift_left, libarb), Nothing,
       (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
    return z
 end
@@ -183,7 +183,7 @@ end
 function shift_right(x::arb_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:arb_poly_shift_right, :libarb), Nothing,
+   ccall((:arb_poly_shift_right, libarb), Nothing,
        (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
    return z
 end
@@ -196,7 +196,7 @@ end
 
 function -(x::arb_poly)
   z = parent(x)()
-  ccall((:arb_poly_neg, :libarb), Nothing, (Ref{arb_poly}, Ref{arb_poly}), z, x)
+  ccall((:arb_poly_neg, libarb), Nothing, (Ref{arb_poly}, Ref{arb_poly}), z, x)
   return z
 end
 
@@ -208,7 +208,7 @@ end
 
 function +(x::arb_poly, y::arb_poly)
   z = parent(x)()
-  ccall((:arb_poly_add, :libarb), Nothing,
+  ccall((:arb_poly_add, libarb), Nothing,
               (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -216,7 +216,7 @@ end
 
 function *(x::arb_poly, y::arb_poly)
   z = parent(x)()
-  ccall((:arb_poly_mul, :libarb), Nothing,
+  ccall((:arb_poly_mul, libarb), Nothing,
               (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -224,7 +224,7 @@ end
 
 function -(x::arb_poly, y::arb_poly)
   z = parent(x)()
-  ccall((:arb_poly_sub, :libarb), Nothing,
+  ccall((:arb_poly_sub, libarb), Nothing,
               (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -233,7 +233,7 @@ end
 function ^(x::arb_poly, y::Int)
   y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
   z = parent(x)()
-  ccall((:arb_poly_pow_ui, :libarb), Nothing,
+  ccall((:arb_poly_pow_ui, libarb), Nothing,
               (Ref{arb_poly}, Ref{arb_poly}, UInt, Int),
               z, x, y, prec(parent(x)))
   return z
@@ -301,7 +301,7 @@ function divrem(x::arb_poly, y::arb_poly)
    iszero(y) && throw(DivideError())
    q = parent(x)()
    r = parent(x)()
-   if (ccall((:arb_poly_divrem, :libarb), Int,
+   if (ccall((:arb_poly_divrem, libarb), Int,
          (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
                q, r, x, y, prec(parent(x))) == 1)
       return (q, r)
@@ -331,7 +331,7 @@ function truncate(a::arb_poly, n::Int)
    end
    # todo: implement set_trunc in arb
    z = deepcopy(a)
-   ccall((:arb_poly_truncate, :libarb), Nothing,
+   ccall((:arb_poly_truncate, libarb), Nothing,
                 (Ref{arb_poly}, Int), z, n)
    return z
 end
@@ -339,7 +339,7 @@ end
 function mullow(x::arb_poly, y::arb_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:arb_poly_mullow, :libarb), Nothing,
+   ccall((:arb_poly_mullow, libarb), Nothing,
          (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int, Int),
             z, x, y, n, prec(parent(x)))
    return z
@@ -354,7 +354,7 @@ end
 #function reverse(x::arb_poly, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:arb_poly_reverse, :libarb), Nothing,
+#   ccall((:arb_poly_reverse, libarb), Nothing,
 #                (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, len)
 #   return z
 #end
@@ -367,7 +367,7 @@ end
 
 function evaluate(x::arb_poly, y::arb)
    z = parent(y)()
-   ccall((:arb_poly_evaluate, :libarb), Nothing,
+   ccall((:arb_poly_evaluate, libarb), Nothing,
                 (Ref{arb}, Ref{arb_poly}, Ref{arb}, Int),
                 z, x, y, prec(parent(y)))
    return z
@@ -381,7 +381,7 @@ end
 function evaluate2(x::arb_poly, y::arb)
    z = parent(y)()
    w = parent(y)()
-   ccall((:arb_poly_evaluate2, :libarb), Nothing,
+   ccall((:arb_poly_evaluate2, libarb), Nothing,
                 (Ref{arb}, Ref{arb}, Ref{arb_poly}, Ref{arb}, Int),
                 z, w, x, y, prec(parent(y)))
    return z, w
@@ -389,7 +389,7 @@ end
 
 function evaluate(x::arb_poly, y::acb)
    z = parent(y)()
-   ccall((:arb_poly_evaluate_acb, :libarb), Nothing,
+   ccall((:arb_poly_evaluate_acb, libarb), Nothing,
                 (Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
                 z, x, y, prec(parent(y)))
    return z
@@ -403,7 +403,7 @@ end
 function evaluate2(x::arb_poly, y::acb)
    z = parent(y)()
    w = parent(y)()
-   ccall((:arb_poly_evaluate2_acb, :libarb), Nothing,
+   ccall((:arb_poly_evaluate2_acb, libarb), Nothing,
                 (Ref{acb}, Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
                 z, w, x, y, prec(parent(y)))
    return z, w
@@ -461,7 +461,7 @@ end
 
 function compose(x::arb_poly, y::arb_poly)
    z = parent(x)()
-   ccall((:arb_poly_compose, :libarb), Nothing,
+   ccall((:arb_poly_compose, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
                 z, x, y, prec(parent(x)))
    return z
@@ -475,14 +475,14 @@ end
 
 function derivative(x::arb_poly)
    z = parent(x)()
-   ccall((:arb_poly_derivative, :libarb), Nothing,
+   ccall((:arb_poly_derivative, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
 
 function integral(x::arb_poly)
    z = parent(x)()
-   ccall((:arb_poly_integral, :libarb), Nothing,
+   ccall((:arb_poly_integral, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Int), z, x, prec(parent(x)))
    return z
 end
@@ -494,13 +494,13 @@ end
 ###############################################################################
 
 function arb_vec(n::Int)
-   return ccall((:_arb_vec_init, :libarb), Ptr{arb_struct}, (Int,), n)
+   return ccall((:_arb_vec_init, libarb), Ptr{arb_struct}, (Int,), n)
 end
 
 function arb_vec(b::Array{arb, 1})
-   v = ccall((:_arb_vec_init, :libarb), Ptr{arb_struct}, (Int,), length(b))
+   v = ccall((:_arb_vec_init, libarb), Ptr{arb_struct}, (Int,), length(b))
    for i=1:length(b)
-       ccall((:arb_set, :libarb), Nothing, (Ptr{arb_struct}, Ref{arb}),
+       ccall((:arb_set, libarb), Nothing, (Ptr{arb_struct}, Ref{arb}),
            v + (i-1)*sizeof(arb_struct), b[i])
    end
    return v
@@ -510,14 +510,14 @@ function array(R::ArbField, v::Ptr{arb_struct}, n::Int)
    r = Vector{arb}(undef, n)
    for i=1:n
        r[i] = R()
-       ccall((:arb_set, :libarb), Nothing, (Ref{arb}, Ptr{arb_struct}),
+       ccall((:arb_set, libarb), Nothing, (Ref{arb}, Ptr{arb_struct}),
            r[i], v + (i-1)*sizeof(arb_struct))
    end
    return r
 end
 
 function arb_vec_clear(v::Ptr{arb_struct}, n::Int)
-   ccall((:_arb_vec_clear, :libarb), Nothing, (Ptr{arb_struct}, Int), v, n)
+   ccall((:_arb_vec_clear, libarb), Nothing, (Ptr{arb_struct}, Int), v, n)
 end
 
 @doc Markdown.doc"""
@@ -527,7 +527,7 @@ end
 function from_roots(R::ArbPolyRing, b::Array{arb, 1})
    z = R()
    tmp = arb_vec(b)
-   ccall((:arb_poly_product_roots, :libarb), Nothing,
+   ccall((:arb_poly_product_roots, libarb), Nothing,
                 (Ref{arb_poly}, Ptr{arb_struct}, Int, Int), z, tmp, length(b), prec(R))
    arb_vec_clear(tmp, length(b))
    return z
@@ -539,7 +539,7 @@ end
 
 function evaluate_fast(x::arb_poly, b::Array{arb, 1})
    tmp = arb_vec(b)
-   ccall((:arb_poly_evaluate_vec_fast, :libarb), Nothing,
+   ccall((:arb_poly_evaluate_vec_fast, libarb), Nothing,
                 (Ptr{arb_struct}, Ref{arb_poly}, Ptr{arb_struct}, Int, Int),
             tmp, x, tmp, length(b), prec(parent(x)))
    res = array(base_ring(parent(x)), tmp, length(b))
@@ -552,7 +552,7 @@ function interpolate_newton(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{arb, 1}
    z = R()
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
-   ccall((:arb_poly_interpolate_newton, :libarb), Nothing,
+   ccall((:arb_poly_interpolate_newton, libarb), Nothing,
                 (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
@@ -565,7 +565,7 @@ function interpolate_barycentric(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{ar
    z = R()
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
-   ccall((:arb_poly_interpolate_barycentric, :libarb), Nothing,
+   ccall((:arb_poly_interpolate_barycentric, libarb), Nothing,
                 (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
@@ -578,7 +578,7 @@ function interpolate_fast(R::ArbPolyRing, xs::Array{arb, 1}, ys::Array{arb, 1})
    z = R()
    xsv = arb_vec(xs)
    ysv = arb_vec(ys)
-   ccall((:arb_poly_interpolate_fast, :libarb), Nothing,
+   ccall((:arb_poly_interpolate_fast, libarb), Nothing,
                 (Ref{arb_poly}, Ptr{arb_struct}, Ptr{arb_struct}, Int, Int),
             z, xsv, ysv, length(xs), prec(R))
    arb_vec_clear(xsv, length(xs))
@@ -611,14 +611,14 @@ function roots_upper_bound(x::arb_poly)
    z = base_ring(x)()
    p = prec(base_ring(x))
    GC.@preserve x z begin
-      t = ccall((:arb_rad_ptr, :libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
-      ccall((:arb_poly_root_bound_fujiwara, :libarb), Nothing,
+      t = ccall((:arb_rad_ptr, libarb), Ptr{mag_struct}, (Ref{arb}, ), z)
+      ccall((:arb_poly_root_bound_fujiwara, libarb), Nothing,
             (Ptr{mag_struct}, Ref{arb_poly}), t, x)
-      s = ccall((:arb_mid_ptr, :libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
-      ccall((:arf_set_mag, :libarb), Nothing, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
-      ccall((:arf_set_round, :libarb), Nothing,
+      s = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), z)
+      ccall((:arf_set_mag, libarb), Nothing, (Ptr{arf_struct}, Ptr{mag_struct}), s, t)
+      ccall((:arf_set_round, libarb), Nothing,
             (Ptr{arf_struct}, Ptr{arf_struct}, Int, Cint), s, s, p, ARB_RND_CEIL)
-      ccall((:mag_zero, :libarb), Nothing, (Ptr{mag_struct},), t)
+      ccall((:mag_zero, libarb), Nothing, (Ptr{mag_struct},), t)
    end
    return z
 end
@@ -630,45 +630,45 @@ end
 ###############################################################################
 
 function zero!(z::arb_poly)
-   ccall((:arb_poly_zero, :libarb), Nothing,
+   ccall((:arb_poly_zero, libarb), Nothing,
                     (Ref{arb_poly}, ), z)
    return z
 end
 
 function fit!(z::arb_poly, n::Int)
-   ccall((:arb_poly_fit_length, :libarb), Nothing,
+   ccall((:arb_poly_fit_length, libarb), Nothing,
                     (Ref{arb_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::fmpz)
-   ccall((:arb_poly_set_coeff_fmpz, :libarb), Nothing,
+   ccall((:arb_poly_set_coeff_fmpz, libarb), Nothing,
                     (Ref{arb_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::arb_poly, n::Int, x::arb)
-   ccall((:arb_poly_set_coeff_arb, :libarb), Nothing,
+   ccall((:arb_poly_set_coeff_arb, libarb), Nothing,
                     (Ref{arb_poly}, Int, Ref{arb}), z, n, x)
    return z
 end
 
 function mul!(z::arb_poly, x::arb_poly, y::arb_poly)
-   ccall((:arb_poly_mul, :libarb), Nothing,
+   ccall((:arb_poly_mul, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
                     z, x, y, prec(parent(z)))
    return z
 end
 
 function addeq!(z::arb_poly, x::arb_poly)
-   ccall((:arb_poly_add, :libarb), Nothing,
+   ccall((:arb_poly_add, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
                     z, z, x, prec(parent(z)))
    return z
 end
 
 function add!(z::arb_poly, x::arb_poly, y::arb_poly)
-   ccall((:arb_poly_add, :libarb), Nothing,
+   ccall((:arb_poly_add, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
                     z, x, y, prec(parent(z)))
    return z

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -20,29 +20,29 @@ mutable struct fmpz <: RingElem
 
     function fmpz()
         z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
+        ccall((:fmpz_init, libflint), Nothing, (Ref{fmpz},), z)
         finalizer(_fmpz_clear_fn, z)
         return z
     end
 
     function fmpz(x::Int)
         z = new()
-        ccall((:fmpz_init_set_si, :libflint), Nothing, (Ref{fmpz}, Int), z, x)
+        ccall((:fmpz_init_set_si, libflint), Nothing, (Ref{fmpz}, Int), z, x)
         finalizer(_fmpz_clear_fn, z)
         return z
     end
 
     function fmpz(x::UInt)
         z = new()
-        ccall((:fmpz_init_set_ui, :libflint), Nothing, (Ref{fmpz}, UInt), z, x)
+        ccall((:fmpz_init_set_ui, libflint), Nothing, (Ref{fmpz}, UInt), z, x)
         finalizer(_fmpz_clear_fn, z)
         return z
     end
 
     function fmpz(x::BigInt)
         z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
-        ccall((:fmpz_set_mpz, :libflint), Nothing, (Ref{fmpz}, Ref{BigInt}), z, x)
+        ccall((:fmpz_init, libflint), Nothing, (Ref{fmpz},), z)
+        ccall((:fmpz_set_mpz, libflint), Nothing, (Ref{fmpz}, Ref{BigInt}), z, x)
         finalizer(_fmpz_clear_fn, z)
         return z
     end
@@ -50,8 +50,8 @@ mutable struct fmpz <: RingElem
     function fmpz(x::Float64)
         !isinteger(x) && throw(InexactError(:convert, fmpz, x))
         z = new()
-        ccall((:fmpz_init, :libflint), Nothing, (Ref{fmpz},), z)
-        ccall((:fmpz_set_d, :libflint), Nothing, (Ref{fmpz}, Cdouble), z, x)
+        ccall((:fmpz_init, libflint), Nothing, (Ref{fmpz},), z)
+        ccall((:fmpz_set_d, libflint), Nothing, (Ref{fmpz}, Cdouble), z, x)
         finalizer(_fmpz_clear_fn, z)
         return z
     end
@@ -60,7 +60,7 @@ mutable struct fmpz <: RingElem
 end
 
 function _fmpz_clear_fn(a::fmpz)
-   ccall((:fmpz_clear, :libflint), Nothing, (Ref{fmpz},), a)
+   ccall((:fmpz_clear, libflint), Nothing, (Ref{fmpz},), a)
 end
 
 mutable struct fmpz_factor
@@ -72,14 +72,14 @@ mutable struct fmpz_factor
 
    function fmpz_factor()
       z = new()
-      ccall((:fmpz_factor_init, :libflint), Nothing, (Ref{fmpz_factor}, ), z)
+      ccall((:fmpz_factor_init, libflint), Nothing, (Ref{fmpz_factor}, ), z)
       finalizer(_fmpz_factor_clear_fn, z)
       return z
    end
 end
 
 function _fmpz_factor_clear_fn(a::fmpz_factor)
-   ccall((:fmpz_factor_clear, :libflint), Nothing,
+   ccall((:fmpz_factor_clear, libflint), Nothing,
          (Ref{fmpz_factor}, ), a)
 end
 
@@ -100,7 +100,7 @@ mutable struct fmpq <: FracElem{fmpz}
 
    function fmpq()
       z = new()
-      ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
+      ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
       finalizer(_fmpq_clear_fn, z)
       return z
    end
@@ -108,8 +108,8 @@ mutable struct fmpq <: FracElem{fmpz}
    function fmpq(a::fmpz, b::fmpz)
       iszero(b) && throw(DivideError())
       z = new()
-      ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
-      ccall((:fmpq_set_fmpz_frac, :libflint), Nothing,
+      ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
+      ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
             (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
       finalizer(_fmpq_clear_fn, z)
       return z
@@ -117,9 +117,9 @@ mutable struct fmpq <: FracElem{fmpz}
 
    function fmpq(a::fmpz)
       z = new()
-      ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
+      ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
       b = fmpz(1)
-      ccall((:fmpq_set_fmpz_frac, :libflint), Nothing,
+      ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
             (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, a, b)
       finalizer(_fmpq_clear_fn, z)
       return z
@@ -131,16 +131,16 @@ mutable struct fmpq <: FracElem{fmpz}
       if b == typemin(Int) || (b < 0 && a == typemin(Int))
          bz = -ZZ(b)
          az = -ZZ(a)
-         ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
-         ccall((:fmpq_set_fmpz_frac, :libflint), Nothing,
+         ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
+         ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
 	       (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), z, az, bz)
       else
          if b < 0 # Flint requires positive denominator
             b = -b
             a = -a
          end
-         ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
-         ccall((:fmpq_set_si, :libflint), Nothing,
+         ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
+         ccall((:fmpq_set_si, libflint), Nothing,
                (Ref{fmpq}, Int, Int), z, a, b)
       end
       finalizer(_fmpq_clear_fn, z)
@@ -149,8 +149,8 @@ mutable struct fmpq <: FracElem{fmpz}
 
    function fmpq(a::Int)
       z = new()
-      ccall((:fmpq_init, :libflint), Nothing, (Ref{fmpq},), z)
-      ccall((:fmpq_set_si, :libflint), Nothing,
+      ccall((:fmpq_init, libflint), Nothing, (Ref{fmpq},), z)
+      ccall((:fmpq_set_si, libflint), Nothing,
             (Ref{fmpq}, Int, Int), z, a, 1)
       finalizer(_fmpq_clear_fn, z)
       return z
@@ -159,7 +159,7 @@ mutable struct fmpq <: FracElem{fmpz}
    fmpq(a::fmpq) = a
 end
 
-_fmpq_clear_fn(a::fmpq) = ccall((:fmpq_clear, :libflint), Nothing, (Ref{fmpq},), a)
+_fmpq_clear_fn(a::fmpq) = ccall((:fmpq_clear, libflint), Nothing, (Ref{fmpq},), a)
 
 ###############################################################################
 #
@@ -194,17 +194,17 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 
    function fmpz_poly()
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_poly},), z)
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_poly},), z)
       finalizer(_fmpz_poly_clear_fn, z)
       return z
    end
 
    function fmpz_poly(a::Array{fmpz, 1})
       z = new()
-      ccall((:fmpz_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_poly_init2, libflint), Nothing,
             (Ref{fmpz_poly}, Int), z, length(a))
       for i = 1:length(a)
-         ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_poly}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       finalizer(_fmpz_poly_clear_fn, z)
@@ -213,16 +213,16 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 
    function fmpz_poly(a::Int)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_poly},), z)
-      ccall((:fmpz_poly_set_si, :libflint), Nothing, (Ref{fmpz_poly}, Int), z, a)
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_poly},), z)
+      ccall((:fmpz_poly_set_si, libflint), Nothing, (Ref{fmpz_poly}, Int), z, a)
       finalizer(_fmpz_poly_clear_fn, z)
       return z
    end
 
    function fmpz_poly(a::fmpz)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_poly},), z)
-      ccall((:fmpz_poly_set_fmpz, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_poly},), z)
+      ccall((:fmpz_poly_set_fmpz, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz}), z, a)
       finalizer(_fmpz_poly_clear_fn, z)
       return z
@@ -230,8 +230,8 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 
    function fmpz_poly(a::fmpz_poly)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_poly},), z)
-      ccall((:fmpz_poly_set, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_poly},), z)
+      ccall((:fmpz_poly_set, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz_poly}), z, a)
       finalizer(_fmpz_poly_clear_fn, z)
       return z
@@ -239,7 +239,7 @@ mutable struct fmpz_poly <: PolyElem{fmpz}
 end
 
 function _fmpz_poly_clear_fn(a::fmpz_poly)
-   ccall((:fmpz_poly_clear, :libflint), Nothing, (Ref{fmpz_poly},), a)
+   ccall((:fmpz_poly_clear, libflint), Nothing, (Ref{fmpz_poly},), a)
 end
 
 mutable struct fmpz_poly_factor
@@ -251,7 +251,7 @@ mutable struct fmpz_poly_factor
 
   function fmpz_poly_factor()
     z = new()
-    ccall((:fmpz_poly_factor_init, :libflint), Nothing,
+    ccall((:fmpz_poly_factor_init, libflint), Nothing,
                 (Ref{fmpz_poly_factor}, ), z)
     finalizer(_fmpz_poly_factor_clear_fn, z)
     return z
@@ -259,7 +259,7 @@ mutable struct fmpz_poly_factor
 end
 
 function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
-  ccall((:fmpz_poly_factor_clear, :libflint), Nothing,
+  ccall((:fmpz_poly_factor_clear, libflint), Nothing,
             (Ref{fmpz_poly_factor}, ), f)
   nothing
 end
@@ -298,17 +298,17 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly()
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
    end
 
    function fmpq_poly(a::Array{fmpq, 1})
       z = new()
-      ccall((:fmpq_poly_init2, :libflint), Nothing,
+      ccall((:fmpq_poly_init2, libflint), Nothing,
             (Ref{fmpq_poly}, Int), z, length(a))
       for i = 1:length(a)
-         ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                      (Ref{fmpq_poly}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       finalizer(_fmpq_poly_clear_fn, z)
@@ -317,16 +317,16 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly(a::Int)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
-      ccall((:fmpq_poly_set_si, :libflint), Nothing, (Ref{fmpq_poly}, Int), z, a)
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set_si, libflint), Nothing, (Ref{fmpq_poly}, Int), z, a)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
    end
 
    function fmpq_poly(a::fmpz)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
-      ccall((:fmpq_poly_set_fmpz, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set_fmpz, libflint), Nothing,
             (Ref{fmpq_poly}, Ref{fmpz}), z, a)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
@@ -334,8 +334,8 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly(a::fmpq)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
-      ccall((:fmpq_poly_set_fmpq, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set_fmpq, libflint), Nothing,
             (Ref{fmpq_poly}, Ref{fmpq}), z, a)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
@@ -343,8 +343,8 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly(a::fmpz_poly)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
-      ccall((:fmpq_poly_set_fmpz_poly, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set_fmpz_poly, libflint), Nothing,
             (Ref{fmpq_poly}, Ref{fmpz_poly}), z, a)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
@@ -352,8 +352,8 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 
    function fmpq_poly(a::fmpq_poly)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_poly},), z)
-      ccall((:fmpq_poly_set, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_poly},), z)
+      ccall((:fmpq_poly_set, libflint), Nothing,
             (Ref{fmpq_poly}, Ref{fmpq_poly}), z, a)
       finalizer(_fmpq_poly_clear_fn, z)
       return z
@@ -361,7 +361,7 @@ mutable struct fmpq_poly <: PolyElem{fmpq}
 end
 
 function _fmpq_poly_clear_fn(a::fmpq_poly)
-   ccall((:fmpq_poly_clear, :libflint), Nothing, (Ref{fmpq_poly},), a)
+   ccall((:fmpq_poly_clear, libflint), Nothing, (Ref{fmpq_poly},), a)
 end
 
 ###############################################################################
@@ -378,7 +378,7 @@ mutable struct NmodRing <: Ring
       if cached && haskey(NmodRingID, n)
          return NmodRingID[n]
       else
-         ninv = ccall((:n_preinvert_limb, :libflint), UInt, (UInt,), n)
+         ninv = ccall((:n_preinvert_limb, libflint), UInt, (UInt,), n)
          z = new(n, ninv)
          if cached
             NmodRingID[n] = z
@@ -409,7 +409,7 @@ mutable struct GaloisField <: FinField
       if cached && haskey(GaloisFieldID, n)
          return GaloisFieldID[n]
       else
-         ninv = ccall((:n_preinvert_limb, :libflint), UInt, (UInt,), n)
+         ninv = ccall((:n_preinvert_limb, libflint), UInt, (UInt,), n)
          z = new(n, ninv)
          if cached
             GaloisFieldID[n] = z
@@ -457,7 +457,7 @@ mutable struct FmpzModRing <: Ring
          return FmpzModRingID[n]
       else
          ninv = fmpz_mod_ctx_struct()
-         ccall((:fmpz_mod_ctx_init, :libflint), Nothing, (Ref{fmpz_mod_ctx_struct}, Ref{fmpz}), ninv, n)
+         ccall((:fmpz_mod_ctx_init, libflint), Nothing, (Ref{fmpz_mod_ctx_struct}, Ref{fmpz}), ninv, n)
          z = new(n, ninv)
          if cached
             FmpzModRingID[n] = z
@@ -489,7 +489,7 @@ mutable struct GaloisFmpzField <: FinField
          return GaloisFmpzFieldID[n]
       else
          ninv = fmpz_mod_ctx_struct()
-         ccall((:fmpz_mod_ctx_init, :libflint), Nothing, (Ref{fmpz_mod_ctx_struct}, Ref{fmpz}), ninv, n)
+         ccall((:fmpz_mod_ctx_init, libflint), Nothing, (Ref{fmpz_mod_ctx_struct}, Ref{fmpz}), ninv, n)
          z = new(n, ninv)
          if cached
             GaloisFmpzFieldID[n] = z
@@ -544,15 +544,15 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
       finalizer(_nmod_poly_clear_fn, z)
       return z
    end
 
    function nmod_poly(n::UInt, a::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
-      ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{nmod_poly}, Int, UInt), z, 0, a)
       finalizer(_nmod_poly_clear_fn, z)
       return z
@@ -560,8 +560,8 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, a::Int)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
-      ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{nmod_poly}, UInt), z, n)
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{nmod_poly}, Int, UInt), z, 0, mod(a, n))
       finalizer(_nmod_poly_clear_fn, z)
       return z
@@ -569,11 +569,11 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, arr::Array{fmpz, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), arr[i], n)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         tt = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), arr[i], n)
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{nmod_poly}, Int, UInt), z, i - 1, tt)
       end
       finalizer(_nmod_poly_clear_fn, z)
@@ -582,10 +582,10 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, arr::Array{UInt, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{nmod_poly}, Int, UInt), z, i - 1, arr[i])
       end
       finalizer(_nmod_poly_clear_fn, z)
@@ -594,10 +594,10 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, arr::Array{nmod, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{nmod_poly}, Int, UInt), z, i-1, arr[i].data)
       end
       finalizer(_nmod_poly_clear_fn, z)
@@ -606,9 +606,9 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, f::fmpz_poly)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_poly}, UInt, Int), z, n, length(f))
-      ccall((:fmpz_poly_get_nmod_poly, :libflint), Nothing,
+      ccall((:fmpz_poly_get_nmod_poly, libflint), Nothing,
             (Ref{nmod_poly}, Ref{fmpz_poly}), z, f)
       finalizer(_nmod_poly_clear_fn, z)
       return z
@@ -616,9 +616,9 @@ mutable struct nmod_poly <: PolyElem{nmod}
 
    function nmod_poly(n::UInt, f::nmod_poly)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_poly}, UInt, Int), z, n, length(f))
-      ccall((:nmod_poly_set, :libflint), Nothing,
+      ccall((:nmod_poly_set, libflint), Nothing,
             (Ref{nmod_poly}, Ref{nmod_poly}), z, f)
       finalizer(_nmod_poly_clear_fn, z)
       return z
@@ -626,7 +626,7 @@ mutable struct nmod_poly <: PolyElem{nmod}
 end
 
 function _nmod_poly_clear_fn(x::nmod_poly)
-  ccall((:nmod_poly_clear, :libflint), Nothing, (Ref{nmod_poly}, ), x)
+  ccall((:nmod_poly_clear, libflint), Nothing, (Ref{nmod_poly}, ), x)
 end
 
 mutable struct nmod_poly_factor
@@ -638,7 +638,7 @@ mutable struct nmod_poly_factor
 
   function nmod_poly_factor(n::UInt)
     z = new()
-    ccall((:nmod_poly_factor_init, :libflint), Nothing,
+    ccall((:nmod_poly_factor_init, libflint), Nothing,
             (Ref{nmod_poly_factor}, ), z)
     z.n = n
     finalizer(_nmod_poly_factor_clear_fn, z)
@@ -647,7 +647,7 @@ mutable struct nmod_poly_factor
 end
 
 function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
-  ccall((:nmod_poly_factor_clear, :libflint), Nothing,
+  ccall((:nmod_poly_factor_clear, libflint), Nothing,
           (Ref{nmod_poly_factor}, ), a)
 end
 
@@ -689,15 +689,15 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
       finalizer(_gfp_poly_clear_fn, z)
       return z
    end
 
    function gfp_poly(n::UInt, a::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
-      ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_poly}, Int, UInt), z, 0, a)
       finalizer(_gfp_poly_clear_fn, z)
       return z
@@ -705,8 +705,8 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, a::Int)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
-      ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing, (Ref{gfp_poly}, UInt), z, n)
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_poly}, Int, UInt), z, 0, mod(a, n))
       finalizer(_gfp_poly_clear_fn, z)
       return z
@@ -714,11 +714,11 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, arr::Array{fmpz, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{gfp_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), arr[i], n)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         tt = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), arr[i], n)
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_poly}, Int, UInt), z, i - 1, tt)
       end
       finalizer(_gfp_poly_clear_fn, z)
@@ -727,10 +727,10 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, arr::Array{UInt, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{gfp_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_poly}, Int, UInt), z, i - 1, arr[i])
       end
       finalizer(_gfp_poly_clear_fn, z)
@@ -739,10 +739,10 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, arr::Array{gfp_elem, 1})
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{gfp_poly}, UInt, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_poly}, Int, UInt), z, i-1, arr[i].data)
       end
       finalizer(_gfp_poly_clear_fn, z)
@@ -751,9 +751,9 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, f::fmpz_poly)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{gfp_poly}, UInt, Int), z, n, length(f))
-      ccall((:fmpz_poly_get_nmod_poly, :libflint), Nothing,
+      ccall((:fmpz_poly_get_nmod_poly, libflint), Nothing,
             (Ref{gfp_poly}, Ref{fmpz_poly}), z, f)
       finalizer(_gfp_poly_clear_fn, z)
       return z
@@ -761,9 +761,9 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 
    function gfp_poly(n::UInt, f::gfp_poly)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{gfp_poly}, UInt, Int), z, n, length(f))
-      ccall((:nmod_poly_set, :libflint), Nothing,
+      ccall((:nmod_poly_set, libflint), Nothing,
             (Ref{gfp_poly}, Ref{gfp_poly}), z, f)
       finalizer(_gfp_poly_clear_fn, z)
       return z
@@ -771,7 +771,7 @@ mutable struct gfp_poly <: PolyElem{gfp_elem}
 end
 
 function _gfp_poly_clear_fn(x::gfp_poly)
-  ccall((:nmod_poly_clear, :libflint), Nothing, (Ref{gfp_poly}, ), x)
+  ccall((:nmod_poly_clear, libflint), Nothing, (Ref{gfp_poly}, ), x)
 end
 
 mutable struct gfp_poly_factor
@@ -783,7 +783,7 @@ mutable struct gfp_poly_factor
 
   function gfp_poly_factor(n::UInt)
     z = new()
-    ccall((:nmod_poly_factor_init, :libflint), Nothing,
+    ccall((:nmod_poly_factor_init, libflint), Nothing,
             (Ref{gfp_poly_factor}, ), z)
     z.n = n
     finalizer(_gfp_poly_factor_clear_fn, z)
@@ -792,7 +792,7 @@ mutable struct gfp_poly_factor
 end
 
 function _gfp_poly_factor_clear_fn(a::gfp_poly_factor)
-  ccall((:nmod_poly_factor_clear, :libflint), Nothing,
+  ccall((:nmod_poly_factor_clear, libflint), Nothing,
           (Ref{gfp_poly_factor}, ), a)
 end
 
@@ -834,7 +834,7 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -842,9 +842,9 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz, a::UInt)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
-      ccall((:fmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:fmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{fmpz_mod_poly}, Int, UInt), z, 0, a)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -852,9 +852,9 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz, a::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}), z, n)
-      ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, 0, a)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -863,10 +863,10 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
    function fmpz_mod_poly(n::fmpz, arr::Array{fmpz, 1})
       length(arr) == 0 && error("Array must have length > 0")
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i])
       end
       finalizer(_fmpz_mod_poly_clear_fn, z)
@@ -875,10 +875,10 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz, arr::Array{fmpz_mod, 1})
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{fmpz_mod_poly}, Int, Ref{fmpz}), z, i - 1, arr[i].data)
       end
       finalizer(_fmpz_mod_poly_clear_fn, z)
@@ -887,9 +887,9 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz, f::fmpz_poly)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
-      ccall((:fmpz_mod_poly_set_fmpz_poly, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_fmpz_poly, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz_poly}), z, f)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -897,9 +897,9 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 
    function fmpz_mod_poly(n::fmpz, f::fmpz_mod_poly)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz}, Int), z, n, length(f))
-      ccall((:fmpz_mod_poly_set, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set, libflint), Nothing,
             (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}), z, f)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -907,7 +907,7 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
 end
 
 function _fmpz_mod_poly_clear_fn(x::fmpz_mod_poly)
-  ccall((:fmpz_mod_poly_clear, :libflint), Nothing, (Ref{fmpz_mod_poly}, ), x)
+  ccall((:fmpz_mod_poly_clear, libflint), Nothing, (Ref{fmpz_mod_poly}, ), x)
 end
 
 mutable struct fmpz_mod_poly_factor
@@ -919,7 +919,7 @@ mutable struct fmpz_mod_poly_factor
 
   function fmpz_mod_poly_factor(n::fmpz)
     z = new()
-    ccall((:fmpz_mod_poly_factor_init, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_init, libflint), Nothing,
             (Ref{fmpz_mod_poly_factor}, ), z)
     z.n = n
     finalizer(_fmpz_mod_poly_factor_clear_fn, z)
@@ -928,7 +928,7 @@ mutable struct fmpz_mod_poly_factor
 end
 
 function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
-  ccall((:fmpz_mod_poly_factor_clear, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_factor_clear, libflint), Nothing,
           (Ref{fmpz_mod_poly_factor}, ), a)
 end
 
@@ -970,7 +970,7 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}), z, n)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -978,9 +978,9 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz, a::UInt)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}), z, n)
-      ccall((:fmod_poly_set_coeff_ui, :libflint), Nothing,
+      ccall((:fmod_poly_set_coeff_ui, libflint), Nothing,
               (Ref{gfp_fmpz_poly}, Int, UInt), z, 0, a)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -988,9 +988,9 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz, a::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}), z, n)
-      ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{gfp_fmpz_poly}, Int, Ref{fmpz}), z, 0, a)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -999,10 +999,10 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
    function gfp_fmpz_poly(n::fmpz, arr::Array{fmpz, 1})
       length(arr) == 0 && error("Array must have length > 0")
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{gfp_fmpz_poly}, Int, Ref{fmpz}), z, i - 1, arr[i])
       end
       finalizer(_fmpz_mod_poly_clear_fn, z)
@@ -1011,10 +1011,10 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz, arr::Array{gfp_fmpz_elem, 1})
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}, Int), z, n, length(arr))
       for i in 1:length(arr)
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
               (Ref{gfp_fmpz_poly}, Int, Ref{fmpz}), z, i - 1, arr[i].data)
       end
       finalizer(_fmpz_mod_poly_clear_fn, z)
@@ -1023,9 +1023,9 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz, f::fmpz_poly)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}, Int), z, n, length(f))
-      ccall((:fmpz_mod_poly_set_fmpz_poly, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_fmpz_poly, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz_poly}), z, f)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -1033,9 +1033,9 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 
    function gfp_fmpz_poly(n::fmpz, f::gfp_fmpz_poly)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{fmpz}, Int), z, n, length(f))
-      ccall((:fmpz_mod_poly_set, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set, libflint), Nothing,
             (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}), z, f)
       finalizer(_fmpz_mod_poly_clear_fn, z)
       return z
@@ -1043,7 +1043,7 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
 end
 
 function _fmpz_mod_poly_clear_fn(x::gfp_fmpz_poly)
-  ccall((:fmpz_mod_poly_clear, :libflint), Nothing, (Ref{gfp_fmpz_poly}, ), x)
+  ccall((:fmpz_mod_poly_clear, libflint), Nothing, (Ref{gfp_fmpz_poly}, ), x)
 end
 
 mutable struct gfp_fmpz_poly_factor
@@ -1055,7 +1055,7 @@ mutable struct gfp_fmpz_poly_factor
 
   function gfp_fmpz_poly_factor(n::fmpz)
     z = new()
-    ccall((:fmpz_mod_poly_factor_init, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_init, libflint), Nothing,
             (Ref{gfp_fmpz_poly_factor}, ), z)
     z.n = n
     finalizer(_gfp_fmpz_poly_factor_clear_fn, z)
@@ -1064,7 +1064,7 @@ mutable struct gfp_fmpz_poly_factor
 end
 
 function _gfp_fmpz_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
-  ccall((:fmpz_mod_poly_factor_clear, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_factor_clear, libflint), Nothing,
           (Ref{gfp_fmpz_poly_factor}, ), a)
 end
 
@@ -1104,7 +1104,7 @@ mutable struct FmpzMPolyRing <: MPolyRing{fmpz}
          end
 
          z = new()
-         ccall((:fmpz_mpoly_ctx_init, :libflint), Nothing,
+         ccall((:fmpz_mpoly_ctx_init, libflint), Nothing,
                (Ref{FmpzMPolyRing}, Int, Int),
                z, length(s), ord)
          z.base_ring = FlintZZ
@@ -1119,7 +1119,7 @@ mutable struct FmpzMPolyRing <: MPolyRing{fmpz}
 end
 
 function _fmpz_mpoly_ctx_clear_fn(a::FmpzMPolyRing)
-   ccall((:fmpz_mpoly_ctx_clear, :libflint), Nothing,
+   ccall((:fmpz_mpoly_ctx_clear, libflint), Nothing,
            (Ref{FmpzMPolyRing},), a)
 end
 
@@ -1136,7 +1136,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
 
    function fmpz_mpoly(ctx::FmpzMPolyRing)
       z = new()
-      ccall((:fmpz_mpoly_init, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init, libflint), Nothing,
             (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
       z.parent = ctx
       finalizer(_fmpz_mpoly_clear_fn, z)
@@ -1145,69 +1145,69 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::Vector{fmpz}, b::Vector{Vector{UInt}})
       z = new()
-      ccall((:fmpz_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init2, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpz_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:fmpz_mpoly_push_term_fmpz_ui, :libflint), Nothing,
+         ccall((:fmpz_mpoly_push_term_fmpz_ui, libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{UInt}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
 
-       ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_sort_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
-       ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        return z
    end
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::Vector{fmpz}, b::Vector{Vector{Int}})
       z = new()
-      ccall((:fmpz_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init2, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpz_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:fmpz_mpoly_push_term_fmpz_ui, :libflint), Nothing,
+         ccall((:fmpz_mpoly_push_term_fmpz_ui, libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Int}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
 
-       ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_sort_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
-       ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        return z
    end
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::Vector{fmpz}, b::Vector{Vector{fmpz}})
       z = new()
-      ccall((:fmpz_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init2, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpz_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:fmpz_mpoly_push_term_fmpz_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mpoly_push_term_fmpz_fmpz, libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Ref{fmpz}}, Ref{FmpzMPolyRing}),
                z, a[i], b[i], ctx)
        end
 
-       ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_sort_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
-       ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:fmpz_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, ctx)
        return z
    end
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::fmpz)
       z = new()
-      ccall((:fmpz_mpoly_init, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init, libflint), Nothing,
             (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
-      ccall((:fmpz_mpoly_set_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mpoly_set_fmpz, libflint), Nothing,
             (Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_fmpz_mpoly_clear_fn, z)
@@ -1216,9 +1216,9 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::Int)
       z = new()
-      ccall((:fmpz_mpoly_init, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init, libflint), Nothing,
             (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
-      ccall((:fmpz_mpoly_set_si, :libflint), Nothing,
+      ccall((:fmpz_mpoly_set_si, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, a, ctx)
       finalizer(_fmpz_mpoly_clear_fn, z)
       z.parent = ctx
@@ -1227,9 +1227,9 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
 
    function fmpz_mpoly(ctx::FmpzMPolyRing, a::UInt)
       z = new()
-      ccall((:fmpz_mpoly_init, :libflint), Nothing,
+      ccall((:fmpz_mpoly_init, libflint), Nothing,
             (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing},), z, ctx)
-      ccall((:fmpz_mpoly_set_ui, :libflint), Nothing,
+      ccall((:fmpz_mpoly_set_ui, libflint), Nothing,
             (Ref{fmpz_mpoly}, UInt, Ref{FmpzMPolyRing}), z, a, ctx)
       finalizer(_fmpz_mpoly_clear_fn, z)
       z.parent = ctx
@@ -1238,7 +1238,7 @@ mutable struct fmpz_mpoly <: MPolyElem{fmpz}
 end
 
 function _fmpz_mpoly_clear_fn(a::fmpz_mpoly)
-   ccall((:fmpz_mpoly_clear, :libflint), Nothing,
+   ccall((:fmpz_mpoly_clear, libflint), Nothing,
           (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
 end
 
@@ -1274,7 +1274,7 @@ mutable struct FmpqMPolyRing <: MPolyRing{fmpq}
          end
 
          z = new()
-         ccall((:fmpq_mpoly_ctx_init, :libflint), Nothing,
+         ccall((:fmpq_mpoly_ctx_init, libflint), Nothing,
                (Ref{FmpqMPolyRing}, Int, Int),
                z, length(s), ord)
          z.base_ring = FlintQQ
@@ -1289,7 +1289,7 @@ mutable struct FmpqMPolyRing <: MPolyRing{fmpq}
 end
 
 function _fmpq_mpoly_ctx_clear_fn(a::FmpqMPolyRing)
-  ccall((:fmpq_mpoly_ctx_clear, :libflint), Nothing,
+  ccall((:fmpq_mpoly_ctx_clear, libflint), Nothing,
           (Ref{FmpqMPolyRing},), a)
 end
 
@@ -1308,7 +1308,7 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 
    function fmpq_mpoly(ctx::FmpqMPolyRing)
       z = new()
-      ccall((:fmpq_mpoly_init, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing},), z, ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
@@ -1317,69 +1317,69 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Vector{fmpq}, b::Vector{Vector{UInt}})
       z = new()
-      ccall((:fmpq_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init2, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-        ccall((:fmpq_mpoly_push_term_fmpq_ui, :libflint), Nothing,
+        ccall((:fmpq_mpoly_push_term_fmpq_ui, libflint), Nothing,
               (Ref{fmpq_mpoly}, Ref{fmpq}, Ptr{UInt}, Ref{FmpqMPolyRing}),
               z, a[i], b[i], ctx)
       end
 
-      ccall((:fmpq_mpoly_sort_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_sort_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
-      ccall((:fmpq_mpoly_combine_like_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_combine_like_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
       return z
    end
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Vector{fmpq}, b::Vector{Vector{Int}})
       z = new()
-      ccall((:fmpq_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init2, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-        ccall((:fmpq_mpoly_push_term_fmpq_ui, :libflint), Nothing,
+        ccall((:fmpq_mpoly_push_term_fmpq_ui, libflint), Nothing,
               (Ref{fmpq_mpoly}, Ref{fmpq}, Ptr{Int}, Ref{FmpqMPolyRing}),
               z, a[i], b[i], ctx)
       end
 
-      ccall((:fmpq_mpoly_sort_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_sort_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
-      ccall((:fmpq_mpoly_combine_like_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_combine_like_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
       return z
    end
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Vector{fmpq}, b::Vector{Vector{fmpz}})
       z = new()
-      ccall((:fmpq_mpoly_init2, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init2, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-        ccall((:fmpq_mpoly_push_term_fmpq_fmpz, :libflint), Nothing,
+        ccall((:fmpq_mpoly_push_term_fmpq_fmpz, libflint), Nothing,
               (Ref{fmpq_mpoly}, Ref{fmpq}, Ptr{Ref{fmpz}}, Ref{FmpqMPolyRing}),
               z, a[i], b[i], ctx)
       end
 
-      ccall((:fmpq_mpoly_sort_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_sort_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
-      ccall((:fmpq_mpoly_combine_like_terms, :libflint), Nothing,
+      ccall((:fmpq_mpoly_combine_like_terms, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, ctx)
       return z
    end
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::fmpz)
       z = new()
-      ccall((:fmpq_mpoly_init, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing},), z, ctx)
-      ccall((:fmpq_mpoly_set_fmpz, :libflint), Nothing,
+      ccall((:fmpq_mpoly_set_fmpz, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{fmpz}, Ref{FmpqMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
@@ -1388,9 +1388,9 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::fmpq)
       z = new()
-      ccall((:fmpq_mpoly_init, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing},), z, ctx)
-      ccall((:fmpq_mpoly_set_fmpq, :libflint), Nothing,
+      ccall((:fmpq_mpoly_set_fmpq, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{fmpq}, Ref{FmpqMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
@@ -1399,9 +1399,9 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::Int)
       z = new()
-      ccall((:fmpq_mpoly_init, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing},), z, ctx)
-      ccall((:fmpq_mpoly_set_si, :libflint), Nothing,
+      ccall((:fmpq_mpoly_set_si, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
@@ -1410,9 +1410,9 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 
    function fmpq_mpoly(ctx::FmpqMPolyRing, a::UInt)
       z = new()
-      ccall((:fmpq_mpoly_init, :libflint), Nothing,
+      ccall((:fmpq_mpoly_init, libflint), Nothing,
             (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing},), z, ctx)
-      ccall((:fmpq_mpoly_set_ui, :libflint), Nothing,
+      ccall((:fmpq_mpoly_set_ui, libflint), Nothing,
             (Ref{fmpq_mpoly}, UInt, Ref{FmpqMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_fmpq_mpoly_clear_fn, z)
@@ -1421,7 +1421,7 @@ mutable struct fmpq_mpoly <: MPolyElem{fmpq}
 end
 
 function _fmpq_mpoly_clear_fn(a::fmpq_mpoly)
-  ccall((:fmpq_mpoly_clear, :libflint), Nothing,
+  ccall((:fmpq_mpoly_clear, libflint), Nothing,
           (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
 end
 
@@ -1461,7 +1461,7 @@ mutable struct NmodMPolyRing <: MPolyRing{nmod}
          end
 
          z = new()
-         ccall((:nmod_mpoly_ctx_init, :libflint), Nothing,
+         ccall((:nmod_mpoly_ctx_init, libflint), Nothing,
                (Ref{NmodMPolyRing}, Int, Cint, UInt),
                z, length(s), ord, R.n)
          z.base_ring = R
@@ -1476,7 +1476,7 @@ mutable struct NmodMPolyRing <: MPolyRing{nmod}
 end
 
 function _nmod_mpoly_ctx_clear_fn(a::NmodMPolyRing)
-   ccall((:nmod_mpoly_ctx_clear, :libflint), Nothing,
+   ccall((:nmod_mpoly_ctx_clear, libflint), Nothing,
            (Ref{NmodMPolyRing},), a)
 end
 
@@ -1493,7 +1493,7 @@ mutable struct nmod_mpoly <: MPolyElem{nmod}
 
    function nmod_mpoly(ctx::NmodMPolyRing)
       z = new()
-      ccall((:nmod_mpoly_init, :libflint), Nothing,
+      ccall((:nmod_mpoly_init, libflint), Nothing,
             (Ref{nmod_mpoly}, Ref{NmodMPolyRing},), z, ctx)
       z.parent = ctx
       finalizer(_nmod_mpoly_clear_fn, z)
@@ -1502,69 +1502,69 @@ mutable struct nmod_mpoly <: MPolyElem{nmod}
 
    function nmod_mpoly(ctx::NmodMPolyRing, a::Vector{nmod}, b::Vector{Vector{UInt}})
       z = new()
-      ccall((:nmod_mpoly_init2, :libflint), Nothing,
+      ccall((:nmod_mpoly_init2, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_nmod_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:nmod_mpoly_push_term_ui_ui, :libflint), Nothing,
+         ccall((:nmod_mpoly_push_term_ui_ui, libflint), Nothing,
                (Ref{nmod_mpoly}, UInt, Ptr{UInt}, Ref{NmodMPolyRing}),
                z, a[i].data, b[i], ctx)
        end
 
-       ccall((:nmod_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_sort_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
-       ccall((:nmod_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
        return z
    end
 
    function nmod_mpoly(ctx::NmodMPolyRing, a::Vector{nmod}, b::Vector{Vector{Int}})
       z = new()
-      ccall((:nmod_mpoly_init2, :libflint), Nothing,
+      ccall((:nmod_mpoly_init2, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_nmod_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:nmod_mpoly_push_term_ui_ui, :libflint), Nothing,
+         ccall((:nmod_mpoly_push_term_ui_ui, libflint), Nothing,
                (Ref{nmod_mpoly}, UInt, Ptr{Int}, Ref{NmodMPolyRing}),
                z, a[i].data, b[i], ctx)
        end
 
-       ccall((:nmod_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_sort_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
-       ccall((:nmod_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
        return z
    end
 
    function nmod_mpoly(ctx::NmodMPolyRing, a::Vector{nmod}, b::Vector{Vector{fmpz}})
       z = new()
-      ccall((:nmod_mpoly_init2, :libflint), Nothing,
+      ccall((:nmod_mpoly_init2, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing},), z, length(a), ctx)
       z.parent = ctx
       finalizer(_nmod_mpoly_clear_fn, z)
 
       for i in 1:length(a)
-         ccall((:nmod_mpoly_push_term_ui_fmpz, :libflint), Nothing,
+         ccall((:nmod_mpoly_push_term_ui_fmpz, libflint), Nothing,
                (Ref{nmod_mpoly}, UInt, Ptr{Ref{fmpz}}, Ref{NmodMPolyRing}),
                z, a[i].data, b[i], ctx)
        end
 
-       ccall((:nmod_mpoly_sort_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_sort_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
-       ccall((:nmod_mpoly_combine_like_terms, :libflint), Nothing,
+       ccall((:nmod_mpoly_combine_like_terms, libflint), Nothing,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, ctx)
        return z
    end
 
    function nmod_mpoly(ctx::NmodMPolyRing, a::UInt)
       z = new()
-      ccall((:nmod_mpoly_init, :libflint), Nothing,
+      ccall((:nmod_mpoly_init, libflint), Nothing,
             (Ref{nmod_mpoly}, Ref{NmodMPolyRing},), z, ctx)
-      ccall((:nmod_mpoly_set_ui, :libflint), Nothing,
+      ccall((:nmod_mpoly_set_ui, libflint), Nothing,
             (Ref{nmod_mpoly}, UInt, Ref{NmodMPolyRing}), z, a, ctx)
       z.parent = ctx
       finalizer(_nmod_mpoly_clear_fn, z)
@@ -1573,9 +1573,9 @@ mutable struct nmod_mpoly <: MPolyElem{nmod}
 
    function nmod_mpoly(ctx::NmodMPolyRing, a::nmod)
       z = new()
-      ccall((:nmod_mpoly_init, :libflint), Nothing,
+      ccall((:nmod_mpoly_init, libflint), Nothing,
             (Ref{nmod_mpoly}, Ref{NmodMPolyRing},), z, ctx)
-      ccall((:nmod_mpoly_set_ui, :libflint), Nothing,
+      ccall((:nmod_mpoly_set_ui, libflint), Nothing,
             (Ref{nmod_mpoly}, UInt, Ref{NmodMPolyRing}), z, a.data, ctx)
       finalizer(_nmod_mpoly_clear_fn, z)
       z.parent = ctx
@@ -1584,7 +1584,7 @@ mutable struct nmod_mpoly <: MPolyElem{nmod}
 end
 
 function _nmod_mpoly_clear_fn(a::nmod_mpoly)
-   ccall((:nmod_mpoly_clear, :libflint), Nothing,
+   ccall((:nmod_mpoly_clear, libflint), Nothing,
           (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
 end
 
@@ -1624,7 +1624,7 @@ mutable struct FqNmodFiniteField <: FinField
          return FqNmodFiniteFieldID[c, deg, s]
       else
          d = new()
-         ccall((:fq_nmod_ctx_init, :libflint), Nothing,
+         ccall((:fq_nmod_ctx_init, libflint), Nothing,
                (Ref{FqNmodFiniteField}, Ref{fmpz}, Int, Ptr{UInt8}),
 			    d, c, deg, string(s))
          d.overfields = Dict{Int, Array{FinFieldMorphism, 1}}()
@@ -1644,7 +1644,7 @@ mutable struct FqNmodFiniteField <: FinField
          return FqNmodFiniteFieldIDNmodPol[parent(f), f, s]
       else
          z = new()
-         ccall((:fq_nmod_ctx_init_modulus, :libflint), Nothing,
+         ccall((:fq_nmod_ctx_init_modulus, libflint), Nothing,
             (Ref{FqNmodFiniteField}, Ref{nmod_poly}, Ptr{UInt8}),
 	      z, f, string(s))
          z.overfields = Dict{Int, Array{FinFieldMorphism, 1}}()
@@ -1663,7 +1663,7 @@ mutable struct FqNmodFiniteField <: FinField
          return FqNmodFiniteFieldIDGFPPol[parent(f), f, s]
       else
          z = new()
-         ccall((:fq_nmod_ctx_init_modulus, :libflint), Nothing,
+         ccall((:fq_nmod_ctx_init_modulus, libflint), Nothing,
             (Ref{FqNmodFiniteField}, Ref{gfp_poly}, Ptr{UInt8}),
 	      z, f, string(s))
          if cached
@@ -1686,7 +1686,7 @@ const FqNmodFiniteFieldIDGFPPol = Dict{Tuple{GFPPolyRing, gfp_poly, Symbol},
 
 
 function _FqNmodFiniteField_clear_fn(a :: FqNmodFiniteField)
-   ccall((:fq_nmod_ctx_clear, :libflint), Nothing, (Ref{FqNmodFiniteField},), a)
+   ccall((:fq_nmod_ctx_clear, libflint), Nothing, (Ref{FqNmodFiniteField},), a)
 end
 
 mutable struct fq_nmod <: FinFieldElem
@@ -1700,7 +1700,7 @@ mutable struct fq_nmod <: FinFieldElem
 
    function fq_nmod(ctx::FqNmodFiniteField)
       d = new()
-      ccall((:fq_nmod_init2, :libflint), Nothing,
+      ccall((:fq_nmod_init2, libflint), Nothing,
             (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(_fq_nmod_clear_fn, d)
       return d
@@ -1708,37 +1708,37 @@ mutable struct fq_nmod <: FinFieldElem
 
    function fq_nmod(ctx::FqNmodFiniteField, x::Int)
       d = new()
-      ccall((:fq_nmod_init2, :libflint), Nothing,
+      ccall((:fq_nmod_init2, libflint), Nothing,
             (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(_fq_nmod_clear_fn, d)
-      ccall((:fq_nmod_set_si, :libflint), Nothing,
+      ccall((:fq_nmod_set_si, libflint), Nothing,
                 (Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 
    function fq_nmod(ctx::FqNmodFiniteField, x::fmpz)
       d = new()
-      ccall((:fq_nmod_init2, :libflint), Nothing,
+      ccall((:fq_nmod_init2, libflint), Nothing,
             (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(_fq_nmod_clear_fn, d)
-      ccall((:fq_nmod_set_fmpz, :libflint), Nothing,
+      ccall((:fq_nmod_set_fmpz, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 
       function fq_nmod(ctx::FqNmodFiniteField, x::fq_nmod)
       d = new()
-      ccall((:fq_nmod_init2, :libflint), Nothing,
+      ccall((:fq_nmod_init2, libflint), Nothing,
             (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, ctx)
       finalizer(_fq_nmod_clear_fn, d)
-      ccall((:fq_nmod_set, :libflint), Nothing,
+      ccall((:fq_nmod_set, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, x, ctx)
       return d
    end
 end
 
 function _fq_nmod_clear_fn(a::fq_nmod)
-   ccall((:fq_nmod_clear, :libflint), Nothing,
+   ccall((:fq_nmod_clear, libflint), Nothing,
          (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 end
 
@@ -1772,7 +1772,7 @@ mutable struct FqFiniteField <: FinField
       else
          d = new()
          finalizer(_FqFiniteField_clear_fn, d)
-         ccall((:fq_ctx_init, :libflint), Nothing,
+         ccall((:fq_ctx_init, libflint), Nothing,
                (Ref{FqFiniteField}, Ref{fmpz}, Int, Ptr{UInt8}),
                   d, char, deg, string(s))
          if cached
@@ -1789,7 +1789,7 @@ mutable struct FqFiniteField <: FinField
          return FqFiniteFieldIDFmpzPol[f, s]
       else
          z = new()
-         ccall((:fq_ctx_init_modulus, :libflint), Nothing,
+         ccall((:fq_ctx_init_modulus, libflint), Nothing,
                (Ref{FqFiniteField}, Ref{fmpz_mod_poly}, Ptr{UInt8}),
                   z, f, string(s))
          if cached
@@ -1806,7 +1806,7 @@ mutable struct FqFiniteField <: FinField
          return FqFiniteFieldIDGFPPol[f, s]
       else
          z = new()
-         ccall((:fq_ctx_init_modulus, :libflint), Nothing,
+         ccall((:fq_ctx_init_modulus, libflint), Nothing,
                (Ref{FqFiniteField}, Ref{gfp_fmpz_poly}, Ptr{UInt8}),
                   z, f, string(s))
          if cached
@@ -1826,7 +1826,7 @@ const FqFiniteFieldIDFmpzPol = Dict{Tuple{fmpz_mod_poly, Symbol}, FqFiniteField}
 const FqFiniteFieldIDGFPPol = Dict{Tuple{gfp_fmpz_poly, Symbol}, FqFiniteField}()
 
 function _FqFiniteField_clear_fn(a :: FqFiniteField)
-   ccall((:fq_ctx_clear, :libflint), Nothing, (Ref{FqFiniteField},), a)
+   ccall((:fq_ctx_clear, libflint), Nothing, (Ref{FqFiniteField},), a)
 end
 
 mutable struct fq <: FinFieldElem
@@ -1837,7 +1837,7 @@ mutable struct fq <: FinFieldElem
 
    function fq(ctx::FqFiniteField)
       d = new()
-      ccall((:fq_init2, :libflint), Nothing,
+      ccall((:fq_init2, libflint), Nothing,
             (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(_fq_clear_fn, d)
       d.parent = ctx
@@ -1846,10 +1846,10 @@ mutable struct fq <: FinFieldElem
 
    function fq(ctx::FqFiniteField, x::Int)
       d = new()
-      ccall((:fq_init2, :libflint), Nothing,
+      ccall((:fq_init2, libflint), Nothing,
             (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(_fq_clear_fn, d)
-      ccall((:fq_set_si, :libflint), Nothing,
+      ccall((:fq_set_si, libflint), Nothing,
                 (Ref{fq}, Int, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
@@ -1857,10 +1857,10 @@ mutable struct fq <: FinFieldElem
 
    function fq(ctx::FqFiniteField, x::fmpz)
       d = new()
-      ccall((:fq_init2, :libflint), Nothing,
+      ccall((:fq_init2, libflint), Nothing,
             (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(_fq_clear_fn, d)
-      ccall((:fq_set_fmpz, :libflint), Nothing,
+      ccall((:fq_set_fmpz, libflint), Nothing,
             (Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
@@ -1868,10 +1868,10 @@ mutable struct fq <: FinFieldElem
 
    function fq(ctx::FqFiniteField, x::fq)
       d = new()
-      ccall((:fq_init2, :libflint), Nothing,
+      ccall((:fq_init2, libflint), Nothing,
             (Ref{fq}, Ref{FqFiniteField}), d, ctx)
       finalizer(_fq_clear_fn, d)
-      ccall((:fq_set, :libflint), Nothing,
+      ccall((:fq_set, libflint), Nothing,
             (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), d, x, ctx)
       d.parent = ctx
       return d
@@ -1879,7 +1879,7 @@ mutable struct fq <: FinFieldElem
 end
 
 function _fq_clear_fn(a::fq)
-   ccall((:fq_clear, :libflint), Nothing,
+   ccall((:fq_clear, libflint), Nothing,
          (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 end
 
@@ -1932,7 +1932,7 @@ mutable struct FlintPadicField <: FlintLocalField
 
       d = new()
 
-      ccall((:padic_ctx_init, :libflint), Nothing,
+      ccall((:padic_ctx_init, libflint), Nothing,
             (Ref{FlintPadicField}, Ref{fmpz}, Int, Int, Cint),
             d, p, 0, 0, 0)
       finalizer(_padic_ctx_clear_fn, d)
@@ -1950,7 +1950,7 @@ end
 const PadicBase = Dict{Tuple{fmpz, Int}, FlintPadicField}()
 
 function _padic_ctx_clear_fn(a::FlintPadicField)
-   ccall((:padic_ctx_clear, :libflint), Nothing, (Ref{FlintPadicField},), a)
+   ccall((:padic_ctx_clear, libflint), Nothing, (Ref{FlintPadicField},), a)
 end
 
 mutable struct padic <: FlintLocalFieldElem
@@ -1961,14 +1961,14 @@ mutable struct padic <: FlintLocalFieldElem
 
    function padic(prec::Int)
       d = new()
-      ccall((:padic_init2, :libflint), Nothing, (Ref{padic}, Int), d, prec)
+      ccall((:padic_init2, libflint), Nothing, (Ref{padic}, Int), d, prec)
       finalizer(_padic_clear_fn, d)
       return d
    end
 end
 
 function _padic_clear_fn(a::padic)
-   ccall((:padic_clear, :libflint), Nothing, (Ref{padic},), a)
+   ccall((:padic_clear, libflint), Nothing, (Ref{padic},), a)
 end
 
 ###############################################################################
@@ -2001,7 +2001,7 @@ mutable struct FlintQadicField <: FlintLocalField
       end
 
       z = new()
-      ccall((:qadic_ctx_init, :libflint), Nothing,
+      ccall((:qadic_ctx_init, libflint), Nothing,
            (Ref{FlintQadicField}, Ref{fmpz}, Int, Int, Int, Cstring, Cint),
                                      z, p, d, 0, 0, "a", 0)
       finalizer(_qadic_ctx_clear_fn, z)
@@ -2019,7 +2019,7 @@ end
 const QadicBase = Dict{Tuple{fmpz, Int, Int}, FlintQadicField}()
 
 function _qadic_ctx_clear_fn(a::FlintQadicField)
-   ccall((:qadic_ctx_clear, :libflint), Nothing, (Ref{FlintQadicField},), a)
+   ccall((:qadic_ctx_clear, libflint), Nothing, (Ref{FlintQadicField},), a)
 end
 
 mutable struct qadic <: FlintLocalFieldElem
@@ -2032,14 +2032,14 @@ mutable struct qadic <: FlintLocalFieldElem
 
    function qadic(prec::Int)
       z = new()
-      ccall((:qadic_init2, :libflint), Nothing, (Ref{qadic}, Int), z, prec)
+      ccall((:qadic_init2, libflint), Nothing, (Ref{qadic}, Int), z, prec)
       finalizer(_qadic_clear_fn, z)
       return z
    end
 end
 
 function _qadic_clear_fn(a::qadic)
-   ccall((:qadic_clear, :libflint), Nothing, (Ref{qadic},), a)
+   ccall((:qadic_clear, libflint), Nothing, (Ref{qadic},), a)
 end
 
 ###############################################################################
@@ -2078,7 +2078,7 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
 
    function fmpz_rel_series()
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing,
             (Ref{fmpz_rel_series},), z)
       finalizer(_fmpz_rel_series_clear_fn, z)
       return z
@@ -2086,10 +2086,10 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
 
    function fmpz_rel_series(a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fmpz_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_poly_init2, libflint), Nothing,
             (Ref{fmpz_rel_series}, Int), z, len)
       for i = 1:len
-         ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_rel_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2100,8 +2100,8 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
 
    function fmpz_rel_series(a::fmpz_rel_series)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_rel_series},), z)
-      ccall((:fmpz_poly_set, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_rel_series},), z)
+      ccall((:fmpz_poly_set, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}), z, a)
       finalizer(_fmpz_rel_series_clear_fn, z)
       return z
@@ -2109,7 +2109,7 @@ mutable struct fmpz_rel_series <: RelSeriesElem{fmpz}
 end
 
 function _fmpz_rel_series_clear_fn(a::fmpz_rel_series)
-   ccall((:fmpz_poly_clear, :libflint), Nothing, (Ref{fmpz_rel_series},), a)
+   ccall((:fmpz_poly_clear, libflint), Nothing, (Ref{fmpz_rel_series},), a)
 end
 
 ###############################################################################
@@ -2147,7 +2147,7 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
 
    function fmpz_abs_series()
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing,
             (Ref{fmpz_abs_series},), z)
       finalizer(_fmpz_abs_series_clear_fn, z)
       return z
@@ -2155,10 +2155,10 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
 
    function fmpz_abs_series(a::Array{fmpz, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fmpz_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_poly_init2, libflint), Nothing,
             (Ref{fmpz_abs_series}, Int), z, len)
       for i = 1:len
-         ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_abs_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2168,8 +2168,8 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
 
    function fmpz_abs_series(a::fmpz_abs_series)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_abs_series},), z)
-      ccall((:fmpz_poly_set, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_abs_series},), z)
+      ccall((:fmpz_poly_set, libflint), Nothing,
             (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}), z, a)
       finalizer(_fmpz_abs_series_clear_fn, z)
       return z
@@ -2177,7 +2177,7 @@ mutable struct fmpz_abs_series <: AbsSeriesElem{fmpz}
 end
 
 function _fmpz_abs_series_clear_fn(a::fmpz_abs_series)
-   ccall((:fmpz_poly_clear, :libflint), Nothing, (Ref{fmpz_abs_series},), a)
+   ccall((:fmpz_poly_clear, libflint), Nothing, (Ref{fmpz_abs_series},), a)
 end
 
 ###############################################################################
@@ -2287,7 +2287,7 @@ mutable struct fmpz_laurent_series <: RingElem
 
    function fmpz_laurent_series()
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing,
             (Ref{fmpz_laurent_series},), z)
       finalizer(_fmpz_laurent_series_clear_fn, z)
       return z
@@ -2295,10 +2295,10 @@ mutable struct fmpz_laurent_series <: RingElem
 
    function fmpz_laurent_series(a::Array{fmpz, 1}, len::Int, prec::Int, val::Int, scale::Int)
       z = new()
-      ccall((:fmpz_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_poly_init2, libflint), Nothing,
             (Ref{fmpz_laurent_series}, Int), z, len)
       for i = 1:len
-         ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_laurent_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2310,8 +2310,8 @@ mutable struct fmpz_laurent_series <: RingElem
 
    function fmpz_laurent_series(a::fmpz_laurent_series)
       z = new()
-      ccall((:fmpz_poly_init, :libflint), Nothing, (Ref{fmpz_laurent_series},), z)
-      ccall((:fmpz_poly_set, :libflint), Nothing,
+      ccall((:fmpz_poly_init, libflint), Nothing, (Ref{fmpz_laurent_series},), z)
+      ccall((:fmpz_poly_set, libflint), Nothing,
             (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}), z, a)
       finalizer(_fmpz_laurent_series_clear_fn, z)
       return z
@@ -2319,7 +2319,7 @@ mutable struct fmpz_laurent_series <: RingElem
 end
 
 function _fmpz_laurent_series_clear_fn(a::fmpz_laurent_series)
-   ccall((:fmpz_poly_clear, :libflint), Nothing, (Ref{fmpz_laurent_series},), a)
+   ccall((:fmpz_poly_clear, libflint), Nothing, (Ref{fmpz_laurent_series},), a)
 end
 
 ###############################################################################
@@ -2359,7 +2359,7 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
 
    function fmpq_rel_series()
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing,
             (Ref{fmpq_rel_series},), z)
       finalizer(_fmpq_rel_series_clear_fn, z)
       return z
@@ -2367,10 +2367,10 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
 
    function fmpq_rel_series(a::Array{fmpq, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fmpq_poly_init2, :libflint), Nothing,
+      ccall((:fmpq_poly_init2, libflint), Nothing,
             (Ref{fmpq_rel_series}, Int), z, len)
       for i = 1:len
-         ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                      (Ref{fmpq_rel_series}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2381,8 +2381,8 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
 
    function fmpq_rel_series(a::fmpq_rel_series)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_rel_series},), z)
-      ccall((:fmpq_poly_set, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_rel_series},), z)
+      ccall((:fmpq_poly_set, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}), z, a)
       finalizer(_fmpq_rel_series_clear_fn, z)
       return z
@@ -2390,7 +2390,7 @@ mutable struct fmpq_rel_series <: RelSeriesElem{fmpq}
 end
 
 function _fmpq_rel_series_clear_fn(a::fmpq_rel_series)
-   ccall((:fmpq_poly_clear, :libflint), Nothing, (Ref{fmpq_rel_series},), a)
+   ccall((:fmpq_poly_clear, libflint), Nothing, (Ref{fmpq_rel_series},), a)
 end
 
 ###############################################################################
@@ -2429,7 +2429,7 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
 
    function fmpq_abs_series()
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing,
             (Ref{fmpq_abs_series},), z)
       finalizer(_fmpq_abs_series_clear_fn, z)
       return z
@@ -2437,10 +2437,10 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
 
    function fmpq_abs_series(a::Array{fmpq, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fmpq_poly_init2, :libflint), Nothing,
+      ccall((:fmpq_poly_init2, libflint), Nothing,
             (Ref{fmpq_abs_series}, Int), z, len)
       for i = 1:len
-         ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                      (Ref{fmpq_abs_series}, Int, Ref{fmpq}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2450,8 +2450,8 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
 
    function fmpq_abs_series(a::fmpq_abs_series)
       z = new()
-      ccall((:fmpq_poly_init, :libflint), Nothing, (Ref{fmpq_abs_series},), z)
-      ccall((:fmpq_poly_set, :libflint), Nothing,
+      ccall((:fmpq_poly_init, libflint), Nothing, (Ref{fmpq_abs_series},), z)
+      ccall((:fmpq_poly_set, libflint), Nothing,
             (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}), z, a)
       finalizer(_fmpq_abs_series_clear_fn, z)
       return z
@@ -2459,7 +2459,7 @@ mutable struct fmpq_abs_series <: AbsSeriesElem{fmpq}
 end
 
 function _fmpq_abs_series_clear_fn(a::fmpq_abs_series)
-   ccall((:fmpq_poly_clear, :libflint), Nothing, (Ref{fmpq_abs_series},), a)
+   ccall((:fmpq_poly_clear, libflint), Nothing, (Ref{fmpq_abs_series},), a)
 end
 
 ###############################################################################
@@ -2503,7 +2503,7 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
 
    function nmod_rel_series(p::UInt)
       z = new()
-      ccall((:nmod_poly_init, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing,
             (Ref{nmod_rel_series}, UInt), z, p)
       finalizer(_nmod_rel_series_clear_fn, z)
       return z
@@ -2511,11 +2511,11 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
 
    function nmod_rel_series(p::UInt, a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
-         tt = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), a[i], p)
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         tt = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), a[i], p)
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                      (Ref{nmod_rel_series}, Int, UInt), z, i - 1, tt)
       end
       z.prec = prec
@@ -2526,10 +2526,10 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
 
    function nmod_rel_series(p::UInt, a::Array{UInt, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                      (Ref{nmod_rel_series}, Int, UInt), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2540,10 +2540,10 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
 
    function nmod_rel_series(p::UInt, a::Array{nmod, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:nmod_poly_init2, :libflint), Nothing,
+      ccall((:nmod_poly_init2, libflint), Nothing,
             (Ref{nmod_rel_series}, UInt, Int), z, p, len)
       for i = 1:len
-         ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+         ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                      (Ref{nmod_rel_series}, Int, UInt), z, i - 1, data(a[i]))
       end
       z.prec = prec
@@ -2555,9 +2555,9 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
    function nmod_rel_series(a::nmod_rel_series)
       z = new()
       p = modulus(base_ring(parent(a)))
-      ccall((:nmod_poly_init, :libflint), Nothing,
+      ccall((:nmod_poly_init, libflint), Nothing,
             (Ref{nmod_rel_series}, UInt), z, p)
-      ccall((:nmod_poly_set, :libflint), Nothing,
+      ccall((:nmod_poly_set, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}), z, a)
       finalizer(_nmod_rel_series_clear_fn, z)
       return z
@@ -2565,7 +2565,7 @@ mutable struct nmod_rel_series <: RelSeriesElem{nmod}
 end
 
 function _nmod_rel_series_clear_fn(a::nmod_rel_series)
-   ccall((:nmod_poly_clear, :libflint), Nothing, (Ref{nmod_rel_series},), a)
+   ccall((:nmod_poly_clear, libflint), Nothing, (Ref{nmod_rel_series},), a)
 end
 
 ###############################################################################
@@ -2607,7 +2607,7 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
 
    function fmpz_mod_rel_series(p::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz}), z, p)
       finalizer(_fmpz_mod_rel_series_clear_fn, z)
       return z
@@ -2615,10 +2615,10 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
 
    function fmpz_mod_rel_series(p::fmpz, a::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2629,10 +2629,10 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
 
    function fmpz_mod_rel_series(p::fmpz, a::Array{fmpz_mod, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}), z, i - 1, data(a[i]))
       end
       z.prec = prec
@@ -2644,9 +2644,9 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
    function fmpz_mod_rel_series(a::fmpz_mod_rel_series)
       z = new()
       p = modulus(base_ring(parent(a)))
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz}), z, p)
-      ccall((:fmpz_mod_poly_set, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}), z, a)
       finalizer(_fmpz_mod_rel_series_clear_fn, z)
       return z
@@ -2654,7 +2654,7 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
 end
 
 function _fmpz_mod_rel_series_clear_fn(a::fmpz_mod_rel_series)
-   ccall((:fmpz_mod_poly_clear, :libflint), Nothing, (Ref{fmpz_mod_rel_series},), a)
+   ccall((:fmpz_mod_poly_clear, libflint), Nothing, (Ref{fmpz_mod_rel_series},), a)
 end
 
 ###############################################################################
@@ -2695,7 +2695,7 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
 
    function fmpz_mod_abs_series(p::fmpz)
       z = new()
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_abs_series}, Ref{fmpz}), z, p)
       finalizer(_fmpz_mod_abs_series_clear_fn, z)
       return z
@@ -2703,10 +2703,10 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
 
    function fmpz_mod_abs_series(p::fmpz, a::Array{fmpz, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_abs_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}), z, i - 1, a[i])
       end
       z.prec = prec
@@ -2716,10 +2716,10 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
 
    function fmpz_mod_abs_series(p::fmpz, a::Array{fmpz_mod, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fmpz_mod_poly_init2, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init2, libflint), Nothing,
             (Ref{fmpz_mod_abs_series}, Ref{fmpz}, Int), z, p, len)
       for i = 1:len
-         ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                      (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}), z, i - 1, data(a[i]))
       end
       z.prec = prec
@@ -2730,9 +2730,9 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
    function fmpz_mod_abs_series(a::fmpz_mod_abs_series)
       z = new()
       p = modulus(base_ring(parent(a)))
-      ccall((:fmpz_mod_poly_init, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_init, libflint), Nothing,
             (Ref{fmpz_mod_abs_series}, Ref{fmpz}), z, p)
-      ccall((:fmpz_mod_poly_set, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set, libflint), Nothing,
             (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}), z, a)
       finalizer(_fmpz_mod_abs_series_clear_fn, z)
       return z
@@ -2740,7 +2740,7 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
 end
 
 function _fmpz_mod_abs_series_clear_fn(a::fmpz_mod_abs_series)
-   ccall((:fmpz_mod_poly_clear, :libflint), Nothing, (Ref{fmpz_mod_abs_series},), a)
+   ccall((:fmpz_mod_poly_clear, libflint), Nothing, (Ref{fmpz_mod_abs_series},), a)
 end
 
 ###############################################################################
@@ -2780,7 +2780,7 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
 
    function fq_rel_series(ctx::FqFiniteField)
       z = new()
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{FqFiniteField}), z, ctx)
       finalizer(_fq_rel_series_clear_fn, z)
       return z
@@ -2788,10 +2788,10 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
 
    function fq_rel_series(ctx::FqFiniteField, a::Array{fq, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fq_poly_init2, :libflint), Nothing,
+      ccall((:fq_poly_init2, libflint), Nothing,
             (Ref{fq_rel_series}, Int, Ref{FqFiniteField}), z, len, ctx)
       for i = 1:len
-         ccall((:fq_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_poly_set_coeff, libflint), Nothing,
                (Ref{fq_rel_series}, Int, Ref{fq}, Ref{FqFiniteField}),
                                                z, i - 1, a[i], ctx)
       end
@@ -2803,9 +2803,9 @@ mutable struct fq_rel_series <: RelSeriesElem{fq}
 
    function fq_rel_series(ctx::FqFiniteField, a::fq_rel_series)
       z = new()
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{FqFiniteField}), z, ctx)
-      ccall((:fq_poly_set, :libflint), Nothing,
+      ccall((:fq_poly_set, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}), z, a, ctx)
       finalizer(_fq_rel_series_clear_fn, z)
       return z
@@ -2814,7 +2814,7 @@ end
 
 function _fq_rel_series_clear_fn(a::fq_rel_series)
    ctx = base_ring(a)
-   ccall((:fq_poly_clear, :libflint), Nothing,
+   ccall((:fq_poly_clear, libflint), Nothing,
          (Ref{fq_rel_series}, Ref{FqFiniteField}), a, ctx)
 end
 
@@ -2854,7 +2854,7 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
 
    function fq_abs_series(ctx::FqFiniteField)
       z = new()
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_abs_series}, Ref{FqFiniteField}), z, ctx)
       finalizer(_fq_abs_series_clear_fn, z)
       return z
@@ -2862,10 +2862,10 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
 
    function fq_abs_series(ctx::FqFiniteField, a::Array{fq, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fq_poly_init2, :libflint), Nothing,
+      ccall((:fq_poly_init2, libflint), Nothing,
             (Ref{fq_abs_series}, Int, Ref{FqFiniteField}), z, len, ctx)
       for i = 1:len
-         ccall((:fq_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_poly_set_coeff, libflint), Nothing,
                (Ref{fq_abs_series}, Int, Ref{fq}, Ref{FqFiniteField}),
                                                z, i - 1, a[i], ctx)
       end
@@ -2876,9 +2876,9 @@ mutable struct fq_abs_series <: AbsSeriesElem{fq}
 
    function fq_abs_series(ctx::FqFiniteField, a::fq_abs_series)
       z = new()
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_abs_series}, Ref{FqFiniteField}), z, ctx)
-      ccall((:fq_poly_set, :libflint), Nothing,
+      ccall((:fq_poly_set, libflint), Nothing,
             (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{FqFiniteField}), z, a, ctx)
       finalizer(_fq_abs_series_clear_fn, z)
       return z
@@ -2887,7 +2887,7 @@ end
 
 function _fq_abs_series_clear_fn(a::fq_abs_series)
    ctx = base_ring(a)
-   ccall((:fq_poly_clear, :libflint), Nothing,
+   ccall((:fq_poly_clear, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{FqFiniteField}), a, ctx)
 end
 
@@ -2929,7 +2929,7 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
 
    function fq_nmod_rel_series(ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, ctx)
       finalizer(_fq_nmod_rel_series_clear_fn, z)
       return z
@@ -2937,10 +2937,10 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
 
    function fq_nmod_rel_series(ctx::FqNmodFiniteField, a::Array{fq_nmod, 1}, len::Int, prec::Int, val::Int)
       z = new()
-      ccall((:fq_nmod_poly_init2, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init2, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}), z, len, ctx)
       for i = 1:len
-         ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                (Ref{fq_nmod_rel_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                z, i - 1, a[i], ctx)
       end
@@ -2952,9 +2952,9 @@ mutable struct fq_nmod_rel_series <: RelSeriesElem{fq_nmod}
 
    function fq_nmod_rel_series(ctx::FqNmodFiniteField, a::fq_nmod_rel_series)
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, ctx)
-      ccall((:fq_nmod_poly_set, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), z, a, ctx)
       finalizer(_fq_nmod_rel_series_clear_fn, z)
       return z
@@ -2963,7 +2963,7 @@ end
 
 function _fq_nmod_rel_series_clear_fn(a::fq_nmod_rel_series)
    ctx = base_ring(a)
-   ccall((:fq_nmod_poly_clear, :libflint), Nothing,
+   ccall((:fq_nmod_poly_clear, libflint), Nothing,
          (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), a, ctx)
 end
 
@@ -3004,7 +3004,7 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
 
    function fq_nmod_abs_series(ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, ctx)
       finalizer(_fq_nmod_abs_series_clear_fn, z)
       return z
@@ -3012,10 +3012,10 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
 
    function fq_nmod_abs_series(ctx::FqNmodFiniteField, a::Array{fq_nmod, 1}, len::Int, prec::Int)
       z = new()
-      ccall((:fq_nmod_poly_init2, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init2, libflint), Nothing,
             (Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}), z, len, ctx)
       for i = 1:len
-         ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                (Ref{fq_nmod_abs_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                z, i - 1, a[i], ctx)
       end
@@ -3026,9 +3026,9 @@ mutable struct fq_nmod_abs_series <: AbsSeriesElem{fq_nmod}
 
    function fq_nmod_abs_series(ctx::FqNmodFiniteField, a::fq_nmod_abs_series)
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, ctx)
-      ccall((:fq_nmod_poly_set, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set, libflint), Nothing,
             (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, a, ctx)
       finalizer(_fq_nmod_abs_series_clear_fn, z)
       return z
@@ -3037,7 +3037,7 @@ end
 
 function _fq_nmod_abs_series_clear_fn(a::fq_nmod_abs_series)
    ctx = base_ring(a)
-   ccall((:fq_nmod_poly_clear, :libflint), Nothing,
+   ccall((:fq_nmod_poly_clear, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, ctx)
 end
 
@@ -3083,7 +3083,7 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int)
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       return z
@@ -3091,14 +3091,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{fmpq, 2})
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set, :libflint), Nothing,
+            ccall((:fmpq_set, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpq}), el, arr[i, j])
          end
       end
@@ -3107,15 +3107,15 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 2})
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       b = fmpz(1)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set_fmpz_frac, :libflint), Nothing,
+            ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[i, j], b)
          end
       end
@@ -3125,14 +3125,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{fmpq, 1})
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set, :libflint), Nothing,
+            ccall((:fmpq_set, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpq}), el, arr[(i-1)*c+j])
          end
       end
@@ -3141,15 +3141,15 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 1})
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       b = fmpz(1)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set_fmpz_frac, :libflint), Nothing,
+            ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j], b)
          end
       end
@@ -3159,14 +3159,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{T, 2}) where {T <: Integer}
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set, :libflint), Nothing,
+            ccall((:fmpq_set, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpq}), el, fmpq(arr[i, j]))
          end
       end
@@ -3175,14 +3175,14 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, arr::AbstractArray{T, 1}) where {T <: Integer}
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+            el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                        (Ref{fmpq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpq_set, :libflint), Nothing,
+            ccall((:fmpq_set, libflint), Nothing,
                   (Ptr{fmpq}, Ref{fmpq}), el, fmpq(arr[(i-1)*c+j]))
          end
       end
@@ -3191,13 +3191,13 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(r::Int, c::Int, d::fmpq)
       z = new()
-      ccall((:fmpq_mat_init, :libflint), Nothing,
+      ccall((:fmpq_mat_init, libflint), Nothing,
             (Ref{fmpq_mat}, Int, Int), z, r, c)
       finalizer(_fmpq_mat_clear_fn, z)
       GC.@preserve z for i = 1:min(r, c)
-         el = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+         el = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                     (Ref{fmpq_mat}, Int, Int), z, i - 1, i - 1)
-         ccall((:fmpq_set, :libflint), Nothing,
+         ccall((:fmpq_set, libflint), Nothing,
                (Ptr{fmpq}, Ref{fmpq}), el, d)
       end
       return z
@@ -3205,7 +3205,7 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 
    function fmpq_mat(m::fmpq_mat)
       z = new()
-      ccall((:fmpq_mat_init_set, :libflint), Nothing,
+      ccall((:fmpq_mat_init_set, libflint), Nothing,
             (Ref{fmpq_mat}, Ref{fmpq_mat}), z, m)
       finalizer(_fmpq_mat_clear_fn, z)
       return z
@@ -3213,7 +3213,7 @@ mutable struct fmpq_mat <: MatElem{fmpq}
 end
 
 function _fmpq_mat_clear_fn(a::fmpq_mat)
-   ccall((:fmpq_mat_clear, :libflint), Nothing, (Ref{fmpq_mat},), a)
+   ccall((:fmpq_mat_clear, libflint), Nothing, (Ref{fmpq_mat},), a)
 end
 
 ###############################################################################
@@ -3258,7 +3258,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int)
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       return z
@@ -3266,14 +3266,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 2})
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
+            ccall((:fmpz_set, libflint), Nothing,
                   (Ptr{fmpz}, Ref{fmpz}), el, arr[i, j])
          end
       end
@@ -3282,14 +3282,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 1})
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
+            ccall((:fmpz_set, libflint), Nothing,
                   (Ptr{fmpz}, Ref{fmpz}), el, arr[(i-1)*c+j])
          end
       end
@@ -3298,14 +3298,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int, arr::AbstractArray{T, 2}) where {T <: Integer}
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
+            ccall((:fmpz_set, libflint), Nothing,
                   (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[i, j]))
          end
       end
@@ -3314,14 +3314,14 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int, arr::AbstractArray{T,1}) where {T <: Integer}
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                        (Ref{fmpz_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fmpz_set, :libflint), Nothing,
+            ccall((:fmpz_set, libflint), Nothing,
                   (Ptr{fmpz}, Ref{fmpz}), el, fmpz(arr[(i-1)*c+j]))
          end
       end
@@ -3330,13 +3330,13 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(r::Int, c::Int, d::fmpz)
       z = new()
-      ccall((:fmpz_mat_init, :libflint), Nothing,
+      ccall((:fmpz_mat_init, libflint), Nothing,
             (Ref{fmpz_mat}, Int, Int), z, r, c)
       finalizer(_fmpz_mat_clear_fn, z)
       GC.@preserve z for i = 1:min(r, c)
-         el = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+         el = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                     (Ref{fmpz_mat}, Int, Int), z, i - 1, i- 1)
-         ccall((:fmpz_set, :libflint), Nothing,
+         ccall((:fmpz_set, libflint), Nothing,
                (Ptr{fmpz}, Ref{fmpz}), el, d)
       end
       return z
@@ -3344,7 +3344,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 
    function fmpz_mat(m::fmpz_mat)
       z = new()
-      ccall((:fmpz_mat_init_set, :libflint), Nothing,
+      ccall((:fmpz_mat_init_set, libflint), Nothing,
             (Ref{fmpz_mat}, Ref{fmpz_mat}), z, m)
       finalizer(_fmpz_mat_clear_fn, z)
       return z
@@ -3352,7 +3352,7 @@ mutable struct fmpz_mat <: MatElem{fmpz}
 end
 
 function _fmpz_mat_clear_fn(a::fmpz_mat)
-   ccall((:fmpz_mat_clear, :libflint), Nothing, (Ref{fmpz_mat},), a)
+   ccall((:fmpz_mat_clear, libflint), Nothing, (Ref{fmpz_mat},), a)
 end
 
 ###############################################################################
@@ -3403,7 +3403,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     return z
@@ -3411,7 +3411,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
@@ -3427,7 +3427,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     for i = 1:r
@@ -3440,7 +3440,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
@@ -3449,7 +3449,7 @@ mutable struct nmod_mat <: MatElem{nmod}
     t = fmpz()
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, :libflint), Nothing,
+        ccall((:fmpz_mod_ui, libflint), Nothing,
 	      (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[i, j], n)
 	setindex_raw!(z, t, i, j)
       end
@@ -3459,14 +3459,14 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     t = fmpz()
     n = fmpz(n)
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, :libflint), Nothing,
+        ccall((:fmpz_mod_ui, libflint), Nothing,
               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[(i - 1) * c + j], n)
         setindex!(z, t, i, j)
       end
@@ -3486,7 +3486,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{nmod, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     if transpose
@@ -3502,7 +3502,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{nmod, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_nmod_mat_clear_fn, z)
     for i = 1:r
@@ -3515,10 +3515,10 @@ mutable struct nmod_mat <: MatElem{nmod}
 
   function nmod_mat(n::UInt, b::fmpz_mat)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{nmod_mat}, Int, Int, UInt), z, b.r, b.c, n)
     finalizer(_nmod_mat_clear_fn, z)
-    ccall((:fmpz_mat_get_nmod_mat, :libflint), Nothing,
+    ccall((:fmpz_mat_get_nmod_mat, libflint), Nothing,
             (Ref{nmod_mat}, Ref{fmpz_mat}), z, b)
     return z
   end
@@ -3537,7 +3537,7 @@ mutable struct nmod_mat <: MatElem{nmod}
 end
 
 function _nmod_mat_clear_fn(mat::nmod_mat)
-  ccall((:nmod_mat_clear, :libflint), Nothing, (Ref{nmod_mat}, ), mat)
+  ccall((:nmod_mat_clear, libflint), Nothing, (Ref{nmod_mat}, ), mat)
 end
 
 ###############################################################################          #
@@ -3585,7 +3585,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz)
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
             (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     return z
@@ -3593,7 +3593,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{fmpz, 2}, transpose::Bool = false)
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
             (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     if transpose
@@ -3609,7 +3609,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{T, 2}, transpose::Bool = false) where T <: Integer
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
 	  (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     if transpose
@@ -3625,7 +3625,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{fmpz_mod, 2}, transpose::Bool = false)
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
 	  (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     if transpose
@@ -3641,7 +3641,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{fmpz, 1})
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
             (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     for i = 1:r
@@ -3654,7 +3654,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{T, 1}) where T <: Integer
     z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
           (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     for i = 1:r
@@ -3666,7 +3666,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
   end
 
   function fmpz_mod_mat(r::Int, c::Int, n::fmpz, arr::AbstractArray{fmpz_mod, 1})                z = new()
-    ccall((:fmpz_mod_mat_init, :libflint), Nothing,
+    ccall((:fmpz_mod_mat_init, libflint), Nothing,
 	  (Ref{fmpz_mod_mat}, Int, Int, Ref{fmpz}), z, r, c, n)
     finalizer(_fmpz_mod_mat_clear_fn, z)
     for i = 1:r
@@ -3679,7 +3679,7 @@ mutable struct fmpz_mod_mat <: MatElem{fmpz_mod}
 end
 
 function _fmpz_mod_mat_clear_fn(mat::fmpz_mod_mat)
-  ccall((:fmpz_mod_mat_clear, :libflint), Nothing, (Ref{fmpz_mod_mat}, ), mat)
+  ccall((:fmpz_mod_mat_clear, libflint), Nothing, (Ref{fmpz_mod_mat}, ), mat)
 end
 
 const Zmod_fmpz_mat = fmpz_mod_mat # eventually a union with future gfp_fmpz_mat
@@ -3732,7 +3732,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     return z
@@ -3740,7 +3740,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
@@ -3756,7 +3756,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{UInt, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     for i = 1:r
@@ -3769,7 +3769,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
@@ -3778,7 +3778,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
     t = fmpz()
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, :libflint), Nothing,
+        ccall((:fmpz_mod_ui, libflint), Nothing,
               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[i, j], n)
         setindex_raw!(z, t, i, j)
       end
@@ -3788,13 +3788,13 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{fmpz, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     t = fmpz()
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, :libflint), Nothing,
+        ccall((:fmpz_mod_ui, libflint), Nothing,
               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[(i - 1) * c + j], n)
         setindex!(z, t, i, j)
       end
@@ -3814,7 +3814,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{gfp_elem, 2}, transpose::Bool = false)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     if transpose
@@ -3830,7 +3830,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(r::Int, c::Int, n::UInt, arr::AbstractArray{gfp_elem, 1})
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, r, c, n)
     finalizer(_gfp_mat_clear_fn, z)
     for i = 1:r
@@ -3843,10 +3843,10 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 
   function gfp_mat(n::UInt, b::fmpz_mat)
     z = new()
-    ccall((:nmod_mat_init, :libflint), Nothing,
+    ccall((:nmod_mat_init, libflint), Nothing,
             (Ref{gfp_mat}, Int, Int, UInt), z, b.r, b.c, n)
     finalizer(_gfp_mat_clear_fn, z)
-    ccall((:fmpz_mat_get_nmod_mat, :libflint), Nothing,
+    ccall((:fmpz_mat_get_nmod_mat, libflint), Nothing,
             (Ref{gfp_mat}, Ref{fmpz_mat}), z, b)
     return z
   end
@@ -3865,7 +3865,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
 end
 
 function _gfp_mat_clear_fn(mat::gfp_mat)
-  ccall((:nmod_mat_clear, :libflint), Nothing, (Ref{gfp_mat}, ), mat)
+  ccall((:nmod_mat_clear, libflint), Nothing, (Ref{gfp_mat}, ), mat)
 end
 
 const Zmodn_mat = Union{nmod_mat, gfp_mat}
@@ -3903,7 +3903,7 @@ mutable struct fq_poly <: PolyElem{fq}
 
    function fq_poly()
       z = new()
-      ccall((:fq_poly_init, :libflint), Nothing, (Ref{fq_poly},), z)
+      ccall((:fq_poly_init, libflint), Nothing, (Ref{fq_poly},), z)
       finalizer(_fq_poly_clear_fn, z)
       return z
    end
@@ -3911,9 +3911,9 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly(a::fq_poly)
       z = new()
       ctx = base_ring(parent(a))
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_poly}, Ref{FqFiniteField}), z, ctx)
-      ccall((:fq_poly_set, :libflint), Nothing,
+      ccall((:fq_poly_set, libflint), Nothing,
             (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
             z, a, ctx)
       finalizer(_fq_poly_clear_fn, z)
@@ -3923,9 +3923,9 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly(a::fq)
       z = new()
       ctx = parent(a)
-      ccall((:fq_poly_init, :libflint), Nothing,
+      ccall((:fq_poly_init, libflint), Nothing,
             (Ref{fq_poly}, Ref{FqFiniteField}), z, ctx)
-      ccall((:fq_poly_set_fq, :libflint), Nothing,
+      ccall((:fq_poly_set_fq, libflint), Nothing,
             (Ref{fq_poly}, Ref{fq}, Ref{FqFiniteField}),
             z, a, ctx)
       finalizer(_fq_poly_clear_fn, z)
@@ -3935,11 +3935,11 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly(a::Array{fq, 1})
       z = new()
       ctx = parent(a[1])
-      ccall((:fq_poly_init2, :libflint), Nothing,
+      ccall((:fq_poly_init2, libflint), Nothing,
             (Ref{fq_poly}, Int, Ref{FqFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
-         ccall((:fq_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_poly_set_coeff, libflint), Nothing,
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, a[i], ctx)
       end
@@ -3950,12 +3950,12 @@ mutable struct fq_poly <: PolyElem{fq}
    function fq_poly(a::Array{fmpz, 1}, ctx::FqFiniteField)
       z = new()
       temp = ctx()
-      ccall((:fq_poly_init2, :libflint), Nothing,
+      ccall((:fq_poly_init2, libflint), Nothing,
             (Ref{fq_poly}, Int, Ref{FqFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(a[i])
-         ccall((:fq_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_poly_set_coeff, libflint), Nothing,
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, temp, ctx)
       end
@@ -3965,12 +3965,12 @@ mutable struct fq_poly <: PolyElem{fq}
 
    function fq_poly(a::fmpz_poly, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_poly_init2, :libflint), Nothing,
+      ccall((:fq_poly_init2, libflint), Nothing,
             (Ref{fq_poly}, Int, Ref{FqFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(coeff(a, i-1))
-         ccall((:fq_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_poly_set_coeff, libflint), Nothing,
                (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, i - 1, temp, ctx)
       end
@@ -3980,7 +3980,7 @@ mutable struct fq_poly <: PolyElem{fq}
 end
 
 function _fq_poly_clear_fn(a::fq_poly)
-   ccall((:fq_poly_clear, :libflint), Nothing, (Ref{fq_poly},), a)
+   ccall((:fq_poly_clear, libflint), Nothing, (Ref{fq_poly},), a)
 end
 
 mutable struct fq_poly_factor
@@ -3992,7 +3992,7 @@ mutable struct fq_poly_factor
 
   function fq_poly_factor(ctx::FqFiniteField)
     z = new()
-    ccall((:fq_poly_factor_init, :libflint), Nothing,
+    ccall((:fq_poly_factor_init, libflint), Nothing,
          (Ref{fq_poly_factor}, Ref{FqFiniteField}), z, ctx)
     z.base_field = ctx
     finalizer(_fq_poly_factor_clear_fn, z)
@@ -4001,7 +4001,7 @@ mutable struct fq_poly_factor
 end
 
 function _fq_poly_factor_clear_fn(a::fq_poly_factor)
-   ccall((:fq_poly_factor_clear, :libflint), Nothing,
+   ccall((:fq_poly_factor_clear, libflint), Nothing,
          (Ref{fq_poly_factor}, Ref{FqFiniteField}),
          a, a.base_field)
 end
@@ -4039,7 +4039,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
 
    function fq_nmod_poly()
       z = new()
-      ccall((:fq_nmod_poly_init, :libflint), Nothing, (Ref{fq_nmod_poly},), z)
+      ccall((:fq_nmod_poly_init, libflint), Nothing, (Ref{fq_nmod_poly},), z)
       finalizer(_fq_nmod_poly_clear_fn, z)
       return z
    end
@@ -4047,9 +4047,9 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly(a::fq_nmod_poly)
       z = new()
       ctx = base_ring(parent(a))
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), z, ctx)
-      ccall((:fq_nmod_poly_set, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
             z, a, ctx)
       finalizer(_fq_nmod_poly_clear_fn, z)
@@ -4059,9 +4059,9 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly(a::fq_nmod)
       z = new()
       ctx = parent(a)
-      ccall((:fq_nmod_poly_init, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), z, ctx)
-      ccall((:fq_nmod_poly_set_fq_nmod, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_fq_nmod, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
             z, a, ctx)
       finalizer(_fq_nmod_poly_clear_fn, z)
@@ -4071,11 +4071,11 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly(a::Array{fq_nmod, 1})
       z = new()
       ctx = parent(a[1])
-      ccall((:fq_nmod_poly_init2, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init2, libflint), Nothing,
             (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
-         ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, a[i], ctx)
       end
@@ -4086,12 +4086,12 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
    function fq_nmod_poly(a::Array{fmpz, 1}, ctx::FqNmodFiniteField)
       z = new()
       temp = ctx()
-      ccall((:fq_nmod_poly_init2, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init2, libflint), Nothing,
             (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(a[i])
-         ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, temp, ctx)
       end
@@ -4101,12 +4101,12 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
 
    function fq_nmod_poly(a::fmpz_poly, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_poly_init2, :libflint), Nothing,
+      ccall((:fq_nmod_poly_init2, libflint), Nothing,
             (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
             z, length(a), ctx)
       for i = 1:length(a)
          temp = ctx(coeff(a,i-1))
-         ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, i - 1, temp, ctx)
       end
@@ -4116,7 +4116,7 @@ mutable struct fq_nmod_poly <: PolyElem{fq_nmod}
 end
 
 function _fq_nmod_poly_clear_fn(a::fq_nmod_poly)
-   ccall((:fq_nmod_poly_clear, :libflint), Nothing, (Ref{fq_nmod_poly},), a)
+   ccall((:fq_nmod_poly_clear, libflint), Nothing, (Ref{fq_nmod_poly},), a)
 end
 
 mutable struct fq_nmod_poly_factor
@@ -4128,7 +4128,7 @@ mutable struct fq_nmod_poly_factor
 
   function fq_nmod_poly_factor(ctx::FqNmodFiniteField)
     z = new()
-    ccall((:fq_nmod_poly_factor_init, :libflint), Nothing,
+    ccall((:fq_nmod_poly_factor_init, libflint), Nothing,
          (Ref{fq_nmod_poly_factor}, Ref{FqNmodFiniteField}), z, ctx)
     z.base_field = ctx
     finalizer(_fq_nmod_poly_factor_clear_fn, z)
@@ -4137,7 +4137,7 @@ mutable struct fq_nmod_poly_factor
 end
 
 function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
-   ccall((:fq_nmod_poly_factor_clear, :libflint), Nothing,
+   ccall((:fq_nmod_poly_factor_clear, libflint), Nothing,
          (Ref{fq_nmod_poly_factor}, Ref{FqNmodFiniteField}),
          a, a.base_field)
 end
@@ -4184,7 +4184,7 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       z.base_ring = ctx
       finalizer(_fq_mat_clear_fn, z)
@@ -4193,11 +4193,11 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{fq, 2}, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_mat_entry_set, libflint), Nothing,
                   (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}),
                    z, i - 1, j - 1, arr[i, j], ctx)
          end
@@ -4209,11 +4209,11 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{fq, 1}, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_mat_entry_set, libflint), Nothing,
                        (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}),
                         z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
          end
@@ -4225,13 +4225,13 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 2}, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fq_mat_entry, :libflint), Ptr{fq},
+            el = ccall((:fq_mat_entry, libflint), Ptr{fq},
                        (Ref{fq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fq_set_fmpz, :libflint), Nothing,
+            ccall((:fq_set_fmpz, libflint), Nothing,
                   (Ptr{fq}, Ref{fmpz}, Ref{FqFiniteField}), el, arr[i, j], ctx)
          end
       end
@@ -4242,13 +4242,13 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 1}, ctx::FqFiniteField)
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fq_mat_entry, :libflint), Ptr{fq},
+            el = ccall((:fq_mat_entry, libflint), Ptr{fq},
                        (Ref{fq_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fq_set_fmpz, :libflint), Nothing,
+            ccall((:fq_set_fmpz, libflint), Nothing,
                   (Ptr{fq}, Ref{fmpz}, Ref{FqFiniteField}), el, arr[(i - 1) * c + j], ctx)
          end
       end
@@ -4259,11 +4259,11 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{T, 2}, ctx::FqFiniteField) where {T <: Integer}
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_mat_entry_set, libflint), Nothing,
                     (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}),
                      z, i - 1, j - 1, ctx(arr[i, j]), ctx)
          end
@@ -4275,11 +4275,11 @@ mutable struct fq_mat <: MatElem{fq}
 
    function fq_mat(r::Int, c::Int, arr::AbstractArray{T ,1}, ctx::FqFiniteField) where {T <: Integer}
       z = new()
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_mat_entry_set, libflint), Nothing,
                        (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}),
                         z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
          end
@@ -4292,10 +4292,10 @@ mutable struct fq_mat <: MatElem{fq}
    function fq_mat(r::Int, c::Int, d::fq)
       z = new()
       ctx = parent(d)
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       for i = 1:min(r, c)
-         ccall((:fq_mat_entry_set, :libflint), Nothing,
+         ccall((:fq_mat_entry_set, libflint), Nothing,
                (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}), z, i - 1, i- 1, d, ctx)
       end
       z.base_ring = ctx
@@ -4307,16 +4307,16 @@ mutable struct fq_mat <: MatElem{fq}
       z = new()
       r = nrows(m)
       c = ncols(m)
-      ccall((:fq_mat_init, :libflint), Nothing,
+      ccall((:fq_mat_init, libflint), Nothing,
             (Ref{fq_mat}, Int, Int, Ref{FqFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el1 = ccall((:fq_mat_entry, :libflint), Ptr{fq},
+            el1 = ccall((:fq_mat_entry, libflint), Ptr{fq},
                         (Ref{fq_mat}, Int, Int), z, i - 1, j - 1)
-            el2 = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el2 = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                         (Ref{fmpz_mat}, Int, Int), m, i - 1, j - 1)
 
-            ccall((:fq_set_fmpz, :libflint), Nothing,
+            ccall((:fq_set_fmpz, libflint), Nothing,
                   (Ptr{fq}, Ptr{fmpz}, Ref{FqFiniteField}), el1, el2, ctx)
          end
       end
@@ -4327,7 +4327,7 @@ mutable struct fq_mat <: MatElem{fq}
 end
 
 function _fq_mat_clear_fn(a::fq_mat)
-   ccall((:fq_mat_clear, :libflint), Nothing, (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
+   ccall((:fq_mat_clear, libflint), Nothing, (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
 ###############################################################################
@@ -4372,7 +4372,7 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       z.base_ring = ctx
       finalizer(_fq_nmod_mat_clear_fn, z)
@@ -4381,11 +4381,11 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{fq_nmod, 2}, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
                   (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                    z, i - 1, j - 1, arr[i, j], ctx)
          end
@@ -4397,11 +4397,11 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{fq_nmod, 1}, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
                        (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                         z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
          end
@@ -4413,13 +4413,13 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 2}, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fq_nmod_mat_entry, :libflint), Ptr{fq_nmod},
+            el = ccall((:fq_nmod_mat_entry, libflint), Ptr{fq_nmod},
                        (Ref{fq_nmod_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fq_nmod_set_fmpz, :libflint), Nothing,
+            ccall((:fq_nmod_set_fmpz, libflint), Nothing,
                   (Ptr{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}), el, arr[i, j], ctx)
          end
       end
@@ -4430,13 +4430,13 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{fmpz, 1}, ctx::FqNmodFiniteField)
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el = ccall((:fq_nmod_mat_entry, :libflint), Ptr{fq_nmod},
+            el = ccall((:fq_nmod_mat_entry, libflint), Ptr{fq_nmod},
                        (Ref{fq_nmod_mat}, Int, Int), z, i - 1, j - 1)
-            ccall((:fq_nmod_set_fmpz, :libflint), Nothing,
+            ccall((:fq_nmod_set_fmpz, libflint), Nothing,
                   (Ptr{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}), el, arr[(i - 1) * c + j], ctx)
          end
       end
@@ -4447,11 +4447,11 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{T, 2}, ctx::FqNmodFiniteField) where {T <: Integer}
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
                     (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                      z, i - 1, j - 1, ctx(arr[i, j]), ctx)
          end
@@ -4463,11 +4463,11 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 
    function fq_nmod_mat(r::Int, c::Int, arr::AbstractArray{T ,1}, ctx::FqNmodFiniteField) where {T <: Integer}
       z = new()
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+            ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
                        (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                         z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
          end
@@ -4480,10 +4480,10 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
    function fq_nmod_mat(r::Int, c::Int, d::fq_nmod)
       z = new()
       ctx = parent(d)
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       for i = 1:min(r, c)
-         ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+         ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
                (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, i - 1, i- 1, d, ctx)
       end
       z.base_ring = ctx
@@ -4495,16 +4495,16 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
       z = new()
       r = nrows(m)
       c = ncols(m)
-      ccall((:fq_nmod_mat_init, :libflint), Nothing,
+      ccall((:fq_nmod_mat_init, libflint), Nothing,
             (Ref{fq_nmod_mat}, Int, Int, Ref{FqNmodFiniteField}), z, r, c, ctx)
       GC.@preserve z for i = 1:r
          for j = 1:c
-            el1 = ccall((:fq_nmod_mat_entry, :libflint), Ptr{fq_nmod},
+            el1 = ccall((:fq_nmod_mat_entry, libflint), Ptr{fq_nmod},
                         (Ref{fq_nmod_mat}, Int, Int), z, i - 1, j - 1)
-            el2 = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+            el2 = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                         (Ref{fmpz_mat}, Int, Int), m, i - 1, j - 1)
 
-            ccall((:fq_nmod_set_fmpz, :libflint), Nothing,
+            ccall((:fq_nmod_set_fmpz, libflint), Nothing,
                   (Ptr{fq_nmod}, Ptr{fmpz}, Ref{FqNmodFiniteField}), el1, el2, ctx)
          end
       end
@@ -4515,7 +4515,7 @@ mutable struct fq_nmod_mat <: MatElem{fq_nmod}
 end
 
 function _fq_nmod_mat_clear_fn(a::fq_nmod_mat)
-   ccall((:fq_nmod_mat_clear, :libflint), Nothing, (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
+   ccall((:fq_nmod_mat_clear, libflint), Nothing, (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
 ################################################################################

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -19,7 +19,7 @@ fmpq(a::Rational{BigInt}) = fmpq(fmpz(a.num), fmpz(a.den))
 
 function fmpq(a::Rational{Int})
   r = fmpq()
-  ccall((:fmpq_set_si, :libflint), Nothing, (Ref{fmpq}, Int64, UInt64), r, numerator(a), denominator(a))
+  ccall((:fmpq_set_si, libflint), Nothing, (Ref{fmpq}, Int64, UInt64), r, numerator(a), denominator(a))
   return r
 end
 
@@ -79,13 +79,13 @@ end
 
 function numerator(a::fmpq)
    z = fmpz()
-   ccall((:fmpq_numerator, :libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), z, a)
+   ccall((:fmpq_numerator, libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), z, a)
    return z
 end
 
 function denominator(a::fmpq)
    z = fmpz()
-   ccall((:fmpq_denominator, :libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), z, a)
+   ccall((:fmpq_denominator, libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -101,7 +101,7 @@ sign(a::fmpq) = fmpq(sign(numerator(a)))
 """
 function abs(a::fmpq)
    z = fmpq()
-   ccall((:fmpq_abs, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
+   ccall((:fmpq_abs, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -113,11 +113,11 @@ zero(::Type{fmpq}) = fmpq(0)
 one(a::FlintRationalField) = fmpq(1)
 
 function isone(a::fmpq)
-   return Bool(ccall((:fmpq_is_one, :libflint), Cint, (Ref{fmpq}, ), a))
+   return Bool(ccall((:fmpq_is_one, libflint), Cint, (Ref{fmpq}, ), a))
 end
 
 function iszero(a::fmpq)
-   return Bool(ccall((:fmpq_is_zero, :libflint), Cint, (Ref{fmpq}, ), a))
+   return Bool(ccall((:fmpq_is_zero, libflint), Cint, (Ref{fmpq}, ), a))
 end
 
 isunit(a::fmpq) = !iszero(a)
@@ -129,7 +129,7 @@ isunit(a::fmpq) = !iszero(a)
 """
 function height(a::fmpq)
    temp = fmpz()
-   ccall((:fmpq_height, :libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), temp, a)
+   ccall((:fmpq_height, libflint), Nothing, (Ref{fmpz}, Ref{fmpq}), temp, a)
    return temp
 end
 
@@ -138,12 +138,12 @@ end
 > Return the number of bits of the height of the fraction $a$.
 """
 function height_bits(a::fmpq)
-   return ccall((:fmpq_height_bits, :libflint), Int, (Ref{fmpq},), a)
+   return ccall((:fmpq_height_bits, libflint), Int, (Ref{fmpq},), a)
 end
 
 function deepcopy_internal(a::fmpq, dict::IdDict)
    z = fmpq()
-   ccall((:fmpq_set, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
+   ccall((:fmpq_set, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -202,7 +202,7 @@ show_minus_one(::Type{fmpq}) = false
 
 function -(a::fmpq)
    z = fmpq()
-   ccall((:fmpq_neg, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
+   ccall((:fmpq_neg, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
    return z
 end
 
@@ -214,21 +214,21 @@ end
 
 function +(a::fmpq, b::fmpq)
    z = fmpq()
-   ccall((:fmpq_add, :libflint), Nothing,
+   ccall((:fmpq_add, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
 function -(a::fmpq, b::fmpq)
    z = fmpq()
-   ccall((:fmpq_sub, :libflint), Nothing,
+   ccall((:fmpq_sub, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
 
 function *(a::fmpq, b::fmpq)
    z = fmpq()
-   ccall((:fmpq_mul, :libflint), Nothing,
+   ccall((:fmpq_mul, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
@@ -241,14 +241,14 @@ end
 
 function +(a::fmpq, b::Int)
    z = fmpq()
-   ccall((:fmpq_add_si, :libflint), Nothing,
+   ccall((:fmpq_add_si, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
 function +(a::fmpq, b::fmpz)
    z = fmpq()
-   ccall((:fmpq_add_fmpz, :libflint), Nothing,
+   ccall((:fmpq_add_fmpz, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
@@ -263,14 +263,14 @@ end
 
 function -(a::fmpq, b::Int)
    z = fmpq()
-   ccall((:fmpq_sub_si, :libflint), Nothing,
+   ccall((:fmpq_sub_si, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
 
 function -(a::fmpq, b::fmpz)
    z = fmpq()
-   ccall((:fmpq_sub_fmpz, :libflint), Nothing,
+   ccall((:fmpq_sub_fmpz, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
@@ -281,7 +281,7 @@ end
 
 function *(a::fmpq, b::fmpz)
    z = fmpq()
-   ccall((:fmpq_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mul_fmpz, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
@@ -308,7 +308,7 @@ end
 ###############################################################################
 
 function ==(a::fmpq, b::fmpq)
-   return ccall((:fmpq_equal, :libflint), Bool,
+   return ccall((:fmpq_equal, libflint), Bool,
                 (Ref{fmpq}, Ref{fmpq}), a, b)
 end
 
@@ -317,7 +317,7 @@ end
 > Return `true` if $a < b$, otherwise return `false`.
 """
 function isless(a::fmpq, b::fmpq)
-   return ccall((:fmpq_cmp, :libflint), Cint,
+   return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, b) < 0
 end
 
@@ -328,13 +328,13 @@ end
 ###############################################################################
 
 function ==(a::fmpq, b::Int)
-   return ccall((:fmpq_equal_si, :libflint), Bool, (Ref{fmpq}, Int), a, b)
+   return ccall((:fmpq_equal_si, libflint), Bool, (Ref{fmpq}, Int), a, b)
 end
 
 ==(a::Int, b::fmpq) = b == a
 
 function ==(a::fmpq, b::fmpz)
-   return ccall((:fmpq_equal_fmpz, :libflint), Bool,
+   return ccall((:fmpq_equal_fmpz, libflint), Bool,
                 (Ref{fmpq}, Ref{fmpz}), a, b)
 end
 
@@ -350,7 +350,7 @@ end
 """
 function isless(a::fmpq, b::Integer)
    z = fmpq(b)
-   return ccall((:fmpq_cmp, :libflint), Cint,
+   return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
@@ -360,7 +360,7 @@ end
 """
 function isless(a::Integer, b::fmpq)
    z = fmpq(a)
-   return ccall((:fmpq_cmp, :libflint), Cint,
+   return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), z, b) < 0
 end
 
@@ -370,7 +370,7 @@ end
 """
 function isless(a::fmpq, b::fmpz)
    z = fmpq(b)
-   return ccall((:fmpq_cmp, :libflint), Cint,
+   return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
@@ -380,7 +380,7 @@ end
 """
 function isless(a::fmpz, b::fmpq)
    z = fmpq(a)
-   return ccall((:fmpq_cmp, :libflint), Cint,
+   return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), z, b) < 0
 end
 
@@ -397,7 +397,7 @@ isless(a::fmpq, b::Rational{T}) where {T <: Integer} = isless(a, fmpq(b))
 function ^(a::fmpq, b::Int)
    iszero(a) && b < 0 && throw(DivideError())
    temp = fmpq()
-   ccall((:fmpq_pow_si, :libflint), Nothing,
+   ccall((:fmpq_pow_si, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), temp, a, b)
    return temp
 end
@@ -414,7 +414,7 @@ end
 """
 function >>(a::fmpq, b::Int)
    z = fmpq()
-   ccall((:fmpq_div_2exp, :libflint), Nothing,
+   ccall((:fmpq_div_2exp, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
@@ -425,7 +425,7 @@ end
 """
 function <<(a::fmpq, b::Int)
    z = fmpq()
-   ccall((:fmpq_mul_2exp, :libflint), Nothing,
+   ccall((:fmpq_mul_2exp, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Int), z, a, b)
    return z
 end
@@ -454,7 +454,7 @@ function inv(a::fmpq)
        throw(error("Element not invertible"))
     end
     z = fmpq()
-    ccall((:fmpq_inv, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
+    ccall((:fmpq_inv, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
     return z
  end
 
@@ -467,7 +467,7 @@ function inv(a::fmpq)
 function divexact(a::fmpq, b::fmpq)
    iszero(b) && throw(DivideError())
    z = fmpq()
-   ccall((:fmpq_div, :libflint), Nothing,
+   ccall((:fmpq_div, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
@@ -488,7 +488,7 @@ end
 function divexact(a::fmpq, b::fmpz)
    iszero(b) && throw(DivideError())
    z = fmpq()
-   ccall((:fmpq_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_div_fmpz, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
@@ -523,7 +523,7 @@ divexact(a::Rational{T}, b::fmpq) where {T <: Integer} = divexact(fmpq(a), b)
 function mod(a::fmpq, b::fmpz)
    iszero(b) && throw(DivideError())
    z = fmpz()
-   ccall((:fmpq_mod_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mod_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpq}, Ref{fmpz}), z, a, b)
    return z
 end
@@ -543,7 +543,7 @@ mod(a::fmpq, b::Integer) = mod(a, fmpz(b))
 
 function gcd(a::fmpq, b::fmpq)
    z = fmpq()
-   ccall((:fmpq_gcd, :libflint), Nothing,
+   ccall((:fmpq_gcd, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), z, a, b)
    return z
 end
@@ -573,7 +573,7 @@ valuation(a::fmpq, b::Integer) = valuation(a, fmpz(b))
 """
 function reconstruct(a::fmpz, b::fmpz)
    c = fmpq()
-   if !Bool(ccall((:fmpq_reconstruct_fmpz, :libflint), Cint,
+   if !Bool(ccall((:fmpq_reconstruct_fmpz, libflint), Cint,
                   (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), c, a, b))
       error("Impossible rational reconstruction")
    end
@@ -628,7 +628,7 @@ reconstruct(a::Integer, b::Integer) =  reconstruct(fmpz(a), fmpz(b))
 function next_minimal(a::fmpq)
    a < 0 && throw(DomainError(a, "Argument must be non-negative"))
    c = fmpq()
-   ccall((:fmpq_next_minimal, :libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), c, a)
+   ccall((:fmpq_next_minimal, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
 
@@ -643,7 +643,7 @@ end
 """
 function next_signed_minimal(a::fmpq)
    c = fmpq()
-   ccall((:fmpq_next_signed_minimal, :libflint), Nothing,
+   ccall((:fmpq_next_signed_minimal, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
@@ -662,7 +662,7 @@ end
 function next_calkin_wilf(a::fmpq)
    a < 0 && throw(DomainError(a, "Argument must be non-negative"))
    c = fmpq()
-   ccall((:fmpq_next_calkin_wilf, :libflint), Nothing,
+   ccall((:fmpq_next_calkin_wilf, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
@@ -677,7 +677,7 @@ end
 """
 function next_signed_calkin_wilf(a::fmpq)
    c = fmpq()
-   ccall((:fmpq_next_signed_calkin_wilf, :libflint), Nothing,
+   ccall((:fmpq_next_signed_calkin_wilf, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}), c, a)
    return c
 end
@@ -697,7 +697,7 @@ end
 function harmonic(n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    c = fmpq()
-   ccall((:fmpq_harmonic_ui, :libflint), Nothing, (Ref{fmpq}, Int), c, n)
+   ccall((:fmpq_harmonic_ui, libflint), Nothing, (Ref{fmpq}, Int), c, n)
    return c
 end
 
@@ -708,7 +708,7 @@ end
 function bernoulli(n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    c = fmpq()
-   ccall((:bernoulli_fmpq_ui, :libarb), Nothing, (Ref{fmpq}, Int), c, n)
+   ccall((:bernoulli_fmpq_ui, libarb), Nothing, (Ref{fmpq}, Int), c, n)
    return c
 end
 
@@ -722,7 +722,7 @@ end
 function bernoulli_cache(n::Int)
    n = n + 1
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
-   ccall((:bernoulli_cache_compute, :libarb), Nothing, (Int,), n)
+   ccall((:bernoulli_cache_compute, libarb), Nothing, (Int,), n)
 end
 
 @doc Markdown.doc"""
@@ -730,7 +730,7 @@ end
 """
 function dedekind_sum(h::fmpz, k::fmpz)
    c = fmpq()
-   ccall((:fmpq_dedekind_sum, :libflint), Nothing,
+   ccall((:fmpq_dedekind_sum, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpz}, Ref{fmpz}), c, h, k)
    return c
 end
@@ -760,25 +760,25 @@ dedekind_sum(h::Integer, k::Integer) = dedekind_sum(fmpz(h), fmpz(k))
 ###############################################################################
 
 function zero!(c::fmpq)
-   ccall((:fmpq_zero, :libflint), Nothing,
+   ccall((:fmpq_zero, libflint), Nothing,
          (Ref{fmpq},), c)
    return c
 end
 
 function mul!(c::fmpq, a::fmpq, b::fmpq)
-   ccall((:fmpq_mul, :libflint), Nothing,
+   ccall((:fmpq_mul, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
    return c
 end
 
 function addeq!(c::fmpq, a::fmpq)
-   ccall((:fmpq_add, :libflint), Nothing,
+   ccall((:fmpq_add, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, c, a)
    return c
 end
 
 function add!(c::fmpq, a::fmpq, b::fmpq)
-   ccall((:fmpq_add, :libflint), Nothing,
+   ccall((:fmpq_add, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
    return c
 end
@@ -791,7 +791,7 @@ end
 
 function Rational(z::fmpq)
    r = Rational{BigInt}(0)
-   ccall((:fmpq_get_mpz_frac, :libflint), Nothing,
+   ccall((:fmpq_get_mpz_frac, libflint), Nothing,
          (Ref{BigInt}, Ref{BigInt}, Ref{fmpq}), r.num, r.den, z)
    return r
 end
@@ -848,7 +848,7 @@ end
 function rand_bits(::FlintRationalField, b::Int)
    b > 0 || throw(DomainError(b, "Bit count must be positive"))
    z = fmpq()
-   ccall((:fmpq_randbits, :libflint), Nothing, (Ref{fmpq}, Ptr{Cvoid}, Int),
+   ccall((:fmpq_randbits, libflint), Nothing, (Ref{fmpq}, Ptr{Cvoid}, Int),
          z, _flint_rand_states[Threads.threadid()].ptr, b)
    return z
 end

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -44,13 +44,13 @@ max_precision(R::FmpqAbsSeriesRing) = R.prec_max
 function normalise(a::fmpq_abs_series, len::Int)
    if len > 0
       c = fmpq()
-      ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+      ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
             (Ref{fmpq}, Ref{fmpq_abs_series}, Int), c, a, len - 1)
       end
    end
@@ -63,13 +63,13 @@ function coeff(x::fmpq_abs_series, n::Int)
       return fmpq(0)
    end
    z = fmpq()
-   ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_abs_series}, Int), z, x, n)
    return z
 end
 
 function length(x::fmpq_abs_series)
-   return ccall((:fmpq_poly_length, :libflint), Int, (Ref{fmpq_abs_series},), x)
+   return ccall((:fmpq_poly_length, libflint), Int, (Ref{fmpq_abs_series},), x)
 end
 
 precision(x::fmpq_abs_series) = x.prec
@@ -92,7 +92,7 @@ function deepcopy_internal(a::fmpq_abs_series, dict::IdDict)
 end
 
 function isgen(a::fmpq_abs_series)
-   return precision(a) == 0 || ccall((:fmpq_poly_is_x, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpq_poly_is_x, libflint), Bool,
                             (Ref{fmpq_abs_series},), a)
 end
 
@@ -101,7 +101,7 @@ iszero(a::fmpq_abs_series) = length(a) == 0
 isunit(a::fmpq_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpq_abs_series)
-   return precision(a) == 0 || ccall((:fmpq_poly_is_one, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpq_poly_is_one, libflint), Bool,
                                 (Ref{fmpq_abs_series},), a)
 end
 
@@ -138,7 +138,7 @@ show_minus_one(::Type{fmpq_abs_series}) = show_minus_one(fmpq)
 
 function -(x::fmpq_abs_series)
    z = parent(x)()
-   ccall((:fmpq_poly_neg, :libflint), Nothing,
+   ccall((:fmpq_poly_neg, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}),
                z, x)
    z.prec = x.prec
@@ -164,7 +164,7 @@ function +(a::fmpq_abs_series, b::fmpq_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpq_poly_add_series, :libflint), Nothing,
+   ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -183,7 +183,7 @@ function -(a::fmpq_abs_series, b::fmpq_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpq_poly_sub_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sub_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -212,7 +212,7 @@ function *(a::fmpq_abs_series, b::fmpq_abs_series)
 
    lenz = min(lena + lenb - 1, prec)
 
-   ccall((:fmpq_poly_mullow, :libflint), Nothing,
+   ccall((:fmpq_poly_mullow, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -228,7 +228,7 @@ end
 function *(x::Int, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpq_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, y, x)
    return z
@@ -237,7 +237,7 @@ end
 function *(x::fmpz, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpz}),
                z, y, x)
    return z
@@ -246,7 +246,7 @@ end
 function *(x::fmpq, y::fmpq_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpq, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq}),
                z, y, x)
    return z
@@ -287,10 +287,10 @@ function shift_left(x::fmpq_abs_series, len::Int)
    z.prec = x.prec + len
    z.prec = min(z.prec, max_precision(parent(x)))
    zlen = min(z.prec, xlen + len)
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
          (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, x, len)
-   ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpq_poly_set_trunc, libflint), Nothing,
          (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, z, zlen)
    return z
@@ -304,7 +304,7 @@ function shift_right(x::fmpq_abs_series, len::Int)
       z.prec = max(0, x.prec - len)
    else
       z.prec = x.prec - len
-      ccall((:fmpq_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_right, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, x, len)
    end
@@ -324,7 +324,7 @@ function truncate(x::fmpq_abs_series, prec::Int)
    end
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpq_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, x, prec)
    return z
@@ -380,7 +380,7 @@ function ==(x::fmpq_abs_series, y::fmpq_abs_series)
    n = max(length(x), length(y))
    n = min(n, prec)
 
-   return Bool(ccall((:fmpq_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpq_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                x, y, n))
 end
@@ -392,7 +392,7 @@ function isequal(x::fmpq_abs_series, y::fmpq_abs_series)
    if x.prec != y.prec || length(x) != length(y)
       return false
    end
-   return Bool(ccall((:fmpq_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpq_poly_equal, libflint), Cint,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                x, y, length(x)))
 end
@@ -432,7 +432,7 @@ function divexact(x::fmpq_abs_series, y::fmpq_abs_series)
    prec = min(x.prec, y.prec - v2 + v1)
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpq_poly_div_series, :libflint), Nothing,
+   ccall((:fmpq_poly_div_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, x, y, prec)
    return z
@@ -448,7 +448,7 @@ function divexact(x::fmpq_abs_series, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpq_poly_scalar_div_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_si, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, x, y)
    return z
@@ -458,7 +458,7 @@ function divexact(x::fmpq_abs_series, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -468,7 +468,7 @@ function divexact(x::fmpq_abs_series, y::fmpq)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpq, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq}),
                z, x, y)
    return z
@@ -489,7 +489,7 @@ function inv(a::fmpq_abs_series)
    !isunit(a) && error("Unable to invert power series")
    ainv = parent(a)()
    ainv.prec = a.prec
-   ccall((:fmpq_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpq_poly_inv_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -508,7 +508,7 @@ function Base.exp(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_exp_series, :libflint), Nothing,
+   ccall((:fmpq_poly_exp_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -525,7 +525,7 @@ function log(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_log_series, :libflint), Nothing,
+   ccall((:fmpq_poly_log_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -542,7 +542,7 @@ function tan(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_tan_series, :libflint), Nothing,
+   ccall((:fmpq_poly_tan_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -559,7 +559,7 @@ function tanh(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_tanh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_tanh_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -576,7 +576,7 @@ function sin(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_sin_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sin_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -593,7 +593,7 @@ function sinh(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_sinh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sinh_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -610,7 +610,7 @@ function cos(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_cos_series, :libflint), Nothing,
+   ccall((:fmpq_poly_cos_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -627,7 +627,7 @@ function cosh(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_cosh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_cosh_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -644,7 +644,7 @@ function asin(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_asin_series, :libflint), Nothing,
+   ccall((:fmpq_poly_asin_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -661,7 +661,7 @@ function asinh(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_asinh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_asinh_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -678,7 +678,7 @@ function atan(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_atan_series, :libflint), Nothing,
+   ccall((:fmpq_poly_atan_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -695,7 +695,7 @@ function atanh(a::fmpq_abs_series)
    end
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_atanh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_atanh_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -710,7 +710,7 @@ function Base.sqrt(a::fmpq_abs_series)
    !isone(coeff(a, 0)) && error("Constant term not one in sqrt")
    z = parent(a)()
    z.prec = a.prec
-   ccall((:fmpq_poly_sqrt_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sqrt_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, a.prec)
    return z
@@ -723,14 +723,14 @@ end
 ###############################################################################
 
 function zero!(z::fmpq_abs_series)
-   ccall((:fmpq_poly_zero, :libflint), Nothing,
+   ccall((:fmpq_poly_zero, libflint), Nothing,
                 (Ref{fmpq_abs_series},), z)
    z.prec = parent(z).prec_max
    return z
 end
 
 function setcoeff!(z::fmpq_abs_series, n::Int, x::fmpq)
-   ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Int, Ref{fmpq}),
                z, n, x)
    return z
@@ -755,7 +755,7 @@ function mul!(z::fmpq_abs_series, a::fmpq_abs_series, b::fmpq_abs_series)
    end
 
    z.prec = prec
-   ccall((:fmpq_poly_mullow, :libflint), Nothing,
+   ccall((:fmpq_poly_mullow, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -772,7 +772,7 @@ function addeq!(a::fmpq_abs_series, b::fmpq_abs_series)
 
    lenz = max(lena, lenb)
    a.prec = prec
-   ccall((:fmpq_poly_add_series, :libflint), Nothing,
+   ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Ref{fmpq_abs_series}, Int),
                a, a, b, lenz)
    return a

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -70,7 +70,7 @@ function Base.view(x::fmpq_mat, r1::Int, c1::Int, r2::Int, c2::Int)
   b = fmpq_mat()
   b.view_parent = x
   b.base_ring = x.base_ring
-  ccall((:fmpq_mat_window_init, :libflint), Nothing,
+  ccall((:fmpq_mat_window_init, libflint), Nothing,
         (Ref{fmpq_mat}, Ref{fmpq_mat}, Int, Int, Int, Int),
             b, x, r1 - 1, c1 - 1, r2, c2)
   finalizer(_fmpq_mat_window_clear_fn, b)
@@ -82,7 +82,7 @@ function Base.view(x::fmpq_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fmpq_mat_window_clear_fn(a::fmpq_mat)
-   ccall((:fmpq_mat_window_clear, :libflint), Nothing, (Ref{fmpq_mat},), a)
+   ccall((:fmpq_mat_window_clear, libflint), Nothing, (Ref{fmpq_mat},), a)
 end
 
 function sub(x::fmpq_mat, r1::Int, c1::Int, r2::Int, c2::Int)
@@ -103,9 +103,9 @@ getindex(x::fmpq_mat, r::UnitRange{Int}, c::UnitRange{Int}) = sub(x, r, c)
 
 function getindex!(v::fmpq, a::fmpq_mat, r::Int, c::Int)
    GC.@preserve a begin
-      z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+      z = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpq_set, :libflint), Nothing, (Ref{fmpq}, Ptr{fmpq}), v, z)
+      ccall((:fmpq_set, libflint), Nothing, (Ref{fmpq}, Ptr{fmpq}), v, z)
    end
    return v
 end
@@ -114,9 +114,9 @@ end
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpq()
    GC.@preserve a begin
-      z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+      z = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpq_set, :libflint), Nothing, (Ref{fmpq}, Ptr{fmpq}), v, z)
+      ccall((:fmpq_set, libflint), Nothing, (Ref{fmpq}, Ptr{fmpq}), v, z)
    end
    return v
 end
@@ -124,21 +124,21 @@ end
 @inline function setindex!(a::fmpq_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    GC.@preserve a begin
-      z = ccall((:fmpq_mat_entry_num, :libflint), Ptr{fmpz},
+      z = ccall((:fmpq_mat_entry_num, libflint), Ptr{fmpz},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set, :libflint), Nothing, (Ptr{fmpz}, Ref{fmpz}), z, d)
-      z = ccall((:fmpq_mat_entry_den, :libflint), Ptr{fmpz},
+      ccall((:fmpz_set, libflint), Nothing, (Ptr{fmpz}, Ref{fmpz}), z, d)
+      z = ccall((:fmpq_mat_entry_den, libflint), Ptr{fmpz},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set_si, :libflint), Nothing, (Ptr{fmpz}, Int), z, 1)
+      ccall((:fmpz_set_si, libflint), Nothing, (Ptr{fmpz}, Int), z, 1)
    end
 end
 
 @inline function setindex!(a::fmpq_mat, d::fmpq, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    GC.@preserve a begin
-      z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+      z = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpq_set, :libflint), Nothing, (Ptr{fmpq}, Ref{fmpq}), z, d)
+      ccall((:fmpq_set, libflint), Nothing, (Ptr{fmpq}, Ref{fmpq}), z, d)
    end
 end
 
@@ -149,9 +149,9 @@ Base.@propagate_inbounds setindex!(a::fmpq_mat, d::Integer,
 @inline function setindex!(a::fmpq_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    GC.@preserve a begin
-      z = ccall((:fmpq_mat_entry, :libflint), Ptr{fmpq},
+      z = ccall((:fmpq_mat_entry, libflint), Ptr{fmpq},
                 (Ref{fmpq_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpq_set_si, :libflint), Nothing, (Ptr{fmpq}, Int, Int), z, d, 1)
+      ccall((:fmpq_set_si, libflint), Nothing, (Ptr{fmpq}, Int, Int), z, d, 1)
    end
 end
 
@@ -171,10 +171,10 @@ zero(a::FmpqMatSpace) = a()
 
 one(a::FmpqMatSpace) = a(1)
 
-iszero(a::fmpq_mat) = ccall((:fmpq_mat_is_zero, :libflint), Bool,
+iszero(a::fmpq_mat) = ccall((:fmpq_mat_is_zero, libflint), Bool,
                             (Ref{fmpq_mat},), a)
 
-isone(a::fmpq_mat) = ccall((:fmpq_mat_is_one, :libflint), Bool,
+isone(a::fmpq_mat) = ccall((:fmpq_mat_is_one, libflint), Bool,
                            (Ref{fmpq_mat},), a)
 
 function deepcopy_internal(d::fmpq_mat, dict::IdDict)
@@ -207,7 +207,7 @@ show_minus_one(::Type{fmpq_mat}) = show_minus_one(fmpq)
 
 function -(x::fmpq_mat)
    z = similar(x)
-   ccall((:fmpq_mat_neg, :libflint), Nothing,
+   ccall((:fmpq_mat_neg, libflint), Nothing,
          (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -220,7 +220,7 @@ end
 
 function transpose(x::fmpq_mat)
    z = similar(x, ncols(x), nrows(x))
-   ccall((:fmpq_mat_transpose, :libflint), Nothing,
+   ccall((:fmpq_mat_transpose, libflint), Nothing,
          (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -232,7 +232,7 @@ end
 ###############################################################################
 
 function swap_rows!(x::fmpq_mat, i::Int, j::Int)
-  ccall((:fmpq_mat_swap_rows, :libflint), Nothing,
+  ccall((:fmpq_mat_swap_rows, libflint), Nothing,
         (Ref{fmpq_mat}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -244,7 +244,7 @@ function swap_rows(x::fmpq_mat, i::Int, j::Int)
 end
 
 function swap_cols!(x::fmpq_mat, i::Int, j::Int)
-  ccall((:fmpq_mat_swap_cols, :libflint), Nothing,
+  ccall((:fmpq_mat_swap_cols, libflint), Nothing,
         (Ref{fmpq_mat}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -256,7 +256,7 @@ function swap_cols(x::fmpq_mat, i::Int, j::Int)
 end
 
 function reverse_rows!(x::fmpq_mat)
-   ccall((:fmpq_mat_invert_rows, :libflint), Nothing,
+   ccall((:fmpq_mat_invert_rows, libflint), Nothing,
          (Ref{fmpq_mat}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -264,7 +264,7 @@ end
 reverse_rows(x::fmpq_mat) = reverse_rows!(deepcopy(x))
 
 function reverse_cols!(x::fmpq_mat)
-   ccall((:fmpq_mat_invert_cols, :libflint), Nothing,
+   ccall((:fmpq_mat_invert_cols, libflint), Nothing,
          (Ref{fmpq_mat}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -280,7 +280,7 @@ reverse_cols(x::fmpq_mat) = reverse_cols!(deepcopy(x))
 function +(x::fmpq_mat, y::fmpq_mat)
    check_parent(x, y)
    z = similar(x)
-   ccall((:fmpq_mat_add, :libflint), Nothing,
+   ccall((:fmpq_mat_add, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
                z, x, y)
    return z
@@ -289,7 +289,7 @@ end
 function -(x::fmpq_mat, y::fmpq_mat)
    check_parent(x, y)
    z = similar(x)
-   ccall((:fmpq_mat_sub, :libflint), Nothing,
+   ccall((:fmpq_mat_sub, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
                z, x, y)
    return z
@@ -298,7 +298,7 @@ end
 function *(x::fmpq_mat, y::fmpq_mat)
    ncols(x) != nrows(y) && error("Incompatible matrix dimensions")
    z = similar(x, nrows(x), ncols(y))
-   ccall((:fmpq_mat_mul, :libflint), Nothing,
+   ccall((:fmpq_mat_mul, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat},  Ref{fmpq_mat}),
                z, x, y)
    return z
@@ -312,16 +312,16 @@ end
 
 function *(x::fmpz, y::fmpq_mat)
    z = similar(y)
-   ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function *(x::fmpq, y::fmpq_mat)
    z = similar(y)
-   ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), z, y, numerator(x))
-   ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), z, z, denominator(x))
    return z
 end
@@ -402,7 +402,7 @@ end
 
 function ==(x::fmpq_mat, y::fmpq_mat)
    fl = check_parent(x, y, false)
-   fl && ccall((:fmpq_mat_equal, :libflint), Bool,
+   fl && ccall((:fmpq_mat_equal, libflint), Bool,
                                        (Ref{fmpq_mat}, Ref{fmpq_mat}), x, y)
 end
 
@@ -444,7 +444,7 @@ end
 
 function inv(x::fmpq_mat)
    z = similar(x)
-   success = ccall((:fmpq_mat_inv, :libflint), Cint,
+   success = ccall((:fmpq_mat_inv, libflint), Cint,
          (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    success == 0 && error("Matrix not invertible")
    return z
@@ -469,16 +469,16 @@ end
 
 function divexact(x::fmpq_mat, y::fmpq)
    z = similar(x)
-   ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, x, numerator(y))
-   ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, z, denominator(y))
    return z
 end
 
 function divexact(x::fmpq_mat, y::fmpz)
    z = similar(x)
-   ccall((:fmpq_mat_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -496,7 +496,7 @@ divexact(x::fmpq_mat, y::Rational{T}) where T <: Union{Int, BigInt} = divexact(x
 function kronecker_product(x::fmpq_mat, y::fmpq_mat)
    base_ring(x) == base_ring(y) || error("Incompatible matrices")
    z = similar(x, nrows(x)*nrows(y), ncols(x)*ncols(y))
-   ccall((:fmpq_mat_kronecker_product, :libflint), Nothing,
+   ccall((:fmpq_mat_kronecker_product, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, x, y)
    return z
 end
@@ -510,7 +510,7 @@ end
 function charpoly(R::FmpqPolyRing, x::fmpq_mat)
    nrows(x) != ncols(x) && error("Non-square")
    z = R()
-   ccall((:fmpq_mat_charpoly, :libflint), Nothing,
+   ccall((:fmpq_mat_charpoly, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -524,7 +524,7 @@ end
 function minpoly(R::FmpqPolyRing, x::fmpq_mat)
    nrows(x) != ncols(x) && error("Non-square")
    z = R()
-   ccall((:fmpq_mat_minpoly, :libflint), Nothing,
+   ccall((:fmpq_mat_minpoly, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -538,7 +538,7 @@ end
 function det(x::fmpq_mat)
    nrows(x) != ncols(x) && error("Non-square matrix")
    z = fmpq()
-   ccall((:fmpq_mat_det, :libflint), Nothing,
+   ccall((:fmpq_mat_det, libflint), Nothing,
                 (Ref{fmpq}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -555,7 +555,7 @@ end
 """
 function gso(x::fmpq_mat)
    z = similar(x)
-   ccall((:fmpq_mat_gso, :libflint), Nothing,
+   ccall((:fmpq_mat_gso, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return z
 end
@@ -573,7 +573,7 @@ end
 """
 function hilbert(R::FmpqMatSpace)
    z = R()
-   ccall((:fmpq_mat_hilbert_matrix, :libflint), Bool,
+   ccall((:fmpq_mat_hilbert_matrix, libflint), Bool,
                    (Ref{fmpq_mat},), z)
    return z
 end
@@ -586,7 +586,7 @@ end
 
 function rank(x::fmpq_mat)
    z = similar(x)
-   r = ccall((:fmpq_mat_rref, :libflint), Int,
+   r = ccall((:fmpq_mat_rref, libflint), Int,
          (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return r
 end
@@ -599,7 +599,7 @@ end
 
 function rref(x::fmpq_mat)
    z = similar(x)
-   r = ccall((:fmpq_mat_rref, :libflint), Int,
+   r = ccall((:fmpq_mat_rref, libflint), Int,
          (Ref{fmpq_mat}, Ref{fmpq_mat}), z, x)
    return r, z
 end
@@ -614,7 +614,7 @@ function solve(a::fmpq_mat, b::fmpq_mat)
    nrows(a) != ncols(a) && error("Not a square matrix in solve")
    nrows(b) != nrows(a) && error("Incompatible dimensions in solve")
    z = similar(b)
-   nonsing = ccall((:fmpq_mat_solve, :libflint), Bool,
+   nonsing = ccall((:fmpq_mat_solve, libflint), Bool,
       (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, a, b)
    !nonsing && error("Singular matrix in solve")
    return z
@@ -629,7 +629,7 @@ function solve_dixon(a::fmpq_mat, b::fmpq_mat)
    nrows(a) != ncols(a) && error("Not a square matrix in solve")
    nrows(b) != nrows(a) && error("Incompatible dimensions in solve")
    z = similar(b)
-   nonsing = ccall((:fmpq_mat_solve_dixon, :libflint), Bool,
+   nonsing = ccall((:fmpq_mat_solve_dixon, libflint), Bool,
       (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, a, b)
    !nonsing && error("Singular matrix in solve")
    return z
@@ -644,7 +644,7 @@ end
 function tr(x::fmpq_mat)
    nrows(x) != ncols(x) && error("Not a square matrix in trace")
    d = fmpq()
-   ccall((:fmpq_mat_trace, :libflint), Nothing,
+   ccall((:fmpq_mat_trace, libflint), Nothing,
                 (Ref{fmpq}, Ref{fmpq_mat}), d, x)
    return d
 end
@@ -658,7 +658,7 @@ end
 function hcat(a::fmpq_mat, b::fmpq_mat)
   nrows(a) != nrows(b) && error("Incompatible number of rows in hcat")
   c = similar(a, nrows(a), ncols(a) + ncols(b))
-  ccall((:fmpq_mat_concat_horizontal, :libflint), Nothing,
+  ccall((:fmpq_mat_concat_horizontal, libflint), Nothing,
         (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), c, a, b)
   return c
 end
@@ -666,7 +666,7 @@ end
 function vcat(a::fmpq_mat, b::fmpq_mat)
   ncols(a) != ncols(b) && error("Incompatible number of columns in vcat")
   c = similar(a, nrows(a) + nrows(b), ncols(a))
-  ccall((:fmpq_mat_concat_vertical, :libflint), Nothing,
+  ccall((:fmpq_mat_concat_vertical, libflint), Nothing,
         (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), c, a, b)
   return c
 end
@@ -678,7 +678,7 @@ end
 ###############################################################################
 
 function similarity!(z::fmpq_mat, r::Int, d::fmpq)
-   ccall((:fmpq_mat_similarity, :libflint), Nothing,
+   ccall((:fmpq_mat_similarity, libflint), Nothing,
          (Ref{fmpq_mat}, Int, Ref{fmpq}), z, r - 1, d)
 end
 
@@ -689,37 +689,37 @@ end
 ###############################################################################
 
 function mul!(z::fmpq_mat, x::fmpq_mat, y::fmpq_mat)
-   ccall((:fmpq_mat_mul, :libflint), Nothing,
+   ccall((:fmpq_mat_mul, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, x, y)
    return z
 end
 
 function add!(z::fmpq_mat, x::fmpq_mat, y::fmpq_mat)
-   ccall((:fmpq_mat_add, :libflint), Nothing,
+   ccall((:fmpq_mat_add, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, x, y)
    return z
 end
 
 function mul!(y::fmpq_mat, x::Int)
-   ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq}), y, y, fmpz(x))
    return y
 end
 
 function mul!(y::fmpq_mat, x::fmpz)
-   ccall((:fmpq_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpz}), y, y, x)
    return y
 end
 
 function addeq!(z::fmpq_mat, x::fmpq_mat)
-   ccall((:fmpq_mat_add, :libflint), Nothing,
+   ccall((:fmpq_mat_add, libflint), Nothing,
                 (Ref{fmpq_mat}, Ref{fmpq_mat}, Ref{fmpq_mat}), z, z, x)
    return z
 end
 
 function zero!(z::fmpq_mat)
-   ccall((:fmpq_mat_zero, :libflint), Nothing,
+   ccall((:fmpq_mat_zero, libflint), Nothing,
                 (Ref{fmpq_mat},), z)
    return z
 end
@@ -816,7 +816,7 @@ end
 function (a::FmpqMatSpace)(M::fmpz_mat)
    (ncols(a) == ncols(M) && nrows(a) == nrows(M)) || error("wrong matrix dimension")
    z = a()
-   ccall((:fmpq_mat_set_fmpz_mat, :libflint), Nothing, (Ref{fmpq_mat}, Ref{fmpz_mat}), z, M)
+   ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing, (Ref{fmpq_mat}, Ref{fmpz_mat}), z, M)
    return z
 end
 
@@ -907,7 +907,7 @@ function identity_matrix(R::FlintRationalField, n::Int)
      error("dimension must not be negative")
    end
    z = fmpq_mat(n, n)
-   ccall((:fmpq_mat_one, :libflint), Nothing, (Ref{fmpq_mat}, ), z)
+   ccall((:fmpq_mat_one, libflint), Nothing, (Ref{fmpq_mat}, ), z)
    z.base_ring = FlintQQ
    return z
 end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -32,7 +32,7 @@ function check_parent(a::fmpq_mpoly, b::fmpq_mpoly)
       error("Incompatible polynomial rings in polynomial operation")
 end
 
-nvars(a::FmpqMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, :libflint), Int,
+nvars(a::FmpqMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, libflint), Int,
                                 (Ref{FmpqMPolyRing}, ), a)
 
 base_ring(a::FmpqMPolyRing) = a.base_ring
@@ -40,7 +40,7 @@ base_ring(a::FmpqMPolyRing) = a.base_ring
 base_ring(f::fmpq_mpoly) = f.parent.base_ring
 
 function ordering(a::FmpqMPolyRing)
-   b = ccall((:fmpq_mpoly_ctx_ord, :libflint), Cint, (Ref{FmpqMPolyRing}, ), a)
+   b = ccall((:fmpq_mpoly_ctx_ord, libflint), Cint, (Ref{FmpqMPolyRing}, ), a)
    return flint_orderings[b + 1]
 end
 
@@ -48,7 +48,7 @@ function gens(R::FmpqMPolyRing)
    A = Vector{fmpq_mpoly}(undef, R.nvars)
    for i = 1:R.nvars
       z = R()
-      ccall((:fmpq_mpoly_gen, :libflint), Nothing,
+      ccall((:fmpq_mpoly_gen, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), z, i - 1, R)
       A[i] = z
    end
@@ -59,7 +59,7 @@ function gen(R::FmpqMPolyRing, i::Int)
    n = nvars(R)
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = R()
-   ccall((:fmpq_mpoly_gen, :libflint), Nothing,
+   ccall((:fmpq_mpoly_gen, libflint), Nothing,
          (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), z, i - 1, R)
    return z
 end
@@ -68,7 +68,7 @@ function isgen(a::fmpq_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    R = parent(a)
-   return Bool(ccall((:fmpq_mpoly_is_gen, :libflint), Cint,
+   return Bool(ccall((:fmpq_mpoly_is_gen, libflint), Cint,
                      (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
                      a, i - 1, a.parent))
 end
@@ -83,39 +83,39 @@ end
 
 function deepcopy_internal(a::fmpq_mpoly, dict::IdDict)
    z = parent(a)()
-   ccall((:fmpq_mpoly_set, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
          z, a, a.parent)
    return z
 end
 
 function length(a::fmpq_mpoly)
-   n = ccall((:fmpq_mpoly_length, :libflint), Int, (Ref{fmpq_mpoly}, ), a)
+   n = ccall((:fmpq_mpoly_length, libflint), Int, (Ref{fmpq_mpoly}, ), a)
    return n
 end
 
 function one(R::FmpqMPolyRing)
    z = R()
-   ccall((:fmpq_mpoly_one, :libflint), Nothing,
+   ccall((:fmpq_mpoly_one, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, R)
    return z
 end
 
 function zero(R::FmpqMPolyRing)
    z = R()
-   ccall((:fmpq_mpoly_zero, :libflint), Nothing,
+   ccall((:fmpq_mpoly_zero, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), z, R)
    return z
 end
 
 function isone(a::fmpq_mpoly)
-   b = ccall((:fmpq_mpoly_is_one, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_is_one, libflint), Cint,
              (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return Bool(b)
 end
 
 function iszero(a::fmpq_mpoly)
-   b = ccall((:fmpq_mpoly_is_zero, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_is_zero, libflint), Cint,
              (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -133,21 +133,21 @@ function isunit(a::fmpq_mpoly)
 end
 
 function isconstant(a::fmpq_mpoly)
-   b = ccall((:fmpq_mpoly_is_fmpq, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_is_fmpq, libflint), Cint,
              (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, parent(a))
    return Bool(b)
 end
 
 function content(a::fmpq_mpoly)
   c = fmpq()
-  ccall((:fmpq_mpoly_content, :libflint), Nothing,
+  ccall((:fmpq_mpoly_content, libflint), Nothing,
         (Ref{fmpq}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), c, a, parent(a))
   return c
 end
 
 function denominator(a::fmpq_mpoly)
   c = fmpz()
-  ccall((:fmpq_mpoly_get_denominator, :libflint), Nothing,
+  ccall((:fmpq_mpoly_get_denominator, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), c, a, parent(a))
   return c
 end
@@ -164,7 +164,7 @@ function coeff(a::fmpq_mpoly, i::Int)
    z = fmpq()
    n = length(a)
    (i < 1 || i > n) && error("Index must be between 1 and $(length(a))")
-   ccall((:fmpq_mpoly_get_term_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          z, a, i - 1, a.parent)
    return z
@@ -174,7 +174,7 @@ function coeff(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    !isone(length(b)) && error("Second argument must be a monomial")
    z = fmpq()
-   ccall((:fmpq_mpoly_get_coeff_fmpq_monomial, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_coeff_fmpq_monomial, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -190,7 +190,7 @@ end
 function degree(a::fmpq_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
-   d = ccall((:fmpq_mpoly_degree_si, :libflint), Int,
+   d = ccall((:fmpq_mpoly_degree_si, libflint), Int,
              (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, i - 1, a.parent)
    return d
 end
@@ -200,7 +200,7 @@ function degree_fmpz(a::fmpq_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    d = fmpz()
-   ccall((:fmpq_mpoly_degree_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mpoly_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          d, a, i - 1, a.parent)
    return d
@@ -208,7 +208,7 @@ end
 
 # Return true if degrees fit into an Int
 function degrees_fit_int(a::fmpq_mpoly)
-   b = ccall((:fmpq_mpoly_degrees_fit_si, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_degrees_fit_si, libflint), Cint,
              (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -216,7 +216,7 @@ end
 # Return an array of the max degrees in each variable
 function degrees(a::fmpq_mpoly)
    degs = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:fmpq_mpoly_degrees_si, :libflint), Nothing,
+   ccall((:fmpq_mpoly_degrees_si, libflint), Nothing,
          (Ptr{Int}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -229,7 +229,7 @@ function degrees_fmpz(a::fmpq_mpoly)
    for i in 1:n
       degs[i] = fmpz()
    end
-   ccall((:fmpq_mpoly_degrees_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mpoly_degrees_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -237,14 +237,14 @@ end
 
 # Return true if degree fits into an Int
 function total_degree_fits_int(a::fmpq_mpoly)
-      b = ccall((:fmpq_mpoly_total_degree_fits_si, :libflint), Cint,
+      b = ccall((:fmpq_mpoly_total_degree_fits_si, libflint), Cint,
                 (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
       return Bool(b)
    end
 
 # Total degree as an Int
 function total_degree(a::fmpq_mpoly)
-   d = ccall((:fmpq_mpoly_total_degree_si, :libflint), Int,
+   d = ccall((:fmpq_mpoly_total_degree_si, libflint), Int,
              (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return d
 end
@@ -252,7 +252,7 @@ end
 # Total degree as an fmpz
 function total_degree_fmpz(a::fmpq_mpoly)
    d = fmpz()
-   ccall((:fmpq_mpoly_total_degree_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mpoly_total_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
             d, a, a.parent)
    return d
@@ -278,7 +278,7 @@ function coeff(a::fmpq_mpoly, vars::Vector{Int}, exps::Vector{Int})
          error("Exponent cannot be negative")
       end
    end
-   ccall((:fmpq_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_coeff_vars_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ptr{Int},
           Ptr{Int}, Int, Ref{FmpqMPolyRing}),
           z, a, vars, exps, length(vars), a.parent)
@@ -295,12 +295,12 @@ function show(io::IO, x::fmpq_mpoly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fmpq_mpoly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fmpq_mpoly_get_str_pretty, libflint), Ptr{UInt8},
           (Ref{fmpq_mpoly}, Ptr{Ptr{UInt8}}, Ref{FmpqMPolyRing}),
           x, [string(s) for s in symbols(parent(x))], x.parent)
       print(io, unsafe_string(cstr))
 
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -331,7 +331,7 @@ end
 
 function -(a::fmpq_mpoly)
    z = parent(a)()
-   ccall((:fmpq_mpoly_neg, :libflint), Nothing,
+   ccall((:fmpq_mpoly_neg, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        z, a, a.parent)
    return z
@@ -340,7 +340,7 @@ end
 function +(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpq_mpoly_add, :libflint), Nothing,
+   ccall((:fmpq_mpoly_add, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -349,7 +349,7 @@ end
 function -(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpq_mpoly_sub, :libflint), Nothing,
+   ccall((:fmpq_mpoly_sub, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -358,7 +358,7 @@ end
 function *(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpq_mpoly_mul, :libflint), Nothing,
+   ccall((:fmpq_mpoly_mul, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -375,7 +375,7 @@ for (jT, cN, cT) in ((fmpq, :fmpq, Ref{fmpq}), (fmpz, :fmpz, Ref{fmpz}),
    @eval begin
       function +(a::fmpq_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpq_mpoly_add_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpq_mpoly_add_, cN)), libflint), Nothing,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, ($cT), Ref{FmpqMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -385,7 +385,7 @@ for (jT, cN, cT) in ((fmpq, :fmpq, Ref{fmpq}), (fmpz, :fmpz, Ref{fmpz}),
 
       function -(a::fmpq_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpq_mpoly_sub_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpq_mpoly_sub_, cN)), libflint), Nothing,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, ($cT), Ref{FmpqMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -395,7 +395,7 @@ for (jT, cN, cT) in ((fmpq, :fmpq, Ref{fmpq}), (fmpz, :fmpz, Ref{fmpz}),
 
       function *(a::fmpq_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpq_mpoly_scalar_mul_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpq_mpoly_scalar_mul_, cN)), libflint), Nothing,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, ($cT), Ref{FmpqMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -405,7 +405,7 @@ for (jT, cN, cT) in ((fmpq, :fmpq, Ref{fmpq}), (fmpz, :fmpz, Ref{fmpz}),
 
       function divexact(a::fmpq_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpq_mpoly_scalar_div_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpq_mpoly_scalar_div_, cN)), libflint), Nothing,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, ($cT), Ref{FmpqMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -456,7 +456,7 @@ divexact(a::fmpq_mpoly, b::Rational{<:Integer}) = divexact(a, fmpq(b))
 function ^(a::fmpq_mpoly, b::Int)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:fmpq_mpoly_pow_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_pow_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -465,7 +465,7 @@ end
 function ^(a::fmpq_mpoly, b::fmpz)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:fmpq_mpoly_pow_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mpoly_pow_fmpz, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpz}, Ref{FmpqMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -480,7 +480,7 @@ end
 function gcd(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   r = Bool(ccall((:fmpq_mpoly_gcd, :libflint), Cint,
+   r = Bool(ccall((:fmpq_mpoly_gcd, libflint), Cint,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
          z, a, b, a.parent))
    r == false && error("Unable to compute gcd")
@@ -495,14 +495,14 @@ end
 
 function ==(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
-   return Bool(ccall((:fmpq_mpoly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpq_mpoly_equal, libflint), Cint,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
                a, b, a.parent))
 end
 
 function Base.isless(a::fmpq_mpoly, b::fmpq_mpoly)
    (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
-   return ccall((:fmpq_mpoly_cmp, :libflint), Cint,
+   return ccall((:fmpq_mpoly_cmp, libflint), Cint,
                (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
                a, b, a.parent) < 0
 end
@@ -514,7 +514,7 @@ end
 ###############################################################################
 
 function ==(a::fmpq_mpoly, b::fmpq)
-   return Bool(ccall((:fmpq_mpoly_equal_fmpq, :libflint), Cint,
+   return Bool(ccall((:fmpq_mpoly_equal_fmpq, libflint), Cint,
                      (Ref{fmpq_mpoly}, Ref{fmpq}, Ref{FmpqMPolyRing}),
                      a, b, a.parent))
 end
@@ -522,7 +522,7 @@ end
 ==(a::fmpq, b::fmpq_mpoly) = b == a
 
 function ==(a::fmpq_mpoly, b::fmpz)
-   return Bool(ccall((:fmpq_mpoly_equal_fmpz, :libflint), Cint,
+   return Bool(ccall((:fmpq_mpoly_equal_fmpz, libflint), Cint,
                      (Ref{fmpq_mpoly}, Ref{fmpz}, Ref{FmpqMPolyRing}),
                      a, b, a.parent))
 end
@@ -530,7 +530,7 @@ end
 ==(a::fmpz, b::fmpq_mpoly) = b == a
 
 function ==(a::fmpq_mpoly, b::Int)
-   return Bool(ccall((:fmpq_mpoly_equal_si, :libflint), Cint,
+   return Bool(ccall((:fmpq_mpoly_equal_si, libflint), Cint,
                (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
                a, b, a.parent))
 end
@@ -560,7 +560,7 @@ function divides(a::fmpq_mpoly, b::fmpq_mpoly)
       return false, zero(parent(a))
    end
    z = parent(a)()
-   d = ccall((:fmpq_mpoly_divides, :libflint), Cint,
+   d = ccall((:fmpq_mpoly_divides, libflint), Cint,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        z, a, b, a.parent)
    return isone(d), z
@@ -575,7 +575,7 @@ end
 function div(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    q = parent(a)()
-   ccall((:fmpq_mpoly_div, :libflint), Nothing,
+   ccall((:fmpq_mpoly_div, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
         Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        q, a, b, a.parent)
@@ -586,7 +586,7 @@ function divrem(a::fmpq_mpoly, b::fmpq_mpoly)
    check_parent(a, b)
    q = parent(a)()
    r = parent(a)()
-   ccall((:fmpq_mpoly_divrem, :libflint), Nothing,
+   ccall((:fmpq_mpoly_divrem, libflint), Nothing,
        (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
         Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),
        q, r, a, b, a.parent)
@@ -597,7 +597,7 @@ function divrem(a::fmpq_mpoly, b::Array{fmpq_mpoly, 1})
    len = length(b)
    q = [parent(a)() for i in 1:len]
    r = parent(a)()
-   ccall((:fmpq_mpoly_divrem_ideal, :libflint), Nothing,
+   ccall((:fmpq_mpoly_divrem_ideal, libflint), Nothing,
          (Ptr{Ref{fmpq_mpoly}}, Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
           Ptr{Ref{fmpq_mpoly}}, Int, Ref{FmpqMPolyRing}),
        q, r, a, b, len, a.parent)
@@ -627,7 +627,7 @@ function derivative(a::fmpq_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = parent(a)()
-   ccall((:fmpq_mpoly_derivative, :libflint), Nothing,
+   ccall((:fmpq_mpoly_derivative, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -637,7 +637,7 @@ function integral(a::fmpq_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = parent(a)()
-   ccall((:fmpq_mpoly_integral, :libflint), Nothing,
+   ccall((:fmpq_mpoly_integral, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -652,7 +652,7 @@ end
 function evaluate(a::fmpq_mpoly, b::Vector{fmpq})
    length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
    z = fmpq()
-   GC.@preserve b ccall((:fmpq_mpoly_evaluate_all_fmpq, :libflint), Nothing,
+   GC.@preserve b ccall((:fmpq_mpoly_evaluate_all_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_mpoly}, Ptr{fmpq}, Ref{FmpqMPolyRing}),
             z, a, b, parent(a))
    return z
@@ -728,27 +728,27 @@ end
 ###############################################################################
 
 function zero!(a::fmpq_mpoly)
-    ccall((:fmpq_mpoly_zero, :libflint), Nothing,
+    ccall((:fmpq_mpoly_zero, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
     return a
 end
 
 function add!(a::fmpq_mpoly, b::fmpq_mpoly, c::fmpq_mpoly)
-   ccall((:fmpq_mpoly_add, :libflint), Nothing,
+   ccall((:fmpq_mpoly_add, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
           Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, b, c, a.parent)
    return a
 end
 
 function addeq!(a::fmpq_mpoly, b::fmpq_mpoly)
-   ccall((:fmpq_mpoly_add, :libflint), Nothing,
+   ccall((:fmpq_mpoly_add, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
           Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a, b, a.parent)
    return a
 end
 
 function mul!(a::fmpq_mpoly, b::fmpq_mpoly, c::fmpq_mpoly)
-   ccall((:fmpq_mpoly_mul, :libflint), Nothing,
+   ccall((:fmpq_mpoly_mul, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly},
           Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, b, c, a.parent)
    return a
@@ -758,10 +758,10 @@ end
 # must be removed with combine_like_terms!
 function setcoeff!(a::fmpq_mpoly, n::Int, c::fmpq)
    if n > length(a)
-      ccall((:fmpq_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpq_mpoly_resize, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpq_mpoly_set_term_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set_term_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq_mpoly}, Int, Ref{fmpq}, Ref{FmpqMPolyRing}),
          a, n - 1, c, a.parent)
    return a
@@ -783,7 +783,7 @@ setcoeff!(a::fmpq_mpoly, i::Int, c::Rational{<:Integer}) =
 # Remove zero terms and combine adjacent terms if they have the same monomial
 # no sorting is performed
 function combine_like_terms!(a::fmpq_mpoly)
-   ccall((:fmpq_mpoly_combine_like_terms, :libflint), Nothing,
+   ccall((:fmpq_mpoly_combine_like_terms, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return a
 end
@@ -796,14 +796,14 @@ end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_ui(a::fmpq_mpoly, i::Int)
-   b = ccall((:fmpq_mpoly_term_exp_fits_ui, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_term_exp_fits_ui, libflint), Cint,
              (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, i - 1, a.parent)
       return Bool(b)
 end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_int(a::fmpq_mpoly, i::Int)
-   b = ccall((:fmpq_mpoly_term_exp_fits_si, :libflint), Cint,
+   b = ccall((:fmpq_mpoly_term_exp_fits_si, libflint), Cint,
              (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, i - 1, a.parent)
    return Bool(b)
 end
@@ -811,7 +811,7 @@ end
 # Return Julia array of UInt's corresponding to exponent vector of i-th term
 function exponent_vector_ui(a::fmpq_mpoly, i::Int)
    z = Vector{UInt}(undef, nvars(parent(a)))
-   ccall((:fmpq_mpoly_get_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_exp_ui, libflint), Nothing,
          (Ptr{UInt}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -822,7 +822,7 @@ function exponent_vector(a::fmpq_mpoly, i::Int)
    exponent_vector_fits_int(a, i) ||
       throw(DomainError(term(a, i), "exponents don't fit in `Int` (try exponent_vector_fmpz)"))
    z = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:fmpq_mpoly_get_term_exp_si, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_exp_si, libflint), Nothing,
          (Ptr{Int}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -835,7 +835,7 @@ function exponent_vector_fmpz(a::fmpq_mpoly, i::Int)
    for j in 1:n
       z[j] = fmpz()
    end
-   ccall((:fmpq_mpoly_get_term_exp_fmpz, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_exp_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -851,10 +851,10 @@ end
 # they don't fit into 31/63 bits
 function set_exponent_vector!(a::fmpq_mpoly, n::Int, exps::Vector{UInt})
    if n > length(a)
-      ccall((:fmpq_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpq_mpoly_resize, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpq_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Int, Ptr{UInt}, Ref{FmpqMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -865,10 +865,10 @@ end
 # no check is performed
 function set_exponent_vector!(a::fmpq_mpoly, n::Int, exps::Vector{Int})
    if n > length(a)
-      ccall((:fmpq_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpq_mpoly_resize, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpq_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Int, Ptr{Int}, Ref{FmpqMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -878,10 +878,10 @@ end
 # No sort is performed, so this is unsafe
 function set_exponent_vector!(a::fmpq_mpoly, n::Int, exps::Vector{fmpz})
    if n > length(a)
-      ccall((:fmpq_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpq_mpoly_resize, libflint), Nothing,
             (Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}), a, n, a.parent)
    end
-   @GC.preserve exps ccall((:fmpq_mpoly_set_term_exp_fmpz, :libflint), Nothing,
+   @GC.preserve exps ccall((:fmpq_mpoly_set_term_exp_fmpz, libflint), Nothing,
          (Ref{fmpq_mpoly}, Int, Ptr{fmpz}, Ref{FmpqMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -890,7 +890,7 @@ end
 # Return j-th coordinate of i-th exponent vector
 function exponent(a::fmpq_mpoly, i::Int, j::Int)
    (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
-   return ccall((:fmpq_mpoly_get_term_var_exp_ui, :libflint), Int,
+   return ccall((:fmpq_mpoly_get_term_var_exp_ui, libflint), Int,
                 (Ref{fmpq_mpoly}, Int, Int, Ref{FmpqMPolyRing}),
                  a, i - 1, j - 1, a.parent)
 end
@@ -899,7 +899,7 @@ end
 # Return zero if there is no such term
 function coeff(a::fmpq_mpoly, exps::Vector{UInt})
    z = fmpq()
-   ccall((:fmpq_mpoly_get_coeff_fmpq_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_coeff_fmpq_ui, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_mpoly}, Ptr{UInt}, Ref{FmpqMPolyRing}),
       z, a, exps, parent(a))
    return z
@@ -909,7 +909,7 @@ end
 # Return zero if there is no such term
 function coeff(a::fmpq_mpoly, exps::Vector{Int})
    z = fmpq()
-   ccall((:fmpq_mpoly_get_coeff_fmpq_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_coeff_fmpq_ui, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_mpoly}, Ptr{Int}, Ref{FmpqMPolyRing}),
       z, a, exps, parent(a))
    return z
@@ -918,7 +918,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpq. Removal of a zero term is performed.
 function setcoeff!(a::fmpq_mpoly, exps::Vector{UInt}, b::fmpq)
-   ccall((:fmpq_mpoly_set_coeff_fmpq_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set_coeff_fmpq_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq}, Ptr{UInt}, Ref{FmpqMPolyRing}),
       a, b, exps, parent(a))
    return a
@@ -927,7 +927,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpq. Removal of a zero term is performed.
 function setcoeff!(a::fmpq_mpoly, exps::Vector{Int}, b::fmpq)
-   ccall((:fmpq_mpoly_set_coeff_fmpq_ui, :libflint), Nothing,
+   ccall((:fmpq_mpoly_set_coeff_fmpq_ui, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq}, Ptr{Int}, Ref{FmpqMPolyRing}),
       a, b, exps, parent(a))
    return a
@@ -953,7 +953,7 @@ setcoeff!(a::fmpq_mpoly, exps::Vector{Int}, b::Integer) =
 # out of order. Note that like terms are not combined and zeros are not
 # removed. For that, call combine_like_terms!
 function sort_terms!(a::fmpq_mpoly)
-   ccall((:fmpq_mpoly_sort_terms, :libflint), Nothing,
+   ccall((:fmpq_mpoly_sort_terms, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}), a, a.parent)
    return a
 end
@@ -961,7 +961,7 @@ end
 # Return the i-th term of the polynomial, as a polynomial
 function term(a::fmpq_mpoly, i::Int)
    z = parent(a)()
-   ccall((:fmpq_mpoly_get_term, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -970,7 +970,7 @@ end
 # Return the i-th monomial of the polynomial, as a polynomial
 function monomial(a::fmpq_mpoly, i::Int)
    z = parent(a)()
-   ccall((:fmpq_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -978,7 +978,7 @@ end
 
 # Sets the given polynomial m to the i-th monomial of the polynomial
 function monomial!(m::fmpq_mpoly, a::fmpq_mpoly, i::Int)
-   ccall((:fmpq_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:fmpq_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Int, Ref{FmpqMPolyRing}),
           m, a, i - 1, a.parent)
    return m

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -33,21 +33,21 @@ var(a::FmpqPolyRing) = a.S
 """
 function denominator(a::fmpq_poly)
    z = fmpz()
-   ccall((:fmpq_poly_get_denominator, :libflint), Nothing,
+   ccall((:fmpq_poly_get_denominator, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpq_poly}), z, a)
    return z
 end
 
-length(x::fmpq_poly) = ccall((:fmpq_poly_length, :libflint), Int,
+length(x::fmpq_poly) = ccall((:fmpq_poly_length, libflint), Int,
                                    (Ref{fmpq_poly},), x)
 
-set_length!(x::fmpq_poly, n::Int) = ccall((:_fmpq_poly_set_length, :libflint), Nothing,
+set_length!(x::fmpq_poly, n::Int) = ccall((:_fmpq_poly_set_length, libflint), Nothing,
                                    (Ref{fmpq_poly}, Int), x, n)
 
 function coeff(x::fmpq_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = fmpq()
-   ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
                (Ref{fmpq}, Ref{fmpq_poly}, Int), z, x, n)
    return z
 end
@@ -58,7 +58,7 @@ one(a::FmpqPolyRing) = a(1)
 
 gen(a::FmpqPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
-isgen(x::fmpq_poly) = ccall((:fmpq_poly_is_x, :libflint), Bool,
+isgen(x::fmpq_poly) = ccall((:fmpq_poly_is_x, libflint), Bool,
                             (Ref{fmpq_poly},), x)
 
 function deepcopy_internal(a::fmpq_poly, dict::IdDict)
@@ -87,12 +87,12 @@ function show(io::IO, x::fmpq_poly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fmpq_poly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fmpq_poly_get_str_pretty, libflint), Ptr{UInt8},
           (Ref{fmpq_poly}, Ptr{UInt8}), x, string(var(parent(x))))
 
       print(io, unsafe_string(cstr))
 
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 =#
@@ -114,7 +114,7 @@ show_minus_one(::Type{fmpq_poly}) = show_minus_one(FracElem{fmpz})
 
 function -(x::fmpq_poly)
    z = parent(x)()
-   ccall((:fmpq_poly_neg, :libflint), Nothing,
+   ccall((:fmpq_poly_neg, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
@@ -128,7 +128,7 @@ end
 function +(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpq_poly_add, :libflint), Nothing,
+   ccall((:fmpq_poly_add, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}),
                z, x, y)
    return z
@@ -137,7 +137,7 @@ end
 function -(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpq_poly_sub, :libflint), Nothing,
+   ccall((:fmpq_poly_sub, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}),
                z, x, y)
    return z
@@ -146,7 +146,7 @@ end
 function *(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpq_poly_mul, :libflint), Nothing,
+   ccall((:fmpq_poly_mul, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly},  Ref{fmpq_poly}),
                z, x, y)
    return z
@@ -160,84 +160,84 @@ end
 
 function *(x::Int, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpz, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function *(x::fmpq, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpq, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, y, x)
    return z
 end
 
 function +(x::fmpq_poly, y::Int)
    z = parent(x)()
-   ccall((:fmpq_poly_add_si, :libflint), Nothing,
+   ccall((:fmpq_poly_add_si, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
 
 function +(x::fmpq_poly, y::fmpz)
    z = parent(x)()
-   ccall((:fmpq_poly_add_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_add_fmpz, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function +(x::fmpq_poly, y::fmpq)
    z = parent(x)()
-   ccall((:fmpq_poly_add_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_add_fmpq, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::Int)
    z = parent(x)()
-   ccall((:fmpq_poly_sub_si, :libflint), Nothing,
+   ccall((:fmpq_poly_sub_si, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::fmpz)
    z = parent(x)()
-   ccall((:fmpq_poly_sub_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_sub_fmpz, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::fmpq_poly, y::fmpq)
    z = parent(x)()
-   ccall((:fmpq_poly_sub_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_sub_fmpq, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
 
 function -(x::Int, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_si_sub, :libflint), Nothing,
+   ccall((:fmpq_poly_si_sub, libflint), Nothing,
                 (Ref{fmpq_poly}, Int, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpz, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_fmpz_sub, :libflint), Nothing,
+   ccall((:fmpq_poly_fmpz_sub, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpz}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpq, y::fmpq_poly)
    z = parent(y)()
-   ccall((:fmpq_poly_fmpq_sub, :libflint), Nothing,
+   ccall((:fmpq_poly_fmpq_sub, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq}, Ref{fmpq_poly}), z, x, y)
    return z
 end
@@ -287,7 +287,7 @@ end
 function ^(x::fmpq_poly, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = parent(x)()
-   ccall((:fmpq_poly_pow, :libflint), Nothing,
+   ccall((:fmpq_poly_pow, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int),
                z, x, y)
    return z
@@ -301,7 +301,7 @@ end
 
 function ==(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
-   return ccall((:fmpq_poly_equal, :libflint), Bool,
+   return ccall((:fmpq_poly_equal, libflint), Bool,
                                       (Ref{fmpq_poly}, Ref{fmpq_poly}), x, y)
 end
 
@@ -316,9 +316,9 @@ function ==(x::fmpq_poly, y::fmpq)
       return false
    elseif length(x) == 1
       z = fmpq()
-      ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+      ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
                        (Ref{fmpq}, Ref{fmpq_poly}, Int), z, x, 0)
-      return ccall((:fmpq_equal, :libflint), Bool,
+      return ccall((:fmpq_equal, libflint), Bool,
                (Ref{fmpq}, Ref{fmpq}, Int), z, y, 0)
    else
       return iszero(y)
@@ -345,7 +345,7 @@ function truncate(a::fmpq_poly, n::Int)
    end
 
    z = parent(a)()
-   ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpq_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, a, n)
    return z
 end
@@ -355,7 +355,7 @@ function mullow(x::fmpq_poly, y::fmpq_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
 
    z = parent(x)()
-   ccall((:fmpq_poly_mullow, :libflint), Nothing,
+   ccall((:fmpq_poly_mullow, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y, n)
    return z
 end
@@ -369,7 +369,7 @@ end
 function reverse(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Length must be non-negative"))
    z = parent(x)()
-   ccall((:fmpq_poly_reverse, :libflint), Nothing,
+   ccall((:fmpq_poly_reverse, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
@@ -383,7 +383,7 @@ end
 function shift_left(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
       (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
@@ -391,7 +391,7 @@ end
 function shift_right(x::fmpq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fmpq_poly_shift_right, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_right, libflint), Nothing,
        (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, len)
    return z
 end
@@ -406,7 +406,7 @@ function mod(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    r = parent(x)()
-   ccall((:fmpq_poly_rem, :libflint), Nothing,
+   ccall((:fmpq_poly_rem, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}),
                r, x, y)
    return r
@@ -419,7 +419,7 @@ function divrem(x::fmpq_poly, y::fmpq_poly)
    iszero(y) && throw(DivideError())
    q = parent(x)()
    r = parent(x)()
-   ccall((:fmpq_poly_divrem, :libflint), Nothing,
+   ccall((:fmpq_poly_divrem, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}),
                q, r, x, y)
    return q, r
@@ -435,7 +435,7 @@ function div(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpq_poly_div, :libflint), Nothing,
+   ccall((:fmpq_poly_div, libflint), Nothing,
             (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
@@ -451,7 +451,7 @@ divexact(x::fmpq_poly, y::fmpq_poly) = div(x,y)
 function divexact(x::fmpq_poly, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpz, libflint), Nothing,
           (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -459,7 +459,7 @@ end
 function divexact(x::fmpq_poly, y::fmpq)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpq, libflint), Nothing,
           (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
@@ -467,7 +467,7 @@ end
 function divexact(x::fmpq_poly, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpq_poly_scalar_div_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_si, libflint), Nothing,
                         (Ref{fmpq_poly}, Ref{fmpq_poly}, Int), z, x, y)
    return z
 end
@@ -502,21 +502,21 @@ end
 function gcd(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpq_poly_gcd, :libflint), Nothing,
+   ccall((:fmpq_poly_gcd, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function content(x::fmpq_poly)
    z = fmpq()
-   ccall((:fmpq_poly_content, :libflint), Nothing,
+   ccall((:fmpq_poly_content, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_poly}), z, x)
    return z
 end
 
 function primpart(x::fmpq_poly)
    z = parent(x)()
-   ccall((:fmpq_poly_primitive_part, :libflint), Nothing,
+   ccall((:fmpq_poly_primitive_part, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
@@ -529,14 +529,14 @@ end
 
 function evaluate(x::fmpq_poly, y::fmpz)
    z = fmpq()
-   ccall((:fmpq_poly_evaluate_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_evaluate_fmpz, libflint), Nothing,
                 (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function evaluate(x::fmpq_poly, y::fmpq)
    z = fmpq()
-   ccall((:fmpq_poly_evaluate_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_evaluate_fmpq, libflint), Nothing,
                 (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpq}), z, x, y)
    return z
 end
@@ -554,7 +554,7 @@ evaluate(x::fmpq_poly, y::Rational) = evaluate(x, fmpq(y))
 function compose(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpq_poly_compose, :libflint), Nothing,
+   ccall((:fmpq_poly_compose, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
@@ -567,7 +567,7 @@ end
 
 function derivative(x::fmpq_poly)
    z = parent(x)()
-   ccall((:fmpq_poly_derivative, :libflint), Nothing,
+   ccall((:fmpq_poly_derivative, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
@@ -580,7 +580,7 @@ end
 
 function integral(x::fmpq_poly)
    z = parent(x)()
-   ccall((:fmpq_poly_integral, :libflint), Nothing,
+   ccall((:fmpq_poly_integral, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}), z, x)
    return z
 end
@@ -594,7 +594,7 @@ end
 function resultant(x::fmpq_poly, y::fmpq_poly)
    check_parent(x, y)
    z = fmpq()
-   ccall((:fmpq_poly_resultant, :libflint), Nothing,
+   ccall((:fmpq_poly_resultant, libflint), Nothing,
                 (Ref{fmpq}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
@@ -610,7 +610,7 @@ function gcdx(x::fmpq_poly, y::fmpq_poly)
    z = parent(x)()
    u = parent(x)()
    v = parent(x)()
-   ccall((:fmpq_poly_xgcd, :libflint), Nothing,
+   ccall((:fmpq_poly_xgcd, libflint), Nothing,
         (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly},
                                      Ref{fmpq_poly}), z, u, v, x, y)
    return (z, u, v)
@@ -634,17 +634,17 @@ end
 function _factor(x::fmpq_poly)
    res = Dict{fmpq_poly, Int}()
    y = fmpz_poly()
-   ccall((:fmpq_poly_get_numerator, :libflint), Nothing,
+   ccall((:fmpq_poly_get_numerator, libflint), Nothing,
          (Ref{fmpz_poly}, Ref{fmpq_poly}), y, x)
    fac = fmpz_poly_factor()
-   ccall((:fmpz_poly_factor, :libflint), Nothing,
+   ccall((:fmpz_poly_factor, libflint), Nothing,
               (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, y)
    z = fmpz()
-   ccall((:fmpz_poly_factor_get_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_factor_get_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
    f = fmpz_poly()
    for i in 1:fac.num
-      ccall((:fmpz_poly_factor_get_fmpz_poly, :libflint), Nothing,
+      ccall((:fmpz_poly_factor_get_fmpz_poly, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
       e = unsafe_load(fac.exp, i)
       res[parent(x)(f)] = e
@@ -676,7 +676,7 @@ function signature(f::fmpq_poly)
    r = Vector{Int}(undef, 1)
    s = Vector{Int}(undef, 1)
    z = fmpz_poly()
-   ccall((:fmpq_poly_get_numerator, :libflint), Nothing,
+   ccall((:fmpq_poly_get_numerator, libflint), Nothing,
          (Ref{fmpz_poly}, Ref{fmpq_poly}), z, f)
    return signature(z)
 end
@@ -703,43 +703,43 @@ end
 ###############################################################################
 
 function zero!(z::fmpq_poly)
-   ccall((:fmpq_poly_zero, :libflint), Nothing,
+   ccall((:fmpq_poly_zero, libflint), Nothing,
                     (Ref{fmpq_poly},), z)
    return z
 end
 
 function fit!(z::fmpq_poly, n::Int)
-   ccall((:fmpq_poly_fit_length, :libflint), Nothing,
+   ccall((:fmpq_poly_fit_length, libflint), Nothing,
                     (Ref{fmpq_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpz)
-   ccall((:fmpq_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_set_coeff_fmpz, libflint), Nothing,
                     (Ref{fmpq_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function setcoeff!(z::fmpq_poly, n::Int, x::fmpq)
-   ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                     (Ref{fmpq_poly}, Int, Ref{fmpq}), z, n, x)
    return z
 end
 
 function mul!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
-   ccall((:fmpq_poly_mul, :libflint), Nothing,
+   ccall((:fmpq_poly_mul, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpq_poly, x::fmpq_poly)
-   ccall((:fmpq_poly_add, :libflint), Nothing,
+   ccall((:fmpq_poly_add, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, z, x)
    return z
 end
 
 function add!(z::fmpq_poly, x::fmpq_poly, y::fmpq_poly)
-   ccall((:fmpq_poly_add, :libflint), Nothing,
+   ccall((:fmpq_poly_add, libflint), Nothing,
                 (Ref{fmpq_poly}, Ref{fmpq_poly}, Ref{fmpq_poly}), z, x, y)
    return z
 end

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -39,13 +39,13 @@ max_precision(R::FmpqRelSeriesRing) = R.prec_max
 function normalise(a::fmpq_rel_series, len::Int)
    if len > 0
       c = fmpq()
-      ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+      ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
             (Ref{fmpq}, Ref{fmpq_rel_series}, Int), c, a, len - 1)
       end
    end
@@ -53,7 +53,7 @@ function normalise(a::fmpq_rel_series, len::Int)
 end
 
 function pol_length(x::fmpq_rel_series)
-   return ccall((:fmpq_poly_length, :libflint), Int, (Ref{fmpq_rel_series},), x)
+   return ccall((:fmpq_poly_length, libflint), Int, (Ref{fmpq_rel_series},), x)
 end
 
 precision(x::fmpq_rel_series) = x.prec
@@ -63,7 +63,7 @@ function polcoeff(x::fmpq_rel_series, n::Int)
       return fmpq(0)
    end
    z = fmpq()
-   ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, n)
    return z
 end
@@ -99,7 +99,7 @@ function renormalize!(z::fmpq_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:fmpq_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_right, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int), z, z, i)
    end
    return nothing
@@ -128,7 +128,7 @@ show_minus_one(::Type{fmpq_rel_series}) = show_minus_one(fmpq)
 
 function -(x::fmpq_rel_series)
    z = parent(x)()
-   ccall((:fmpq_poly_neg, :libflint), Nothing,
+   ccall((:fmpq_poly_neg, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}),
                z, x)
    z.prec = x.prec
@@ -153,29 +153,29 @@ function +(a::fmpq_rel_series, b::fmpq_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -197,31 +197,31 @@ function -(a::fmpq_rel_series, b::fmpq_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpq_poly_neg, :libflint), Nothing,
+      ccall((:fmpq_poly_neg, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}), z, z)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpq_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpq_poly_sub_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpq_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpq_poly_sub_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -247,7 +247,7 @@ function *(a::fmpq_rel_series, b::fmpq_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fmpq_poly_mullow, :libflint), Nothing,
+   ccall((:fmpq_poly_mullow, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, b, lenz)
    return z
@@ -263,7 +263,7 @@ function *(x::Int, y::fmpq_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpq_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, y, x)
    return z
@@ -275,7 +275,7 @@ function *(x::fmpz, y::fmpq_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpq_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
                z, y, x)
    return z
@@ -285,7 +285,7 @@ function *(x::fmpq, y::fmpq_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpq_poly_scalar_mul_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_mul_fmpq, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
                z, y, x)
    return z
@@ -347,7 +347,7 @@ function shift_right(x::fmpq_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:fmpq_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_right, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, x, xlen - zlen)
       renormalize!(z)
@@ -377,7 +377,7 @@ function truncate(x::fmpq_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, x, min(prec - xval, xlen))
    end
@@ -444,7 +444,7 @@ function ==(x::fmpq_rel_series, y::fmpq_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:fmpq_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpq_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                x, y, xlen))
 end
@@ -456,7 +456,7 @@ function isequal(x::fmpq_rel_series, y::fmpq_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:fmpq_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpq_poly_equal, libflint), Cint,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                x, y, pol_length(x)))
 end
@@ -475,9 +475,9 @@ function ==(x::fmpq_rel_series, y::fmpq)
    elseif pol_length(x) == 1
       if x.val == 0
          z = fmpq()
-         ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
                        (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, 0)
-         return ccall((:fmpq_equal, :libflint), Bool,
+         return ccall((:fmpq_equal, libflint), Bool,
                (Ref{fmpq}, Ref{fmpq}, Int), z, y, 0)
       else
          return false
@@ -495,9 +495,9 @@ function ==(x::fmpq_rel_series, y::fmpz)
    elseif pol_length(x) == 1
       if x.val == 0
          z = fmpq()
-         ccall((:fmpq_poly_get_coeff_fmpq, :libflint), Nothing,
+         ccall((:fmpq_poly_get_coeff_fmpq, libflint), Nothing,
                        (Ref{fmpq}, Ref{fmpq_rel_series}, Int), z, x, 0)
-         return isone(denominator(z)) && ccall((:fmpz_equal, :libflint), Bool,
+         return isone(denominator(z)) && ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}, Int), numerator(z), y, 0)
       else
          return false
@@ -542,7 +542,7 @@ function divexact(x::fmpq_rel_series, y::fmpq_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:fmpq_poly_div_series, :libflint), Nothing,
+      ccall((:fmpq_poly_div_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, x, y, prec)
    end
@@ -560,7 +560,7 @@ function divexact(x::fmpq_rel_series, y::Int)
    z = parent(x)()
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpq_poly_scalar_div_si, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_si, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, x, y)
    return z
@@ -572,7 +572,7 @@ function divexact(x::fmpq_rel_series, y::fmpz)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpq_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -584,7 +584,7 @@ function divexact(x::fmpq_rel_series, y::fmpq)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpq_poly_scalar_div_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_scalar_div_fmpq, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq}),
                z, x, y)
    return z
@@ -606,7 +606,7 @@ function inv(a::fmpq_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:fmpq_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpq_poly_inv_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -626,10 +626,10 @@ function Base.exp(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_exp_series, :libflint), Nothing,
+   ccall((:fmpq_poly_exp_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -648,7 +648,7 @@ function log(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_log_series, :libflint), Nothing,
+   ccall((:fmpq_poly_log_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.prec)
    renormalize!(z)
@@ -667,10 +667,10 @@ function tan(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_tan_series, :libflint), Nothing,
+   ccall((:fmpq_poly_tan_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -689,10 +689,10 @@ function tanh(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_tanh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_tanh_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -711,13 +711,13 @@ function sin(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_truncate, :libflint), Nothing,
+   ccall((:fmpq_poly_truncate, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Int),
                z, a.prec)
-   ccall((:fmpq_poly_sin_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sin_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -736,10 +736,10 @@ function sinh(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_sinh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sinh_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -758,13 +758,13 @@ function cos(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_truncate, :libflint), Nothing,
+   ccall((:fmpq_poly_truncate, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Int),
                z, a.prec)
-   ccall((:fmpq_poly_cos_series, :libflint), Nothing,
+   ccall((:fmpq_poly_cos_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -783,10 +783,10 @@ function cosh(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_cosh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_cosh_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -805,10 +805,10 @@ function asin(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_asin_series, :libflint), Nothing,
+   ccall((:fmpq_poly_asin_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -827,10 +827,10 @@ function asinh(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_asinh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_asinh_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -849,10 +849,10 @@ function atan(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_atan_series, :libflint), Nothing,
+   ccall((:fmpq_poly_atan_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -871,10 +871,10 @@ function atanh(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpq_poly_shift_left, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.val)
-   ccall((:fmpq_poly_atanh_series, :libflint), Nothing,
+   ccall((:fmpq_poly_atanh_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, z, a.prec)
    renormalize!(z)
@@ -891,7 +891,7 @@ function Base.sqrt(a::fmpq_rel_series)
    z = parent(a)()
    z.prec = a.prec
    z.val = 0
-   ccall((:fmpq_poly_sqrt_series, :libflint), Nothing,
+   ccall((:fmpq_poly_sqrt_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, a.prec)
    return z
@@ -904,14 +904,14 @@ end
 ###############################################################################
 
 function zero!(z::fmpq_rel_series)
-   ccall((:fmpq_poly_zero, :libflint), Nothing,
+   ccall((:fmpq_poly_zero, libflint), Nothing,
                 (Ref{fmpq_rel_series},), z)
    z.prec = parent(z).prec_max
    return z
 end
 
 function setcoeff!(z::fmpq_rel_series, n::Int, x::fmpq)
-   ccall((:fmpq_poly_set_coeff_fmpq, :libflint), Nothing,
+   ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Int, Ref{fmpq}),
                z, n, x)
    return z
@@ -931,7 +931,7 @@ function mul!(z::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:fmpq_poly_mullow, :libflint), Nothing,
+   ccall((:fmpq_poly_mullow, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                z, a, b, lenz)
    return z
@@ -947,29 +947,29 @@ function addeq!(a::fmpq_rel_series, b::fmpq_rel_series)
    if a.val < b.val
       z = fmpq_rel_series()
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpq_poly_set_trunc, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpq_poly_truncate, :libflint), Nothing,
+      ccall((:fmpq_poly_truncate, libflint), Nothing,
             (Ref{fmpq_rel_series}, Int),
             a, max(0, lenz - a.val + b.val))
-      ccall((:fmpq_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpq_poly_shift_left, libflint), Nothing,
             (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
             a, a, a.val - b.val)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                a, a, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpq_poly_add_series, :libflint), Nothing,
+      ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                a, a, b, lenz)
    end
@@ -990,7 +990,7 @@ function add!(c::fmpq_rel_series, a::fmpq_rel_series, b::fmpq_rel_series)
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:fmpq_poly_add_series, :libflint), Nothing,
+   ccall((:fmpq_poly_add_series, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Ref{fmpq_rel_series}, Int),
                c, a, b, lenc)
    return c

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -132,7 +132,7 @@ end
 
 function deepcopy_internal(a::fmpz, dict::IdDict)
    z = fmpz()
-   ccall((:fmpz_set, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, a)
+   ccall((:fmpz_set, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, a)
    return z
 end
 
@@ -157,14 +157,14 @@ zero(::Type{fmpz}) = fmpz(0)
     sign(a::fmpz)
 > Returns the sign of $a$, i.e. $+1$, $0$ or $-1$.
 """
-sign(a::fmpz) = fmpz(ccall((:fmpz_sgn, :libflint), Cint, (Ref{fmpz},), a))
+sign(a::fmpz) = fmpz(ccall((:fmpz_sgn, libflint), Cint, (Ref{fmpz},), a))
 
 @doc Markdown.doc"""
     fits(::Type{Int}, a::fmpz)
 > Returns `true` if the given integer fits into an `Int`, otherwise returns
 > `false`.
 """
-fits(::Type{Int}, a::fmpz) = ccall((:fmpz_fits_si, :libflint), Bool,
+fits(::Type{Int}, a::fmpz) = ccall((:fmpz_fits_si, libflint), Bool,
                                    (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
@@ -173,32 +173,32 @@ fits(::Type{Int}, a::fmpz) = ccall((:fmpz_fits_si, :libflint), Bool,
 > `false`.
 """
 fits(::Type{UInt}, a::fmpz) = sign(a) < 0 ? false :
-              ccall((:fmpz_abs_fits_ui, :libflint), Bool, (Ref{fmpz},), a)
+              ccall((:fmpz_abs_fits_ui, libflint), Bool, (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
     size(a::fmpz)
 > Returns the number of limbs required to store the absolute value of $a$.
 """
-size(a::fmpz) = Int(ccall((:fmpz_size, :libflint), Cint, (Ref{fmpz},), a))
+size(a::fmpz) = Int(ccall((:fmpz_size, libflint), Cint, (Ref{fmpz},), a))
 
 @doc Markdown.doc"""
     isunit(a::fmpz)
 > Return `true` if the given integer is a unit, i.e. $\pm 1$, otherwise return
 > `false`.
 """
-isunit(a::fmpz) = ccall((:fmpz_is_pm1, :libflint), Bool, (Ref{fmpz},), a)
+isunit(a::fmpz) = ccall((:fmpz_is_pm1, libflint), Bool, (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
     iszero(a::fmpz)
 > Return `true` if the given integer is zero, otherwise return `false`.
 """
-iszero(a::fmpz) = ccall((:fmpz_is_zero, :libflint), Bool, (Ref{fmpz},), a)
+iszero(a::fmpz) = ccall((:fmpz_is_zero, libflint), Bool, (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
     isone(a::fmpz)
 > Return `true` if the given integer is one, otherwise return `false`.
 """
-isone(a::fmpz) = ccall((:fmpz_is_one, :libflint), Bool, (Ref{fmpz},), a)
+isone(a::fmpz) = ccall((:fmpz_is_one, libflint), Bool, (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
     denominator(a::fmpz)
@@ -216,8 +216,8 @@ function numerator(a::fmpz)
    return a
 end
 
-isodd(a::fmpz)  = ccall((:fmpz_is_odd,  :libflint), Cint, (Ref{fmpz},), a) % Bool
-iseven(a::fmpz) = ccall((:fmpz_is_even, :libflint), Cint, (Ref{fmpz},), a) % Bool
+isodd(a::fmpz)  = ccall((:fmpz_is_odd,  libflint), Cint, (Ref{fmpz},), a) % Bool
+iseven(a::fmpz) = ccall((:fmpz_is_even, libflint), Cint, (Ref{fmpz},), a) % Bool
 
 ###############################################################################
 #
@@ -253,19 +253,19 @@ canonical_unit(x::fmpz) = x < 0 ? fmpz(-1) : fmpz(1)
 
 function -(x::fmpz)
     z = fmpz()
-    ccall((:__fmpz_neg, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
+    ccall((:__fmpz_neg, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
 function ~(x::fmpz)
     z = fmpz()
-    ccall((:fmpz_complement, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
+    ccall((:fmpz_complement, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
 function abs(x::fmpz)
     z = fmpz()
-    ccall((:fmpz_abs, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
+    ccall((:fmpz_abs, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
@@ -287,7 +287,7 @@ for (fJ, fC) in ((:+, :add), (:-,:sub), (:*, :mul),
     @eval begin
         function ($fJ)(x::fmpz, y::fmpz)
             z = fmpz()
-            ccall(($(string(:fmpz_, fC)), :libflint), Nothing,
+            ccall(($(string(:fmpz_, fC)), libflint), Nothing,
                   (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
             return z
         end
@@ -302,7 +302,7 @@ for (fJ, fC) in ((:fdiv, :fdiv_q), (:cdiv, :cdiv_q), (:tdiv, :tdiv_q),
         function ($fJ)(x::fmpz, y::fmpz)
             iszero(y) && throw(DivideError())
             z = fmpz()
-            ccall(($(string(:fmpz_, fC)), :libflint), Nothing,
+            ccall(($(string(:fmpz_, fC)), libflint), Nothing,
                   (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
             return z
         end
@@ -313,7 +313,7 @@ function divexact(x::fmpz, y::fmpz)
     iszero(y) && throw(DivideError())
     z = fmpz()
     r = fmpz()
-    ccall((:fmpz_tdiv_qr, :libflint), Nothing,
+    ccall((:fmpz_tdiv_qr, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, r, x, y)
     r != 0 && throw(ArgumentError("Not an exact division"))
     return z
@@ -323,7 +323,7 @@ function rem(x::fmpz, c::fmpz)
     iszero(c) && throw(DivideError())
     q = fmpz()
     r = fmpz()
-    ccall((:fmpz_tdiv_qr, :libflint), Nothing,
+    ccall((:fmpz_tdiv_qr, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), q, r, x, c)
     return r
 end
@@ -337,10 +337,10 @@ end
 function +(x::fmpz, c::Int)
     z = fmpz()
     if c >= 0
-       ccall((:fmpz_add_ui, :libflint), Nothing,
+       ccall((:fmpz_add_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
-       ccall((:fmpz_sub_ui, :libflint), Nothing,
+       ccall((:fmpz_sub_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
     return z
@@ -351,10 +351,10 @@ end
 function -(x::fmpz, c::Int)
     z = fmpz()
     if c >= 0
-       ccall((:fmpz_sub_ui, :libflint), Nothing,
+       ccall((:fmpz_sub_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
-       ccall((:fmpz_add_ui, :libflint), Nothing,
+       ccall((:fmpz_add_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
     return z
@@ -363,20 +363,20 @@ end
 function -(c::Int, x::fmpz)
     z = fmpz()
     if c >= 0
-       ccall((:fmpz_sub_ui, :libflint), Nothing,
+       ccall((:fmpz_sub_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     else
-       ccall((:fmpz_add_ui, :libflint), Nothing,
+       ccall((:fmpz_add_ui, libflint), Nothing,
              (Ref{fmpz}, Ref{fmpz}, Int), z, x, -c)
     end
-    ccall((:__fmpz_neg, :libflint), Nothing,
+    ccall((:__fmpz_neg, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}), z, z)
     return z
 end
 
 function *(x::fmpz, c::Int)
     z = fmpz()
-    ccall((:fmpz_mul_si, :libflint), Nothing,
+    ccall((:fmpz_mul_si, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -414,7 +414,7 @@ divexact(x::Integer, y::fmpz) = divexact(fmpz(x), y)
 function tdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_tdiv_q_2exp, :libflint), Nothing,
+    ccall((:fmpz_tdiv_q_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -422,7 +422,7 @@ end
 function fdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_fdiv_q_2exp, :libflint), Nothing,
+    ccall((:fmpz_fdiv_q_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -430,7 +430,7 @@ end
 function fmodpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_fdiv_r_2exp, :libflint), Nothing,
+    ccall((:fmpz_fdiv_r_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -438,7 +438,7 @@ end
 function cdivpow2(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_cdiv_q_2exp, :libflint), Nothing,
+    ccall((:fmpz_cdiv_q_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -446,7 +446,7 @@ end
 function tdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
-    ccall((:fmpz_tdiv_q_si, :libflint), Nothing,
+    ccall((:fmpz_tdiv_q_si, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -454,7 +454,7 @@ end
 function fdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
-    ccall((:fmpz_fdiv_q_si, :libflint), Nothing,
+    ccall((:fmpz_fdiv_q_si, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -462,7 +462,7 @@ end
 function cdiv(x::fmpz, c::Int)
     c == 0 && throw(DivideError())
     z = fmpz()
-    ccall((:fmpz_cdiv_q_si, :libflint), Nothing,
+    ccall((:fmpz_cdiv_q_si, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -498,7 +498,7 @@ function divrem(x::fmpz, y::fmpz)
     iszero(y) && throw(DivideError())
     z1 = fmpz()
     z2 = fmpz()
-    ccall((:fmpz_tdiv_qr, :libflint), Nothing,
+    ccall((:fmpz_tdiv_qr, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
@@ -507,7 +507,7 @@ function tdivrem(x::fmpz, y::fmpz)
     iszero(y) && throw(DivideError())
     z1 = fmpz()
     z2 = fmpz()
-    ccall((:fmpz_tdiv_qr, :libflint), Nothing,
+    ccall((:fmpz_tdiv_qr, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
@@ -516,7 +516,7 @@ function fdivrem(x::fmpz, y::fmpz)
     iszero(y) && throw(DivideError())
     z1 = fmpz()
     z2 = fmpz()
-    ccall((:fmpz_fdiv_qr, :libflint), Nothing,
+    ccall((:fmpz_fdiv_qr, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z1, z2, x, y)
     z1, z2
 end
@@ -538,7 +538,7 @@ function ^(x::fmpz, y::Int)
       deepcopy(x)
    else
       z = fmpz()
-      ccall((:fmpz_pow_ui, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(y))
+      ccall((:fmpz_pow_ui, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(y))
       z
    end
 end
@@ -550,7 +550,7 @@ end
 ###############################################################################
 
 function cmp(x::fmpz, y::fmpz)
-    Int(ccall((:fmpz_cmp, :libflint), Cint,
+    Int(ccall((:fmpz_cmp, libflint), Cint,
               (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
@@ -565,7 +565,7 @@ end
 >(x::fmpz, y::fmpz) = cmp(x,y) > 0
 
 function cmpabs(x::fmpz, y::fmpz)
-    Int(ccall((:fmpz_cmpabs, :libflint), Cint,
+    Int(ccall((:fmpz_cmpabs, libflint), Cint,
               (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
@@ -582,7 +582,7 @@ isless(x::Integer, y::fmpz) = fmpz(x) < y
 ###############################################################################
 
 function cmp(x::fmpz, y::Int)
-    Int(ccall((:fmpz_cmp_si, :libflint), Cint, (Ref{fmpz}, Int), x, y))
+    Int(ccall((:fmpz_cmp_si, libflint), Cint, (Ref{fmpz}, Int), x, y))
 end
 
 ==(x::fmpz, y::Int) = cmp(x,y) == 0
@@ -606,7 +606,7 @@ end
 >(x::Int, y::fmpz) = cmp(y,x) < 0
 
 function cmp(x::fmpz, y::UInt)
-    Int(ccall((:fmpz_cmp_ui, :libflint), Cint, (Ref{fmpz}, UInt), x, y))
+    Int(ccall((:fmpz_cmp_ui, libflint), Cint, (Ref{fmpz}, UInt), x, y))
 end
 
 ==(x::fmpz, y::UInt) = cmp(x,y) == 0
@@ -643,7 +643,7 @@ function <<(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     c == 0 && return x
     z = fmpz()
-    ccall((:fmpz_mul_2exp, :libflint), Nothing,
+    ccall((:fmpz_mul_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -656,7 +656,7 @@ function >>(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
     c == 0 && return x
     z = fmpz()
-    ccall((:fmpz_fdiv_q_2exp, :libflint), Nothing,
+    ccall((:fmpz_fdiv_q_2exp, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int), z, x, c)
     return z
 end
@@ -675,7 +675,7 @@ end
 function mod(x::fmpz, y::fmpz)
    y == 0 && throw(DivideError())
    r = fmpz()
-   ccall((:fmpz_fdiv_r, :libflint), Nothing,
+   ccall((:fmpz_fdiv_r, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), r, x, y)
    return r
 end
@@ -687,7 +687,7 @@ end
 """
 function mod(x::fmpz, c::UInt)
     c == 0 && throw(DivideError())
-    ccall((:fmpz_fdiv_ui, :libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c)
+    ccall((:fmpz_fdiv_ui, libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c)
 end
 
 @doc Markdown.doc"""
@@ -701,7 +701,7 @@ function powmod(x::fmpz, p::fmpz, m::fmpz)
        p = -p
     end
     r = fmpz()
-    ccall((:fmpz_powm, :libflint), Nothing,
+    ccall((:fmpz_powm, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
           r, x, p, m)
     return r
@@ -718,7 +718,7 @@ function powmod(x::fmpz, p::Int, m::fmpz)
        p = -p
     end
     r = fmpz()
-    ccall((:fmpz_powm_ui, :libflint), Nothing,
+    ccall((:fmpz_powm_ui, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Int, Ref{fmpz}),
           r, x, p, m)
     return r
@@ -734,7 +734,7 @@ function invmod(x::fmpz, m::fmpz)
     if isone(m)
         return fmpz(0)
     end
-    if ccall((:fmpz_invmod, :libflint), Cint,
+    if ccall((:fmpz_invmod, libflint), Cint,
              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, m) == 0
        error("Impossible inverse in invmod")
     end
@@ -750,7 +750,7 @@ end
 function sqrtmod(x::fmpz, m::fmpz)
     m <= 0 && throw(DomainError(m, "Modulus must be non-negative"))
     z = fmpz()
-    if (ccall((:fmpz_sqrtmod, :libflint), Cint,
+    if (ccall((:fmpz_sqrtmod, libflint), Cint,
               (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, m) == 0)
         error("no square root exists")
     end
@@ -765,7 +765,7 @@ end
 """
 function crt(r1::fmpz, m1::fmpz, r2::fmpz, m2::fmpz, signed=false)
    z = fmpz()
-   ccall((:fmpz_CRT, :libflint), Nothing,
+   ccall((:fmpz_CRT, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Cint),
           z, r1, m1, r2, m2, signed)
    return z
@@ -781,7 +781,7 @@ function crt(r1::fmpz, m1::fmpz, r2::Int, m2::Int, signed = false)
    z = fmpz()
    r2 < 0 && throw(DomainError(r2, "Second residue must be non-negative"))
    m2 < 0 && throw(DomainError(m2, "Second modulus must be non-negative"))
-   ccall((:fmpz_CRT_ui, :libflint), Nothing,
+   ccall((:fmpz_CRT_ui, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Int, Int, Cint),
           z, r1, m1, r2, m2, signed)
    return z
@@ -800,7 +800,7 @@ end
 function flog(x::fmpz, c::fmpz)
     c <= 0 && throw(DomainError(c, "Base must be non-negative"))
     x <= 0 && throw(DomainError(x, "Argument must be non-negative"))
-    return ccall((:fmpz_flog, :libflint), Int,
+    return ccall((:fmpz_flog, libflint), Int,
                  (Ref{fmpz}, Ref{fmpz}), x, c)
 end
 
@@ -811,7 +811,7 @@ end
 function clog(x::fmpz, c::fmpz)
     c <= 0 && throw(DomainError(c, "Base must be non-negative"))
     x <= 0 && throw(DomainError(x, "Argument must be non-negative"))
-    return ccall((:fmpz_clog, :libflint), Int,
+    return ccall((:fmpz_clog, libflint), Int,
                  (Ref{fmpz}, Ref{fmpz}), x, c)
 end
 
@@ -821,7 +821,7 @@ end
 """
 function flog(x::fmpz, c::Int)
     c <= 0 && throw(DomainError(c, "Base must be non-negative"))
-    return ccall((:fmpz_flog_ui, :libflint), Int,
+    return ccall((:fmpz_flog_ui, libflint), Int,
                  (Ref{fmpz}, Int), x, c)
 end
 
@@ -831,7 +831,7 @@ end
 """
 function clog(x::fmpz, c::Int)
     c <= 0 && throw(DomainError(c, "Base must be non-negative"))
-    return ccall((:fmpz_clog_ui, :libflint), Int,
+    return ccall((:fmpz_clog_ui, libflint), Int,
                  (Ref{fmpz}, Int), x, c)
 end
 
@@ -848,7 +848,7 @@ end
 """
 function gcd(x::fmpz, y::fmpz)
    z = fmpz()
-   ccall((:fmpz_gcd, :libflint), Nothing,
+   ccall((:fmpz_gcd, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -867,11 +867,11 @@ function gcd(x::Array{fmpz, 1})
    end
 
    z = fmpz()
-   ccall((:fmpz_gcd, :libflint), Nothing,
+   ccall((:fmpz_gcd, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x[1], x[2])
 
    for i in 3:length(x)
-      ccall((:fmpz_gcd, :libflint), Nothing,
+      ccall((:fmpz_gcd, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x[i])
       if isone(z)
          return z
@@ -888,7 +888,7 @@ end
 """
 function lcm(x::fmpz, y::fmpz)
    z = fmpz()
-   ccall((:fmpz_lcm, :libflint), Nothing,
+   ccall((:fmpz_lcm, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -906,11 +906,11 @@ function lcm(x::Array{fmpz, 1})
    end
 
    z = fmpz()
-   ccall((:fmpz_lcm, :libflint), Nothing,
+   ccall((:fmpz_lcm, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x[1], x[2])
 
    for i in 3:length(x)
-      ccall((:fmpz_lcm, :libflint), Nothing,
+      ccall((:fmpz_lcm, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x[i])
    end
 
@@ -954,7 +954,7 @@ function gcdinv(a::fmpz, b::fmpz)
    b < a && throw(DomainError((a, b), "First argument must be smaller than second argument"))
    g = fmpz()
    s = fmpz()
-   ccall((:fmpz_gcdinv, :libflint), Nothing,
+   ccall((:fmpz_gcdinv, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
         g, s, a, b)
    return g, s
@@ -981,7 +981,7 @@ gcdinv(a::Integer, b::fmpz) = gcdinv(fmpz(a), b)
 function isqrt(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_sqrt, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
+    ccall((:fmpz_sqrt, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}), z, x)
     return z
 end
 
@@ -994,7 +994,7 @@ function isqrtrem(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     s = fmpz()
     r = fmpz()
-    ccall((:fmpz_sqrtrem, :libflint), Nothing,
+    ccall((:fmpz_sqrtrem, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), s, r, x)
     return s, r
 end
@@ -1008,7 +1008,7 @@ function Base.sqrt(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     s = fmpz()
     r = fmpz()
-    ccall((:fmpz_sqrtrem, :libflint), Nothing,
+    ccall((:fmpz_sqrtrem, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), s, r, x)
     r != 0 && error("Not a square in sqrt")
     return s
@@ -1023,7 +1023,7 @@ function root(x::fmpz, n::Int)
    x < 0 && iseven(n) && throw(DomainError((x, n), "Argument `x` must be positive if exponent `n` is even"))
    n <= 0 && throw(DomainError(n, "Exponent must be positive"))
    z = fmpz()
-   ccall((:fmpz_root, :libflint), Nothing,
+   ccall((:fmpz_root, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Int), z, x, n)
    return z
 end
@@ -1036,11 +1036,11 @@ end
 
 function _factor(a::fmpz)
    F = fmpz_factor()
-   ccall((:fmpz_factor, :libflint), Nothing, (Ref{fmpz_factor}, Ref{fmpz}), F, a)
+   ccall((:fmpz_factor, libflint), Nothing, (Ref{fmpz_factor}, Ref{fmpz}), F, a)
    res = Dict{fmpz, Int}()
    for i in 1:F.num
      z = fmpz()
-     ccall((:fmpz_factor_get_fmpz, :libflint), Nothing,
+     ccall((:fmpz_factor_get_fmpz, libflint), Nothing,
            (Ref{fmpz}, Ref{fmpz_factor}, Int), z, F, i - 1)
      res[z] = unsafe_load(F.exp, i)
    end
@@ -1056,7 +1056,7 @@ end
 function _ecm(a::fmpz, B1::UInt, B2::UInt, ncrv::UInt,
              rnd = _flint_rand_states[Threads.threadid()])
   f = fmpz()
-  r = ccall((:fmpz_factor_ecm, :libflint), Int32,
+  r = ccall((:fmpz_factor_ecm, libflint), Int32,
             (Ref{fmpz}, UInt, UInt, UInt, Ptr{Cvoid}, Ref{fmpz}),
             f, ncrv, B1, B2, rnd.ptr, a)
   return r, f
@@ -1098,12 +1098,12 @@ end
 
 function _factor_trial_range(N::fmpz, start::Int = 0, np::Int = 10^5)
    F = fmpz_factor()
-   ccall((:fmpz_factor_trial_range, :libflint), Nothing,
+   ccall((:fmpz_factor_trial_range, libflint), Nothing,
          (Ref{Nemo.fmpz_factor}, Ref{fmpz}, UInt, UInt), F, N, start, np)
    res = Dict{fmpz, Int}()
    for i in 1:F.num
      z = fmpz()
-     ccall((:fmpz_factor_get_fmpz, :libflint), Nothing,
+     ccall((:fmpz_factor_get_fmpz, libflint), Nothing,
            (Ref{fmpz}, Ref{Nemo.fmpz_factor}, Int), z, F, i - 1)
      res[z] = unsafe_load(F.exp, i)
    end
@@ -1136,7 +1136,7 @@ end
 """
 function divisible(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
-   Bool(ccall((:fmpz_divisible, :libflint), Cint,
+   Bool(ccall((:fmpz_divisible, libflint), Cint,
               (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
@@ -1147,7 +1147,7 @@ end
 """
 function divisible(x::fmpz, y::Int)
    y == 0 && throw(DivideError())
-   Bool(ccall((:fmpz_divisible_si, :libflint), Cint,
+   Bool(ccall((:fmpz_divisible_si, libflint), Cint,
               (Ref{fmpz}, Int), x, y))
 end
 
@@ -1155,10 +1155,10 @@ end
     issquare(x::fmpz)
 > Return `true` if $x$ is a square, otherwise return `false`.
 """
-issquare(x::fmpz) = Bool(ccall((:fmpz_is_square, :libflint), Cint,
+issquare(x::fmpz) = Bool(ccall((:fmpz_is_square, libflint), Cint,
                                (Ref{fmpz},), x))
 
-isprime(x::UInt) = Bool(ccall((:n_is_prime, :libflint), Cint, (UInt,), x))
+isprime(x::UInt) = Bool(ccall((:n_is_prime, libflint), Cint, (UInt,), x))
 
 @doc Markdown.doc"""
     isprime(x::fmpz)
@@ -1166,7 +1166,7 @@ isprime(x::UInt) = Bool(ccall((:n_is_prime, :libflint), Cint, (UInt,), x))
 """
 function isprime(x::fmpz)
   !isprobable_prime(x) && return false
-  return Bool(ccall((:fmpz_is_prime, :libflint), Cint, (Ref{fmpz},), x))
+  return Bool(ccall((:fmpz_is_prime, libflint), Cint, (Ref{fmpz},), x))
 end
 
 @doc Markdown.doc"""
@@ -1186,7 +1186,7 @@ end
 > `false`. No counterexamples are known to this test, but it is conjectured
 > that infinitely many exist.
 """
-isprobable_prime(x::fmpz) = Bool(ccall((:fmpz_is_probabprime, :libflint), Cint,
+isprobable_prime(x::fmpz) = Bool(ccall((:fmpz_is_probabprime, libflint), Cint,
                                       (Ref{fmpz},), x))
 
 @doc Markdown.doc"""
@@ -1196,7 +1196,7 @@ isprobable_prime(x::fmpz) = Bool(ccall((:fmpz_is_probabprime, :libflint), Cint,
 function remove(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
    z = fmpz()
-   num = ccall((:fmpz_remove, :libflint), Int,
+   num = ccall((:fmpz_remove, libflint), Int,
                (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return num, z
 end
@@ -1234,7 +1234,7 @@ function divisor_lenstra(n::fmpz, r::fmpz, m::fmpz)
    m <= r && throw(DomainError((m, r), "Modulus must be bigger than residue class"))
    n <= m && throw(DomainError((n, m), "Argument must be bigger than modulus"))
    z = fmpz()
-   if !Bool(ccall((:fmpz_divisor_in_residue_class_lenstra, :libflint),
+   if !Bool(ccall((:fmpz_divisor_in_residue_class_lenstra, libflint),
        Cint, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, n, r, m))
       z = 0
    end
@@ -1249,7 +1249,7 @@ end
 function factorial(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_fac_ui, :libflint), Nothing, (Ref{fmpz}, UInt), z, UInt(x))
+    ccall((:fmpz_fac_ui, libflint), Nothing, (Ref{fmpz}, UInt), z, UInt(x))
     return z
 end
 
@@ -1261,7 +1261,7 @@ end
 function rising_factorial(x::fmpz, n::Int)
     n < 0 && throw(DomainError(n, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_rfac_ui, :libflint), Nothing,
+    ccall((:fmpz_rfac_ui, libflint), Nothing,
           (Ref{fmpz}, Ref{fmpz}, UInt), z, x, UInt(n))
     return z
 end
@@ -1287,7 +1287,7 @@ function rising_factorial(x::Int, n::Int)
                           rising_factorial(-x - n + 1, n)
        end
     else
-       ccall((:fmpz_rfac_uiui, :libflint), Nothing,
+       ccall((:fmpz_rfac_uiui, libflint), Nothing,
              (Ref{fmpz}, UInt, UInt), z, x, n)
     end
     return Int(z)
@@ -1301,7 +1301,7 @@ end
 function primorial(x::Int)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_primorial, :libflint), Nothing,
+    ccall((:fmpz_primorial, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
     return Int(z)
 end
@@ -1314,7 +1314,7 @@ end
 function primorial(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:fmpz_primorial, :libflint), Nothing,
+    ccall((:fmpz_primorial, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
     return z
 end
@@ -1326,7 +1326,7 @@ end
 """
 function fibonacci(x::Int)
     z = fmpz()
-    ccall((:fmpz_fib_ui, :libflint), Nothing,
+    ccall((:fmpz_fib_ui, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(abs(x)))
     return x < 0 ? (iseven(x) ? -Int(z) : Int(z)) : Int(z)
 end
@@ -1338,7 +1338,7 @@ end
 """
 function fibonacci(x::fmpz)
     z = fmpz()
-    ccall((:fmpz_fib_ui, :libflint), Nothing,
+    ccall((:fmpz_fib_ui, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(abs(x)))
     return x < 0 ? (iseven(x) ? -z : z) : z
 end
@@ -1350,7 +1350,7 @@ end
 function bell(x::Int)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:arith_bell_number, :libflint), Nothing,
+    ccall((:arith_bell_number, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
     return Int(z)
 end
@@ -1362,7 +1362,7 @@ end
 function bell(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     z = fmpz()
-    ccall((:arith_bell_number, :libflint), Nothing,
+    ccall((:arith_bell_number, libflint), Nothing,
           (Ref{fmpz}, UInt), z, UInt(x))
     return z
 end
@@ -1376,7 +1376,7 @@ function binomial(n::fmpz, k::fmpz)
     n < 0 && return fmpz(0)
     k < 0 && return fmpz(0)
     z = fmpz()
-    ccall((:fmpz_bin_uiui, :libflint), Nothing,
+    ccall((:fmpz_bin_uiui, libflint), Nothing,
           (Ref{fmpz}, UInt, UInt), z, UInt(n), UInt(k))
     return z
 end
@@ -1388,7 +1388,7 @@ end
 """
 function moebius_mu(x::fmpz)
    x <= 0 && throw(DomainError(x, "Argument must be positive"))
-   return Int(ccall((:fmpz_moebius_mu, :libflint), Cint,
+   return Int(ccall((:fmpz_moebius_mu, libflint), Cint,
                     (Ref{fmpz},), x))
 end
 
@@ -1409,7 +1409,7 @@ function jacobi_symbol(x::fmpz, y::fmpz)
    if x < 0 || x >= y
       x = mod(x, y)
    end
-   return Int(ccall((:fmpz_jacobi, :libflint), Cint,
+   return Int(ccall((:fmpz_jacobi, libflint), Cint,
                     (Ref{fmpz}, Ref{fmpz}), x, y))
 end
 
@@ -1423,7 +1423,7 @@ function jacobi_symbol(x::Int, y::Int)
    if x < 0 || x >= y
       x = mod(x, y)
    end
-   return Int(ccall((:n_jacobi, :libflint), Cint, (Int, UInt), x, UInt(y)))
+   return Int(ccall((:n_jacobi, libflint), Cint, (Int, UInt), x, UInt(y)))
 end
 
 @doc Markdown.doc"""
@@ -1435,7 +1435,7 @@ function divisor_sigma(x::fmpz, y::Int)
    x <= 0 && throw(DomainError(x, "Argument must be positive"))
    y < 0 && throw(DomainError(y, "Power must be non-negative"))
    z = fmpz()
-   ccall((:fmpz_divisor_sigma, :libflint), Nothing,
+   ccall((:fmpz_divisor_sigma, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
    return z
 end
@@ -1463,7 +1463,7 @@ divisor_sigma(x::Int, y::Int) = Int(divisor_sigma(fmpz(x), y))
 function euler_phi(x::fmpz)
    x <= 0 && throw(DomainError(x, "Argument must be positive"))
    z = fmpz()
-   ccall((:fmpz_euler_phi, :libflint), Nothing,
+   ccall((:fmpz_euler_phi, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}), z, x)
    return z
 end
@@ -1489,7 +1489,7 @@ function number_of_partitions(x::Int)
    if x < 0
       return 0
    end
-   ccall((:partitions_fmpz_ui, :libarb), Nothing,
+   ccall((:partitions_fmpz_ui, libarb), Nothing,
          (Ref{fmpz}, UInt), z, x)
    return Int(z)
 end
@@ -1507,7 +1507,7 @@ function number_of_partitions(x::fmpz)
    if x < 0
       return z
    end
-   ccall((:partitions_fmpz_fmpz, :libarb), Nothing,
+   ccall((:partitions_fmpz_fmpz, libarb), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Int), z, x, 0)
    return z
 end
@@ -1548,16 +1548,16 @@ hex(n::fmpz) = base(n, 16)
 """
 function base(n::fmpz, b::Integer)
     2 <= b <= 62 || error("invalid base: $b")
-    p = ccall((:fmpz_get_str,:libflint), Ptr{UInt8},
+    p = ccall((:fmpz_get_str,libflint), Ptr{UInt8},
               (Ptr{UInt8}, Cint, Ref{fmpz}), C_NULL, b, n)
     s = unsafe_string(p)
-    ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), p)
+    ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), p)
     return s
 end
 
 function ndigits_internal(x::fmpz, b::Integer = 10)
     # fmpz_sizeinbase might return an answer 1 too big
-    n = Int(ccall((:fmpz_sizeinbase, :libflint), UInt,
+    n = Int(ccall((:fmpz_sizeinbase, libflint), UInt,
                   (Ref{fmpz}, Int32), x, b))
     abs(x) < fmpz(b)^(n - 1) ? n - 1 : n
 end
@@ -1572,7 +1572,7 @@ ndigits(x::fmpz, b::Integer = 10) = iszero(x) ? 1 : ndigits_internal(x, b)
     nbits(x::fmpz)
 > Return the number of binary bits of $x$. We return zero if $x = 0$.
 """
-nbits(x::fmpz) = iszero(x) ? 0 : Int(ccall((:fmpz_sizeinbase, :libflint), UInt,
+nbits(x::fmpz) = iszero(x) ? 0 : Int(ccall((:fmpz_sizeinbase, libflint), UInt,
                   (Ref{fmpz}, Int32), x, 2))  # docu states: always correct
                                 #if base is power of 2
 
@@ -1586,7 +1586,7 @@ nbits(x::fmpz) = iszero(x) ? 0 : Int(ccall((:fmpz_sizeinbase, :libflint), UInt,
     popcount(x::fmpz)
 > Return the number of ones in the binary representation of $x$.
 """
-popcount(x::fmpz) = Int(ccall((:fmpz_popcnt, :libflint), UInt,
+popcount(x::fmpz) = Int(ccall((:fmpz_popcnt, libflint), UInt,
                               (Ref{fmpz},), x))
 
 @doc Markdown.doc"""
@@ -1607,7 +1607,7 @@ nextpow2(x::fmpz) = x < 0 ? -nextpow2(-x) :
     trailing_zeros(x::fmpz)
 > Count the trailing zeros in the binary representation of $x$.
 """
-trailing_zeros(x::fmpz) = ccall((:fmpz_val2, :libflint), Int,
+trailing_zeros(x::fmpz) = ccall((:fmpz_val2, libflint), Int,
                                 (Ref{fmpz},), x)
 
 ###############################################################################
@@ -1623,7 +1623,7 @@ trailing_zeros(x::fmpz) = ccall((:fmpz_val2, :libflint), Int,
 """
 function clrbit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Second argument must be non-negative"))
-    ccall((:fmpz_clrbit, :libflint), Nothing, (Ref{fmpz}, Int), x, c)
+    ccall((:fmpz_clrbit, libflint), Nothing, (Ref{fmpz}, Int), x, c)
 end
 
 @doc Markdown.doc"""
@@ -1633,7 +1633,7 @@ end
 """
 function setbit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Second argument must be non-negative"))
-    ccall((:fmpz_setbit, :libflint), Nothing, (Ref{fmpz}, Int), x, c)
+    ccall((:fmpz_setbit, libflint), Nothing, (Ref{fmpz}, Int), x, c)
 end
 
 @doc Markdown.doc"""
@@ -1643,7 +1643,7 @@ end
 """
 function combit!(x::fmpz, c::Int)
     c < 0 && throw(DomainError(c, "Second argument must be non-negative"))
-    ccall((:fmpz_combit, :libflint), Nothing, (Ref{fmpz}, Int), x, c)
+    ccall((:fmpz_combit, libflint), Nothing, (Ref{fmpz}, Int), x, c)
 end
 
 ###############################################################################
@@ -1653,31 +1653,31 @@ end
 ###############################################################################
 
 function mul!(z::fmpz, x::fmpz, y::fmpz)
-   ccall((:fmpz_mul, :libflint), Nothing,
+   ccall((:fmpz_mul, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function addmul!(z::fmpz, x::fmpz, y::fmpz, c::fmpz)
-   ccall((:fmpz_addmul, :libflint), Nothing,
+   ccall((:fmpz_addmul, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpz, x::fmpz)
-   ccall((:fmpz_add, :libflint), Nothing,
+   ccall((:fmpz_add, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, z, x)
    return z
 end
 
 function add!(z::fmpz, x::fmpz, y::fmpz)
-   ccall((:fmpz_add, :libflint), Nothing,
+   ccall((:fmpz_add, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function zero!(z::fmpz)
-   ccall((:fmpz_zero, :libflint), Nothing,
+   ccall((:fmpz_zero, libflint), Nothing,
          (Ref{fmpz},), z)
    return z
 end
@@ -1715,7 +1715,7 @@ function parse(::Type{fmpz}, s::String, base::Int = 10)
     sgn = s[1] == '-' ? -1 : 1
     i = 1 + (sgn == -1)
     z = fmpz()
-    err = ccall((:fmpz_set_str, :libflint),
+    err = ccall((:fmpz_set_str, libflint),
                Int32, (Ref{fmpz}, Ptr{UInt8}, Int32),
                z, string(SubString(s, i)), base)
     err == 0 || error("Invalid big integer: $(repr(s))")
@@ -1739,7 +1739,7 @@ end
 function rand_bits(::FlintIntegerRing, b::Int)
    b >= 0 || throw(DomainError(b, "Bit count must be non-negative"))
    z = fmpz()
-   ccall((:fmpz_randbits, :libflint), Nothing,(Ref{fmpz}, Ptr{Cvoid}, Int),
+   ccall((:fmpz_randbits, libflint), Nothing,(Ref{fmpz}, Ptr{Cvoid}, Int),
          z, _flint_rand_states[Threads.threadid()].ptr, b)
    return z
 end
@@ -1770,7 +1770,7 @@ convert(::Type{fmpz}, a::Integer) = fmpz(a)
 
 function (::Type{BigInt})(a::fmpz)
    r = BigInt()
-   ccall((:fmpz_get_mpz, :libflint), Nothing, (Ref{BigInt}, Ref{fmpz}), r, a)
+   ccall((:fmpz_get_mpz, libflint), Nothing, (Ref{BigInt}, Ref{fmpz}), r, a)
    return r
 end
 
@@ -1778,21 +1778,21 @@ convert(::Type{BigInt}, a::fmpz) = BigInt(a)
 
 function (::Type{Int})(a::fmpz)
    (a > typemax(Int) || a < typemin(Int)) && throw(InexactError(:convert, Int, a))
-   return ccall((:fmpz_get_si, :libflint), Int, (Ref{fmpz},), a)
+   return ccall((:fmpz_get_si, libflint), Int, (Ref{fmpz},), a)
 end
 
 convert(::Type{Int}, a::fmpz) = Int(a)
 
 function (::Type{UInt})(a::fmpz)
    (a > typemax(UInt) || a < 0) && throw(InexactError(:convert, UInt, a))
-   return ccall((:fmpz_get_ui, :libflint), UInt, (Ref{fmpz}, ), a)
+   return ccall((:fmpz_get_ui, libflint), UInt, (Ref{fmpz}, ), a)
 end
 
 convert(::Type{UInt}, a::fmpz) = UInt(a)
 
 function (::Type{Float64})(n::fmpz)
     # rounds to zero
-    ccall((:fmpz_get_d, :libflint), Float64, (Ref{fmpz},), n)
+    ccall((:fmpz_get_d, libflint), Float64, (Ref{fmpz},), n)
 end
 
 convert(::Type{Float64}, n::fmpz) = Float64(n)

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -42,13 +42,13 @@ max_precision(R::FmpzAbsSeriesRing) = R.prec_max
 function normalise(a::fmpz_abs_series, len::Int)
    if len > 0
       c = fmpz()
-      ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_abs_series}, Int), c, a, len - 1)
       end
    end
@@ -57,7 +57,7 @@ function normalise(a::fmpz_abs_series, len::Int)
 end
 
 function length(x::fmpz_abs_series)
-   return ccall((:fmpz_poly_length, :libflint), Int, (Ref{fmpz_abs_series},), x)
+   return ccall((:fmpz_poly_length, libflint), Int, (Ref{fmpz_abs_series},), x)
 end
 
 precision(x::fmpz_abs_series) = x.prec
@@ -67,7 +67,7 @@ function coeff(x::fmpz_abs_series, n::Int)
       return fmpz(0)
    end
    z = fmpz()
-   ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_abs_series}, Int), z, x, n)
    return z
 end
@@ -90,7 +90,7 @@ function deepcopy_internal(a::fmpz_abs_series, dict::IdDict)
 end
 
 function isgen(a::fmpz_abs_series)
-   return precision(a) == 0 || ccall((:fmpz_poly_is_x, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpz_poly_is_x, libflint), Bool,
                             (Ref{fmpz_abs_series},), a)
 end
 
@@ -99,7 +99,7 @@ iszero(a::fmpz_abs_series) = length(a) == 0
 isunit(a::fmpz_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpz_abs_series)
-   return precision(a) == 0 || ccall((:fmpz_poly_is_one, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpz_poly_is_one, libflint), Bool,
                                 (Ref{fmpz_abs_series},), a)
 end
 
@@ -136,7 +136,7 @@ show_minus_one(::Type{fmpz_abs_series}) = show_minus_one(fmpz)
 
 function -(x::fmpz_abs_series)
    z = parent(x)()
-   ccall((:fmpz_poly_neg, :libflint), Nothing,
+   ccall((:fmpz_poly_neg, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}),
                z, x)
    z.prec = x.prec
@@ -162,7 +162,7 @@ function +(a::fmpz_abs_series, b::fmpz_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpz_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -181,7 +181,7 @@ function -(a::fmpz_abs_series, b::fmpz_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpz_poly_sub_series, :libflint), Nothing,
+   ccall((:fmpz_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -210,7 +210,7 @@ function *(a::fmpz_abs_series, b::fmpz_abs_series)
 
    lenz = min(lena + lenb - 1, prec)
 
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -225,7 +225,7 @@ end
 function *(x::Int, y::fmpz_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpz_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, y, x)
    return z
@@ -236,7 +236,7 @@ end
 function *(x::fmpz, y::fmpz_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz}),
                z, y, x)
    return z
@@ -261,10 +261,10 @@ function shift_left(x::fmpz_abs_series, len::Int)
    z.prec = x.prec + len
    z.prec = min(z.prec, max_precision(parent(x)))
    zlen = min(z.prec, xlen + len)
-   ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpz_poly_shift_left, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, x, len)
-   ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpz_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, z, zlen)
    return z
@@ -278,7 +278,7 @@ function shift_right(x::fmpz_abs_series, len::Int)
       z.prec = max(0, x.prec - len)
    else
       z.prec = x.prec - len
-      ccall((:fmpz_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_right, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, x, len)
    end
@@ -298,7 +298,7 @@ function truncate(x::fmpz_abs_series, prec::Int)
    end
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpz_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, x, prec)
    return z
@@ -324,7 +324,7 @@ function ^(a::fmpz_abs_series, b::Int)
       z = parent(a)()
       z.prec = a.prec + (b - 1)*valuation(a)
       z.prec = min(z.prec, max_precision(parent(a)))
-      ccall((:fmpz_poly_pow_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_pow_trunc, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int, Int),
                z, a, b, z.prec)
    end
@@ -344,7 +344,7 @@ function ==(x::fmpz_abs_series, y::fmpz_abs_series)
    n = max(length(x), length(y))
    n = min(n, prec)
 
-   return Bool(ccall((:fmpz_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpz_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                x, y, n))
 end
@@ -356,7 +356,7 @@ function isequal(x::fmpz_abs_series, y::fmpz_abs_series)
    if x.prec != y.prec || length(x) != length(y)
       return false
    end
-   return Bool(ccall((:fmpz_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpz_poly_equal, libflint), Cint,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                x, y, length(x)))
 end
@@ -372,9 +372,9 @@ function ==(x::fmpz_abs_series, y::fmpz)
       return false
    elseif length(x) == 1
       z = fmpz()
-      ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_abs_series}, Int), z, x, 0)
-      return ccall((:fmpz_equal, :libflint), Bool,
+      return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
    else
       return precision(x) == 0 || iszero(y)
@@ -409,7 +409,7 @@ function divexact(x::fmpz_abs_series, y::fmpz_abs_series)
    prec = min(x.prec, y.prec - v2 + v1)
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpz_poly_div_series, :libflint), Nothing,
+   ccall((:fmpz_poly_div_series, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, x, y, prec)
    return z
@@ -425,7 +425,7 @@ function divexact(x::fmpz_abs_series, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpz_poly_scalar_divexact_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_si, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, x, y)
    return z
@@ -435,7 +435,7 @@ function divexact(x::fmpz_abs_series, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_fmpz, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -454,7 +454,7 @@ function inv(a::fmpz_abs_series)
     !isunit(a) && error("Unable to invert power series")
     ainv = parent(a)()
     ainv.prec = a.prec
-    ccall((:fmpz_poly_inv_series, :libflint), Nothing,
+    ccall((:fmpz_poly_inv_series, libflint), Nothing,
           (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                   ainv, a, a.prec)
     return ainv
@@ -470,7 +470,7 @@ function Base.sqrt(a::fmpz_abs_series)
     asqrt = parent(a)()
     v = valuation(a)
     asqrt.prec = a.prec - div(v, 2)
-    flag = Bool(ccall((:fmpz_poly_sqrt_series, :libflint), Cint,
+    flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                   asqrt, a, a.prec))
     flag == false && error("Not a square in sqrt")
@@ -484,14 +484,14 @@ end
 ###############################################################################
 
 function zero!(z::fmpz_abs_series)
-   ccall((:fmpz_poly_zero, :libflint), Nothing,
+   ccall((:fmpz_poly_zero, libflint), Nothing,
                 (Ref{fmpz_abs_series},), z)
    z.prec = parent(z).prec_max
    return z
 end
 
 function setcoeff!(z::fmpz_abs_series, n::Int, x::fmpz)
-   ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Int, Ref{fmpz}),
                z, n, x)
    return z
@@ -516,7 +516,7 @@ function mul!(z::fmpz_abs_series, a::fmpz_abs_series, b::fmpz_abs_series)
    end
 
    z.prec = prec
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -533,7 +533,7 @@ function addeq!(a::fmpz_abs_series, b::fmpz_abs_series)
 
    lenz = max(lena, lenb)
    a.prec = prec
-   ccall((:fmpz_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                a, a, b, lenz)
    return a

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -146,7 +146,7 @@ function polcoeff(a::fmpz_laurent_series, n::Int)
       return fmpz(0)
    end
    z = fmpz()
-   ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_laurent_series}, Int), z, a, n)
    return z
 end
@@ -580,7 +580,7 @@ function *(a::fmpz_laurent_series, b::fmpz_laurent_series)
    lenb = pol_length(b)
    lenz = div(prec + sz - 1, sz)
    z = parent(a)()
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                z, a, b, lenz)
    set_prec!(z, prec + zval)
@@ -725,7 +725,7 @@ function mullow(a::fmpz_laurent_series, b::fmpz_laurent_series, n::Int)
    prec = min(precision(a), precision(b))
    z = parent(a)()
    lenz = min(lena + lenb - 1, div(n + s - 1, s))
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                z, a, b, lenz)
    set_prec!(z, prec)
@@ -988,7 +988,7 @@ function divexact(a::fmpz_laurent_series, b::fmpz_laurent_series)
    lenb = pol_length(b)
    lenz = div(prec + sz - 1, sz)
    z = parent(a)()
-   ccall((:fmpz_poly_div_series, :libflint), Nothing,
+   ccall((:fmpz_poly_div_series, libflint), Nothing,
                 (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                z, a, b, lenz)
    set_prec!(z, prec + zval)
@@ -1059,7 +1059,7 @@ function inv(a::fmpz_laurent_series)
    set_scale!(ainv, sa)
    !isunit(a1) && error("Unable to invert power series")
    z = parent(a)()
-   ccall((:fmpz_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpz_poly_inv_series, libflint), Nothing,
                 (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                ainv, a, lenz)
    ainv = rescale!(ainv)
@@ -1095,7 +1095,7 @@ function sqrt(a::fmpz_laurent_series)
    zlen = div(prec + s - 1, s)
    set_prec!(asqrt, prec + aval2)
    set_val!(asqrt, aval2)
-   flag = Bool(ccall((:fmpz_poly_sqrt_series, :libflint), Cint,
+   flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
           (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                 asqrt, a, zlen))
    flag == false && error("Not a square in sqrt")
@@ -1168,7 +1168,7 @@ end
 ###############################################################################
 
 function zero!(a::fmpz_laurent_series)
-  ccall((:fmpz_poly_zero, :libflint), Nothing,
+  ccall((:fmpz_poly_zero, libflint), Nothing,
                    (Ref{fmpz_laurent_series},), a)
    set_prec!(a, parent(a).prec_max)
    set_val!(a, parent(a).prec_max)
@@ -1177,7 +1177,7 @@ function zero!(a::fmpz_laurent_series)
 end
 
 function setcoeff!(c::fmpz_laurent_series, n::Int, a::fmpz)
-   ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_laurent_series}, Int, Ref{fmpz}),
                c, n, a)
    return c
@@ -1203,7 +1203,7 @@ function mul!(c::fmpz_laurent_series, a::fmpz_laurent_series, b::fmpz_laurent_se
    lena = min(lena*sa, prec)
    lenb = min(lenb*sb, prec)
    if lena == 0 || lenb == 0
-      ccall((:fmpz_poly_zero, :libflint), Nothing,
+      ccall((:fmpz_poly_zero, libflint), Nothing,
                 (Ref{fmpz_laurent_series},), c)
       set_prec!(c, prec + aval + bval)
       set_val!(c, aval + bval)
@@ -1218,7 +1218,7 @@ function mul!(c::fmpz_laurent_series, a::fmpz_laurent_series, b::fmpz_laurent_se
       lena = pol_length(a)
       lenb = pol_length(b)
       lenc = min(lena + lenb - 1, div(prec + sz - 1, sz))
-      ccall((:fmpz_poly_mullow, :libflint), Nothing,
+      ccall((:fmpz_poly_mullow, libflint), Nothing,
          (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int), c, a, b, lenc)
    end
    set_val!(c, aval + bval)
@@ -1311,7 +1311,7 @@ function eta_qexp(x::fmpz_laurent_series)
    z = parent(x)()
    zscale = valuation(x)
    prec = max_precision(parent(x))
-   ccall((:fmpz_poly_eta_qexp, :libflint), Nothing,
+   ccall((:fmpz_poly_eta_qexp, libflint), Nothing,
                                           (Ref{fmpz_laurent_series}, Int, Int), z, 1, div(prec + zscale - 1, zscale))
    set_scale!(z, zscale)
    set_val!(z, 0)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -83,7 +83,7 @@ function Base.view(x::fmpz_mat, r1::Int, c1::Int, r2::Int, c2::Int)
    b = fmpz_mat()
    b.base_ring = FlintZZ
    b.view_parent = x
-   ccall((:fmpz_mat_window_init, :libflint), Nothing,
+   ccall((:fmpz_mat_window_init, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}, Int, Int, Int, Int),
              b, x, r1 - 1, c1 - 1, r2, c2)
    finalizer(_fmpz_mat_window_clear_fn, b)
@@ -95,7 +95,7 @@ function Base.view(x::fmpz_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fmpz_mat_window_clear_fn(a::fmpz_mat)
-   ccall((:fmpz_mat_window_clear, :libflint), Nothing, (Ref{fmpz_mat},), a)
+   ccall((:fmpz_mat_window_clear, libflint), Nothing, (Ref{fmpz_mat},), a)
 end
 
 function sub(x::fmpz_mat, r1::Int, c1::Int, r2::Int, c2::Int)
@@ -116,9 +116,9 @@ getindex(x::fmpz_mat, r::UnitRange{Int}, c::UnitRange{Int}) = sub(x, r, c)
 
 function getindex!(v::fmpz, a::fmpz_mat, r::Int, c::Int)
    GC.@preserve a begin
-      z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+      z = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                 (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set, :libflint), Nothing, (Ref{fmpz}, Ptr{fmpz}), v, z)
+      ccall((:fmpz_set, libflint), Nothing, (Ref{fmpz}, Ptr{fmpz}), v, z)
    end
 end
 
@@ -126,9 +126,9 @@ end
    @boundscheck Generic._checkbounds(a, r, c)
    v = fmpz()
    GC.@preserve a begin
-      z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+      z = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                 (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set, :libflint), Nothing, (Ref{fmpz}, Ptr{fmpz}), v, z)
+      ccall((:fmpz_set, libflint), Nothing, (Ref{fmpz}, Ptr{fmpz}), v, z)
    end
    return v
 end
@@ -136,9 +136,9 @@ end
 @inline function setindex!(a::fmpz_mat, d::fmpz, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    GC.@preserve a begin
-      z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+      z = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                 (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set, :libflint), Nothing, (Ptr{fmpz}, Ref{fmpz}), z, d)
+      ccall((:fmpz_set, libflint), Nothing, (Ptr{fmpz}, Ref{fmpz}), z, d)
    end
 end
 
@@ -147,9 +147,9 @@ end
 @inline function setindex!(a::fmpz_mat, d::Int, r::Int, c::Int)
    @boundscheck Generic._checkbounds(a, r, c)
    GC.@preserve a begin
-      z = ccall((:fmpz_mat_entry, :libflint), Ptr{fmpz},
+      z = ccall((:fmpz_mat_entry, libflint), Ptr{fmpz},
                 (Ref{fmpz_mat}, Int, Int), a, r - 1, c - 1)
-      ccall((:fmpz_set_si, :libflint), Nothing, (Ptr{fmpz}, Int), z, d)
+      ccall((:fmpz_set_si, libflint), Nothing, (Ptr{fmpz}, Int), z, d)
    end
 end
 
@@ -165,10 +165,10 @@ zero(a::FmpzMatSpace) = a()
 
 one(a::FmpzMatSpace) = a(1)
 
-iszero(a::fmpz_mat) = ccall((:fmpz_mat_is_zero, :libflint), Bool,
+iszero(a::fmpz_mat) = ccall((:fmpz_mat_is_zero, libflint), Bool,
                             (Ref{fmpz_mat},), a)
 
-isone(a::fmpz_mat) = ccall((:fmpz_mat_is_one, :libflint), Bool,
+isone(a::fmpz_mat) = ccall((:fmpz_mat_is_one, libflint), Bool,
                            (Ref{fmpz_mat},), a)
 
 function deepcopy_internal(d::fmpz_mat, dict::IdDict)
@@ -201,7 +201,7 @@ show_minus_one(::Type{fmpz_mat}) = show_minus_one(fmpz)
 
 function -(x::fmpz_mat)
    z = similar(x)
-   ccall((:fmpz_mat_neg, :libflint), Nothing,
+   ccall((:fmpz_mat_neg, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -214,7 +214,7 @@ end
 
 function transpose(x::fmpz_mat)
    z = similar(x, ncols(x), nrows(x))
-   ccall((:fmpz_mat_transpose, :libflint), Nothing,
+   ccall((:fmpz_mat_transpose, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -226,7 +226,7 @@ end
 ###############################################################################
 
 function swap_rows!(x::fmpz_mat, i::Int, j::Int)
-  ccall((:fmpz_mat_swap_rows, :libflint), Nothing,
+  ccall((:fmpz_mat_swap_rows, libflint), Nothing,
         (Ref{fmpz_mat}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -238,7 +238,7 @@ function swap_rows(x::fmpz_mat, i::Int, j::Int)
 end
 
 function swap_cols!(x::fmpz_mat, i::Int, j::Int)
-  ccall((:fmpz_mat_swap_cols, :libflint), Nothing,
+  ccall((:fmpz_mat_swap_cols, libflint), Nothing,
         (Ref{fmpz_mat}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -250,7 +250,7 @@ function swap_cols(x::fmpz_mat, i::Int, j::Int)
 end
 
 function reverse_rows!(x::fmpz_mat)
-   ccall((:fmpz_mat_invert_rows, :libflint), Nothing,
+   ccall((:fmpz_mat_invert_rows, libflint), Nothing,
          (Ref{fmpz_mat}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -258,7 +258,7 @@ end
 reverse_rows(x::fmpz_mat) = reverse_rows!(deepcopy(x))
 
 function reverse_cols!(x::fmpz_mat)
-   ccall((:fmpz_mat_invert_cols, :libflint), Nothing,
+   ccall((:fmpz_mat_invert_cols, libflint), Nothing,
          (Ref{fmpz_mat}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -274,7 +274,7 @@ reverse_cols(x::fmpz_mat) = reverse_cols!(deepcopy(x))
 function +(x::fmpz_mat, y::fmpz_mat)
    check_parent(x, y)
    z = similar(x)
-   ccall((:fmpz_mat_add, :libflint), Nothing,
+   ccall((:fmpz_mat_add, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
                z, x, y)
    return z
@@ -283,7 +283,7 @@ end
 function -(x::fmpz_mat, y::fmpz_mat)
    check_parent(x, y)
    z = similar(x)
-   ccall((:fmpz_mat_sub, :libflint), Nothing,
+   ccall((:fmpz_mat_sub, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
                z, x, y)
    return z
@@ -296,7 +296,7 @@ function *(x::fmpz_mat, y::fmpz_mat)
    else
       z = similar(x, nrows(x), ncols(y))
    end
-   ccall((:fmpz_mat_mul, :libflint), Nothing,
+   ccall((:fmpz_mat_mul, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat},  Ref{fmpz_mat}),
                z, x, y)
    return z
@@ -310,14 +310,14 @@ end
 
 function *(x::Int, y::fmpz_mat)
    z = similar(y)
-   ccall((:fmpz_mat_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpz_mat)
    z = similar(y)
-   ccall((:fmpz_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, y, x)
    return z
 end
@@ -383,7 +383,7 @@ end
 function <<(x::fmpz_mat, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = similar(x)
-   ccall((:fmpz_mat_scalar_mul_2exp, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mul_2exp, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
                z, x, y)
    return z
@@ -396,7 +396,7 @@ end
 function >>(x::fmpz_mat, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = similar(x)
-   ccall((:fmpz_mat_scalar_tdiv_q_2exp, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_tdiv_q_2exp, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
                z, x, y)
    return z
@@ -412,7 +412,7 @@ function ^(x::fmpz_mat, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    nrows(x) != ncols(x) && error("Incompatible matrix dimensions")
    z = similar(x)
-   ccall((:fmpz_mat_pow, :libflint), Nothing,
+   ccall((:fmpz_mat_pow, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int),
                z, x, y)
    return z
@@ -426,7 +426,7 @@ end
 
 function ==(x::fmpz_mat, y::fmpz_mat)
    b = check_parent(x, y, false)
-   b && ccall((:fmpz_mat_equal, :libflint), Bool,
+   b && ccall((:fmpz_mat_equal, libflint), Bool,
                                        (Ref{fmpz_mat}, Ref{fmpz_mat}), x, y)
 end
 
@@ -469,7 +469,7 @@ end
 function inv(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
-   ccall((:fmpz_mat_inv, :libflint), Nothing,
+   ccall((:fmpz_mat_inv, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    if d == 1
       return z
@@ -494,7 +494,7 @@ end
 function pseudo_inv(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
-   ccall((:fmpz_mat_inv, :libflint), Nothing,
+   ccall((:fmpz_mat_inv, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    if !iszero(d)
       return (z, d)
@@ -521,14 +521,14 @@ end
 
 function divexact(x::fmpz_mat, y::Int)
    z = similar(x)
-   ccall((:fmpz_mat_scalar_divexact_si, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_divexact_si, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, x, y)
    return z
 end
 
 function divexact(x::fmpz_mat, y::fmpz)
    z = similar(x)
-   ccall((:fmpz_mat_scalar_divexact_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_divexact_fmpz, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -544,7 +544,7 @@ divexact(x::fmpz_mat, y::Integer) = divexact(x, fmpz(y))
 function kronecker_product(x::fmpz_mat, y::fmpz_mat)
    base_ring(x) == base_ring(y) || error("Incompatible matrices")
    z = similar(x, nrows(x)*nrows(y), ncols(x)*ncols(y))
-   ccall((:fmpz_mat_kronecker_product, :libflint), Nothing,
+   ccall((:fmpz_mat_kronecker_product, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, x, y)
    return z
 end
@@ -561,7 +561,7 @@ end
 """
 function reduce_mod(x::fmpz_mat, y::fmpz)
    z = similar(x)
-   ccall((:fmpz_mat_scalar_mod_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mod_fmpz, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -581,7 +581,7 @@ reduce_mod(x::fmpz_mat, y::Integer) = reduce_mod(x, fmpz(y))
 function charpoly(R::FmpzPolyRing, x::fmpz_mat)
    nrows(x) != ncols(x) && error("Non-square")
    z = R()
-   ccall((:fmpz_mat_charpoly, :libflint), Nothing,
+   ccall((:fmpz_mat_charpoly, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -595,7 +595,7 @@ end
 function minpoly(R::FmpzPolyRing, x::fmpz_mat)
    nrows(x) != ncols(x) && error("Non-square")
    z = R()
-   ccall((:fmpz_mat_minpoly, :libflint), Nothing,
+   ccall((:fmpz_mat_minpoly, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -609,7 +609,7 @@ end
 function det(x::fmpz_mat)
    nrows(x) != ncols(x) && error("Non-square matrix")
    z = fmpz()
-   ccall((:fmpz_mat_det, :libflint), Nothing,
+   ccall((:fmpz_mat_det, libflint), Nothing,
                 (Ref{fmpz}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -622,7 +622,7 @@ end
 function det_divisor(x::fmpz_mat)
    nrows(x) != ncols(x) && error("Non-square matrix")
    z = fmpz()
-   ccall((:fmpz_mat_det_divisor, :libflint), Nothing,
+   ccall((:fmpz_mat_det_divisor, libflint), Nothing,
                 (Ref{fmpz}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -636,7 +636,7 @@ end
 function det_given_divisor(x::fmpz_mat, d::fmpz, proved=true)
    nrows(x) != ncols(x) && error("Non-square")
    z = fmpz()
-   ccall((:fmpz_mat_det_modular_given_divisor, :libflint), Nothing,
+   ccall((:fmpz_mat_det_modular_given_divisor, libflint), Nothing,
                (Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz}, Cint), z, x, d, proved)
    return z
 end
@@ -659,7 +659,7 @@ end
 
 function gram(x::fmpz_mat)
    z = similar(x, nrows(x), nrows(x))
-   ccall((:fmpz_mat_gram, :libflint), Nothing,
+   ccall((:fmpz_mat_gram, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -678,7 +678,7 @@ end
 function hadamard(R::FmpzMatSpace)
    nrows(R) != ncols(R) && error("Unable to create Hadamard matrix")
    z = R()
-   success = ccall((:fmpz_mat_hadamard, :libflint), Bool,
+   success = ccall((:fmpz_mat_hadamard, libflint), Bool,
                    (Ref{fmpz_mat},), z)
    !success && error("Unable to create Hadamard matrix")
    return z
@@ -689,7 +689,7 @@ end
 > Return `true` if the given matrix is Hadamard, otherwise return `false`.
 """
 function ishadamard(x::fmpz_mat)
-   return ccall((:fmpz_mat_is_hadamard, :libflint), Bool,
+   return ccall((:fmpz_mat_is_hadamard, libflint), Bool,
                    (Ref{fmpz_mat},), x)
 end
 
@@ -705,7 +705,7 @@ end
 """
 function hnf(x::fmpz_mat)
    z = similar(x)
-   ccall((:fmpz_mat_hnf, :libflint), Nothing,
+   ccall((:fmpz_mat_hnf, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -718,7 +718,7 @@ end
 function hnf_with_transform(x::fmpz_mat)
    z = similar(x)
    u = similar(x, nrows(x), nrows(x))
-   ccall((:fmpz_mat_hnf_transform, :libflint), Nothing,
+   ccall((:fmpz_mat_hnf_transform, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, u, x)
    return z, u
 end
@@ -730,7 +730,7 @@ end
 """
 function hnf_modular(x::fmpz_mat, d::fmpz)
    z = similar(x)
-   ccall((:fmpz_mat_hnf_modular, :libflint), Nothing,
+   ccall((:fmpz_mat_hnf_modular, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, x, d)
    return z
 end
@@ -744,7 +744,7 @@ function hnf_modular_eldiv(x::fmpz_mat, d::fmpz)
    (nrows(x) < ncols(x)) &&
                 error("Matrix must have at least as many rows as columns")
    z = deepcopy(x)
-   ccall((:fmpz_mat_hnf_modular_eldiv, :libflint), Nothing,
+   ccall((:fmpz_mat_hnf_modular_eldiv, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz}), z, d)
    return z
 end
@@ -755,7 +755,7 @@ end
 > `false`.
 """
 function ishnf(x::fmpz_mat)
-   return ccall((:fmpz_mat_is_in_hnf, :libflint), Bool,
+   return ccall((:fmpz_mat_is_in_hnf, libflint), Bool,
                    (Ref{fmpz_mat},), x)
 end
 
@@ -792,7 +792,7 @@ function lll_with_transform(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51))
    for i in 1:nrows(u)
       u[i, i] = 1
    end
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z, u
 end
@@ -810,7 +810,7 @@ function lll(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51))
    if nrows(z) == 0
      return z
    end
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ptr{nothing}, Ref{lll_ctx}), z, C_NULL, ctx)
    return z
 end
@@ -827,7 +827,7 @@ function lll!(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51))
    if nrows(x) == 0
      return x
    end
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ptr{nothing}, Ref{lll_ctx}), x, C_NULL, ctx)
    return x
 end
@@ -844,7 +844,7 @@ function lll_gram_with_transform(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51,
    for i in 1:nrows(u)
       u[i, i] = 1
    end
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), z, u, ctx)
    return z, u
 end
@@ -856,7 +856,7 @@ end
 """
 function lll_gram(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51, :gram))
    z = deepcopy(x)
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ptr{nothing}, Ref{lll_ctx}), z, C_NULL, ctx)
    return z
 end
@@ -868,7 +868,7 @@ end
 """
 function lll_gram!(x::fmpz_mat, ctx::lll_ctx = lll_ctx(0.99, 0.51, :gram))
    u = similar(x, nrows(x), nrows(x))
-   ccall((:fmpz_lll, :libflint), Nothing,
+   ccall((:fmpz_lll, libflint), Nothing,
          (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{lll_ctx}), x, u, ctx)
    return x
 end
@@ -886,7 +886,7 @@ function lll_with_removal_transform(x::fmpz_mat, b::fmpz, ctx::lll_ctx = lll_ctx
    for i in 1:nrows(u)
       u[i, i] = 1
    end
-   d = Int(ccall((:fmpz_lll_with_removal, :libflint), Cint,
+   d = Int(ccall((:fmpz_lll_with_removal, libflint), Cint,
     (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}, Ref{lll_ctx}), z, u, b, ctx))
    return d, z, u
 end
@@ -900,7 +900,7 @@ end
 function lll_with_removal(x::fmpz_mat, b::fmpz, ctx::lll_ctx = lll_ctx(0.99, 0.51))
    z = deepcopy(x)
    u = similar(x, nrows(x), nrows(x))
-   d = Int(ccall((:fmpz_lll_with_removal, :libflint), Cint,
+   d = Int(ccall((:fmpz_lll_with_removal, libflint), Cint,
     (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}, Ref{lll_ctx}), z, u, b, ctx))
    return d, z
 end
@@ -939,7 +939,7 @@ $\mathbb{Q}$.
 function nullspace_right_rational(x::fmpz_mat)
    z = similar(x)
    u = similar(x, ncols(x), ncols(x))
-   rank = ccall((:fmpz_mat_nullspace, :libflint), Cint,
+   rank = ccall((:fmpz_mat_nullspace, libflint), Cint,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}), u, x)
    return rank, u
 end
@@ -951,7 +951,7 @@ end
 ###############################################################################
 
 function rank(x::fmpz_mat)
-   return ccall((:fmpz_mat_rank, :libflint), Int,
+   return ccall((:fmpz_mat_rank, libflint), Int,
                 (Ref{fmpz_mat},), x)
 end
 
@@ -964,7 +964,7 @@ end
 function rref(x::fmpz_mat)
    z = similar(x)
    d = fmpz()
-   r = ccall((:fmpz_mat_rref, :libflint), Int,
+   r = ccall((:fmpz_mat_rref, libflint), Int,
             (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}), z, d, x)
    return r, z, d
 end
@@ -981,7 +981,7 @@ end
 """
 function snf(x::fmpz_mat)
    z = similar(x)
-   ccall((:fmpz_mat_snf, :libflint), Nothing,
+   ccall((:fmpz_mat_snf, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -992,7 +992,7 @@ end
 """
 function snf_diagonal(x::fmpz_mat)
    z = similar(x)
-   ccall((:fmpz_mat_snf_diagonal, :libflint), Nothing,
+   ccall((:fmpz_mat_snf_diagonal, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}), z, x)
    return z
 end
@@ -1002,7 +1002,7 @@ end
 > Return `true` if $x$ is in Smith normal form, otherwise return `false`.
 """
 function issnf(x::fmpz_mat)
-   return ccall((:fmpz_mat_is_in_snf, :libflint), Bool,
+   return ccall((:fmpz_mat_is_in_snf, libflint), Bool,
                    (Ref{fmpz_mat},), x)
 end
 
@@ -1126,7 +1126,7 @@ function solve_rational(a::fmpz_mat, b::fmpz_mat)
    nrows(b) != nrows(a) && error("Incompatible dimensions in solve_rational")
    z = similar(b)
    d = fmpz()
-   nonsing = ccall((:fmpz_mat_solve, :libflint), Bool,
+   nonsing = ccall((:fmpz_mat_solve, libflint), Bool,
       (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, d, a, b)
    !nonsing && error("Singular matrix in solve_rational")
    return z, d
@@ -1148,7 +1148,7 @@ function solve_dixon(a::fmpz_mat, b::fmpz_mat)
    nrows(b) != nrows(a) && error("Incompatible dimensions in solve")
    z = similar(b)
    d = fmpz()
-   nonsing = ccall((:fmpz_mat_solve_dixon, :libflint), Bool,
+   nonsing = ccall((:fmpz_mat_solve_dixon, libflint), Bool,
       (Ref{fmpz_mat}, Ref{fmpz}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, d, a, b)
    !nonsing && error("Singular matrix in solve")
    return z, d
@@ -1163,7 +1163,7 @@ end
 function tr(x::fmpz_mat)
    nrows(x) != ncols(x) && error("Not a square matrix in trace")
    d = fmpz()
-   ccall((:fmpz_mat_trace, :libflint), Int,
+   ccall((:fmpz_mat_trace, libflint), Int,
                 (Ref{fmpz}, Ref{fmpz_mat}), d, x)
    return d
 end
@@ -1176,7 +1176,7 @@ end
 
 function content(x::fmpz_mat)
   d = fmpz()
-  ccall((:fmpz_mat_content, :libflint), Nothing,
+  ccall((:fmpz_mat_content, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz_mat}), d, x)
   return d
 end
@@ -1190,7 +1190,7 @@ end
 function hcat(a::fmpz_mat, b::fmpz_mat)
   nrows(a) != nrows(b) && error("Incompatible number of rows in hcat")
   c = similar(a, nrows(a), ncols(a) + ncols(b))
-  ccall((:fmpz_mat_concat_horizontal, :libflint), Nothing,
+  ccall((:fmpz_mat_concat_horizontal, libflint), Nothing,
         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), c, a, b)
   return c
 end
@@ -1198,7 +1198,7 @@ end
 function vcat(a::fmpz_mat, b::fmpz_mat)
   ncols(a) != ncols(b) && error("Incompatible number of columns in vcat")
   c = similar(a, nrows(a) + nrows(b), ncols(a))
-  ccall((:fmpz_mat_concat_vertical, :libflint), Nothing,
+  ccall((:fmpz_mat_concat_vertical, libflint), Nothing,
         (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), c, a, b)
   return c
 end
@@ -1210,49 +1210,49 @@ end
 ###############################################################################
 
 function add!(z::fmpz_mat, x::fmpz_mat, y::fmpz_mat)
-   ccall((:fmpz_mat_add, :libflint), Nothing,
+   ccall((:fmpz_mat_add, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, x, y)
    return z
 end
 
 function mul!(z::fmpz_mat, x::fmpz_mat, y::fmpz_mat)
-   ccall((:fmpz_mat_mul, :libflint), Nothing,
+   ccall((:fmpz_mat_mul, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, x, y)
    return z
 end
 
 function mul!(y::fmpz_mat, x::Int)
-   ccall((:fmpz_mat_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), y, y, x)
    return y
 end
 
 function mul!(y::fmpz_mat, x::fmpz)
-   ccall((:fmpz_mat_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), y, y, x)
    return y
 end
 
 function addmul!(z::fmpz_mat, y::fmpz_mat, x::fmpz)
-   ccall((:fmpz_mat_scalar_addmul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_addmul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz}), z, y, x)
    return y
 end
 
 function addmul!(z::fmpz_mat, y::fmpz_mat, x::Int)
-   ccall((:fmpz_mat_scalar_addmul_si, :libflint), Nothing,
+   ccall((:fmpz_mat_scalar_addmul_si, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Int), z, y, x)
    return y
 end
 
 function addeq!(z::fmpz_mat, x::fmpz_mat)
-   ccall((:fmpz_mat_add, :libflint), Nothing,
+   ccall((:fmpz_mat_add, libflint), Nothing,
                 (Ref{fmpz_mat}, Ref{fmpz_mat}, Ref{fmpz_mat}), z, z, x)
    return z
 end
 
 function zero!(z::fmpz_mat)
-   ccall((:fmpz_mat_zero, :libflint), Nothing,
+   ccall((:fmpz_mat_zero, libflint), Nothing,
                 (Ref{fmpz_mat},), z)
    return z
 end
@@ -1398,7 +1398,7 @@ function identity_matrix(R::FlintIntegerRing, n::Int)
      error("dimension must not be negative")
    end
    z = fmpz_mat(n, n)
-   ccall((:fmpz_mat_one, :libflint), Nothing, (Ref{fmpz_mat}, ), z)
+   ccall((:fmpz_mat_one, libflint), Nothing, (Ref{fmpz_mat}, ), z)
    z.base_ring = FlintZZ
    return z
 end

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -157,7 +157,7 @@ function *(x::fmpz_mod, y::fmpz_mod)
    check_parent(x, y)
    R = parent(x)
    d = fmpz()
-   ccall((:fmpz_mod_mul, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+   ccall((:fmpz_mod_mul, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
              d, x.data, y.data, R.ninv)
    return fmpz_mod(d, R)
 end
@@ -196,7 +196,7 @@ function ^(x::fmpz_mod, y::Int)
       y = -y
    end
    d = fmpz()
-   ccall((:fmpz_mod_pow_ui, :libflint), Nothing,
+   ccall((:fmpz_mod_pow_ui, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, UInt, Ref{fmpz_mod_ctx_struct}),
              d, x.data, y, R.ninv)
    return fmpz_mod(d, R)
@@ -242,7 +242,7 @@ function inv(x::fmpz_mod)
    end
    s = fmpz()
    g = fmpz()
-   ccall((:fmpz_gcdinv, :libflint), Nothing,
+   ccall((:fmpz_gcdinv, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
             g, s, x.data, R.n)
    g != 1 && error("Impossible inverse in ", R)
@@ -280,7 +280,7 @@ function divides(a::fmpz_mod, b::fmpz_mod)
    end
    ub = divexact(B, gb)
    b1 = fmpz()
-   ccall((:fmpz_invmod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+   ccall((:fmpz_invmod, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
            b1, ub, divexact(m, gb))
    rr = R(q)*b1
    return true, rr
@@ -323,14 +323,14 @@ end
 ###############################################################################
 
 function zero!(z::fmpz_mod)
-   ccall((:fmpz_set_ui, :libflint), Nothing,
+   ccall((:fmpz_set_ui, libflint), Nothing,
 		(Ref{fmpz}, UInt), z.data, UInt(0))
    return z
 end
 
 function mul!(z::fmpz_mod, x::fmpz_mod, y::fmpz_mod)
    R = parent(z)
-   ccall((:fmpz_mod_mul, :libflint), Nothing,
+   ccall((:fmpz_mod_mul, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 	      z.data, x.data, y.data, R.ninv)
    return z
@@ -338,7 +338,7 @@ end
 
 function addeq!(z::fmpz_mod, x::fmpz_mod)
    R = parent(z)
-   ccall((:fmpz_mod_add, :libflint), Nothing,
+   ccall((:fmpz_mod_add, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 	    z.data, z.data, x.data, R.ninv)
    return z
@@ -346,7 +346,7 @@ end
 
 function add!(z::fmpz_mod, x::fmpz_mod, y::fmpz_mod)
    R = parent(z)
-   ccall((:fmpz_mod_add, :libflint), Nothing,
+   ccall((:fmpz_mod_add, libflint), Nothing,
 	(Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 	   z.data, x.data, y.data, R.ninv)
    return z
@@ -397,7 +397,7 @@ end
 
 function (R::FmpzModRing)(a::fmpz)
    d = fmpz()
-   ccall((:fmpz_mod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+   ccall((:fmpz_mod, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
              d, a, R.n)
    return fmpz_mod(d, R)
 end

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -42,13 +42,13 @@ max_precision(R::FmpzModAbsSeriesRing) = R.prec_max
 function normalise(a::fmpz_mod_abs_series, len::Int)
    if len > 0
       c = fmpz()
-      ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), c, a, len - 1)
       end
    end
@@ -56,7 +56,7 @@ function normalise(a::fmpz_mod_abs_series, len::Int)
 end
 
 function length(x::fmpz_mod_abs_series)
-   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ref{fmpz_mod_abs_series},), x)
+   return ccall((:fmpz_mod_poly_length, libflint), Int, (Ref{fmpz_mod_abs_series},), x)
 end
 
 precision(x::fmpz_mod_abs_series) = x.prec
@@ -67,7 +67,7 @@ function coeff(x::fmpz_mod_abs_series, n::Int)
       return R(0)
    end
    z = fmpz()
-   ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, n)
    return R(z)
 end
@@ -90,7 +90,7 @@ function deepcopy_internal(a::fmpz_mod_abs_series, dict::IdDict)
 end
 
 function isgen(a::fmpz_mod_abs_series)
-   return precision(a) == 0 || ccall((:fmpz_mod_poly_is_x, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpz_mod_poly_is_x, libflint), Bool,
                             (Ref{fmpz_mod_abs_series},), a)
 end
 
@@ -99,7 +99,7 @@ iszero(a::fmpz_mod_abs_series) = length(a) == 0
 isunit(a::fmpz_mod_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fmpz_mod_abs_series)
-   return precision(a) == 0 || ccall((:fmpz_mod_poly_is_one, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fmpz_mod_poly_is_one, libflint), Bool,
                                 (Ref{fmpz_mod_abs_series},), a)
 end
 
@@ -136,7 +136,7 @@ show_minus_one(::Type{fmpz_mod_abs_series}) = show_minus_one(fmpz)
 
 function -(x::fmpz_mod_abs_series)
    z = parent(x)()
-   ccall((:fmpz_mod_poly_neg, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_neg, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}),
                z, x)
    z.prec = x.prec
@@ -162,7 +162,7 @@ function +(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -181,7 +181,7 @@ function -(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fmpz_mod_poly_sub_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -210,7 +210,7 @@ function *(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
 
    lenz = min(lena + lenb - 1, prec)
 
-   ccall((:fmpz_mod_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -225,7 +225,7 @@ end
 function *(x::fmpz_mod, y::fmpz_mod_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
                z, y, x.data)
    return z
@@ -237,7 +237,7 @@ function *(x::fmpz, y::fmpz_mod_abs_series)
    z = parent(y)()
    z.prec = y.prec
    r = mod(x, modulus(y))
-   ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
                z, y, r)
    return z
@@ -260,10 +260,10 @@ function shift_left(x::fmpz_mod_abs_series, len::Int)
    z.prec = x.prec + len
    z.prec = min(z.prec, max_precision(parent(x)))
    zlen = min(z.prec, xlen + len)
-   ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, x, len)
-   ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, z, zlen)
    return z
@@ -277,7 +277,7 @@ function shift_right(x::fmpz_mod_abs_series, len::Int)
       z.prec = max(0, x.prec - len)
    else
       z.prec = x.prec - len
-      ccall((:fmpz_mod_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, x, len)
    end
@@ -297,7 +297,7 @@ function truncate(x::fmpz_mod_abs_series, prec::Int)
    end
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, x, prec)
    return z
@@ -323,7 +323,7 @@ function ^(a::fmpz_mod_abs_series, b::Int)
       z = parent(a)()
       z.prec = a.prec + (b - 1)*valuation(a)
       z.prec = min(z.prec, max_precision(parent(a)))
-      ccall((:fmpz_mod_poly_pow_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_pow_trunc, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int, Int),
                z, a, b, z.prec)
    end
@@ -343,7 +343,7 @@ function ==(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
    n = max(length(x), length(y))
    n = min(n, prec)
 
-   return Bool(ccall((:fmpz_mod_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpz_mod_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                x, y, n))
 end
@@ -355,7 +355,7 @@ function isequal(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
    if x.prec != y.prec || length(x) != length(y)
       return false
    end
-   return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpz_mod_poly_equal, libflint), Cint,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                x, y, length(x)))
 end
@@ -371,9 +371,9 @@ function ==(x::fmpz_mod_abs_series, y::fmpz_mod)
       return false
    elseif length(x) == 1
       z = fmpz()
-      ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, 0)
-      return ccall((:fmpz_equal, :libflint), Bool,
+      return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}), z, y)
    else
       return precision(x) == 0 || iszero(y)
@@ -388,9 +388,9 @@ function ==(x::fmpz_mod_abs_series, y::fmpz)
    elseif length(x) == 1
       z = fmpz()
       r = mod(y, modulus(x))
-      ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_mod_abs_series}, Int), z, x, 0)
-      return ccall((:fmpz_equal, :libflint), Bool,
+      return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}), z, r)
    else
       r = mod(y, modulus(x))
@@ -425,7 +425,7 @@ function divexact(x::fmpz_mod_abs_series, y::fmpz_mod_abs_series)
    prec = min(x.prec, y.prec - v2 + v1)
    z = parent(x)()
    z.prec = prec
-   ccall((:fmpz_mod_poly_div_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_div_series, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, x, y, prec)
    return z
@@ -441,7 +441,7 @@ function divexact(x::fmpz_mod_abs_series, y::fmpz_mod)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -452,7 +452,7 @@ function divexact(x::fmpz_mod_abs_series, y::fmpz)
    z = parent(x)()
    z.prec = x.prec
    r = mod(y, modulus(x))
-   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -471,7 +471,7 @@ function inv(a::fmpz_mod_abs_series)
    !isunit(a) && error("Unable to invert power series")
    ainv = parent(a)()
    ainv.prec = a.prec
-   ccall((:fmpz_mod_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_inv_series, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -484,14 +484,14 @@ end
 ###############################################################################
 
 function zero!(z::fmpz_mod_abs_series)
-   ccall((:fmpz_mod_poly_zero, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_zero, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series},), z)
    z.prec = parent(z).prec_max
    return z
 end
 
 function setcoeff!(z::fmpz_mod_abs_series, n::Int, x::fmpz)
-   ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}),
                z, n, x)
    return z
@@ -516,7 +516,7 @@ function mul!(z::fmpz_mod_abs_series, a::fmpz_mod_abs_series, b::fmpz_mod_abs_se
    end
 
    z.prec = prec
-   ccall((:fmpz_mod_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                z, a, b, lenz)
    return z
@@ -533,7 +533,7 @@ function addeq!(a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)
 
    lenz = max(lena, lenb)
    a.prec = prec
-   ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Ref{fmpz_mod_abs_series}, Int),
                a, a, b, lenz)
    return a

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -48,7 +48,7 @@ end
 @inline function getindex(a::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
   @boundscheck Generic._checkbounds(a, i, j)
   u = fmpz()
-  ccall((:fmpz_mod_mat_get_entry, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_get_entry, libflint), Nothing,
               (Ref{fmpz}, Ref{T}, Int, Int), u, a, i - 1 , j - 1)
   return fmpz_mod(u, base_ring(a)) # no reduction needed
 end
@@ -56,7 +56,7 @@ end
 # as above, but as a plain fmpz, no bounds checking
 function getindex_raw(a::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
   u = fmpz()
-  ccall((:fmpz_mod_mat_get_entry, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_get_entry, libflint), Nothing,
                  (Ref{fmpz}, Ref{T}, Int, Int), u, a, i - 1, j - 1)
   return u
 end
@@ -79,7 +79,7 @@ end
 
 # as per setindex! but no reduction mod n and no bounds checking
 @inline function setindex_raw!(a::T, u::fmpz, i::Int, j::Int) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_set_entry, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_set_entry, libflint), Nothing,
         (Ref{T}, Int, Int, Ref{fmpz}), a, i - 1, j - 1, u)
 end
 
@@ -88,7 +88,7 @@ function deepcopy_internal(a::fmpz_mod_mat, dict::IdDict)
   if isdefined(a, :base_ring)
     z.base_ring = a.base_ring
   end
-  ccall((:fmpz_mod_mat_set, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_set, libflint), Nothing,
           (Ref{fmpz_mod_mat}, Ref{fmpz_mod_mat}), z, a)
   return z
 end
@@ -114,12 +114,12 @@ zero(a::FmpzModMatSpace) = a()
 function one(a::FmpzModMatSpace)
   (nrows(a) != ncols(a)) && error("Matrices must be square")
   z = a()
-  ccall((:fmpz_mod_mat_one, :libflint), Nothing, (Ref{fmpz_mod_mat}, ), z)
+  ccall((:fmpz_mod_mat_one, libflint), Nothing, (Ref{fmpz_mod_mat}, ), z)
   return z
 end
 
 function iszero(a::T) where T <: Zmod_fmpz_mat
-  r = ccall((:fmpz_mod_mat_is_zero, :libflint), Cint, (Ref{T}, ), a)
+  r = ccall((:fmpz_mod_mat_is_zero, libflint), Cint, (Ref{T}, ), a)
   return Bool(r)
 end
 
@@ -130,7 +130,7 @@ end
 ################################################################################
 
 ==(a::T, b::T) where T <: Zmod_fmpz_mat = (a.base_ring == b.base_ring) &&
-        Bool(ccall((:fmpz_mod_mat_equal, :libflint), Cint,
+        Bool(ccall((:fmpz_mod_mat_equal, libflint), Cint,
                 (Ref{T}, Ref{T}), a, b))
 
 isequal(a::T, b::T) where T <: Zmod_fmpz_mat = ==(a, b)
@@ -143,14 +143,14 @@ isequal(a::T, b::T) where T <: Zmod_fmpz_mat = ==(a, b)
 
 function transpose(a::T) where T <: Zmod_fmpz_mat
   z = similar(a, ncols(a), nrows(a))
-  ccall((:fmpz_mod_mat_transpose, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_transpose, libflint), Nothing,
           (Ref{T}, Ref{T}), z, a)
   return z
 end
 
 function transpose!(a::T) where T <: Zmod_fmpz_mat
   !issquare(a) && error("Matrix must be a square matrix")
-  ccall((:fmpz_mod_mat_transpose, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_transpose, libflint), Nothing,
           (Ref{T}, Ref{T}), a, a)
 end
 
@@ -163,7 +163,7 @@ end
 #= Not currently implemented in Flint
 
 function swap_rows!(x::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_swap_rows, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_swap_rows, libflint), Nothing,
         (Ref{T}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -175,7 +175,7 @@ function swap_rows(x::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
 end
 
 function swap_cols!(x::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_swap_cols, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_swap_cols, libflint), Nothing,
         (Ref{T}, Ptr{Nothing}, Int, Int), x, C_NULL, i - 1, j - 1)
   return x
 end
@@ -187,7 +187,7 @@ function swap_cols(x::T, i::Int, j::Int) where T <: Zmod_fmpz_mat
 end
 
 function reverse_rows!(x::T) where T <: Zmod_fmpz_mat
-   ccall((:fmpz_mod_mat_invert_rows, :libflint), Nothing,
+   ccall((:fmpz_mod_mat_invert_rows, libflint), Nothing,
          (Ref{T}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -195,7 +195,7 @@ end
 reverse_rows(x::T) where T <: Zmod_fmpz_mat = reverse_rows!(deepcopy(x))
 
 function reverse_cols!(x::T) where T <: Zmod_fmpz_mat
-   ccall((:fmpz_mod_mat_invert_cols, :libflint), Nothing,
+   ccall((:fmpz_mod_mat_invert_cols, libflint), Nothing,
          (Ref{T}, Ptr{Nothing}), x, C_NULL)
    return x
 end
@@ -212,7 +212,7 @@ reverse_cols(x::T) where T <: Zmod_fmpz_mat = reverse_cols!(deepcopy(x))
 
 function -(x::T) where T <: Zmod_fmpz_mat
   z = similar(x)
-  ccall((:fmpz_mod_mat_neg, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_neg, libflint), Nothing,
           (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -226,7 +226,7 @@ end
 function +(x::T, y::T) where T <: Zmod_fmpz_mat
   check_parent(x,y)
   z = similar(x)
-  ccall((:fmpz_mod_mat_add, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_add, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -234,7 +234,7 @@ end
 function -(x::T, y::T) where T <: Zmod_fmpz_mat
   check_parent(x,y)
   z = similar(x)
-  ccall((:fmpz_mod_mat_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_sub, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -243,7 +243,7 @@ function *(x::T, y::T) where T <: Zmod_fmpz_mat
   (base_ring(x) != base_ring(y)) && error("Base ring must be equal")
   (ncols(x) != nrows(y)) && error("Dimensions are wrong")
   z = similar(x, nrows(x), ncols(y))
-  ccall((:fmpz_mod_mat_mul, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_mul, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -256,17 +256,17 @@ end
 ################################################################################
 
 function mul!(a::T, b::T, c::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_mul, :libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
+  ccall((:fmpz_mod_mat_mul, libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
   return a
 end
 
 function add!(a::T, b::T, c::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_add, :libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
+  ccall((:fmpz_mod_mat_add, libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
   return a
 end
 
 function zero!(a::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_zero, :libflint), Nothing, (Ref{T}, ), a)
+  ccall((:fmpz_mod_mat_zero, libflint), Nothing, (Ref{T}, ), a)
   return a
 end
 
@@ -278,7 +278,7 @@ end
 
 function *(x::T, y::Int) where T <: Zmod_fmpz_mat
   z = similar(x)
-  ccall((:fmpz_mod_mat_scalar_mul_si, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_scalar_mul_si, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, y)
   return z
 end
@@ -287,7 +287,7 @@ end
 
 function *(x::T, y::fmpz) where T <: Zmod_fmpz_mat
   z = similar(x)
-  ccall((:fmpz_mod_mat_scalar_mul_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_scalar_mul_fmpz, libflint), Nothing,
 	(Ref{T}, Ref{T}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -321,7 +321,7 @@ function ^(x::T, y::Int) where T <: Zmod_fmpz_mat
      y = -y
   end
   z = similar(x)
-  ccall((:fmpz_mod_mat_pow, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_pow, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, y)
   return z
 end
@@ -342,7 +342,7 @@ end
 ################################################################################
 
 function strong_echelon_form!(a::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_strong_echelon_form, :libflint), Nothing, (Ref{T}, ), a)
+  ccall((:fmpz_mod_mat_strong_echelon_form, libflint), Nothing, (Ref{T}, ), a)
 end
 
 @doc Markdown.doc"""
@@ -359,7 +359,7 @@ function strong_echelon_form(a::fmpz_mod_mat)
 end
 
 function howell_form!(a::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_howell_form, :libflint), Nothing, (Ref{T}, ), a)
+  ccall((:fmpz_mod_mat_howell_form, libflint), Nothing, (Ref{T}, ), a)
 end
 
 @doc Markdown.doc"""
@@ -386,7 +386,7 @@ function tr(a::T) where T <: Zmod_fmpz_mat
   !issquare(a) && error("Matrix must be a square matrix")
   R = base_ring(a)
   r = fmpz()
-  ccall((:fmpz_mod_mat_trace, :libflint), Nothing, (Ref{fmpz}, Ref{T}), r, a)
+  ccall((:fmpz_mod_mat_trace, libflint), Nothing, (Ref{fmpz}, Ref{T}), r, a)
   return fmpz_mod(r, R)
 end
 
@@ -401,7 +401,7 @@ end
 function det(a::fmpz_mod_mat)
   !issquare(a) && error("Matrix must be a square matrix")
   if isprime(a.n)
-     r = ccall((:fmpz_mod_mat_det, :libflint), UInt, (Ref{fmpz_mod_mat}, ), a)
+     r = ccall((:fmpz_mod_mat_det, libflint), UInt, (Ref{fmpz_mod_mat}, ), a)
      return base_ring(a)(r)
   else
      try
@@ -423,7 +423,7 @@ end
 #= Not implemented in Flint yet
 
 function rank(a::T) where T <: Zmod_fmpz_mat
-  r = ccall((:fmpz_mod_mat_rank, :libflint), Int, (Ref{T}, ), a)
+  r = ccall((:fmpz_mod_mat_rank, libflint), Int, (Ref{T}, ), a)
   return r
 end
 
@@ -440,7 +440,7 @@ end
 function inv(a::T) where T <: Zmod_fmpz_mat
   !issquare(a) && error("Matrix must be a square matrix")
   z = similar(a)
-  r = ccall((:fmpz_mod_mat_inv, :libflint), Int,
+  r = ccall((:fmpz_mod_mat_inv, libflint), Int,
           (Ref{T}, Ref{T}), z, a)
   !Bool(r) && error("Matrix not invertible")
   return z
@@ -461,7 +461,7 @@ function solve(x::T, y::T) where T <: Zmod_fmpz_mat
   !issquare(x)&& error("First argument not a square matrix in solve")
   (y.r != x.r) || y.c != 1 && ("Not a column vector in solve")
   z = similar(y)
-  r = ccall((:fmpz_mod_mat_solve, :libflint), Int,
+  r = ccall((:fmpz_mod_mat_solve, libflint), Int,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   !Bool(r) && error("Singular matrix in solve")
   return z
@@ -478,7 +478,7 @@ end
 #= Not implemented in Flint yet
 
 function lu!(P::Generic.Perm, x::T) where T <: Zmod_fmpz_mat
-  rank = Int(ccall((:fmpz_mod_mat_lu, :libflint), Cint, (Ptr{Int}, Ref{T}, Cint),
+  rank = Int(ccall((:fmpz_mod_mat_lu, libflint), Cint, (Ptr{Int}, Ref{T}, Cint),
            P.d, x, 0))
 
   for i in 1:length(P.d)
@@ -546,7 +546,7 @@ function Base.view(x::fmpz_mod_mat, r1::Int, c1::Int, r2::Int, c2::Int)
   z = fmpz_mod_mat()
   z.base_ring = x.base_ring
   z.view_parent = x
-  ccall((:fmpz_mod_mat_window_init, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_window_init, libflint), Nothing,
           (Ref{fmpz_mod_mat}, Ref{fmpz_mod_mat}, Int, Int, Int, Int),
           z, x, r1 - 1, c1 - 1, r2, c2)
   finalizer(_fmpz_mod_mat_window_clear_fn, z)
@@ -558,7 +558,7 @@ function Base.view(x::T, r::UnitRange{Int}, c::UnitRange{Int}) where T <: Zmod_f
 end
 
 function _fmpz_mod_mat_window_clear_fn(a::fmpz_mod_mat)
-  ccall((:fmpz_mod_mat_window_clear, :libflint), Nothing, (Ref{fmpz_mod_mat}, ), a)
+  ccall((:fmpz_mod_mat_window_clear, libflint), Nothing, (Ref{fmpz_mod_mat}, ), a)
 end
 
 function sub(x::T, r1::Int, c1::Int, r2::Int, c2::Int) where T <: Zmod_fmpz_mat
@@ -583,7 +583,7 @@ function hcat(x::T, y::T) where T <: Zmod_fmpz_mat
   (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
   (x.r != y.r) && error("Matrices must have same number of rows")
   z = similar(x, nrows(x), ncols(x) + ncols(y))
-  ccall((:fmpz_mod_mat_concat_horizontal, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_concat_horizontal, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -592,7 +592,7 @@ function vcat(x::T, y::T) where T <: Zmod_fmpz_mat
   (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
   (x.c != y.c) && error("Matrices must have same number of columns")
   z = similar(x, nrows(x) + nrows(y), ncols(x))
-  ccall((:fmpz_mod_mat_concat_vertical, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_concat_vertical, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -629,13 +629,13 @@ end
 function lift(a::T) where {T <: Zmod_fmpz_mat}
   z = fmpz_mat(nrows(a), ncols(a))
   z.base_ring = FlintZZ
-  ccall((:fmpz_mat_set_fmpz_mod_mat, :libflint), Nothing,
+  ccall((:fmpz_mat_set_fmpz_mod_mat, libflint), Nothing,
           (Ref{fmpz_mat}, Ref{T}), z, a)
   return z
 end
 
 function lift!(z::fmpz_mat, a::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mat_set_fmpz_mod_mat, :libflint), Nothing,
+  ccall((:fmpz_mat_set_fmpz_mod_mat, libflint), Nothing,
           (Ref{fmpz_mat}, Ref{T}), z, a)
   return z
 end
@@ -653,7 +653,7 @@ end
 function charpoly(R::FmpzModPolyRing, a::fmpz_mod_mat)
   m = deepcopy(a)
   p = R()
-  ccall((:fmpz_mod_mat_charpoly, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_charpoly, libflint), Nothing,
           (Ref{fmpz_mod_poly}, Ref{fmpz_mod_mat}), p, m)
   return p
 end
@@ -670,7 +670,7 @@ end
 
 function minpoly(R::FmpzModPolyRing, a::fmpz_mod_mat)
   p = R()
-  ccall((:fmpz_mod_mat_minpoly, :libflint), Nothing,
+  ccall((:fmpz_mod_mat_minpoly, libflint), Nothing,
           (Ref{fmpz_mod_poly}, Ref{fmpz_mod_mat}), p, a)
   return p
 end

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -36,17 +36,17 @@ end
 ################################################################################
 
 function length(x::T) where {T <: Zmodn_fmpz_poly}
-  return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ref{T}, ), x)
+  return ccall((:fmpz_mod_poly_length, libflint), Int, (Ref{T}, ), x)
 end
 
 function degree(x::T) where {T <: Zmodn_fmpz_poly}
-  return ccall((:fmpz_mod_poly_degree, :libflint), Int, (Ref{T}, ), x)
+  return ccall((:fmpz_mod_poly_degree, libflint), Int, (Ref{T}, ), x)
 end
 
 function coeff(x::T, n::Int) where {T <: Zmodn_fmpz_poly}
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   z = fmpz()
-  ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
         (Ref{fmpz}, Ref{T}, Int), z, x, n)
   return base_ring(x)(z)
 end
@@ -61,7 +61,7 @@ isgen(a::Zmodn_fmpz_poly) = (degree(a) == 1 &&
                               iszero(coeff(a,0)) && isone(coeff(a,1)))
 
 function iszero(a::T) where {T <: Zmodn_fmpz_poly}
-  return Bool(ccall((:fmpz_mod_poly_is_zero, :libflint), Cint, (Ref{T}, ), a))
+  return Bool(ccall((:fmpz_mod_poly_is_zero, libflint), Cint, (Ref{T}, ), a))
 end
 
 var(R::ZmodNFmpzPolyRing) = R.S
@@ -160,7 +160,7 @@ canonical_unit(a::Zmodn_fmpz_poly) = canonical_unit(lead(a))
 
 function -(x::T) where {T <: Zmodn_fmpz_poly}
   z = parent(x)()
-  ccall((:fmpz_mod_poly_neg, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_neg, libflint), Nothing,
           (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -174,7 +174,7 @@ end
 function +(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x,y)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_add, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}),
                z, x, y)
   return z
@@ -183,7 +183,7 @@ end
 function -(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x,y)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}),
               z, x, y)
   return z
@@ -192,7 +192,7 @@ end
 function *(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x,y)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_mul, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_mul, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}),
               z, x, y)
   return z
@@ -206,7 +206,7 @@ end
 
 function *(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
           (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -226,7 +226,7 @@ end
 
 function +(x::fmpz_mod_poly, y::Int)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_add_si, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add_si, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, y)
   return z
 end
@@ -235,7 +235,7 @@ end
 
 function +(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_add_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add_fmpz, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -255,28 +255,28 @@ end
 
 function -(x::fmpz_mod_poly, y::Int)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_sub_si, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub_si, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Int), z, x, y)
   return z
 end
 
 function -(x::Int, y::fmpz_mod_poly)
   z = parent(y)()
-  ccall((:fmpz_mod_poly_si_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_si_sub, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Int, Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
 
 function -(x::fmpz_mod_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_sub_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub_fmpz, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y)
   return z
 end
 
 function -(x::fmpz, y::fmpz_mod_poly)
   z = parent(y)()
-  ccall((:fmpz_mod_poly_fmpz_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_fmpz_sub, libflint), Nothing,
     (Ref{fmpz_mod_poly}, Ref{fmpz}, Ref{fmpz_mod_poly}), z, x, y)
   return z
 end
@@ -304,7 +304,7 @@ end
 function ^(x::T, y::Int) where {T <: Zmodn_fmpz_poly}
   y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
   z = parent(x)()
-  ccall((:fmpz_mod_poly_pow, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_pow, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, y)
   return z
 end
@@ -317,7 +317,7 @@ end
 
 function ==(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x, y)
-  return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Int32,
+  return Bool(ccall((:fmpz_mod_poly_equal, libflint), Int32,
              (Ref{T}, Ref{T}), x, y))
 end
 
@@ -333,7 +333,7 @@ function ==(x::fmpz_mod_poly, y::fmpz_mod)
      return false
   elseif length(x) == 1
      u = fmpz()
-     ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+     ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_mod_poly}, Int), u, x, 0)
      return u == y
   else
@@ -358,7 +358,7 @@ function truncate(a::T, n::Int) where {T <: Zmodn_fmpz_poly}
     return z
   end
 
-  ccall((:fmpz_mod_poly_truncate, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
           (Ref{T}, Int), z, n)
   return z
 end
@@ -368,7 +368,7 @@ function mullow(x::T, y::T, n::Int) where {T <: Zmodn_fmpz_poly}
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
 
   z = parent(x)()
-  ccall((:fmpz_mod_poly_mullow, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}, Int),
                 z, x, y, n)
   return z
@@ -383,7 +383,7 @@ end
 function reverse(x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   len < 0 && throw(DomainError(n, "Index must be non-negative"))
   z = parent(x)()
-  ccall((:fmpz_mod_poly_reverse, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_reverse, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -397,7 +397,7 @@ end
 function shift_left(x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   len < 0 && throw(DomainError(len, "Shift must be non-negative"))
   z = parent(x)()
-  ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -405,7 +405,7 @@ end
 function shift_right(x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   len < 0 && throw(DomainError(len, "Shift must be non-negative"))
   z = parent(x)()
-  ccall((:fmpz_mod_poly_shift_right, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
             (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -422,7 +422,7 @@ function divexact(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   d = fmpz()
   q = parent(x)()
   r = parent(x)()
-  ccall((:fmpz_mod_poly_divrem_f, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_divrem_f, libflint), Nothing,
         (Ref{fmpz}, Ref{T}, Ref{T}, Ref{T}, Ref{T}),
                d, q, r, x, y)
   d != 1 && error("Impossible inverse in divexact")
@@ -441,7 +441,7 @@ function divexact(x::fmpz_mod_poly, y::fmpz_mod)
   base_ring(x) != parent(y) && error("Elements must have same parent")
   iszero(y) && throw(DivideError())
   q = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
           (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly}, Ref{fmpz}),
                q, x, y.data)
   return q
@@ -450,7 +450,7 @@ end
 function divexact(x::T, y::fmpz) where {T <: Zmodn_fmpz_poly}
   iszero(y) && throw(DivideError())
   q = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{fmpz}),
                q, x, y)
   return q
@@ -459,7 +459,7 @@ end
 function divexact(x::T, y::Int) where {T <: Zmodn_fmpz_poly}
   y == 0 && throw(DivideError())
   q = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{fmpz}),
                q, x, fmpz(y))
   return q
@@ -477,7 +477,7 @@ function divrem(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   q = parent(x)()
   r = parent(x)()
   d = fmpz()
-  ccall((:fmpz_mod_poly_divrem_f, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_divrem_f, libflint), Nothing,
         (Ref{fmpz}, Ref{T}, Ref{T}, Ref{T}, Ref{T}),
           d, q, r, x, y)
   d > 1 && error("Impossible inverse in divrem")
@@ -524,7 +524,7 @@ function gcd(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x, y)
   z = parent(x)()
   f = fmpz()
-  ccall((:fmpz_mod_poly_gcd_f, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_gcd_f, libflint), Nothing,
           (Ref{fmpz}, Ref{T}, Ref{T}, Ref{T}),
               f, z, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
@@ -537,7 +537,7 @@ function gcdx(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   s = parent(x)()
   t = parent(x)()
   f = fmpz()
-  ccall((:fmpz_mod_poly_xgcd_f, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_xgcd_f, libflint), Nothing,
         (Ref{fmpz}, Ref{T}, Ref{T}, Ref{T},
          Ref{T}, Ref{T}), f, g, s, t, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
@@ -550,7 +550,7 @@ function gcdinv(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   g = parent(x)()
   s = parent(x)()
   f = fmpz()
-  ccall((:fmpz_mod_poly_gcdinv_f, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_gcdinv_f, libflint), Nothing,
           (Ref{fmpz}, Ref{T}, Ref{T}, Ref{T}, Ref{T}),
           f, g, s, x, y)
   f > 1 && error("Impossible inverse: $(f) divides modulus")
@@ -570,7 +570,7 @@ function invmod(x::T, y::T) where {T <: Zmodn_fmpz_poly}
     return parent(x)(inv(eval(x, coeff(y, 0))))
   end
   z = parent(x)()
-  r = ccall((:fmpz_mod_poly_invmod, :libflint), Int32,
+  r = ccall((:fmpz_mod_poly_invmod, libflint), Int32,
             (Ref{T}, Ref{T}, Ref{T}),
                z, x, y)
   r == 0 ? error("Impossible inverse in invmod") : return z
@@ -580,7 +580,7 @@ function mulmod(x::T, y::T, z::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x, y)
   check_parent(y, z)
   w = parent(x)()
-  ccall((:fmpz_mod_poly_mulmod, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_mulmod, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{T}, Ref{T}),
         w, x, y, z)
   return w
@@ -598,7 +598,7 @@ function powmod(x::T, e::Int, y::T) where {T <: Zmodn_fmpz_poly}
     e = -e
   end
 
-  ccall((:fmpz_mod_poly_powmod_ui_binexp, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_powmod_ui_binexp, libflint), Nothing,
         (Ref{T}, Ref{T}, Int, Ref{T}), z, x, e, y)
 
   return z
@@ -619,7 +619,7 @@ function powmod(x::T, e::fmpz, y::T) where {T <: Zmodn_fmpz_poly}
     e = -e
   end
 
-  ccall((:fmpz_mod_poly_powmod_fmpz_binexp, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_powmod_fmpz_binexp, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{fmpz}, Ref{T}),
             z, x, e, y)
   return z
@@ -636,7 +636,7 @@ function resultant(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   z = parent(x)()
   !isprobable_prime(modulus(x)) && error("Modulus not prime in resultant")
   r = fmpz()
-  ccall((:fmpz_mod_poly_resultant, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_resultant, libflint), Nothing,
           (Ref{fmpz}, Ref{T}, Ref{T}), r, x, y)
   return base_ring(x)(r)
 end
@@ -650,7 +650,7 @@ end
 function evaluate(x::fmpz_mod_poly, y::fmpz_mod)
   base_ring(x) != parent(y) && error("Elements must have same parent")
   z = fmpz()
-  ccall((:fmpz_mod_poly_evaluate_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_evaluate_fmpz, libflint), Nothing,
               (Ref{fmpz}, Ref{fmpz_mod_poly}, Ref{fmpz}), z, x, y.data)
   return parent(y)(z)
 end
@@ -663,7 +663,7 @@ end
 
 function derivative(x::T) where {T <: Zmodn_fmpz_poly}
   z = parent(x)()
-  ccall((:fmpz_mod_poly_derivative, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_derivative, libflint), Nothing,
         (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -693,7 +693,7 @@ end
 function compose(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   check_parent(x,y)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_compose, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_compose, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}),
                z, x, y)
   return z
@@ -713,7 +713,7 @@ end
 """
 function lift(R::FmpzPolyRing, y::fmpz_mod_poly)
    z = fmpz_poly()
-   ccall((:fmpz_mod_poly_get_fmpz_poly, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_get_fmpz_poly, libflint), Nothing,
           (Ref{fmpz_poly}, Ref{fmpz_mod_poly}), z, y)
    z.parent = R
   return z
@@ -731,7 +731,7 @@ end
 """
 function isirreducible(x::fmpz_mod_poly)
   !isprobable_prime(modulus(x)) && error("Modulus not prime in isirreducible")
-  return Bool(ccall((:fmpz_mod_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:fmpz_mod_poly_is_irreducible, libflint), Int32,
           (Ref{fmpz_mod_poly}, ), x))
 end
 
@@ -747,7 +747,7 @@ end
 """
 function issquarefree(x::fmpz_mod_poly)
    !isprobable_prime(modulus(x)) && error("Modulus not prime in issquarefree")
-   return Bool(ccall((:fmpz_mod_poly_is_squarefree, :libflint), Int32,
+   return Bool(ccall((:fmpz_mod_poly_is_squarefree, libflint), Int32,
       (Ref{fmpz_mod_poly}, ), x))
 end
 
@@ -769,12 +769,12 @@ end
 
 function _factor(x::fmpz_mod_poly)
   fac = fmpz_mod_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor, libflint), UInt,
           (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}), fac, x)
   res = Dict{fmpz_mod_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
@@ -794,12 +794,12 @@ end
 
 function _factor_squarefree(x::fmpz_mod_poly)
   fac = fmpz_mod_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor_squarefree, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor_squarefree, libflint), UInt,
           (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}), fac, x)
   res = Dict{fmpz_mod_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
@@ -817,13 +817,13 @@ function factor_distinct_deg(x::fmpz_mod_poly)
   degs = Vector{Int}(undef, degree(x))
   degss = [ pointer(degs) ]
   fac = fmpz_mod_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor_distinct_deg, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor_distinct_deg, libflint), UInt,
           (Ref{fmpz_mod_poly_factor}, Ref{fmpz_mod_poly}, Ptr{Ptr{Int}}),
           fac, x, degss)
   res = Dict{Int, fmpz_mod_poly}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{fmpz_mod_poly}, Ref{fmpz_mod_poly_factor}, Int), f, fac, i - 1)
     res[degs[i]] = f
   end
@@ -837,31 +837,31 @@ end
 ################################################################################
 
 function zero!(x::T) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_zero, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_zero, libflint), Nothing,
                    (Ref{T}, ), x)
   return x
 end
 
 function fit!(x::T, n::Int) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_fit_length, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_fit_length, libflint), Nothing,
                    (Ref{T}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(x::T, n::Int, y::UInt) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_set_coeff_ui, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_set_coeff_ui, libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::T, n::Int, y::Int) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_set_coeff_si, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_set_coeff_si, libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::T, n::Int, y::fmpz) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                    (Ref{T}, Int, Ref{fmpz}), x, n, y)
   return x
 end
@@ -871,25 +871,25 @@ setcoeff!(x::T, n::Int, y::Integer) where {T <: Zmodn_fmpz_poly} = setcoeff!(x, 
 setcoeff!(x::fmpz_mod_poly, n::Int, y::fmpz_mod) = setcoeff!(x, n, y.data)
 
 function add!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_add, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add, libflint), Nothing,
      (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
 
 function addeq!(z::T, y::T) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_add, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add, libflint), Nothing,
      (Ref{T}, Ref{T},  Ref{T}), z, z, y)
   return z
 end
 
 function sub!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub, libflint), Nothing,
      (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
 
 function mul!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
-  ccall((:fmpz_mod_poly_mul, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_mul, libflint), Nothing,
      (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -39,13 +39,13 @@ max_precision(R::FmpzModRelSeriesRing) = R.prec_max
 function normalise(a::fmpz_mod_rel_series, len::Int)
    if len > 0
       c = fmpz()
-      ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), c, a, len - 1)
       end
    end
@@ -53,7 +53,7 @@ function normalise(a::fmpz_mod_rel_series, len::Int)
 end
 
 function pol_length(x::fmpz_mod_rel_series)
-   return ccall((:fmpz_mod_poly_length, :libflint), Int, (Ref{fmpz_mod_rel_series},), x)
+   return ccall((:fmpz_mod_poly_length, libflint), Int, (Ref{fmpz_mod_rel_series},), x)
 end
 
 precision(x::fmpz_mod_rel_series) = x.prec
@@ -64,7 +64,7 @@ function polcoeff(x::fmpz_mod_rel_series, n::Int)
       return R(0)
    end
    z = fmpz()
-   ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, n)
    return R(z)
 end
@@ -102,7 +102,7 @@ function renormalize!(z::fmpz_mod_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:fmpz_mod_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int), z, z, i)
    end
    return nothing
@@ -131,7 +131,7 @@ show_minus_one(::Type{fmpz_mod_rel_series}) = show_minus_one(fmpz)
 
 function -(x::fmpz_mod_rel_series)
    z = parent(x)()
-   ccall((:fmpz_mod_poly_neg, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_neg, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}),
                z, x)
    z.prec = x.prec
@@ -156,29 +156,29 @@ function +(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -200,31 +200,31 @@ function -(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_mod_poly_neg, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_neg, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}), z, z)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpz_mod_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_mod_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -250,7 +250,7 @@ function *(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fmpz_mod_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, a, b, lenz)
    renormalize!(z)
@@ -267,7 +267,7 @@ function *(x::fmpz_mod, y::fmpz_mod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
                z, y, x.data)
    renormalize!(z)
@@ -281,7 +281,7 @@ function *(x::fmpz, y::fmpz_mod_rel_series)
    z.prec = y.prec
    z.val = y.val
    r = mod(x, modulus(y))
-   ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
                z, y, r)
    renormalize!(z)
@@ -322,7 +322,7 @@ function shift_right(x::fmpz_mod_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:fmpz_mod_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, x, xlen - zlen)
       renormalize!(z)
@@ -352,7 +352,7 @@ function truncate(x::fmpz_mod_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, x, min(prec - xval, xlen))
    end
@@ -387,7 +387,7 @@ function ^(a::fmpz_mod_rel_series, b::Int)
       z = parent(a)()
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
-      ccall((:fmpz_mod_poly_pow_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_pow_trunc, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int, Int),
                z, a, b, z.prec - z.val)
    end
@@ -415,7 +415,7 @@ function ==(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:fmpz_mod_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpz_mod_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                x, y, xlen))
 end
@@ -427,7 +427,7 @@ function isequal(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:fmpz_mod_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpz_mod_poly_equal, libflint), Cint,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                x, y, pol_length(x)))
 end
@@ -446,9 +446,9 @@ function ==(x::fmpz_mod_rel_series, y::fmpz_mod)
    elseif pol_length(x) == 1
       if x.val == 0
          z = fmpz()
-         ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, 0)
-         return ccall((:fmpz_equal, :libflint), Bool,
+         return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}), z, y.data)
       else
          return false
@@ -468,10 +468,10 @@ function ==(x::fmpz_mod_rel_series, y::fmpz)
    elseif pol_length(x) == 1
       if x.val == 0
          z = fmpz()
-         ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_mod_rel_series}, Int), z, x, 0)
          r = mod(y, modulus(x))
-         return ccall((:fmpz_equal, :libflint), Bool,
+         return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}, Int), z, r, 0)
       else
          return false
@@ -511,7 +511,7 @@ function divexact(x::fmpz_mod_rel_series, y::fmpz_mod_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:fmpz_mod_poly_div_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_div_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, x, y, prec)
    end
@@ -529,7 +529,7 @@ function divexact(x::fmpz_mod_rel_series, y::fmpz_mod)
    z = parent(x)()
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
                z, x, y.data)
    return z
@@ -542,7 +542,7 @@ function divexact(x::fmpz_mod_rel_series, y::fmpz)
    z.prec = x.prec
    z.val = x.val
    r = mod(y, modulus(x))
-   ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz}),
                z, x, r)
    return z
@@ -562,7 +562,7 @@ function inv(a::fmpz_mod_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:fmpz_mod_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_inv_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -600,7 +600,7 @@ function Base.exp(a::fmpz_mod_rel_series)
       d[k + 1] = divexact(base_ring(a)(s), k).data
    end
    z = parent(a)(d, preca, preca, 0)
-   ccall((:_fmpz_mod_poly_set_length, :libflint), Nothing,
+   ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
          (Ref{fmpz_mod_rel_series}, Int), z, normalise(z, preca))
    return z
 end
@@ -612,27 +612,27 @@ end
 ###############################################################################
 
 function zero!(x::fmpz_mod_rel_series)
-  ccall((:fmpz_mod_poly_zero, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_zero, libflint), Nothing,
                    (Ref{fmpz_mod_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(x::fmpz_mod_rel_series, n::Int)
-  ccall((:fmpz_mod_poly_fit_length, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_fit_length, libflint), Nothing,
                    (Ref{fmpz_mod_rel_series}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::fmpz)
-   ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}),
                z, n, x)
    return z
 end
 
 function setcoeff!(z::fmpz_mod_rel_series, n::Int, x::fmpz_mod)
-   ccall((:fmpz_mod_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Int, Ref{fmpz}),
                z, n, x.data)
    return z
@@ -652,7 +652,7 @@ function mul!(z::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:fmpz_mod_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                z, a, b, lenz)
    renormalize!(z)
@@ -670,29 +670,29 @@ function addeq!(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    if a.val < b.val
       z = fmpz_mod_rel_series(modulus)
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_mod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_mod_poly_truncate, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Int),
             a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_mod_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
             a, a, a.val - b.val)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                a, a, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                a, a, b, lenz)
    end
@@ -713,7 +713,7 @@ function add!(c::fmpz_mod_rel_series, a::fmpz_mod_rel_series, b::fmpz_mod_rel_se
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:fmpz_mod_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int),
                c, a, b, lenc)
    return c

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -27,7 +27,7 @@ function check_parent(a::fmpz_mpoly, b::fmpz_mpoly)
       error("Incompatible polynomial rings in polynomial operation")
 end
 
-nvars(a::FmpzMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, :libflint), Int,
+nvars(a::FmpzMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, libflint), Int,
                                 (Ref{FmpzMPolyRing}, ), a)
 
 base_ring(a::FmpzMPolyRing) = a.base_ring
@@ -35,7 +35,7 @@ base_ring(a::FmpzMPolyRing) = a.base_ring
 base_ring(f::fmpz_mpoly) = f.parent.base_ring
 
 function ordering(a::FmpzMPolyRing)
-   b = ccall((:fmpz_mpoly_ctx_ord, :libflint), Cint, (Ref{FmpzMPolyRing}, ), a)
+   b = ccall((:fmpz_mpoly_ctx_ord, libflint), Cint, (Ref{FmpzMPolyRing}, ), a)
    return flint_orderings[b + 1]
 end
 
@@ -43,7 +43,7 @@ function gens(R::FmpzMPolyRing)
    A = Vector{fmpz_mpoly}(undef, R.nvars)
    for i = 1:R.nvars
       z = R()
-      ccall((:fmpz_mpoly_gen, :libflint), Nothing,
+      ccall((:fmpz_mpoly_gen, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, i - 1, R)
       A[i] = z
    end
@@ -54,7 +54,7 @@ function gen(R::FmpzMPolyRing, i::Int)
    n = nvars(R)
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = R()
-   ccall((:fmpz_mpoly_gen, :libflint), Nothing,
+   ccall((:fmpz_mpoly_gen, libflint), Nothing,
          (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), z, i - 1, R)
    return z
 end
@@ -63,7 +63,7 @@ function isgen(a::fmpz_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    R = parent(a)
-   return Bool(ccall((:fmpz_mpoly_is_gen, :libflint), Cint,
+   return Bool(ccall((:fmpz_mpoly_is_gen, libflint), Cint,
                      (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
                      a, i - 1, a.parent))
 end
@@ -78,39 +78,39 @@ end
 
 function deepcopy_internal(a::fmpz_mpoly, dict::IdDict)
    z = parent(a)()
-   ccall((:fmpz_mpoly_set, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
          z, a, a.parent)
    return z
 end
 
 function length(a::fmpz_mpoly)
-   n = ccall((:fmpz_mpoly_length, :libflint), Int, (Ref{fmpz_mpoly}, ), a)
+   n = ccall((:fmpz_mpoly_length, libflint), Int, (Ref{fmpz_mpoly}, ), a)
    return n
 end
 
 function one(R::FmpzMPolyRing)
    z = R()
-   ccall((:fmpz_mpoly_one, :libflint), Nothing,
+   ccall((:fmpz_mpoly_one, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, R)
    return z
 end
 
 function zero(R::FmpzMPolyRing)
    z = R()
-   ccall((:fmpz_mpoly_zero, :libflint), Nothing,
+   ccall((:fmpz_mpoly_zero, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), z, R)
    return z
 end
 
 function isone(a::fmpz_mpoly)
-   b = ccall((:fmpz_mpoly_is_one, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_is_one, libflint), Cint,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return Bool(b)
 end
 
 function iszero(a::fmpz_mpoly)
-   b = ccall((:fmpz_mpoly_is_zero, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_is_zero, libflint), Cint,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -128,7 +128,7 @@ function isunit(a::fmpz_mpoly)
 end
 
 function isconstant(a::fmpz_mpoly)
-   b = ccall((:fmpz_mpoly_is_fmpz, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_is_fmpz, libflint), Cint,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, parent(a))
    return Bool(b)
 end
@@ -143,7 +143,7 @@ function coeff(a::fmpz_mpoly, i::Int)
    z = fmpz()
    n = length(a)
    (i < 1 || i > n) && error("Index must be between 1 and $(length(a))")
-   ccall((:fmpz_mpoly_get_term_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
          z, a, i - 1, a.parent)
    return z
@@ -153,7 +153,7 @@ function coeff(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    !isone(length(b)) && error("Second argument must be a monomial")
    z = fmpz()
-   ccall((:fmpz_mpoly_get_coeff_fmpz_monomial, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_coeff_fmpz_monomial, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -169,7 +169,7 @@ end
 function degree(a::fmpz_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
-   d = ccall((:fmpz_mpoly_degree_si, :libflint), Int,
+   d = ccall((:fmpz_mpoly_degree_si, libflint), Int,
              (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, i - 1, a.parent)
    return d
 end
@@ -179,7 +179,7 @@ function degree_fmpz(a::fmpz_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    d = fmpz()
-   ccall((:fmpz_mpoly_degree_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
          d, a, i - 1, a.parent)
    return d
@@ -187,7 +187,7 @@ end
 
 # Return true if degrees fit into an Int
 function degrees_fit_int(a::fmpz_mpoly)
-   b = ccall((:fmpz_mpoly_degrees_fit_si, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_degrees_fit_si, libflint), Cint,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -195,7 +195,7 @@ end
 # Return an array of the max degrees in each variable
 function degrees(a::fmpz_mpoly)
    degs = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:fmpz_mpoly_degrees_si, :libflint), Nothing,
+   ccall((:fmpz_mpoly_degrees_si, libflint), Nothing,
          (Ptr{Int}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -208,7 +208,7 @@ degs = Vector{fmpz}(undef, n)
    for i in 1:n
       degs[i] = fmpz()
    end
-   ccall((:fmpz_mpoly_degrees_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_degrees_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -216,14 +216,14 @@ end
 
 # Return true if degree fits into an Int
 function total_degree_fits_int(a::fmpz_mpoly)
-      b = ccall((:fmpz_mpoly_total_degree_fits_si, :libflint), Cint,
+      b = ccall((:fmpz_mpoly_total_degree_fits_si, libflint), Cint,
                 (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
       return Bool(b)
    end
 
 # Total degree as an Int
 function total_degree(a::fmpz_mpoly)
-   d = ccall((:fmpz_mpoly_total_degree_si, :libflint), Int,
+   d = ccall((:fmpz_mpoly_total_degree_si, libflint), Int,
              (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return d
 end
@@ -231,7 +231,7 @@ end
 # Total degree as an fmpz
 function total_degree_fmpz(a::fmpz_mpoly)
    d = fmpz()
-   ccall((:fmpz_mpoly_total_degree_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_total_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
             d, a, a.parent)
    return d
@@ -259,7 +259,7 @@ function coeff(a::fmpz_mpoly, vars::Vector{Int}, exps::Vector{Int})
          error("Exponent cannot be negative")
       end
    end
-   ccall((:fmpz_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_coeff_vars_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ptr{Int},
           Ptr{Int}, Int, Ref{FmpzMPolyRing}),
           z, a, vars, exps, length(vars), a.parent)
@@ -276,12 +276,12 @@ function show(io::IO, x::fmpz_mpoly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fmpz_mpoly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fmpz_mpoly_get_str_pretty, libflint), Ptr{UInt8},
           (Ref{fmpz_mpoly}, Ptr{Ptr{UInt8}}, Ref{FmpzMPolyRing}),
           x, [string(s) for s in symbols(parent(x))], x.parent)
       print(io, unsafe_string(cstr))
 
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -312,7 +312,7 @@ end
 
 function -(a::fmpz_mpoly)
    z = parent(a)()
-   ccall((:fmpz_mpoly_neg, :libflint), Nothing,
+   ccall((:fmpz_mpoly_neg, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        z, a, a.parent)
    return z
@@ -321,7 +321,7 @@ end
 function +(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpz_mpoly_add, :libflint), Nothing,
+   ccall((:fmpz_mpoly_add, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -330,7 +330,7 @@ end
 function -(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpz_mpoly_sub, :libflint), Nothing,
+   ccall((:fmpz_mpoly_sub, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -339,7 +339,7 @@ end
 function *(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:fmpz_mpoly_mul, :libflint), Nothing,
+   ccall((:fmpz_mpoly_mul, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -355,7 +355,7 @@ for (jT, cN, cT) in ((fmpz, :fmpz, Ref{fmpz}), (Int, :si, Int))
    @eval begin
       function +(a::fmpz_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpz_mpoly_add_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpz_mpoly_add_, cN)), libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, ($cT), Ref{FmpzMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -365,7 +365,7 @@ for (jT, cN, cT) in ((fmpz, :fmpz, Ref{fmpz}), (Int, :si, Int))
 
       function -(a::fmpz_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpz_mpoly_sub_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpz_mpoly_sub_, cN)), libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, ($cT), Ref{FmpzMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -375,7 +375,7 @@ for (jT, cN, cT) in ((fmpz, :fmpz, Ref{fmpz}), (Int, :si, Int))
 
       function *(a::fmpz_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:fmpz_mpoly_scalar_mul_, cN)), :libflint), Nothing,
+         ccall(($(string(:fmpz_mpoly_scalar_mul_, cN)), libflint), Nothing,
                (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, ($cT), Ref{FmpzMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -387,12 +387,12 @@ for (jT, cN, cT) in ((fmpz, :fmpz, Ref{fmpz}), (Int, :si, Int))
          z = parent(a)()
          checked = true
          if checked
-            divides = Bool(ccall(($(string(:fmpz_mpoly_scalar_divides_, cN)), :libflint), Cint,
+            divides = Bool(ccall(($(string(:fmpz_mpoly_scalar_divides_, cN)), libflint), Cint,
                                  (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, ($cT), Ref{FmpzMPolyRing}),
                                  z, a, b, parent(a)))
             divides || error("Division is not exact in divexact")
          else
-            ccall(($(string(:fmpz_mpoly_scalar_divexact_, cN)), :libflint), Nothing,
+            ccall(($(string(:fmpz_mpoly_scalar_divexact_, cN)), libflint), Nothing,
                   (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, ($cT), Ref{FmpzMPolyRing}),
                   z, a, b, parent(a))
          end
@@ -424,7 +424,7 @@ divexact(a::fmpz_mpoly, b::Integer) = divexact(a, fmpz(b))
 function ^(a::fmpz_mpoly, b::Int)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:fmpz_mpoly_pow_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_pow_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -433,7 +433,7 @@ end
 function ^(a::fmpz_mpoly, b::fmpz)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:fmpz_mpoly_pow_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_pow_fmpz, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -448,7 +448,7 @@ end
 function gcd(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   r = Bool(ccall((:fmpz_mpoly_gcd, :libflint), Cint,
+   r = Bool(ccall((:fmpz_mpoly_gcd, libflint), Cint,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
          z, a, b, a.parent))
    r == false && error("Unable to compute gcd")
@@ -463,14 +463,14 @@ end
 
 function ==(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
-   return Bool(ccall((:fmpz_mpoly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpz_mpoly_equal, libflint), Cint,
                (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
                a, b, a.parent))
 end
 
 function Base.isless(a::fmpz_mpoly, b::fmpz_mpoly)
    (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
-   return ccall((:fmpz_mpoly_cmp, :libflint), Cint,
+   return ccall((:fmpz_mpoly_cmp, libflint), Cint,
                (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
                a, b, a.parent) < 0
 end
@@ -482,7 +482,7 @@ end
 ###############################################################################
 
 function ==(a::fmpz_mpoly, b::fmpz)
-   return Bool(ccall((:fmpz_mpoly_equal_fmpz, :libflint), Cint,
+   return Bool(ccall((:fmpz_mpoly_equal_fmpz, libflint), Cint,
                      (Ref{fmpz_mpoly}, Ref{fmpz}, Ref{FmpzMPolyRing}),
                      a, b, a.parent))
 end
@@ -490,7 +490,7 @@ end
 ==(a::fmpz, b::fmpz_mpoly) = b == a
 
 function ==(a::fmpz_mpoly, b::Int)
-   return Bool(ccall((:fmpz_mpoly_equal_si, :libflint), Cint,
+   return Bool(ccall((:fmpz_mpoly_equal_si, libflint), Cint,
                (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
                a, b, a.parent))
 end
@@ -516,7 +516,7 @@ function divides(a::fmpz_mpoly, b::fmpz_mpoly)
       return false, zero(parent(a))
    end
    z = parent(a)()
-   d = ccall((:fmpz_mpoly_divides, :libflint), Cint,
+   d = ccall((:fmpz_mpoly_divides, libflint), Cint,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        z, a, b, a.parent)
    return isone(d), z
@@ -531,7 +531,7 @@ end
 function div(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    q = parent(a)()
-   ccall((:fmpz_mpoly_div, :libflint), Nothing,
+   ccall((:fmpz_mpoly_div, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
         Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        q, a, b, a.parent)
@@ -542,7 +542,7 @@ function divrem(a::fmpz_mpoly, b::fmpz_mpoly)
    check_parent(a, b)
    q = parent(a)()
    r = parent(a)()
-   ccall((:fmpz_mpoly_divrem, :libflint), Nothing,
+   ccall((:fmpz_mpoly_divrem, libflint), Nothing,
        (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
         Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),
        q, r, a, b, a.parent)
@@ -553,7 +553,7 @@ function divrem(a::fmpz_mpoly, b::Array{fmpz_mpoly, 1})
    len = length(b)
    q = [parent(a)() for i in 1:len]
    r = parent(a)()
-   ccall((:fmpz_mpoly_divrem_ideal, :libflint), Nothing,
+   ccall((:fmpz_mpoly_divrem_ideal, libflint), Nothing,
          (Ptr{Ref{fmpz_mpoly}}, Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
           Ptr{Ref{fmpz_mpoly}}, Int, Ref{FmpzMPolyRing}),
        q, r, a, b, len, a.parent)
@@ -583,7 +583,7 @@ function derivative(a::fmpz_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = parent(a)()
-   ccall((:fmpz_mpoly_derivative, :libflint), Nothing,
+   ccall((:fmpz_mpoly_derivative, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -598,7 +598,7 @@ end
 function evaluate(a::fmpz_mpoly, b::Vector{fmpz})
    length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
    z = fmpz()
-   GC.@preserve b ccall((:fmpz_mpoly_evaluate_all_fmpz, :libflint), Nothing,
+   GC.@preserve b ccall((:fmpz_mpoly_evaluate_all_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Ptr{fmpz}, Ref{FmpzMPolyRing}),
             z, a, b, parent(a))
    return z
@@ -666,27 +666,27 @@ end
 ###############################################################################
 
 function zero!(a::fmpz_mpoly)
-    ccall((:fmpz_mpoly_zero, :libflint), Nothing,
+    ccall((:fmpz_mpoly_zero, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
     return a
 end
 
 function add!(a::fmpz_mpoly, b::fmpz_mpoly, c::fmpz_mpoly)
-   ccall((:fmpz_mpoly_add, :libflint), Nothing,
+   ccall((:fmpz_mpoly_add, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
           Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, b, c, a.parent)
    return a
 end
 
 function addeq!(a::fmpz_mpoly, b::fmpz_mpoly)
-   ccall((:fmpz_mpoly_add, :libflint), Nothing,
+   ccall((:fmpz_mpoly_add, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
           Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a, b, a.parent)
    return a
 end
 
 function mul!(a::fmpz_mpoly, b::fmpz_mpoly, c::fmpz_mpoly)
-   ccall((:fmpz_mpoly_mul, :libflint), Nothing,
+   ccall((:fmpz_mpoly_mul, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly},
           Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, b, c, a.parent)
    return a
@@ -696,10 +696,10 @@ end
 # must be removed with combine_like_terms!
 function setcoeff!(a::fmpz_mpoly, n::Int, c::fmpz)
    if n > length(a)
-      ccall((:fmpz_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpz_mpoly_resize, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpz_mpoly_set_term_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set_term_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz_mpoly}, Int, Ref{fmpz}, Ref{FmpzMPolyRing}),
          a, n - 1, c, a.parent)
    return a
@@ -712,7 +712,7 @@ setcoeff!(a::fmpz_mpoly, i::Int, c::Integer) = setcoeff!(a, i, fmpz(c))
 # Remove zero terms and combine adjacent terms if they have the same monomial
 # no sorting is performed
 function combine_like_terms!(a::fmpz_mpoly)
-   ccall((:fmpz_mpoly_combine_like_terms, :libflint), Nothing,
+   ccall((:fmpz_mpoly_combine_like_terms, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return a
 end
@@ -725,14 +725,14 @@ end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_ui(a::fmpz_mpoly, i::Int)
-   b = ccall((:fmpz_mpoly_term_exp_fits_ui, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_term_exp_fits_ui, libflint), Cint,
              (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, i - 1, a.parent)
       return Bool(b)
 end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_int(a::fmpz_mpoly, i::Int)
-   b = ccall((:fmpz_mpoly_term_exp_fits_si, :libflint), Cint,
+   b = ccall((:fmpz_mpoly_term_exp_fits_si, libflint), Cint,
              (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, i - 1, a.parent)
    return Bool(b)
 end
@@ -740,7 +740,7 @@ end
 # Return Julia array of UInt's corresponding to exponent vector of i-th term
 function exponent_vector_ui(a::fmpz_mpoly, i::Int)
    z = Vector{UInt}(undef, nvars(parent(a)))
-   ccall((:fmpz_mpoly_get_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_exp_ui, libflint), Nothing,
          (Ptr{UInt}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -751,7 +751,7 @@ function exponent_vector(a::fmpz_mpoly, i::Int)
    exponent_vector_fits_int(a, i) ||
       throw(DomainError(term(a, i), "exponents don't fit in `Int` (try exponent_vector_fmpz)"))
    z = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:fmpz_mpoly_get_term_exp_si, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_exp_si, libflint), Nothing,
          (Ptr{Int}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -764,7 +764,7 @@ function exponent_vector_fmpz(a::fmpz_mpoly, i::Int)
    for j in 1:n
       z[j] = fmpz()
    end
-   ccall((:fmpz_mpoly_get_term_exp_fmpz, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_exp_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -780,10 +780,10 @@ end
 # they don't fit into 31/63 bits
 function set_exponent_vector!(a::fmpz_mpoly, n::Int, exps::Vector{UInt})
    if n > length(a)
-      ccall((:fmpz_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpz_mpoly_resize, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpz_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Int, Ptr{UInt}, Ref{FmpzMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -794,10 +794,10 @@ end
 # no check is performed
 function set_exponent_vector!(a::fmpz_mpoly, n::Int, exps::Vector{Int})
    if n > length(a)
-      ccall((:fmpz_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpz_mpoly_resize, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, n, a.parent)
    end
-   ccall((:fmpz_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Int, Ptr{Int}, Ref{FmpzMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -807,11 +807,11 @@ end
 # No sort is performed, so this is unsafe
 function set_exponent_vector!(a::fmpz_mpoly, n::Int, exps::Vector{fmpz})
    if n > length(a)
-      ccall((:fmpz_mpoly_resize, :libflint), Nothing,
+      ccall((:fmpz_mpoly_resize, libflint), Nothing,
             (Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}), a, n, a.parent)
       return a
    end
-   @GC.preserve exps ccall((:fmpz_mpoly_set_term_exp_fmpz, :libflint), Nothing,
+   @GC.preserve exps ccall((:fmpz_mpoly_set_term_exp_fmpz, libflint), Nothing,
          (Ref{fmpz_mpoly}, Int, Ptr{fmpz}, Ref{FmpzMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -820,7 +820,7 @@ end
 # Return j-th coordinate of i-th exponent vector
 function exponent(a::fmpz_mpoly, i::Int, j::Int)
    (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
-   return ccall((:fmpz_mpoly_get_term_var_exp_ui, :libflint), Int,
+   return ccall((:fmpz_mpoly_get_term_var_exp_ui, libflint), Int,
                 (Ref{fmpz_mpoly}, Int, Int, Ref{FmpzMPolyRing}),
                  a, i - 1, j - 1, a.parent)
 end
@@ -829,7 +829,7 @@ end
 # Return zero if there is no such term
 function coeff(a::fmpz_mpoly, exps::Vector{UInt})
    z = fmpz()
-   ccall((:fmpz_mpoly_get_coeff_fmpz_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_coeff_fmpz_ui, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Ptr{UInt}, Ref{FmpzMPolyRing}),
       z, a, exps, parent(a))
    return z
@@ -839,7 +839,7 @@ end
 # Return zero if there is no such term
 function coeff(a::fmpz_mpoly, exps::Vector{Int})
    z = fmpz()
-   ccall((:fmpz_mpoly_get_coeff_fmpz_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_coeff_fmpz_ui, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_mpoly}, Ptr{Int}, Ref{FmpzMPolyRing}),
       z, a, exps, parent(a))
    return z
@@ -848,7 +848,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpz. Removal of a zero term is performed.
 function setcoeff!(a::fmpz_mpoly, exps::Vector{UInt}, b::fmpz)
-   ccall((:fmpz_mpoly_set_coeff_fmpz_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set_coeff_fmpz_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{UInt}, Ref{FmpzMPolyRing}),
       a, b, exps, parent(a))
    return a
@@ -857,7 +857,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpz. Removal of a zero term is performed.
 function setcoeff!(a::fmpz_mpoly, exps::Vector{Int}, b::fmpz)
-   ccall((:fmpz_mpoly_set_coeff_fmpz_ui, :libflint), Nothing,
+   ccall((:fmpz_mpoly_set_coeff_fmpz_ui, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz}, Ptr{Int}, Ref{FmpzMPolyRing}),
       a, b, exps, parent(a))
    return a
@@ -872,7 +872,7 @@ setcoeff!(a::fmpz_mpoly, exps::Vector{Int}, b::Integer) =
 # out of order. Note that like terms are not combined and zeros are not
 # removed. For that, call combine_like_terms!
 function sort_terms!(a::fmpz_mpoly)
-   ccall((:fmpz_mpoly_sort_terms, :libflint), Nothing,
+   ccall((:fmpz_mpoly_sort_terms, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}), a, a.parent)
    return a
 end
@@ -880,7 +880,7 @@ end
 # Return the i-th term of the polynomial, as a polynomial
 function term(a::fmpz_mpoly, i::Int)
    z = parent(a)()
-   ccall((:fmpz_mpoly_get_term, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -889,7 +889,7 @@ end
 # Return the i-th monomial of the polynomial, as a polynomial
 function monomial(a::fmpz_mpoly, i::Int)
    z = parent(a)()
-   ccall((:fmpz_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -897,7 +897,7 @@ end
 
 # Sets the given polynomial m to the i-th monomial of the polynomial
 function monomial!(m::fmpz_mpoly, a::fmpz_mpoly, i::Int)
-   ccall((:fmpz_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:fmpz_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Int, Ref{FmpzMPolyRing}),
           m, a, i - 1, a.parent)
    return m

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -29,13 +29,13 @@ var(a::FmpzPolyRing) = a.S
 #
 ###############################################################################
 
-length(x::fmpz_poly) = ccall((:fmpz_poly_length, :libflint), Int,
+length(x::fmpz_poly) = ccall((:fmpz_poly_length, libflint), Int,
                              (Ref{fmpz_poly},), x)
 
 function coeff(x::fmpz_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = fmpz()
-   ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
                (Ref{fmpz}, Ref{fmpz_poly}, Int), z, x, n)
    return z
 end
@@ -46,7 +46,7 @@ one(a::FmpzPolyRing) = a(1)
 
 gen(a::FmpzPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
-isgen(x::fmpz_poly) = ccall((:fmpz_poly_is_x, :libflint), Bool,
+isgen(x::fmpz_poly) = ccall((:fmpz_poly_is_x, libflint), Bool,
                             (Ref{fmpz_poly},), x)
 
 function deepcopy_internal(a::fmpz_poly, dict::IdDict)
@@ -75,12 +75,12 @@ function show(io::IO, x::fmpz_poly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fmpz_poly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fmpz_poly_get_str_pretty, libflint), Ptr{UInt8},
           (Ref{fmpz_poly}, Ptr{UInt8}), x, string(var(parent(x))))
 
       print(io, unsafe_string(cstr))
 
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -101,7 +101,7 @@ show_minus_one(::Type{fmpz_poly}) = show_minus_one(fmpz)
 
 function -(x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_neg, :libflint), Nothing,
+   ccall((:fmpz_poly_neg, libflint), Nothing,
          (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
@@ -115,7 +115,7 @@ end
 function +(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpz_poly_add, :libflint), Nothing,
+   ccall((:fmpz_poly_add, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}),
                z, x, y)
    return z
@@ -124,7 +124,7 @@ end
 function -(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpz_poly_sub, :libflint), Nothing,
+   ccall((:fmpz_poly_sub, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}),
                z, x, y)
    return z
@@ -133,7 +133,7 @@ end
 function *(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpz_poly_mul, :libflint), Nothing,
+   ccall((:fmpz_poly_mul, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly},  Ref{fmpz_poly}),
                z, x, y)
    return z
@@ -147,56 +147,56 @@ end
 
 function *(x::Int, y::fmpz_poly)
    z = parent(y)()
-   ccall((:fmpz_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, y, x)
    return z
 end
 
 function *(x::fmpz, y::fmpz_poly)
    z = parent(y)()
-   ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, y, x)
    return z
 end
 
 function +(x::fmpz_poly, y::Int)
    z = parent(x)()
-   ccall((:fmpz_poly_add_si, :libflint), Nothing,
+   ccall((:fmpz_poly_add_si, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
 
 function +(x::fmpz_poly, y::fmpz)
    z = parent(x)()
-   ccall((:fmpz_poly_add_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_add_fmpz, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::fmpz_poly, y::Int)
    z = parent(x)()
-   ccall((:fmpz_poly_sub_si, :libflint), Nothing,
+   ccall((:fmpz_poly_sub_si, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
 
 function -(x::fmpz_poly, y::fmpz)
    z = parent(x)()
-   ccall((:fmpz_poly_sub_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_sub_fmpz, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
 
 function -(x::Int, y::fmpz_poly)
    z = parent(y)()
-   ccall((:fmpz_poly_si_sub, :libflint), Nothing,
+   ccall((:fmpz_poly_si_sub, libflint), Nothing,
                 (Ref{fmpz_poly}, Int, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function -(x::fmpz, y::fmpz_poly)
    z = parent(y)()
-   ccall((:fmpz_poly_fmpz_sub, :libflint), Nothing,
+   ccall((:fmpz_poly_fmpz_sub, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz}, Ref{fmpz_poly}), z, x, y)
    return z
 end
@@ -230,7 +230,7 @@ end
 function ^(x::fmpz_poly, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = parent(x)()
-   ccall((:fmpz_poly_pow, :libflint), Nothing,
+   ccall((:fmpz_poly_pow, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int),
                z, x, y)
    return z
@@ -244,7 +244,7 @@ end
 
 function ==(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
-   return ccall((:fmpz_poly_equal, :libflint), Bool,
+   return ccall((:fmpz_poly_equal, libflint), Bool,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}), x, y)
 end
 
@@ -259,9 +259,9 @@ function ==(x::fmpz_poly, y::fmpz)
       return false
    elseif length(x) == 1
       z = fmpz()
-      ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_poly}, Int), z, x, 0)
-      return ccall((:fmpz_equal, :libflint), Bool,
+      return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
    else
       return iszero(y)
@@ -288,7 +288,7 @@ function truncate(a::fmpz_poly, n::Int)
    end
 
    z = parent(a)()
-   ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+   ccall((:fmpz_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, a, n)
    return z
 end
@@ -298,7 +298,7 @@ function mullow(x::fmpz_poly, y::fmpz_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
 
    z = parent(x)()
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
          (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y, n)
    return z
 end
@@ -312,7 +312,7 @@ end
 function reverse(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError(len, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:fmpz_poly_reverse, :libflint), Nothing,
+   ccall((:fmpz_poly_reverse, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
@@ -326,7 +326,7 @@ end
 function shift_left(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+   ccall((:fmpz_poly_shift_left, libflint), Nothing,
       (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
@@ -334,7 +334,7 @@ end
 function shift_right(x::fmpz_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fmpz_poly_shift_right, :libflint), Nothing,
+   ccall((:fmpz_poly_shift_right, libflint), Nothing,
        (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, len)
    return z
 end
@@ -349,7 +349,7 @@ function divexact(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpz_poly_div, :libflint), Nothing,
+   ccall((:fmpz_poly_div, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
@@ -359,7 +359,7 @@ function divrem(x::fmpz_poly, y::fmpz_poly)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    r = parent(x)()
-   ccall((:fmpz_poly_divrem, :libflint), Nothing,
+   ccall((:fmpz_poly_divrem, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, r, x, y)
    return z, r
 end
@@ -368,7 +368,7 @@ function divides(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   flag = Bool(ccall((:fmpz_poly_divides, :libflint), Cint,
+   flag = Bool(ccall((:fmpz_poly_divides, libflint), Cint,
            (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y))
    return flag, z
 end
@@ -382,7 +382,7 @@ end
 function divexact(x::fmpz_poly, y::fmpz)
    iszero(y) && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_fmpz, libflint), Nothing,
           (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -390,7 +390,7 @@ end
 function divexact(x::fmpz_poly, y::Int)
    y == 0 && throw(DivideError())
    z = parent(x)()
-   ccall((:fmpz_poly_scalar_divexact_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_si, libflint), Nothing,
                         (Ref{fmpz_poly}, Ref{fmpz_poly}, Int), z, x, y)
    return z
 end
@@ -409,7 +409,7 @@ function pseudorem(x::fmpz_poly, y::fmpz_poly)
    diff = length(x) - length(y) + 1
    r = parent(x)()
    d = Vector{Int}(undef, 1)
-   ccall((:fmpz_poly_pseudo_rem, :libflint), Nothing,
+   ccall((:fmpz_poly_pseudo_rem, libflint), Nothing,
      (Ref{fmpz_poly}, Ptr{Int}, Ref{fmpz_poly}, Ref{fmpz_poly}), r, d, x, y)
    if (diff > d[1])
       return lead(y)^(diff - d[1])*r
@@ -425,7 +425,7 @@ function pseudodivrem(x::fmpz_poly, y::fmpz_poly)
    q = parent(x)()
    r = parent(x)()
    d = Vector{Int}(undef, 1)
-   ccall((:fmpz_poly_pseudo_divrem_divconquer, :libflint), Nothing,
+   ccall((:fmpz_poly_pseudo_divrem_divconquer, libflint), Nothing,
     (Ref{fmpz_poly}, Ref{fmpz_poly}, Ptr{Int}, Ref{fmpz_poly}, Ref{fmpz_poly}),
                q, r, d, x, y)
    if (diff > d[1])
@@ -445,21 +445,21 @@ end
 function gcd(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpz_poly_gcd, :libflint), Nothing,
+   ccall((:fmpz_poly_gcd, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function content(x::fmpz_poly)
    z = fmpz()
-   ccall((:fmpz_poly_content, :libflint), Nothing,
+   ccall((:fmpz_poly_content, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_poly}), z, x)
    return z
 end
 
 function primpart(x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_primitive_part, :libflint), Nothing,
+   ccall((:fmpz_poly_primitive_part, libflint), Nothing,
          (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
@@ -472,7 +472,7 @@ end
 
 function Base.sqrt(x::fmpz_poly)
     z = parent(x)()
-    flag = Bool(ccall((:fmpz_poly_sqrt, :libflint), Cint,
+    flag = Bool(ccall((:fmpz_poly_sqrt, libflint), Cint,
           (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x))
     flag == false && error("Not a square in sqrt")
     return z
@@ -486,7 +486,7 @@ function Base.sqrt(x::fmpz_poly)
 
 function evaluate(x::fmpz_poly, y::fmpz)
    z = fmpz()
-   ccall((:fmpz_poly_evaluate_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_evaluate_fmpz, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz}), z, x, y)
    return z
 end
@@ -502,7 +502,7 @@ evaluate(x::fmpz_poly, y::Integer) = evaluate(x, fmpz(y))
 function compose(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = parent(x)()
-   ccall((:fmpz_poly_compose, :libflint), Nothing,
+   ccall((:fmpz_poly_compose, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
@@ -515,7 +515,7 @@ end
 
 function derivative(x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_derivative, :libflint), Nothing,
+   ccall((:fmpz_poly_derivative, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x)
    return z
 end
@@ -529,7 +529,7 @@ end
 function resultant(x::fmpz_poly, y::fmpz_poly)
    check_parent(x, y)
    z = fmpz()
-   ccall((:fmpz_poly_resultant, :libflint), Nothing,
+   ccall((:fmpz_poly_resultant, libflint), Nothing,
                 (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
@@ -542,7 +542,7 @@ end
 
 function discriminant(x::fmpz_poly)
    z = fmpz()
-   ccall((:fmpz_poly_discriminant, :libflint), Nothing,
+   ccall((:fmpz_poly_discriminant, libflint), Nothing,
                 (Ref{fmpz}, Ref{fmpz_poly}), z, x)
    return z
 end
@@ -568,7 +568,7 @@ function resx(a::fmpz_poly, b::fmpz_poly)
    c2 = content(b)
    x = divexact(a, c1)
    y = divexact(b, c2)
-   ccall((:fmpz_poly_xgcd_modular, :libflint), Nothing,
+   ccall((:fmpz_poly_xgcd_modular, libflint), Nothing,
    (Ref{fmpz}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}),
             z, u, v, x, y)
    r = z*c1^(lenb - 1)*c2^(lena - 1)
@@ -602,7 +602,7 @@ end
 function signature(f::fmpz_poly)
    r = Vector{Int}(undef, 1)
    s = Vector{Int}(undef, 1)
-   ccall((:fmpz_poly_signature, :libflint), Nothing,
+   ccall((:fmpz_poly_signature, libflint), Nothing,
          (Ptr{Int}, Ptr{Int}, Ref{fmpz_poly}), r, s, f)
    return (r[1], s[1])
 end
@@ -627,7 +627,7 @@ function interpolate(R::FmpzPolyRing, x::Array{fmpz, 1},
     ay[i] = y[i].d
   end
 
-  ccall((:fmpz_poly_interpolate_fmpz_vec, :libflint), Nothing,
+  ccall((:fmpz_poly_interpolate_fmpz_vec, libflint), Nothing,
           (Ref{fmpz_poly}, Ptr{Int}, Ptr{Int}, Int),
           z, ax, ay, length(x))
   return z
@@ -656,15 +656,15 @@ end
 
 function _factor(x::fmpz_poly)
   fac = fmpz_poly_factor()
-  ccall((:fmpz_poly_factor, :libflint), Nothing,
+  ccall((:fmpz_poly_factor, libflint), Nothing,
               (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, x)
   res = Dict{fmpz_poly,Int}()
   z = fmpz()
-  ccall((:fmpz_poly_factor_get_fmpz, :libflint), Nothing,
+  ccall((:fmpz_poly_factor_get_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_poly_factor_get_fmpz_poly, :libflint), Nothing,
+    ccall((:fmpz_poly_factor_get_fmpz_poly, libflint), Nothing,
             (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
@@ -696,14 +696,14 @@ end
 
 function chebyshev_t(n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_chebyshev_t, :libflint), Nothing,
+   ccall((:fmpz_poly_chebyshev_t, libflint), Nothing,
                                                   (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
 
 function chebyshev_u(n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_chebyshev_u, :libflint), Nothing,
+   ccall((:fmpz_poly_chebyshev_u, libflint), Nothing,
                                                   (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -716,7 +716,7 @@ end
 """
 function cyclotomic(n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_cyclotomic, :libflint), Nothing,
+   ccall((:fmpz_poly_cyclotomic, libflint), Nothing,
                                                   (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -732,7 +732,7 @@ end
 """
 function swinnerton_dyer(n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_swinnerton_dyer, :libflint), Nothing,
+   ccall((:fmpz_poly_swinnerton_dyer, libflint), Nothing,
                                                   (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -745,7 +745,7 @@ end
 """
 function cos_minpoly(n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_cos_minpoly, :libflint), Nothing,
+   ccall((:fmpz_poly_cos_minpoly, libflint), Nothing,
                                                   (Ref{fmpz_poly}, Int), z, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -758,7 +758,7 @@ end
 """
 function theta_qexp(e::Int, n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_theta_qexp, :libflint), Nothing,
+   ccall((:fmpz_poly_theta_qexp, libflint), Nothing,
                                           (Ref{fmpz_poly}, Int, Int), z, e, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -775,7 +775,7 @@ end
 """
 function eta_qexp(e::Int, n::Int, x::fmpz_poly)
    z = parent(x)()
-   ccall((:fmpz_poly_eta_qexp, :libflint), Nothing,
+   ccall((:fmpz_poly_eta_qexp, libflint), Nothing,
                                           (Ref{fmpz_poly}, Int, Int), z, e, n)
    return isgen(x) ? z : compose(z, x)
 end
@@ -802,37 +802,37 @@ end
 ###############################################################################
 
 function zero!(z::fmpz_poly)
-   ccall((:fmpz_poly_zero, :libflint), Nothing,
+   ccall((:fmpz_poly_zero, libflint), Nothing,
                     (Ref{fmpz_poly},), z)
    return z
 end
 
 function fit!(z::fmpz_poly, n::Int)
-   ccall((:fmpz_poly_fit_length, :libflint), Nothing,
+   ccall((:fmpz_poly_fit_length, libflint), Nothing,
                     (Ref{fmpz_poly}, Int), z, n)
    return nothing
 end
 
 function setcoeff!(z::fmpz_poly, n::Int, x::fmpz)
-   ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                     (Ref{fmpz_poly}, Int, Ref{fmpz}), z, n, x)
    return z
 end
 
 function mul!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
-   ccall((:fmpz_poly_mul, :libflint), Nothing,
+   ccall((:fmpz_poly_mul, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end
 
 function addeq!(z::fmpz_poly, x::fmpz_poly)
-   ccall((:fmpz_poly_add, :libflint), Nothing,
+   ccall((:fmpz_poly_add, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, z, x)
    return z
 end
 
 function add!(z::fmpz_poly, x::fmpz_poly, y::fmpz_poly)
-   ccall((:fmpz_poly_add, :libflint), Nothing,
+   ccall((:fmpz_poly_add, libflint), Nothing,
                 (Ref{fmpz_poly}, Ref{fmpz_poly}, Ref{fmpz_poly}), z, x, y)
    return z
 end

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -39,13 +39,13 @@ max_precision(R::FmpzRelSeriesRing) = R.prec_max
 function normalise(a::fmpz_rel_series, len::Int)
    if len > 0
       c = fmpz()
-      ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+      ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_rel_series}, Int), c, a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{fmpz}, Ref{fmpz_rel_series}, Int), c, a, len - 1)
       end
    end
@@ -53,7 +53,7 @@ function normalise(a::fmpz_rel_series, len::Int)
 end
 
 function pol_length(x::fmpz_rel_series)
-   return ccall((:fmpz_poly_length, :libflint), Int, (Ref{fmpz_rel_series},), x)
+   return ccall((:fmpz_poly_length, libflint), Int, (Ref{fmpz_rel_series},), x)
 end
 
 precision(x::fmpz_rel_series) = x.prec
@@ -63,7 +63,7 @@ function polcoeff(x::fmpz_rel_series, n::Int)
       return fmpz(0)
    end
    z = fmpz()
-   ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz_rel_series}, Int), z, x, n)
    return z
 end
@@ -99,7 +99,7 @@ function renormalize!(z::fmpz_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:fmpz_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_right, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int), z, z, i)
    end
    return nothing
@@ -128,7 +128,7 @@ show_minus_one(::Type{fmpz_rel_series}) = show_minus_one(fmpz)
 
 function -(x::fmpz_rel_series)
    z = parent(x)()
-   ccall((:fmpz_poly_neg, :libflint), Nothing,
+   ccall((:fmpz_poly_neg, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}),
                z, x)
    z.prec = x.prec
@@ -153,29 +153,29 @@ function +(a::fmpz_rel_series, b::fmpz_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -197,31 +197,31 @@ function -(a::fmpz_rel_series, b::fmpz_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_poly_neg, :libflint), Nothing,
+      ccall((:fmpz_poly_neg, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}), z, z)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:fmpz_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpz_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_poly_sub_series, :libflint), Nothing,
+      ccall((:fmpz_poly_sub_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -247,7 +247,7 @@ function *(a::fmpz_rel_series, b::fmpz_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, a, b, lenz)
 
@@ -264,7 +264,7 @@ function *(x::Int, y::fmpz_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpz_poly_scalar_mul_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_si, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, y, x)
    return z
@@ -276,7 +276,7 @@ function *(x::fmpz, y::fmpz_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fmpz_poly_scalar_mul_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_mul_fmpz, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz}),
                z, y, x)
    return z
@@ -316,7 +316,7 @@ function shift_right(x::fmpz_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:fmpz_poly_shift_right, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_right, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, x, xlen - zlen)
       renormalize!(z)
@@ -346,7 +346,7 @@ function truncate(x::fmpz_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, x, min(prec - xval, xlen))
    end
@@ -379,7 +379,7 @@ function ^(a::fmpz_rel_series, b::Int)
       z = parent(a)()
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
-      ccall((:fmpz_poly_pow_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_pow_trunc, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int, Int),
                z, a, b, z.prec - z.val)
    end
@@ -406,7 +406,7 @@ function ==(x::fmpz_rel_series, y::fmpz_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:fmpz_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fmpz_poly_equal_trunc, libflint), Cint,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                x, y, xlen))
 end
@@ -418,7 +418,7 @@ function isequal(x::fmpz_rel_series, y::fmpz_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:fmpz_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fmpz_poly_equal, libflint), Cint,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                x, y, pol_length(x)))
 end
@@ -437,9 +437,9 @@ function ==(x::fmpz_rel_series, y::fmpz)
    elseif pol_length(x) == 1
       if x.val == 0
          z = fmpz()
-         ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+         ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
                        (Ref{fmpz}, Ref{fmpz_rel_series}, Int), z, x, 0)
-         return ccall((:fmpz_equal, :libflint), Bool,
+         return ccall((:fmpz_equal, libflint), Bool,
                (Ref{fmpz}, Ref{fmpz}, Int), z, y, 0)
       else
          return false
@@ -479,7 +479,7 @@ function divexact(x::fmpz_rel_series, y::fmpz_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:fmpz_poly_div_series, :libflint), Nothing,
+      ccall((:fmpz_poly_div_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, x, y, prec)
    end
@@ -497,7 +497,7 @@ function divexact(x::fmpz_rel_series, y::Int)
    z = parent(x)()
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpz_poly_scalar_divexact_si, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_si, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, x, y)
    return z
@@ -509,7 +509,7 @@ function divexact(x::fmpz_rel_series, y::fmpz)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   ccall((:fmpz_poly_scalar_divexact_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_scalar_divexact_fmpz, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz}),
                z, x, y)
    return z
@@ -529,7 +529,7 @@ function inv(a::fmpz_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:fmpz_poly_inv_series, :libflint), Nothing,
+   ccall((:fmpz_poly_inv_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -546,7 +546,7 @@ function Base.sqrt(a::fmpz_rel_series)
     val = div(valuation(a), 2)
     asqrt.prec = a.prec - val
     asqrt.val = val
-    flag = Bool(ccall((:fmpz_poly_sqrt_series, :libflint), Cint,
+    flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
           (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                 asqrt, a, a.prec - 2*val))
     flag == false && error("Not a square in sqrt")
@@ -560,14 +560,14 @@ end
 ###############################################################################
 
 function zero!(x::fmpz_rel_series)
-  ccall((:fmpz_poly_zero, :libflint), Nothing,
+  ccall((:fmpz_poly_zero, libflint), Nothing,
                    (Ref{fmpz_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function setcoeff!(z::fmpz_rel_series, n::Int, x::fmpz)
-   ccall((:fmpz_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Int, Ref{fmpz}),
                z, n, x)
    return z
@@ -587,7 +587,7 @@ function mul!(z::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:fmpz_poly_mullow, :libflint), Nothing,
+   ccall((:fmpz_poly_mullow, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                z, a, b, lenz)
    return z
@@ -603,29 +603,29 @@ function addeq!(a::fmpz_rel_series, b::fmpz_rel_series)
    if a.val < b.val
       z = fmpz_rel_series()
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fmpz_poly_set_trunc, :libflint), Nothing,
+      ccall((:fmpz_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fmpz_poly_truncate, :libflint), Nothing,
+      ccall((:fmpz_poly_truncate, libflint), Nothing,
             (Ref{fmpz_rel_series}, Int),
             a, max(0, lenz - a.val + b.val))
-      ccall((:fmpz_poly_shift_left, :libflint), Nothing,
+      ccall((:fmpz_poly_shift_left, libflint), Nothing,
             (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
             a, a, a.val - b.val)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                a, a, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:fmpz_poly_add_series, :libflint), Nothing,
+      ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                a, a, b, lenz)
    end
@@ -646,7 +646,7 @@ function add!(c::fmpz_rel_series, a::fmpz_rel_series, b::fmpz_rel_series)
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:fmpz_poly_add_series, :libflint), Nothing,
+   ccall((:fmpz_poly_add_series, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                c, a, b, lenc)
    return c

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -64,7 +64,7 @@ end
 function coeff(x::fq, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = fmpz()
-   ccall((:fmpz_poly_get_coeff_fmpz, :libflint), Nothing,
+   ccall((:fmpz_poly_get_coeff_fmpz, libflint), Nothing,
                (Ref{fmpz}, Ref{fq}, Int), z, x, n)
    return z
 end
@@ -75,7 +75,7 @@ end
 """
 function zero(a::FqFiniteField)
    d = a()
-   ccall((:fq_zero, :libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
+   ccall((:fq_zero, libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -85,7 +85,7 @@ end
 """
 function one(a::FqFiniteField)
    d = a()
-   ccall((:fq_one, :libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
+   ccall((:fq_one, libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -97,7 +97,7 @@ end
 """
 function gen(a::FqFiniteField)
    d = a()
-   ccall((:fq_gen, :libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
+   ccall((:fq_gen, libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
@@ -106,7 +106,7 @@ end
 > Return `true` if the given finite field element is zero, otherwise return
 > `false`.
 """
-iszero(a::fq) = ccall((:fq_is_zero, :libflint), Bool,
+iszero(a::fq) = ccall((:fq_is_zero, libflint), Bool,
                      (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 @doc Markdown.doc"""
@@ -114,7 +114,7 @@ iszero(a::fq) = ccall((:fq_is_zero, :libflint), Bool,
 > Return `true` if the given finite field element is one, otherwise return
 > `false`.
 """
-isone(a::fq) = ccall((:fq_is_one, :libflint), Bool,
+isone(a::fq) = ccall((:fq_is_one, libflint), Bool,
                     (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 @doc Markdown.doc"""
@@ -129,7 +129,7 @@ isgen(a::fq) = a == gen(parent(a))
 > Return `true` if the given finite field element is invertible, i.e. nonzero,
 > otherwise return `false`.
 """
-isunit(a::fq) = ccall((:fq_is_invertible, :libflint), Bool,
+isunit(a::fq) = ccall((:fq_is_invertible, libflint), Bool,
                      (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
 @doc Markdown.doc"""
@@ -138,7 +138,7 @@ isunit(a::fq) = ccall((:fq_is_invertible, :libflint), Bool,
 """
 function characteristic(a::FqFiniteField)
    d = fmpz()
-   ccall((:__fq_ctx_prime, :libflint), Nothing,
+   ccall((:__fq_ctx_prime, libflint), Nothing,
          (Ref{fmpz}, Ref{FqFiniteField}), d, a)
    return d
 end
@@ -149,7 +149,7 @@ end
 """
 function order(a::FqFiniteField)
    d = fmpz()
-   ccall((:fq_ctx_order, :libflint), Nothing,
+   ccall((:fq_ctx_order, libflint), Nothing,
          (Ref{fmpz}, Ref{FqFiniteField}), d, a)
    return d
 end
@@ -159,7 +159,7 @@ end
 > Return the degree of the given finite field.
 """
 function degree(a::FqFiniteField)
-   return ccall((:fq_ctx_degree, :libflint), Int, (Ref{FqFiniteField},), a)
+   return ccall((:fq_ctx_degree, libflint), Int, (Ref{FqFiniteField},), a)
 end
 
 function deepcopy_internal(d::fq, dict::IdDict)
@@ -182,12 +182,12 @@ canonical_unit(x::fq) = x
 ###############################################################################
 
 function show(io::IO, x::fq)
-   cstr = ccall((:fq_get_str_pretty, :libflint), Ptr{UInt8},
+   cstr = ccall((:fq_get_str_pretty, libflint), Ptr{UInt8},
                 (Ref{fq}, Ref{FqFiniteField}), x, x.parent)
 
    print(io, unsafe_string(cstr))
 
-   ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+   ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
 end
 
 function show(io::IO, a::FqFiniteField)
@@ -209,7 +209,7 @@ show_minus_one(::Type{fq}) = true
 
 function -(x::fq)
    z = parent(x)()
-   ccall((:fq_neg, :libflint), Nothing,
+   ccall((:fq_neg, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
@@ -223,7 +223,7 @@ end
 function +(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_add, :libflint), Nothing,
+   ccall((:fq_add, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
@@ -231,7 +231,7 @@ end
 function -(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_sub, :libflint), Nothing,
+   ccall((:fq_sub, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
@@ -239,7 +239,7 @@ end
 function *(x::fq, y::fq)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_mul, :libflint), Nothing,
+   ccall((:fq_mul, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
@@ -252,7 +252,7 @@ end
 
 function *(x::Int, y::fq)
    z = parent(y)()
-   ccall((:fq_mul_si, :libflint), Nothing,
+   ccall((:fq_mul_si, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, y, x, y.parent)
    return z
 end
@@ -263,7 +263,7 @@ end
 
 function *(x::fmpz, y::fq)
    z = parent(y)()
-   ccall((:fq_mul_fmpz, :libflint), Nothing,
+   ccall((:fq_mul_fmpz, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}),
                                             z, y, x, y.parent)
    return z
@@ -299,7 +299,7 @@ function ^(x::fq, y::Int)
       y = -y
    end
    z = parent(x)()
-   ccall((:fq_pow_ui, :libflint), Nothing,
+   ccall((:fq_pow_ui, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, x, y, x.parent)
    return z
 end
@@ -310,7 +310,7 @@ function ^(x::fq, y::fmpz)
       y = -y
    end
    z = parent(x)()
-   ccall((:fq_pow, :libflint), Nothing,
+   ccall((:fq_pow, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Ref{fmpz}, Ref{FqFiniteField}),
                                             z, x, y, x.parent)
    return z
@@ -324,7 +324,7 @@ end
 
 function ==(x::fq, y::fq)
    check_parent(x, y)
-   ccall((:fq_equal, :libflint), Bool,
+   ccall((:fq_equal, libflint), Bool,
          (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), x, y, y.parent)
 end
 
@@ -352,7 +352,7 @@ function divexact(x::fq, y::fq)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    z = parent(y)()
-   ccall((:fq_div, :libflint), Nothing,
+   ccall((:fq_div, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
@@ -394,7 +394,7 @@ divexact(x::fmpz, y::fq) = divexact(parent(y)(x), y)
 function inv(x::fq)
    iszero(x) && throw(DivideError())
    z = parent(x)()
-   ccall((:fq_inv, :libflint), Nothing,
+   ccall((:fq_inv, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
@@ -412,7 +412,7 @@ end
 """
 function pth_root(x::fq)
    z = parent(x)()
-   ccall((:fq_pth_root, :libflint), Nothing,
+   ccall((:fq_pth_root, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return z
 end
@@ -424,7 +424,7 @@ end
 """
 function tr(x::fq)
    z = fmpz()
-   ccall((:fq_trace, :libflint), Nothing,
+   ccall((:fq_trace, libflint), Nothing,
          (Ref{fmpz}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
@@ -436,7 +436,7 @@ end
 """
 function norm(x::fq)
    z = fmpz()
-   ccall((:fq_norm, :libflint), Nothing,
+   ccall((:fq_norm, libflint), Nothing,
          (Ref{fmpz}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
@@ -450,7 +450,7 @@ end
 """
 function frobenius(x::fq, n = 1)
    z = parent(x)()
-   ccall((:fq_frobenius, :libflint), Nothing,
+   ccall((:fq_frobenius, libflint), Nothing,
          (Ref{fq}, Ref{fq}, Int, Ref{FqFiniteField}), z, x, n, x.parent)
    return z
 end
@@ -462,25 +462,25 @@ end
 ###############################################################################
 
 function zero!(z::fq)
-   ccall((:fq_zero, :libflint), Nothing,
+   ccall((:fq_zero, libflint), Nothing,
         (Ref{fq}, Ref{FqFiniteField}), z, z.parent)
    return z
 end
 
 function mul!(z::fq, x::fq, y::fq)
-   ccall((:fq_mul, :libflint), Nothing,
+   ccall((:fq_mul, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, y.parent)
    return z
 end
 
 function addeq!(z::fq, x::fq)
-   ccall((:fq_add, :libflint), Nothing,
+   ccall((:fq_add, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, z, x, x.parent)
    return z
 end
 
 function add!(z::fq, x::fq, y::fq)
-   ccall((:fq_add, :libflint), Nothing,
+   ccall((:fq_add, libflint), Nothing,
         (Ref{fq}, Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, y, x.parent)
    return z
 end

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -43,14 +43,14 @@ function normalise(a::fq_abs_series, len::Int)
    ctx = base_ring(a)
    if len > 0
       c = base_ring(a)()
-      ccall((:fq_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_poly_get_coeff, libflint), Nothing,
          (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
           c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fq_poly_get_coeff, :libflint), Nothing,
+         ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
              c, a, len - 1, ctx)
       end
@@ -60,7 +60,7 @@ function normalise(a::fq_abs_series, len::Int)
 end
 
 function length(x::fq_abs_series)
-   return ccall((:fq_poly_length, :libflint), Int,
+   return ccall((:fq_poly_length, libflint), Int,
                 (Ref{fq_abs_series}, Ref{FqFiniteField}), x, base_ring(x))
 end
 
@@ -71,7 +71,7 @@ function coeff(x::fq_abs_series, n::Int)
       return base_ring(x)()
    end
    z = base_ring(x)()
-   ccall((:fq_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_poly_get_coeff, libflint), Nothing,
          (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
           z, x, n, base_ring(x))
    return z
@@ -96,7 +96,7 @@ function deepcopy_internal(a::fq_abs_series, dict::IdDict)
 end
 
 function isgen(a::fq_abs_series)
-   return precision(a) == 0 || ccall((:fq_poly_is_gen, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fq_poly_is_gen, libflint), Bool,
                    (Ref{fq_abs_series}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
@@ -105,7 +105,7 @@ iszero(a::fq_abs_series) = length(a) == 0
 isunit(a::fq_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fq_abs_series)
-   return precision(a) == 0 || ccall((:fq_poly_is_one, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fq_poly_is_one, libflint), Bool,
                    (Ref{fq_abs_series}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
@@ -142,7 +142,7 @@ show_minus_one(::Type{fq_abs_series}) = show_minus_one(fq)
 
 function -(x::fq_abs_series)
    z = parent(x)()
-   ccall((:fq_poly_neg, :libflint), Nothing,
+   ccall((:fq_poly_neg, libflint), Nothing,
                 (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{FqFiniteField}),
                z, x, base_ring(x))
    z.prec = x.prec
@@ -165,7 +165,7 @@ function +(a::fq_abs_series, b::fq_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fq_poly_add_series, :libflint), Nothing,
+   ccall((:fq_poly_add_series, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -182,7 +182,7 @@ function -(a::fq_abs_series, b::fq_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fq_poly_sub_series, :libflint), Nothing,
+   ccall((:fq_poly_sub_series, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -205,7 +205,7 @@ function *(a::fq_abs_series, b::fq_abs_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fq_poly_mullow, :libflint), Nothing,
+   ccall((:fq_poly_mullow, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -221,7 +221,7 @@ end
 function *(x::fq, y::fq_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fq_poly_scalar_mul_fq, :libflint), Nothing,
+   ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{fq}, Ref{FqFiniteField}),
                z, y, x, base_ring(y))
    return z
@@ -242,10 +242,10 @@ function shift_left(x::fq_abs_series, len::Int)
    z.prec = x.prec + len
    z.prec = min(z.prec, max_precision(parent(x)))
    zlen = min(z.prec, xlen + len)
-   ccall((:fq_poly_shift_left, :libflint), Nothing,
+   ccall((:fq_poly_shift_left, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, x, len, base_ring(x))
-   ccall((:fq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_poly_set_trunc, libflint), Nothing,
                 (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, z, zlen, base_ring(x))
    return z
@@ -259,7 +259,7 @@ function shift_right(x::fq_abs_series, len::Int)
       z.prec = max(0, x.prec - len)
    else
       z.prec = x.prec - len
-      ccall((:fq_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_poly_shift_right, libflint), Nothing,
             (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, x, len, base_ring(x))
    end
@@ -279,7 +279,7 @@ function truncate(x::fq_abs_series, prec::Int)
    end
    z = parent(x)()
    z.prec = prec
-   ccall((:fq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_poly_set_trunc, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, x, prec, base_ring(x))
    return z
@@ -329,7 +329,7 @@ function ==(x::fq_abs_series, y::fq_abs_series)
    prec = min(x.prec, y.prec)
    n = max(length(x), length(y))
    n = min(n, prec)
-   return Bool(ccall((:fq_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
              (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                x, y, n, base_ring(x)))
 end
@@ -341,7 +341,7 @@ function isequal(x::fq_abs_series, y::fq_abs_series)
    if x.prec != y.prec || length(x) != length(y)
       return false
    end
-   return Bool(ccall((:fq_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fq_poly_equal, libflint), Cint,
              (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                x, y, length(x), base_ring(x)))
 end
@@ -357,7 +357,7 @@ function ==(x::fq_abs_series, y::fq)
       return false
    elseif length(x) == 1
       z = base_ring(x)()
-      ccall((:fq_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
              z, x, 0, base_ring(x))
       return z == y
@@ -373,7 +373,7 @@ function ==(x::fq_abs_series, y::fmpz)
       return false
    elseif length(x) == 1
       z = base_ring(x)()
-      ccall((:fq_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{fq}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
              z, x, 0, base_ring(x))
       return z == y
@@ -409,7 +409,7 @@ function divexact(x::fq_abs_series, y::fq_abs_series)
    prec = min(x.prec, y.prec - v2 + v1)
    z = parent(x)()
    z.prec = prec
-   ccall((:fq_poly_div_series, :libflint), Nothing,
+   ccall((:fq_poly_div_series, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, x, y, prec, base_ring(x))
@@ -426,7 +426,7 @@ function divexact(x::fq_abs_series, y::fq)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fq_poly_scalar_div_fq, :libflint), Nothing,
+   ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series}, Ref{fq}, Ref{FqFiniteField}),
                z, x, y, base_ring(x))
    return z
@@ -443,7 +443,7 @@ function inv(a::fq_abs_series)
    !isunit(a) && error("Unable to invert power series")
    ainv = parent(a)()
    ainv.prec = a.prec
-   ccall((:fq_poly_inv_series, :libflint), Nothing,
+   ccall((:fq_poly_inv_series, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                ainv, a, a.prec, base_ring(a))
    return ainv
@@ -456,21 +456,21 @@ end
 ###############################################################################
 
 function zero!(z::fq_abs_series)
-   ccall((:fq_poly_zero, :libflint), Nothing,
+   ccall((:fq_poly_zero, libflint), Nothing,
                 (Ref{fq_abs_series}, Ref{FqFiniteField}), z, base_ring(z))
    z.prec = parent(z).prec_max
    return z
 end
 
 function fit!(z::fq_abs_series, n::Int)
-   ccall((:fq_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_poly_fit_length, libflint), Nothing,
          (Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
          z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_abs_series, n::Int, x::fq)
-   ccall((:fq_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_poly_set_coeff, libflint), Nothing,
                 (Ref{fq_abs_series}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, n, x, base_ring(z))
    return z
@@ -490,7 +490,7 @@ function mul!(z::fq_abs_series, a::fq_abs_series, b::fq_abs_series)
       lenz = 0
    end
    z.prec = prec
-   ccall((:fq_poly_mullow, :libflint), Nothing,
+   ccall((:fq_poly_mullow, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(z))
@@ -505,7 +505,7 @@ function addeq!(a::fq_abs_series, b::fq_abs_series)
    lenb = min(lenb, prec)
    lenz = max(lena, lenb)
    a.prec = prec
-   ccall((:fq_poly_add_series, :libflint), Nothing,
+   ccall((:fq_poly_add_series, libflint), Nothing,
          (Ref{fq_abs_series}, Ref{fq_abs_series},
           Ref{fq_abs_series}, Int, Ref{FqFiniteField}),
                a, a, b, lenz, base_ring(a))

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -49,17 +49,17 @@ zero(m::fq_mat, R::FqFiniteField, r::Int, c::Int) = fq_mat(r, c, R)
 @inline function getindex(a::fq_mat, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
-      el = ccall((:fq_mat_entry, :libflint), Ptr{fq},
+      el = ccall((:fq_mat_entry, libflint), Ptr{fq},
                  (Ref{fq_mat}, Int, Int), a, i - 1 , j - 1)
       z = base_ring(a)()
-      ccall((:fq_set, :libflint), Nothing, (Ref{fq}, Ptr{fq}), z, el)
+      ccall((:fq_set, libflint), Nothing, (Ref{fq}, Ptr{fq}), z, el)
    end
    return z
 end
 
 @inline function setindex!(a::fq_mat, u::fq, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
-   ccall((:fq_mat_entry_set, :libflint), Nothing,
+   ccall((:fq_mat_entry_set, libflint), Nothing,
          (Ref{fq_mat}, Int, Int, Ref{fq}, Ref{FqFiniteField}),
          a, i - 1, j - 1, u, base_ring(a))
 end
@@ -67,9 +67,9 @@ end
 @inline function setindex!(a::fq_mat, u::fmpz, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
-      el = ccall((:fq_mat_entry, :libflint), Ptr{fq},
+      el = ccall((:fq_mat_entry, libflint), Ptr{fq},
                  (Ref{fq_mat}, Int, Int), a, i - 1, j - 1)
-      ccall((:fq_set_fmpz, :libflint), Nothing,
+      ccall((:fq_set_fmpz, libflint), Nothing,
             (Ptr{fq}, Ref{fmpz}, Ref{FqFiniteField}), el, u, base_ring(a))
    end
 end
@@ -79,7 +79,7 @@ setindex!(a::fq_mat, u::Integer, i::Int, j::Int) =
 
 function deepcopy_internal(a::fq_mat, dict::IdDict)
   z = fq_mat(nrows(a), ncols(a), base_ring(a))
-  ccall((:fq_mat_set, :libflint), Nothing,
+  ccall((:fq_mat_set, libflint), Nothing,
         (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), z, a, base_ring(a))
   return z
 end
@@ -106,7 +106,7 @@ function one(a::FqMatSpace)
 end
 
 function iszero(a::fq_mat)
-   r = ccall((:fq_mat_is_zero, :libflint), Cint,
+   r = ccall((:fq_mat_is_zero, libflint), Cint,
              (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
   return Bool(r)
 end
@@ -121,7 +121,7 @@ function ==(a::fq_mat, b::fq_mat)
    if !(a.base_ring == b.base_ring)
       return false
    end
-   r = ccall((:fq_mat_equal, :libflint), Cint,
+   r = ccall((:fq_mat_equal, libflint), Cint,
              (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), a, b, base_ring(a))
    return Bool(r)
 end
@@ -147,14 +147,14 @@ end
 # There is no transpose for fq_mat
 #function transpose(a::fq_mat)
 #  z = FqMatSpace(base_ring(a), ncols(a), nrows(a))()
-#  ccall((:fq_mat_transpose, :libflint), Nothing,
+#  ccall((:fq_mat_transpose, libflint), Nothing,
 #        (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), z, a, base_ring(a))
 #  return z
 #end
 #
 #function transpose!(a::fq_mat)
 #  !issquare(a) && error("Matrix must be a square matrix")
-#  ccall((:fq_mat_transpose, :libflint), Nothing,
+#  ccall((:fq_mat_transpose, libflint), Nothing,
 #        (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), a, a, base_ring(a))
 #end
 
@@ -165,7 +165,7 @@ end
 ###############################################################################
 
 function swap_rows!(x::fq_mat, i::Int, j::Int)
-  ccall((:fq_mat_swap_rows, :libflint), Nothing,
+  ccall((:fq_mat_swap_rows, libflint), Nothing,
         (Ref{fq_mat}, Ptr{Nothing}, Int, Int, Ref{FqFiniteField}),
         x, C_NULL, i - 1, j - 1, base_ring(x))
   return x
@@ -178,7 +178,7 @@ function swap_rows(x::fq_mat, i::Int, j::Int)
 end
 
 function swap_cols!(x::fq_mat, i::Int, j::Int)
-  ccall((:fq_mat_swap_cols, :libflint), Nothing,
+  ccall((:fq_mat_swap_cols, libflint), Nothing,
         (Ref{fq_mat}, Ptr{Nothing}, Int, Int, Ref{FqFiniteField}),
         x, C_NULL, i - 1, j - 1, base_ring(x))
   return x
@@ -191,7 +191,7 @@ function swap_cols(x::fq_mat, i::Int, j::Int)
 end
 
 function reverse_rows!(x::fq_mat)
-   ccall((:fq_mat_invert_rows, :libflint), Nothing,
+   ccall((:fq_mat_invert_rows, libflint), Nothing,
          (Ref{fq_mat}, Ptr{Nothing}, Ref{FqFiniteField}), x, C_NULL, base_ring(x))
    return x
 end
@@ -199,7 +199,7 @@ end
 reverse_rows(x::fq_mat) = reverse_rows!(deepcopy(x))
 
 function reverse_cols!(x::fq_mat)
-   ccall((:fq_mat_invert_cols, :libflint), Nothing,
+   ccall((:fq_mat_invert_cols, libflint), Nothing,
          (Ref{fq_mat}, Ptr{Nothing}, Ref{FqFiniteField}), x, C_NULL, base_ring(x))
    return x
 end
@@ -214,7 +214,7 @@ reverse_cols(x::fq_mat) = reverse_cols!(deepcopy(x))
 
 function -(x::fq_mat)
    z = similar(x)
-   ccall((:fq_mat_neg, :libflint), Nothing,
+   ccall((:fq_mat_neg, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), z, x, base_ring(x))
    return z
 end
@@ -228,7 +228,7 @@ end
 function +(x::fq_mat, y::fq_mat)
    check_parent(x,y)
    z = similar(x)
-   ccall((:fq_mat_add, :libflint), Nothing,
+   ccall((:fq_mat_add, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -237,7 +237,7 @@ end
 function -(x::fq_mat, y::fq_mat)
    check_parent(x,y)
    z = similar(x)
-   ccall((:fq_mat_sub, :libflint), Nothing,
+   ccall((:fq_mat_sub, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          z, x, y, base_ring(x))
 
@@ -248,7 +248,7 @@ function *(x::fq_mat, y::fq_mat)
    (base_ring(x) != base_ring(y)) && error("Base ring must be equal")
    (ncols(x) != nrows(y)) && error("Dimensions are wrong")
    z = similar(x, nrows(x), ncols(y))
-   ccall((:fq_mat_mul, :libflint), Nothing,
+   ccall((:fq_mat_mul, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), z, x, y, base_ring(x))
    return z
 end
@@ -261,21 +261,21 @@ end
 ################################################################################
 
 function mul!(a::fq_mat, b::fq_mat, c::fq_mat)
-   ccall((:fq_mat_mul, :libflint), Nothing,
+   ccall((:fq_mat_mul, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          a, b, c, base_ring(a))
   return a
 end
 
 function add!(a::fq_mat, b::fq_mat, c::fq_mat)
-   ccall((:fq_mat_add, :libflint), Nothing,
+   ccall((:fq_mat_add, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          a, b, c, base_ring(a))
   return a
 end
 
 function zero!(a::fq_mat)
-   ccall((:fq_mat_zero, :libflint), Nothing,
+   ccall((:fq_mat_zero, libflint), Nothing,
          (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
    return a
 end
@@ -326,13 +326,13 @@ end
 
 function rref(a::fq_mat)
    z = deepcopy(a)
-   r = ccall((:fq_mat_rref, :libflint), Int,
+   r = ccall((:fq_mat_rref, libflint), Int,
              (Ref{fq_mat}, Ref{FqFiniteField}), z, base_ring(a))
    return r, z
 end
 
 function rref!(a::fq_mat)
-   r = ccall((:fq_mat_rref, :libflint), Int,
+   r = ccall((:fq_mat_rref, libflint), Int,
          (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
    return r
 end
@@ -402,7 +402,7 @@ end
 function inv(a::fq_mat)
    !issquare(a) && error("Matrix must be a square matrix")
    z = similar(a)
-   r = ccall((:fq_mat_inv, :libflint), Int,
+   r = ccall((:fq_mat_inv, libflint), Int,
              (Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}), z, a, base_ring(a))
    !Bool(r) && error("Matrix not invertible")
    return z
@@ -419,7 +419,7 @@ function solve(x::fq_mat, y::fq_mat)
    !issquare(x)&& error("First argument not a square matrix in solve")
    (nrows(y) != nrows(x)) || ncols(y) != 1 && ("Not a column vector in solve")
    z = similar(y)
-   r = ccall((:fq_mat_solve, :libflint), Int,
+   r = ccall((:fq_mat_solve, libflint), Int,
              (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
              z, x, y, base_ring(x))
    !Bool(r) && error("Singular matrix in solve")
@@ -433,7 +433,7 @@ end
 ################################################################################
 
 function lu!(P::Generic.Perm, x::fq_mat)
-   rank = Int(ccall((:fq_mat_lu, :libflint), Cint,
+   rank = Int(ccall((:fq_mat_lu, libflint), Cint,
                 (Ptr{Int}, Ref{fq_mat}, Cint, Ref{FqFiniteField}),
                 P.d, x, 0, base_ring(x)))
 
@@ -500,7 +500,7 @@ function Base.view(x::fq_mat, r1::Int, c1::Int, r2::Int, c2::Int)
    z = fq_mat()
    z.base_ring = x.base_ring
    z.view_parent = x
-   ccall((:fq_mat_window_init, :libflint), Nothing,
+   ccall((:fq_mat_window_init, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Int, Int, Int, Int, Ref{FqFiniteField}),
          z, x, r1 - 1, c1 - 1, r2, c2, base_ring(x))
    finalizer(_fq_mat_window_clear_fn, z)
@@ -512,7 +512,7 @@ function Base.view(x::fq_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fq_mat_window_clear_fn(a::fq_mat)
-   ccall((:fq_mat_window_clear, :libflint), Nothing,
+   ccall((:fq_mat_window_clear, libflint), Nothing,
          (Ref{fq_mat}, Ref{FqFiniteField}), a, base_ring(a))
 end
 
@@ -536,7 +536,7 @@ function hcat(x::fq_mat, y::fq_mat)
    (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
    (x.r != y.r) && error("Matrices must have same number of rows")
    z = similar(x, nrows(x), ncols(x) + ncols(y))
-   ccall((:fq_mat_concat_horizontal, :libflint), Nothing,
+   ccall((:fq_mat_concat_horizontal, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -546,7 +546,7 @@ function vcat(x::fq_mat, y::fq_mat)
    (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
    (x.c != y.c) && error("Matrices must have same number of columns")
    z = similar(x, nrows(x) + nrows(y), ncols(x))
-   ccall((:fq_mat_concat_vertical, :libflint), Nothing,
+   ccall((:fq_mat_concat_vertical, libflint), Nothing,
          (Ref{fq_mat}, Ref{fq_mat}, Ref{fq_mat}, Ref{FqFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -578,7 +578,7 @@ function charpoly(R::FqPolyRing, a::fq_mat)
   !issquare(a) && error("Matrix must be square")
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   p = R()
-  ccall((:fq_mat_charpoly, :libflint), Nothing,
+  ccall((:fq_mat_charpoly, libflint), Nothing,
           (Ref{fq_poly}, Ref{fq_mat}, Ref{FqFiniteField}), p, a, base_ring(a))
   return p
 end
@@ -587,7 +587,7 @@ function charpoly_danivlesky!(R::FqPolyRing, a::fq_mat)
   !issquare(a) && error("Matrix must be square")
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   p = R()
-  ccall((:fq_mat_charpoly_danilevsky, :libflint), Nothing,
+  ccall((:fq_mat_charpoly_danilevsky, libflint), Nothing,
           (Ref{fq_poly}, Ref{fq_mat}, Ref{FqFiniteField}), p, a, base_ring(a))
   return p
 end
@@ -604,7 +604,7 @@ function minpoly(R::FqPolyRing, a::fq_mat)
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   m = deepcopy(a)
   p = R()
-  ccall((:fq_mat_minpoly, :libflint), Nothing,
+  ccall((:fq_mat_minpoly, libflint), Nothing,
           (Ref{fq_poly}, Ref{fq_mat}, Ref{FqFiniteField}), p, m, base_ring(a))
   return p
 end

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -45,58 +45,58 @@ end
 
 function coeff(x::fq_nmod, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
-   return ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+   return ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                 (Ref{fq_nmod}, Int), x, n)
 end
 
 function zero(a::FqNmodFiniteField)
    d = a()
-   ccall((:fq_nmod_zero, :libflint), Nothing,
+   ccall((:fq_nmod_zero, libflint), Nothing,
          (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function one(a::FqNmodFiniteField)
    d = a()
-   ccall((:fq_nmod_one, :libflint), Nothing,
+   ccall((:fq_nmod_one, libflint), Nothing,
          (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function gen(a::FqNmodFiniteField)
    d = a()
-   ccall((:fq_nmod_gen, :libflint), Nothing,
+   ccall((:fq_nmod_gen, libflint), Nothing,
          (Ref{fq_nmod}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
-iszero(a::fq_nmod) = ccall((:fq_nmod_is_zero, :libflint), Bool,
+iszero(a::fq_nmod) = ccall((:fq_nmod_is_zero, libflint), Bool,
                      (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
-isone(a::fq_nmod) = ccall((:fq_nmod_is_one, :libflint), Bool,
+isone(a::fq_nmod) = ccall((:fq_nmod_is_one, libflint), Bool,
                     (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
 isgen(a::fq_nmod) = a == gen(parent(a)) # there is no isgen in flint
 
-isunit(a::fq_nmod) = ccall((:fq_nmod_is_invertible, :libflint), Bool,
+isunit(a::fq_nmod) = ccall((:fq_nmod_is_invertible, libflint), Bool,
                      (Ref{fq_nmod}, Ref{FqNmodFiniteField}), a, a.parent)
 
 function characteristic(a::FqNmodFiniteField)
    d = fmpz()
-   ccall((:__fq_nmod_ctx_prime, :libflint), Nothing,
+   ccall((:__fq_nmod_ctx_prime, libflint), Nothing,
          (Ref{fmpz}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function order(a::FqNmodFiniteField)
    d = fmpz()
-   ccall((:fq_nmod_ctx_order, :libflint), Nothing,
+   ccall((:fq_nmod_ctx_order, libflint), Nothing,
          (Ref{fmpz}, Ref{FqNmodFiniteField}), d, a)
    return d
 end
 
 function degree(a::FqNmodFiniteField)
-   return ccall((:fq_nmod_ctx_degree, :libflint), Int,
+   return ccall((:fq_nmod_ctx_degree, libflint), Int,
                 (Ref{FqNmodFiniteField},), a)
 end
 
@@ -121,12 +121,12 @@ canonical_unit(x::fq_nmod) = x
 ###############################################################################
 
 function show(io::IO, x::fq_nmod)
-   cstr = ccall((:fq_nmod_get_str_pretty, :libflint), Ptr{UInt8},
+   cstr = ccall((:fq_nmod_get_str_pretty, libflint), Ptr{UInt8},
                 (Ref{fq_nmod}, Ref{FqNmodFiniteField}), x, x.parent)
 
    print(io, unsafe_string(cstr))
 
-   ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+   ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
 end
 
 function show(io::IO, a::FqNmodFiniteField)
@@ -148,7 +148,7 @@ show_minus_one(::Type{fq_nmod}) = true
 
 function -(x::fq_nmod)
    z = parent(x)()
-   ccall((:fq_nmod_neg, :libflint), Nothing,
+   ccall((:fq_nmod_neg, libflint), Nothing,
        (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
@@ -162,7 +162,7 @@ end
 function +(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_nmod_add, :libflint), Nothing,
+   ccall((:fq_nmod_add, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, y.parent)
    return z
@@ -171,7 +171,7 @@ end
 function -(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_nmod_sub, :libflint), Nothing,
+   ccall((:fq_nmod_sub, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, y.parent)
    return z
@@ -180,7 +180,7 @@ end
 function *(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    z = parent(y)()
-   ccall((:fq_nmod_mul, :libflint), Nothing,
+   ccall((:fq_nmod_mul, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, y.parent)
    return z
@@ -194,7 +194,7 @@ end
 
 function *(x::Int, y::fq_nmod)
    z = parent(y)()
-   ccall((:fq_nmod_mul_si, :libflint), Nothing,
+   ccall((:fq_nmod_mul_si, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
                                                z, y, x, y.parent)
    return z
@@ -208,7 +208,7 @@ end
 
 function *(x::fmpz, y::fq_nmod)
    z = parent(y)()
-   ccall((:fq_nmod_mul_fmpz, :libflint), Nothing,
+   ccall((:fq_nmod_mul_fmpz, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}),
                                                     z, y, x, y.parent)
    return z
@@ -244,7 +244,7 @@ function ^(x::fq_nmod, y::Int)
       y = -y
    end
    z = parent(x)()
-   ccall((:fq_nmod_pow_ui, :libflint), Nothing,
+   ccall((:fq_nmod_pow_ui, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
                                                z, x, y, x.parent)
    return z
@@ -256,7 +256,7 @@ function ^(x::fq_nmod, y::fmpz)
       y = -y
    end
    z = parent(x)()
-   ccall((:fq_nmod_pow, :libflint), Nothing,
+   ccall((:fq_nmod_pow, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}),
                                                     z, x, y, x.parent)
    return z
@@ -270,7 +270,7 @@ end
 
 function ==(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
-   ccall((:fq_nmod_equal, :libflint), Bool,
+   ccall((:fq_nmod_equal, libflint), Bool,
        (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), x, y, y.parent)
 end
 
@@ -297,7 +297,7 @@ end
 function inv(x::fq_nmod)
    iszero(x) && throw(DivideError())
    z = parent(x)()
-   ccall((:fq_nmod_inv, :libflint), Nothing,
+   ccall((:fq_nmod_inv, libflint), Nothing,
        (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
@@ -312,7 +312,7 @@ function divexact(x::fq_nmod, y::fq_nmod)
    check_parent(x, y)
    iszero(y) && throw(DivideError())
    z = parent(y)()
-   ccall((:fq_nmod_div, :libflint), Nothing,
+   ccall((:fq_nmod_div, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, y.parent)
    return z
@@ -350,28 +350,28 @@ divexact(x::fmpz, y::fq_nmod) = divexact(parent(y)(x), y)
 
 function pth_root(x::fq_nmod)
    z = parent(x)()
-   ccall((:fq_nmod_pth_root, :libflint), Nothing,
+   ccall((:fq_nmod_pth_root, libflint), Nothing,
        (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return z
 end
 
 function tr(x::fq_nmod)
    z = fmpz()
-   ccall((:fq_nmod_trace, :libflint), Nothing,
+   ccall((:fq_nmod_trace, libflint), Nothing,
          (Ref{fmpz}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
 function norm(x::fq_nmod)
    z = fmpz()
-   ccall((:fq_nmod_norm, :libflint), Nothing,
+   ccall((:fq_nmod_norm, libflint), Nothing,
          (Ref{fmpz}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
    return parent(x)(z)
 end
 
 function frobenius(x::fq_nmod, n = 1)
    z = parent(x)()
-   ccall((:fq_nmod_frobenius, :libflint), Nothing,
+   ccall((:fq_nmod_frobenius, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Int, Ref{FqNmodFiniteField}),
                                                z, x, n, x.parent)
    return z
@@ -384,27 +384,27 @@ end
 ###############################################################################
 
 function zero!(z::fq_nmod)
-   ccall((:fq_nmod_zero, :libflint), Nothing,
+   ccall((:fq_nmod_zero, libflint), Nothing,
         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, z.parent)
    return z
 end
 
 function mul!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
-   ccall((:fq_nmod_mul, :libflint), Nothing,
+   ccall((:fq_nmod_mul, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, y.parent)
    return z
 end
 
 function addeq!(z::fq_nmod, x::fq_nmod)
-   ccall((:fq_nmod_add, :libflint), Nothing,
+   ccall((:fq_nmod_add, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, z, x, x.parent)
    return z
 end
 
 function add!(z::fq_nmod, x::fq_nmod, y::fq_nmod)
-   ccall((:fq_nmod_add, :libflint), Nothing,
+   ccall((:fq_nmod_add, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                                                        z, x, y, x.parent)
    return z
@@ -497,9 +497,9 @@ function modulus(k::FqNmodFiniteField)
     p::Int = characteristic(k)
     R = PolynomialRing(ResidueRing(ZZ, p), "T")[1]
     Q = R()
-    P = ccall((:fq_nmod_ctx_modulus, :libflint), Ref{nmod_poly},
+    P = ccall((:fq_nmod_ctx_modulus, libflint), Ref{nmod_poly},
                  (Ref{FqNmodFiniteField},), k)
-    ccall((:nmod_poly_set, :libflint), Nothing,
+    ccall((:nmod_poly_set, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}),
           Q, P)
 

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -43,14 +43,14 @@ function normalise(a::fq_nmod_abs_series, len::Int)
    ctx = base_ring(a)
    if len > 0
       c = base_ring(a)()
-      ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
           c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
              c, a, len - 1, ctx)
       end
@@ -60,7 +60,7 @@ function normalise(a::fq_nmod_abs_series, len::Int)
 end
 
 function length(x::fq_nmod_abs_series)
-   return ccall((:fq_nmod_poly_length, :libflint), Int,
+   return ccall((:fq_nmod_poly_length, libflint), Int,
                 (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
 end
 
@@ -71,7 +71,7 @@ function coeff(x::fq_nmod_abs_series, n::Int)
       return base_ring(x)()
    end
    z = base_ring(x)()
-   ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
           z, x, n, base_ring(x))
    return z
@@ -96,7 +96,7 @@ function deepcopy_internal(a::fq_nmod_abs_series, dict::IdDict)
 end
 
 function isgen(a::fq_nmod_abs_series)
-   return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, libflint), Bool,
                    (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
@@ -105,7 +105,7 @@ iszero(a::fq_nmod_abs_series) = length(a) == 0
 isunit(a::fq_nmod_abs_series) = valuation(a) == 0 && isunit(coeff(a, 0))
 
 function isone(a::fq_nmod_abs_series)
-   return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, :libflint), Bool,
+   return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, libflint), Bool,
                    (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
@@ -142,7 +142,7 @@ show_minus_one(::Type{fq_nmod_abs_series}) = show_minus_one(fq)
 
 function -(x::fq_nmod_abs_series)
    z = parent(x)()
-   ccall((:fq_nmod_poly_neg, :libflint), Nothing,
+   ccall((:fq_nmod_poly_neg, libflint), Nothing,
                 (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}),
                z, x, base_ring(x))
    z.prec = x.prec
@@ -165,7 +165,7 @@ function +(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add_series, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -182,7 +182,7 @@ function -(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    lenz = max(lena, lenb)
    z = parent(a)()
    z.prec = prec
-   ccall((:fq_nmod_poly_sub_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -205,7 +205,7 @@ function *(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fq_nmod_poly_mullow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mullow, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -221,7 +221,7 @@ end
 function *(x::fq_nmod, y::fq_nmod_abs_series)
    z = parent(y)()
    z.prec = y.prec
-   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, y, x, parent(x))
    return z
@@ -242,10 +242,10 @@ function shift_left(x::fq_nmod_abs_series, len::Int)
    z.prec = x.prec + len
    z.prec = min(z.prec, max_precision(parent(x)))
    zlen = min(z.prec, xlen + len)
-   ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+   ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, x, len, base_ring(x))
-   ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, z, zlen, base_ring(x))
    return z
@@ -259,7 +259,7 @@ function shift_right(x::fq_nmod_abs_series, len::Int)
       z.prec = max(0, x.prec - len)
    else
       z.prec = x.prec - len
-      ccall((:fq_nmod_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
             (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, x, len, base_ring(x))
    end
@@ -279,7 +279,7 @@ function truncate(x::fq_nmod_abs_series, prec::Int)
    end
    z = parent(x)()
    z.prec = prec
-   ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, x, prec, base_ring(x))
    return z
@@ -329,7 +329,7 @@ function ==(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
    prec = min(x.prec, y.prec)
    n = max(length(x), length(y))
    n = min(n, prec)
-   return Bool(ccall((:fq_nmod_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
              (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                x, y, n, base_ring(x)))
 end
@@ -341,7 +341,7 @@ function isequal(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
    if x.prec != y.prec || length(x) != length(y)
       return false
    end
-   return Bool(ccall((:fq_nmod_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
              (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                x, y, length(x), base_ring(x)))
 end
@@ -357,7 +357,7 @@ function ==(x::fq_nmod_abs_series, y::fq_nmod)
       return false
    elseif length(x) == 1
       z = base_ring(x)()
-      ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
              z, x, 0, base_ring(x))
       return z == y
@@ -373,7 +373,7 @@ function ==(x::fq_nmod_abs_series, y::fmpz)
       return false
    elseif length(x) == 1
       z = base_ring(x)()
-      ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
              z, x, 0, base_ring(x))
       return z == y
@@ -409,7 +409,7 @@ function divexact(x::fq_nmod_abs_series, y::fq_nmod_abs_series)
    prec = min(x.prec, y.prec - v2 + v1)
    z = parent(x)()
    z.prec = prec
-   ccall((:fq_nmod_poly_div_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_div_series, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, x, y, prec, base_ring(x))
@@ -426,7 +426,7 @@ function divexact(x::fq_nmod_abs_series, y::fq_nmod)
    iszero(y) && throw(DivideError())
    z = parent(x)()
    z.prec = x.prec
-   ccall((:fq_nmod_poly_scalar_div_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, x, y, base_ring(x))
    return z
@@ -443,7 +443,7 @@ function inv(a::fq_nmod_abs_series)
    !isunit(a) && error("Unable to invert power series")
    ainv = parent(a)()
    ainv.prec = a.prec
-   ccall((:fq_nmod_poly_inv_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                ainv, a, a.prec, base_ring(a))
    return ainv
@@ -456,21 +456,21 @@ end
 ###############################################################################
 
 function zero!(z::fq_nmod_abs_series)
-   ccall((:fq_nmod_poly_zero, :libflint), Nothing,
+   ccall((:fq_nmod_poly_zero, libflint), Nothing,
                 (Ref{fq_nmod_abs_series}, Ref{FqNmodFiniteField}), z, base_ring(z))
    z.prec = parent(z).prec_max
    return z
 end
 
 function fit!(z::fq_nmod_abs_series, n::Int)
-   ccall((:fq_nmod_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
          z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_abs_series, n::Int, x::fq_nmod)
-   ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                 (Ref{fq_nmod_abs_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, n, x, base_ring(z))
    return z
@@ -490,7 +490,7 @@ function mul!(z::fq_nmod_abs_series, a::fq_nmod_abs_series, b::fq_nmod_abs_serie
       lenz = 0
    end
    z.prec = prec
-   ccall((:fq_nmod_poly_mullow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mullow, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(z))
@@ -505,7 +505,7 @@ function addeq!(a::fq_nmod_abs_series, b::fq_nmod_abs_series)
    lenb = min(lenb, prec)
    lenz = max(lena, lenb)
    a.prec = prec
-   ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add_series, libflint), Nothing,
          (Ref{fq_nmod_abs_series}, Ref{fq_nmod_abs_series},
           Ref{fq_nmod_abs_series}, Int, Ref{FqNmodFiniteField}),
                a, a, b, lenz, base_ring(a))

--- a/src/flint/fq_nmod_embed.jl
+++ b/src/flint/fq_nmod_embed.jl
@@ -12,7 +12,7 @@
 
 function linear_factor(x::fq_nmod_poly)
     y = parent(x)()
-    ccall((:fq_nmod_poly_factor_split_single, :libflint), Nothing, (Ref{fq_nmod_poly},
+    ccall((:fq_nmod_poly_factor_split_single, libflint), Nothing, (Ref{fq_nmod_poly},
           Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), y, x, base_ring(x))
     return y
 end
@@ -31,7 +31,7 @@ function embed_gens(k::FqNmodFiniteField, K::FqNmodFiniteField)
     PR = PolynomialRing(R, "T")[1]
     P = PR()
 
-    ccall((:fq_nmod_embed_gens, :libflint), Nothing, (Ref{fq_nmod}, Ref{fq_nmod},
+    ccall((:fq_nmod_embed_gens, libflint), Nothing, (Ref{fq_nmod}, Ref{fq_nmod},
     Ref{nmod_poly}, Ref{FqNmodFiniteField}, Ref{FqNmodFiniteField}), a, b,
     P, k, K)
 
@@ -57,7 +57,7 @@ function embed_matrices(k::FqNmodFiniteField, K::FqNmodFiniteField)
     s1 = S1()
     s2 = S2()
 
-    ccall((:fq_nmod_embed_matrices, :libflint), Nothing, (Ref{nmod_mat},
+    ccall((:fq_nmod_embed_matrices, libflint), Nothing, (Ref{nmod_mat},
     Ref{nmod_mat}, Ref{fq_nmod}, Ref{FqNmodFiniteField}, Ref{fq_nmod},
     Ref{FqNmodFiniteField}, Ref{nmod_poly}), s1, s2, a, k, b, K, P)
     return s1, s2
@@ -73,14 +73,14 @@ function embed_matrices_pre(a::fq_nmod, b::fq_nmod, P::nmod_poly)
     s1 = S1()
     s2 = S2()
 
-    ccall((:fq_nmod_embed_matrices, :libflint), Nothing, (Ref{nmod_mat},
+    ccall((:fq_nmod_embed_matrices, libflint), Nothing, (Ref{nmod_mat},
     Ref{nmod_mat}, Ref{fq_nmod}, Ref{FqNmodFiniteField}, Ref{fq_nmod},
     Ref{FqNmodFiniteField}, Ref{nmod_poly}), s1, s2, a, k, b, K, P)
     return s1, s2
 end
 
 function coeff!(x::fq_nmod, j::Int, c::Int)
-    ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+    ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
           (Ref{fq_nmod}, Int, UInt), x, j, c)
 end
 

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -49,17 +49,17 @@ zero(::fq_nmod_mat, R::FqNmodFiniteField, r::Int, c::Int) = fq_nmod_mat(r, c, R)
 @inline function getindex(a::fq_nmod_mat, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
-      el = ccall((:fq_nmod_mat_entry, :libflint), Ptr{fq_nmod},
+      el = ccall((:fq_nmod_mat_entry, libflint), Ptr{fq_nmod},
                  (Ref{fq_nmod_mat}, Int, Int), a, i - 1 , j - 1)
       z = base_ring(a)()
-      ccall((:fq_nmod_set, :libflint), Nothing, (Ref{fq_nmod}, Ptr{fq_nmod}), z, el)
+      ccall((:fq_nmod_set, libflint), Nothing, (Ref{fq_nmod}, Ptr{fq_nmod}), z, el)
    end
    return z
 end
 
 @inline function setindex!(a::fq_nmod_mat, u::fq_nmod, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
-   ccall((:fq_nmod_mat_entry_set, :libflint), Nothing,
+   ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
          (Ref{fq_nmod_mat}, Int, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
          a, i - 1, j - 1, u, base_ring(a))
 end
@@ -67,9 +67,9 @@ end
 @inline function setindex!(a::fq_nmod_mat, u::fmpz, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
-      el = ccall((:fq_nmod_mat_entry, :libflint), Ptr{fq_nmod},
+      el = ccall((:fq_nmod_mat_entry, libflint), Ptr{fq_nmod},
                  (Ref{fq_nmod_mat}, Int, Int), a, i - 1, j - 1)
-      ccall((:fq_nmod_set_fmpz, :libflint), Nothing,
+      ccall((:fq_nmod_set_fmpz, libflint), Nothing,
             (Ptr{fq_nmod}, Ref{fmpz}, Ref{FqNmodFiniteField}), el, u, base_ring(a))
    end
 end
@@ -79,7 +79,7 @@ setindex!(a::fq_nmod_mat, u::Integer, i::Int, j::Int) =
 
 function deepcopy_internal(a::fq_nmod_mat, dict::IdDict)
   z = fq_nmod_mat(nrows(a), ncols(a), base_ring(a))
-  ccall((:fq_nmod_mat_set, :libflint), Nothing,
+  ccall((:fq_nmod_mat_set, libflint), Nothing,
         (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, a, base_ring(a))
   return z
 end
@@ -106,7 +106,7 @@ function one(a::FqNmodMatSpace)
 end
 
 function iszero(a::fq_nmod_mat)
-   r = ccall((:fq_nmod_mat_is_zero, :libflint), Cint,
+   r = ccall((:fq_nmod_mat_is_zero, libflint), Cint,
              (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
   return Bool(r)
 end
@@ -121,7 +121,7 @@ function ==(a::fq_nmod_mat, b::fq_nmod_mat)
    if !(a.base_ring == b.base_ring)
       return false
    end
-   r = ccall((:fq_nmod_mat_equal, :libflint), Cint,
+   r = ccall((:fq_nmod_mat_equal, libflint), Cint,
              (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, b, base_ring(a))
    return Bool(r)
 end
@@ -147,14 +147,14 @@ end
 # There is no transpose for fq_nmod_mat
 #function transpose(a::fq_nmod_mat)
 #  z = FqNmodMatSpace(base_ring(a), ncols(a), nrows(a))()
-#  ccall((:fq_nmod_mat_transpose, :libflint), Nothing,
+#  ccall((:fq_nmod_mat_transpose, libflint), Nothing,
 #        (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, a, base_ring(a))
 #  return z
 #end
 #
 #function transpose!(a::fq_nmod_mat)
 #  !issquare(a) && error("Matrix must be a square matrix")
-#  ccall((:fq_nmod_mat_transpose, :libflint), Nothing,
+#  ccall((:fq_nmod_mat_transpose, libflint), Nothing,
 #        (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, a, base_ring(a))
 #end
 
@@ -165,7 +165,7 @@ end
 ###############################################################################
 
 function swap_rows!(x::fq_nmod_mat, i::Int, j::Int)
-  ccall((:fq_nmod_mat_swap_rows, :libflint), Nothing,
+  ccall((:fq_nmod_mat_swap_rows, libflint), Nothing,
         (Ref{fq_nmod_mat}, Ptr{Nothing}, Int, Int, Ref{FqNmodFiniteField}),
         x, C_NULL, i - 1, j - 1, base_ring(x))
   return x
@@ -178,7 +178,7 @@ function swap_rows(x::fq_nmod_mat, i::Int, j::Int)
 end
 
 function swap_cols!(x::fq_nmod_mat, i::Int, j::Int)
-  ccall((:fq_nmod_mat_swap_cols, :libflint), Nothing,
+  ccall((:fq_nmod_mat_swap_cols, libflint), Nothing,
         (Ref{fq_nmod_mat}, Ptr{Nothing}, Int, Int, Ref{FqNmodFiniteField}),
         x, C_NULL, i - 1, j - 1, base_ring(x))
   return x
@@ -191,7 +191,7 @@ function swap_cols(x::fq_nmod_mat, i::Int, j::Int)
 end
 
 function reverse_rows!(x::fq_nmod_mat)
-   ccall((:fq_nmod_mat_invert_rows, :libflint), Nothing,
+   ccall((:fq_nmod_mat_invert_rows, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ptr{Nothing}, Ref{FqNmodFiniteField}), x, C_NULL, base_ring(x))
    return x
 end
@@ -199,7 +199,7 @@ end
 reverse_rows(x::fq_nmod_mat) = reverse_rows!(deepcopy(x))
 
 function reverse_cols!(x::fq_nmod_mat)
-   ccall((:fq_nmod_mat_invert_cols, :libflint), Nothing,
+   ccall((:fq_nmod_mat_invert_cols, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ptr{Nothing}, Ref{FqNmodFiniteField}), x, C_NULL, base_ring(x))
    return x
 end
@@ -214,7 +214,7 @@ reverse_cols(x::fq_nmod_mat) = reverse_cols!(deepcopy(x))
 
 function -(x::fq_nmod_mat)
    z = similar(x)
-   ccall((:fq_nmod_mat_neg, :libflint), Nothing,
+   ccall((:fq_nmod_mat_neg, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, x, base_ring(x))
    return z
 end
@@ -228,7 +228,7 @@ end
 function +(x::fq_nmod_mat, y::fq_nmod_mat)
    check_parent(x,y)
    z = similar(x)
-   ccall((:fq_nmod_mat_add, :libflint), Nothing,
+   ccall((:fq_nmod_mat_add, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -237,7 +237,7 @@ end
 function -(x::fq_nmod_mat, y::fq_nmod_mat)
    check_parent(x,y)
    z = similar(x)
-   ccall((:fq_nmod_mat_sub, :libflint), Nothing,
+   ccall((:fq_nmod_mat_sub, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(x))
 
@@ -248,7 +248,7 @@ function *(x::fq_nmod_mat, y::fq_nmod_mat)
    (base_ring(x) != base_ring(y)) && error("Base ring must be equal")
    (ncols(x) != nrows(y)) && error("Dimensions are wrong")
    z = similar(x, nrows(x), ncols(y))
-   ccall((:fq_nmod_mat_mul, :libflint), Nothing,
+   ccall((:fq_nmod_mat_mul, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, x, y, base_ring(x))
    return z
 end
@@ -261,21 +261,21 @@ end
 ################################################################################
 
 function mul!(a::fq_nmod_mat, b::fq_nmod_mat, c::fq_nmod_mat)
-   ccall((:fq_nmod_mat_mul, :libflint), Nothing,
+   ccall((:fq_nmod_mat_mul, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          a, b, c, base_ring(a))
   return a
 end
 
 function add!(a::fq_nmod_mat, b::fq_nmod_mat, c::fq_nmod_mat)
-   ccall((:fq_nmod_mat_add, :libflint), Nothing,
+   ccall((:fq_nmod_mat_add, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          a, b, c, base_ring(a))
   return a
 end
 
 function zero!(a::fq_nmod_mat)
-   ccall((:fq_nmod_mat_zero, :libflint), Nothing,
+   ccall((:fq_nmod_mat_zero, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
    return a
 end
@@ -326,13 +326,13 @@ end
 
 function rref(a::fq_nmod_mat)
    z = deepcopy(a)
-   r = ccall((:fq_nmod_mat_rref, :libflint), Int,
+   r = ccall((:fq_nmod_mat_rref, libflint), Int,
              (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, base_ring(a))
    return r, z
 end
 
 function rref!(a::fq_nmod_mat)
-   r = ccall((:fq_nmod_mat_rref, :libflint), Int,
+   r = ccall((:fq_nmod_mat_rref, libflint), Int,
          (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
    return r
 end
@@ -402,7 +402,7 @@ end
 function inv(a::fq_nmod_mat)
    !issquare(a) && error("Matrix must be a square matrix")
    z = similar(a)
-   r = ccall((:fq_nmod_mat_inv, :libflint), Int,
+   r = ccall((:fq_nmod_mat_inv, libflint), Int,
              (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), z, a, base_ring(a))
    !Bool(r) && error("Matrix not invertible")
    return z
@@ -419,7 +419,7 @@ function solve(x::fq_nmod_mat, y::fq_nmod_mat)
    !issquare(x)&& error("First argument not a square matrix in solve")
    (nrows(y) != nrows(x)) || ncols(y) != 1 && ("Not a column vector in solve")
    z = similar(y)
-   r = ccall((:fq_nmod_mat_solve, :libflint), Int,
+   r = ccall((:fq_nmod_mat_solve, libflint), Int,
              (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
              z, x, y, base_ring(x))
    !Bool(r) && error("Singular matrix in solve")
@@ -433,7 +433,7 @@ end
 ################################################################################
 
 function lu!(P::Generic.Perm, x::fq_nmod_mat)
-   rank = Int(ccall((:fq_nmod_mat_lu, :libflint), Cint,
+   rank = Int(ccall((:fq_nmod_mat_lu, libflint), Cint,
                 (Ptr{Int}, Ref{fq_nmod_mat}, Cint, Ref{FqNmodFiniteField}),
                 P.d, x, 0, base_ring(x)))
 
@@ -500,7 +500,7 @@ function Base.view(x::fq_nmod_mat, r1::Int, c1::Int, r2::Int, c2::Int)
    z = fq_nmod_mat()
    z.base_ring = x.base_ring
    z.view_parent = x
-   ccall((:fq_nmod_mat_window_init, :libflint), Nothing,
+   ccall((:fq_nmod_mat_window_init, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Int, Int, Int, Int, Ref{FqNmodFiniteField}),
          z, x, r1 - 1, c1 - 1, r2, c2, base_ring(x))
    finalizer(_fq_nmod_mat_window_clear_fn, z)
@@ -512,7 +512,7 @@ function Base.view(x::fq_nmod_mat, r::UnitRange{Int}, c::UnitRange{Int})
 end
 
 function _fq_nmod_mat_window_clear_fn(a::fq_nmod_mat)
-   ccall((:fq_nmod_mat_window_clear, :libflint), Nothing,
+   ccall((:fq_nmod_mat_window_clear, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), a, base_ring(a))
 end
 
@@ -536,7 +536,7 @@ function hcat(x::fq_nmod_mat, y::fq_nmod_mat)
    (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
    (x.r != y.r) && error("Matrices must have same number of rows")
    z = similar(x, nrows(x), ncols(x) + ncols(y))
-   ccall((:fq_nmod_mat_concat_horizontal, :libflint), Nothing,
+   ccall((:fq_nmod_mat_concat_horizontal, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -546,7 +546,7 @@ function vcat(x::fq_nmod_mat, y::fq_nmod_mat)
    (base_ring(x) != base_ring(y)) && error("Matrices must have same base ring")
    (x.c != y.c) && error("Matrices must have same number of columns")
    z = similar(x, nrows(x) + nrows(y), ncols(x))
-   ccall((:fq_nmod_mat_concat_vertical, :libflint), Nothing,
+   ccall((:fq_nmod_mat_concat_vertical, libflint), Nothing,
          (Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(x))
    return z
@@ -578,7 +578,7 @@ function charpoly(R::FqNmodPolyRing, a::fq_nmod_mat)
   !issquare(a) && error("Matrix must be square")
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   p = R()
-  ccall((:fq_nmod_mat_charpoly, :libflint), Nothing,
+  ccall((:fq_nmod_mat_charpoly, libflint), Nothing,
           (Ref{fq_nmod_poly}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), p, a, base_ring(a))
   return p
 end
@@ -587,7 +587,7 @@ function charpoly_danivlesky!(R::FqNmodPolyRing, a::fq_nmod_mat)
   !issquare(a) && error("Matrix must be square")
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   p = R()
-  ccall((:fq_nmod_mat_charpoly_danilevsky, :libflint), Nothing,
+  ccall((:fq_nmod_mat_charpoly_danilevsky, libflint), Nothing,
           (Ref{fq_nmod_poly}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), p, a, base_ring(a))
   return p
 end
@@ -604,7 +604,7 @@ function minpoly(R::FqNmodPolyRing, a::fq_nmod_mat)
   base_ring(R) != base_ring(a) && error("Must have common base ring")
   m = deepcopy(a)
   p = R()
-  ccall((:fq_nmod_mat_minpoly, :libflint), Nothing,
+  ccall((:fq_nmod_mat_minpoly, libflint), Nothing,
           (Ref{fq_nmod_poly}, Ref{fq_nmod_mat}, Ref{FqNmodFiniteField}), p, m, base_ring(a))
   return p
 end

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -33,17 +33,17 @@ end
 #
 ################################################################################
 
-length(x::fq_nmod_poly) = ccall((:fq_nmod_poly_length, :libflint), Int,
+length(x::fq_nmod_poly) = ccall((:fq_nmod_poly_length, libflint), Int,
                                 (Ref{fq_nmod_poly},), x)
 
-set_length!(x::fq_nmod_poly, n::Int) = ccall((:_fq_nmod_poly_set_length, :libflint), Nothing,
+set_length!(x::fq_nmod_poly, n::Int) = ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
                               (Ref{fq_nmod_poly}, Int), x, n)
 
 function coeff(x::fq_nmod_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    F = (x.parent).base_ring
    temp = F(1)
-   ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          temp, x, n, F)
    return temp
@@ -55,15 +55,15 @@ one(a::FqNmodPolyRing) = a(one(base_ring(a)))
 
 gen(a::FqNmodPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
-iszero(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_zero, :libflint), Bool,
+iszero(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_zero, libflint), Bool,
                               (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
                               x, base_ring(x.parent))
 
-isone(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_one, :libflint), Bool,
+isone(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_one, libflint), Bool,
                               (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
                               x, base_ring(x.parent))
 
-isgen(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_gen, :libflint), Bool,
+isgen(x::fq_nmod_poly) = ccall((:fq_nmod_poly_is_gen, libflint), Bool,
                               (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
                               x, base_ring(x.parent))
 
@@ -95,12 +95,12 @@ function show(io::IO, x::fq_nmod_poly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fq_nmod_poly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fq_nmod_poly_get_str_pretty, libflint), Ptr{UInt8},
                   (Ref{fq_nmod_poly}, Ptr{UInt8}, Ref{FqNmodFiniteField}),
                   x, string(var(parent(x))),
                   (x.parent).base_ring)
       print(io, unsafe_string(cstr))
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -121,7 +121,7 @@ show_minus_one(::Type{fq_nmod_poly}) = show_minus_one(fq_nmod)
 
 function -(x::fq_nmod_poly)
    z = parent(x)()
-   ccall((:fq_nmod_poly_neg, :libflint), Nothing,
+   ccall((:fq_nmod_poly_neg, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, x, base_ring(parent(x)))
    return z
@@ -136,7 +136,7 @@ end
 function +(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_add, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -146,7 +146,7 @@ end
 function -(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_sub, :libflint), Nothing,
+   ccall((:fq_nmod_poly_sub, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -156,7 +156,7 @@ end
 function *(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_mul, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mul, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -173,7 +173,7 @@ function *(x::fq_nmod, y::fq_nmod_poly)
    parent(x) != base_ring(parent(y)) &&
          error("Coefficient rings must be equal")
    z = parent(y)()
-   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{fq_nmod}, Ref{FqNmodFiniteField}),
          z, y, x, parent(x))
@@ -223,7 +223,7 @@ end
 function ^(x::fq_nmod_poly, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = parent(x)()
-   ccall((:fq_nmod_poly_pow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_pow, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, x, y, base_ring(parent(x)))
    return z
@@ -237,7 +237,7 @@ end
 
 function ==(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
-   r = ccall((:fq_nmod_poly_equal, :libflint), Cint,
+   r = ccall((:fq_nmod_poly_equal, libflint), Cint,
              (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
              x, y, base_ring(parent(x)))
    return Bool(r)
@@ -254,7 +254,7 @@ function ==(x::fq_nmod_poly, y::fq_nmod)
    if length(x) > 1
       return false
    elseif length(x) == 1
-      r = ccall((:fq_nmod_poly_equal_fq_nmod, :libflint), Cint,
+      r = ccall((:fq_nmod_poly_equal_fq_nmod, libflint), Cint,
                 (Ref{fq_nmod_poly}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                 x, y, base_ring(parent(x)))
       return Bool(r)
@@ -285,7 +285,7 @@ function truncate(x::fq_nmod_poly, n::Int)
       return x
    end
    z = parent(x)()
-   ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, x, n, base_ring(parent(x)))
    return z
@@ -295,7 +295,7 @@ function mullow(x::fq_nmod_poly, y::fq_nmod_poly, n::Int)
    check_parent(x,y)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:fq_nmod_poly_mullow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mullow, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Int, Ref{FqNmodFiniteField}),
          z, x, y, n, base_ring(parent(x)))
@@ -311,7 +311,7 @@ end
 function reverse(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError(len, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:fq_nmod_poly_reverse, :libflint), Nothing,
+   ccall((:fq_nmod_poly_reverse, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -326,7 +326,7 @@ end
 function shift_left(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+   ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -335,7 +335,7 @@ end
 function shift_right(x::fq_nmod_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fq_nmod_poly_shift_right, :libflint), Nothing,
+   ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -350,7 +350,7 @@ end
 function div(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_div_basecase, :libflint), Nothing,
+   ccall((:fq_nmod_poly_div_basecase, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
   return z
@@ -359,7 +359,7 @@ end
 function rem(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_rem, :libflint), Nothing,
+   ccall((:fq_nmod_poly_rem, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
   return z
@@ -371,7 +371,7 @@ function divrem(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
    r = parent(x)()
-   ccall((:fq_nmod_poly_divrem, :libflint), Nothing, (Ref{fq_nmod_poly},
+   ccall((:fq_nmod_poly_divrem, libflint), Nothing, (Ref{fq_nmod_poly},
          Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, r, x, y, base_ring(parent(x)))
    return z,r
@@ -394,7 +394,7 @@ function remove(z::fq_nmod_poly, p::fq_nmod_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
-   v = ccall((:fq_nmod_poly_remove, :libflint), Int,
+   v = ccall((:fq_nmod_poly_remove, libflint), Int,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
              z,  p, base_ring(parent(z)))
    return v, z
@@ -409,7 +409,7 @@ function divides(z::fq_nmod_poly, x::fq_nmod_poly)
       return false, zero(parent(z))
    end
    q = parent(z)()
-   v = Bool(ccall((:fq_nmod_poly_divides, :libflint), Cint,
+   v = Bool(ccall((:fq_nmod_poly_divides, libflint), Cint,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
              Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
              q, z, x, base_ring(parent(z))))
@@ -434,7 +434,7 @@ function powmod(x::fq_nmod_poly, n::Int, y::fq_nmod_poly)
       n = -n
    end
 
-   ccall((:fq_nmod_poly_powmod_ui_binexp, :libflint), Nothing,
+   ccall((:fq_nmod_poly_powmod_ui_binexp, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Int, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
@@ -452,7 +452,7 @@ function powmod(x::fq_nmod_poly, n::fmpz, y::fq_nmod_poly)
       n = -n
    end
 
-   ccall((:fq_nmod_poly_powmod_fmpz_binexp, :libflint), Nothing,
+   ccall((:fq_nmod_poly_powmod_fmpz_binexp, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fmpz}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
@@ -467,7 +467,7 @@ end
 function gcd(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_gcd, :libflint), Nothing,
+   ccall((:fq_nmod_poly_gcd, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -478,7 +478,7 @@ function gcdinv(x::fq_nmod_poly, y::fq_nmod_poly)
    z = parent(x)()
    s = parent(x)()
    t = parent(x)()
-   ccall((:fq_nmod_poly_xgcd, :libflint), Nothing,
+   ccall((:fq_nmod_poly_xgcd, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
           Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
            Ref{FqNmodFiniteField}), z, s, t, x, y, base_ring(parent(x)))
@@ -490,7 +490,7 @@ function gcdx(x::fq_nmod_poly, y::fq_nmod_poly)
    z = parent(x)()
    s = parent(x)()
    t = parent(x)()
-   ccall((:fq_nmod_poly_xgcd, :libflint), Nothing,
+   ccall((:fq_nmod_poly_xgcd, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
           Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
            Ref{FqNmodFiniteField}), z, s, t, x, y, base_ring(parent(x)))
@@ -506,7 +506,7 @@ end
 function evaluate(x::fq_nmod_poly, y::fq_nmod)
    base_ring(parent(x)) != parent(y) && error("Incompatible coefficient rings")
    z = parent(y)()
-   ccall((:fq_nmod_poly_evaluate_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_evaluate_fq_nmod, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_poly}, Ref{fq_nmod},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -521,7 +521,7 @@ end
 function compose(x::fq_nmod_poly, y::fq_nmod_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_nmod_poly_compose, :libflint), Nothing,
+   ccall((:fq_nmod_poly_compose, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -535,7 +535,7 @@ end
 
 function derivative(x::fq_nmod_poly)
    z = parent(x)()
-   ccall((:fq_nmod_poly_derivative, :libflint), Nothing,
+   ccall((:fq_nmod_poly_derivative, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, x, base_ring(parent(x)))
    return z
@@ -549,7 +549,7 @@ end
 
 function inflate(x::fq_nmod_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_nmod_poly_inflate, :libflint), Nothing, (Ref{fq_nmod_poly},
+   ccall((:fq_nmod_poly_inflate, libflint), Nothing, (Ref{fq_nmod_poly},
          Ref{fq_nmod_poly}, Culong, Ref{FqNmodFiniteField}),
          z, x, UInt(n), base_ring(parent(x)))
    return z
@@ -557,7 +557,7 @@ end
 
 function deflate(x::fq_nmod_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_nmod_poly_deflate, :libflint), Nothing,
+   ccall((:fq_nmod_poly_deflate, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Culong, Ref{FqNmodFiniteField}),
          z, x, UInt(n), base_ring(parent(x)))
   return z
@@ -574,7 +574,7 @@ end
 > Return `true` if $x$ is irreducible, otherwise return `false`.
 """
 function isirreducible(x::fq_nmod_poly)
-  return Bool(ccall((:fq_nmod_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:fq_nmod_poly_is_irreducible, libflint), Int32,
                     (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField} ),
                     x, base_ring(parent(x))))
 end
@@ -590,7 +590,7 @@ end
 > Return `true` if $x$ is squarefree, otherwise return `false`.
 """
 function issquarefree(x::fq_nmod_poly)
-   return Bool(ccall((:fq_nmod_poly_is_squarefree, :libflint), Int32,
+   return Bool(ccall((:fq_nmod_poly_is_squarefree, libflint), Int32,
        (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), x, base_ring(parent(x))))
 end
 
@@ -614,13 +614,13 @@ function _factor(x::fq_nmod_poly)
    F = base_ring(R)
    a = F()
    fac = fq_nmod_poly_factor(F)
-   ccall((:fq_nmod_poly_factor, :libflint), Nothing, (Ref{fq_nmod_poly_factor},
+   ccall((:fq_nmod_poly_factor, libflint), Nothing, (Ref{fq_nmod_poly_factor},
          Ref{fq_nmod}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          fac, a, x, F)
    res = Dict{fq_nmod_poly,Int}()
    for i in 1:fac.num
       f = R()
-      ccall((:fq_nmod_poly_factor_get_poly, :libflint), Nothing,
+      ccall((:fq_nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
             Ref{FqNmodFiniteField}), f, fac, i-1, F)
       e = unsafe_load(fac.exp,i)
@@ -641,12 +641,12 @@ end
 function _factor_squarefree(x::fq_nmod_poly)
   F = base_ring(parent(x))
   fac = fq_nmod_poly_factor(F)
-  ccall((:fq_nmod_poly_factor_squarefree, :libflint), UInt,
+  ccall((:fq_nmod_poly_factor_squarefree, libflint), UInt,
         (Ref{fq_nmod_poly_factor}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}), fac, x, F)
   res = Dict{fq_nmod_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fq_nmod_poly_factor_get_poly, :libflint), Nothing,
+    ccall((:fq_nmod_poly_factor_get_poly, libflint), Nothing,
           (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
            Ref{FqNmodFiniteField}), f, fac, i-1, F)
     e = unsafe_load(fac.exp, i)
@@ -664,13 +664,13 @@ function factor_distinct_deg(x::fq_nmod_poly)
    F = base_ring(R)
    fac = fq_nmod_poly_factor(F)
    degrees = Vector{Int}(undef, degree(x))
-   ccall((:fq_nmod_poly_factor_distinct_deg, :libflint), Nothing,
+   ccall((:fq_nmod_poly_factor_distinct_deg, libflint), Nothing,
          (Ref{fq_nmod_poly_factor}, Ref{fq_nmod_poly}, Ref{Vector{Int}},
          Ref{FqNmodFiniteField}), fac, x, degrees, F)
    res = Dict{Int, fq_nmod_poly}()
    for i in 1:fac.num
       f = R()
-      ccall((:fq_nmod_poly_factor_get_poly, :libflint), Nothing,
+      ccall((:fq_nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{fq_nmod_poly}, Ref{fq_nmod_poly_factor}, Int,
             Ref{FqNmodFiniteField}), f, fac, i-1, F)
       res[degrees[i]] = f
@@ -685,42 +685,42 @@ end
 ################################################################################
 
 function zero!(z::fq_nmod_poly)
-   ccall((:fq_nmod_poly_zero, :libflint), Nothing,
+   ccall((:fq_nmod_poly_zero, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
          z, base_ring(parent(z)))
    return z
 end
 
 function fit!(z::fq_nmod_poly, n::Int)
-   ccall((:fq_nmod_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
          (Ref{fq_nmod_poly}, Int, Ref{FqNmodFiniteField}),
          z, n, base_ring(parent(z)))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_poly, n::Int, x::fq_nmod)
-   ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
          (Ref{fq_nmod_poly}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
          z, n, x, base_ring(parent(z)))
    return z
 end
 
 function mul!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
-   ccall((:fq_nmod_poly_mul, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mul, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function add!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
-   ccall((:fq_nmod_poly_add, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function sub!(z::fq_nmod_poly, x::fq_nmod_poly, y::fq_nmod_poly)
-   ccall((:fq_nmod_poly_sub, :libflint), Nothing,
+   ccall((:fq_nmod_poly_sub, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -728,7 +728,7 @@ end
 
 
 function addeq!(z::fq_nmod_poly, x::fq_nmod_poly)
-   ccall((:fq_nmod_poly_add, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add, libflint), Nothing,
          (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{fq_nmod_poly},
          Ref{FqNmodFiniteField}), z, z, x, base_ring(parent(x)))
    return z

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -40,14 +40,14 @@ function normalise(a::fq_nmod_rel_series, len::Int)
    ctx = base_ring(a)
    if len > 0
       c = base_ring(a)()
-      ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                                                          c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+         ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                                                          c, a, len - 1, ctx)
       end
@@ -56,7 +56,7 @@ function normalise(a::fq_nmod_rel_series, len::Int)
 end
 
 function pol_length(x::fq_nmod_rel_series)
-   return ccall((:fq_nmod_poly_length, :libflint), Int,
+   return ccall((:fq_nmod_poly_length, libflint), Int,
                 (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
 end
 
@@ -67,7 +67,7 @@ function polcoeff(x::fq_nmod_rel_series, n::Int)
    if n < 0
       return z
    end
-   ccall((:fq_nmod_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
          (Ref{fq_nmod}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                                                       z, x, n, base_ring(x))
    return z
@@ -104,7 +104,7 @@ function renormalize!(z::fq_nmod_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:fq_nmod_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                                                       z, z, i, base_ring(z))
    end
@@ -134,7 +134,7 @@ show_minus_one(::Type{fq_nmod_rel_series}) = show_minus_one(fq_nmod)
 
 function -(x::fq_nmod_rel_series)
    z = parent(x)()
-   ccall((:fq_nmod_poly_neg, :libflint), Nothing,
+   ccall((:fq_nmod_poly_neg, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}),
                z, x, base_ring(x))
    z.prec = x.prec
@@ -160,31 +160,31 @@ function +(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    ctx = base_ring(a)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, z, a.val - b.val, ctx)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, ctx)
@@ -208,34 +208,34 @@ function -(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    ctx = base_ring(a)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_nmod_poly_neg, :libflint), Nothing,
+      ccall((:fq_nmod_poly_neg, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}),
             z, z, ctx)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, z, a.val - b.val, ctx)
-      ccall((:fq_nmod_poly_sub_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_nmod_poly_sub_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, ctx)
@@ -262,7 +262,7 @@ function *(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fq_nmod_poly_mullow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mullow, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -279,7 +279,7 @@ function *(x::fq_nmod, y::fq_nmod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, y, x, base_ring(y))
@@ -316,7 +316,7 @@ function shift_right(x::fq_nmod_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:fq_nmod_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Int, Ref{FqNmodFiniteField}),
                z, x, xlen - zlen, base_ring(x))
@@ -347,7 +347,7 @@ function truncate(x::fq_nmod_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Int, Ref{FqNmodFiniteField}),
                z, x, min(prec - xval, xlen), base_ring(x))
@@ -415,7 +415,7 @@ function ==(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:fq_nmod_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Int, Ref{FqNmodFiniteField}),
                x, y, xlen, base_ring(x)))
@@ -428,7 +428,7 @@ function isequal(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:fq_nmod_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Int, Ref{FqNmodFiniteField}),
                x, y, pol_length(x), base_ring(x)))
@@ -457,7 +457,7 @@ function divexact(x::fq_nmod_rel_series, y::fq_nmod_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:fq_nmod_poly_div_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_div_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, x, y, prec, base_ring(x))
@@ -477,7 +477,7 @@ function divexact(x::fq_nmod_rel_series, y::fq_nmod)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   ccall((:fq_nmod_poly_scalar_div_fq_nmod, :libflint), Nothing,
+   ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, x, y, base_ring(x))
@@ -496,7 +496,7 @@ function inv(a::fq_nmod_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:fq_nmod_poly_inv_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
          (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                ainv, a, a.prec, base_ring(a))
    return ainv
@@ -509,28 +509,28 @@ end
 ###############################################################################
 
 function zero!(x::fq_nmod_rel_series)
-  ccall((:fq_nmod_poly_zero, :libflint), Nothing,
+  ccall((:fq_nmod_poly_zero, libflint), Nothing,
                    (Ref{fq_nmod_rel_series}, Ref{FqNmodFiniteField}), x, base_ring(x))
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(z::fq_nmod_rel_series, n::Int)
-   ccall((:fq_nmod_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
          (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
          z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fmpz)
-   ccall((:fq_nmod_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Int, Ref{fmpz}, Ref{FqNmodFiniteField}),
                z, n, x, base_ring(z))
    return z
 end
 
 function setcoeff!(z::fq_nmod_rel_series, n::Int, x::fq_nmod)
-   ccall((:fq_nmod_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Int, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                z, n, x, base_ring(z))
    return z
@@ -550,7 +550,7 @@ function mul!(z::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:fq_nmod_poly_mullow, :libflint), Nothing,
+   ccall((:fq_nmod_poly_mullow, libflint), Nothing,
          (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
           Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                z, a, b, lenz, base_ring(z))
@@ -568,31 +568,31 @@ function addeq!(a::fq_nmod_rel_series, b::fq_nmod_rel_series)
    if a.val < b.val
       z = fq_nmod_rel_series(base_ring(a))
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                a, a, z, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_nmod_poly_truncate, :libflint), Nothing,
+      ccall((:fq_nmod_poly_truncate, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
             (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
             a, a, a.val - b.val, ctx)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                a, a, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
                 (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series},
                  Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                a, a, b, lenz, ctx)
@@ -615,7 +615,7 @@ function add!(c::fq_nmod_rel_series, a::fq_nmod_rel_series, b::fq_nmod_rel_serie
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:fq_nmod_poly_add_series, :libflint), Nothing,
+   ccall((:fq_nmod_poly_add_series, libflint), Nothing,
      (Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Ref{fq_nmod_rel_series}, Int, Ref{FqNmodFiniteField}),
                c, a, b, lenc, ctx)
    return c

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -33,20 +33,20 @@ end
 #
 ################################################################################
 
-length(x::fq_poly) = ccall((:fq_poly_length, :libflint), Int,
+length(x::fq_poly) = ccall((:fq_poly_length, libflint), Int,
                                 (Ref{fq_poly},), x)
 
 function coeff(x::fq_poly, n::Int)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    F = (x.parent).base_ring
    temp = F(1)
-   ccall((:fq_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_poly_get_coeff, libflint), Nothing,
          (Ref{fq}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          temp, x, n, F)
    return temp
 end
 
-set_length!(x::fq_poly, n::Int) = ccall((:_fq_poly_set_length, :libflint), Nothing,
+set_length!(x::fq_poly, n::Int) = ccall((:_fq_poly_set_length, libflint), Nothing,
                               (Ref{fq_poly}, Int), x, n)
 
 zero(a::FqPolyRing) = a(zero(base_ring(a)))
@@ -55,15 +55,15 @@ one(a::FqPolyRing) = a(one(base_ring(a)))
 
 gen(a::FqPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
-isgen(x::fq_poly) = ccall((:fq_poly_is_gen, :libflint), Bool,
+isgen(x::fq_poly) = ccall((:fq_poly_is_gen, libflint), Bool,
                               (Ref{fq_poly}, Ref{FqFiniteField}),
                               x, base_ring(x.parent))
 
-iszero(x::fq_poly) = ccall((:fq_poly_is_zero, :libflint), Bool,
+iszero(x::fq_poly) = ccall((:fq_poly_is_zero, libflint), Bool,
                               (Ref{fq_poly}, Ref{FqFiniteField}),
                               x, base_ring(x.parent))
 
-isone(x::fq_poly) = ccall((:fq_poly_is_one, :libflint), Bool,
+isone(x::fq_poly) = ccall((:fq_poly_is_one, libflint), Bool,
                               (Ref{fq_poly}, Ref{FqFiniteField}),
                               x, base_ring(x.parent))
 
@@ -95,12 +95,12 @@ function show(io::IO, x::fq_poly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:fq_poly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:fq_poly_get_str_pretty, libflint), Ptr{UInt8},
                   (Ref{fq_poly}, Ptr{UInt8}, Ref{FqFiniteField}),
                   x, string(var(parent(x))),
                   (x.parent).base_ring)
       print(io, unsafe_string(cstr))
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -121,7 +121,7 @@ show_minus_one(::Type{fq_poly}) = show_minus_one(fq)
 
 function -(x::fq_poly)
    z = parent(x)()
-   ccall((:fq_poly_neg, :libflint), Nothing,
+   ccall((:fq_poly_neg, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
          z, x, base_ring(parent(x)))
    return z
@@ -136,7 +136,7 @@ end
 function +(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_add, :libflint), Nothing,
+   ccall((:fq_poly_add, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly},
          Ref{fq_poly}, Ref{FqFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -146,7 +146,7 @@ end
 function -(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_sub, :libflint), Nothing,
+   ccall((:fq_poly_sub, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly},
          Ref{fq_poly}, Ref{FqFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -156,7 +156,7 @@ end
 function *(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_mul, :libflint), Nothing,
+   ccall((:fq_poly_mul, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly},
          Ref{fq_poly}, Ref{FqFiniteField}),
          z, x, y, base_ring(parent(x)))
@@ -173,7 +173,7 @@ function *(x::fq, y::fq_poly)
    parent(x) != base_ring(parent(y)) &&
          error("Coefficient rings must be equal")
    z = parent(y)()
-   ccall((:fq_poly_scalar_mul_fq, :libflint), Nothing,
+   ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly},
          Ref{fq}, Ref{FqFiniteField}),
          z, y, x, parent(x))
@@ -223,7 +223,7 @@ end
 function ^(x::fq_poly, y::Int)
    y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
    z = parent(x)()
-   ccall((:fq_poly_pow, :libflint), Nothing,
+   ccall((:fq_poly_pow, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, x, y, base_ring(parent(x)))
    return z
@@ -237,7 +237,7 @@ end
 
 function ==(x::fq_poly, y::fq_poly)
    check_parent(x,y)
-   r = ccall((:fq_poly_equal, :libflint), Cint,
+   r = ccall((:fq_poly_equal, libflint), Cint,
              (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
              x, y, base_ring(parent(x)))
    return Bool(r)
@@ -254,7 +254,7 @@ function ==(x::fq_poly, y::fq)
    if length(x) > 1
       return false
    elseif length(x) == 1
-      r = ccall((:fq_poly_equal_fq, :libflint), Cint,
+      r = ccall((:fq_poly_equal_fq, libflint), Cint,
                 (Ref{fq_poly}, Ref{fq}, Ref{FqFiniteField}),
                 x, y, base_ring(parent(x)))
       return Bool(r)
@@ -285,7 +285,7 @@ function truncate(x::fq_poly, n::Int)
       return x
    end
    z = parent(x)()
-   ccall((:fq_poly_set_trunc, :libflint), Nothing,
+   ccall((:fq_poly_set_trunc, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, x, n, base_ring(parent(x)))
    return z
@@ -295,7 +295,7 @@ function mullow(x::fq_poly, y::fq_poly, n::Int)
    check_parent(x,y)
    n < 0 && throw(DomainError(n, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:fq_poly_mullow, :libflint), Nothing,
+   ccall((:fq_poly_mullow, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Int, Ref{FqFiniteField}),
          z, x, y, n, base_ring(parent(x)))
@@ -311,7 +311,7 @@ end
 function reverse(x::fq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Index must be non-negative"))
    z = parent(x)()
-   ccall((:fq_poly_reverse, :libflint), Nothing,
+   ccall((:fq_poly_reverse, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -326,7 +326,7 @@ end
 function shift_left(x::fq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fq_poly_shift_left, :libflint), Nothing,
+   ccall((:fq_poly_shift_left, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -335,7 +335,7 @@ end
 function shift_right(x::fq_poly, len::Int)
    len < 0 && throw(DomainError(len, "Shift must be non-negative"))
    z = parent(x)()
-   ccall((:fq_poly_shift_right, :libflint), Nothing,
+   ccall((:fq_poly_shift_right, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, x, len, base_ring(parent(x)))
    return z
@@ -350,7 +350,7 @@ end
 function div(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_div_basecase, :libflint), Nothing,
+   ccall((:fq_poly_div_basecase, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
   return z
@@ -359,7 +359,7 @@ end
 function rem(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_rem, :libflint), Nothing,
+   ccall((:fq_poly_rem, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
   return z
@@ -371,7 +371,7 @@ function divrem(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
    r = parent(x)()
-   ccall((:fq_poly_divrem, :libflint), Nothing, (Ref{fq_poly},
+   ccall((:fq_poly_divrem, libflint), Nothing, (Ref{fq_poly},
          Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, r, x, y, base_ring(parent(x)))
    return z, r
@@ -394,7 +394,7 @@ function remove(z::fq_poly, p::fq_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
-   v = ccall((:fq_poly_remove, :libflint), Int,
+   v = ccall((:fq_poly_remove, libflint), Int,
             (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
              z,  p, base_ring(parent(z)))
    return v, z
@@ -409,7 +409,7 @@ function divides(z::fq_poly, x::fq_poly)
    end
    check_parent(z, x)
    q = parent(z)()
-   v = Bool(ccall((:fq_poly_divides, :libflint), Cint,
+   v = Bool(ccall((:fq_poly_divides, libflint), Cint,
             (Ref{fq_poly}, Ref{fq_poly},
              Ref{fq_poly}, Ref{FqFiniteField}),
              q, z, x, base_ring(parent(z))))
@@ -434,7 +434,7 @@ function powmod(x::fq_poly, n::Int, y::fq_poly)
       n = -n
    end
 
-   ccall((:fq_poly_powmod_ui_binexp, :libflint), Nothing,
+   ccall((:fq_poly_powmod_ui_binexp, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Int, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
@@ -452,7 +452,7 @@ function powmod(x::fq_poly, n::fmpz, y::fq_poly)
       n = -n
    end
 
-   ccall((:fq_poly_powmod_fmpz_binexp, :libflint), Nothing,
+   ccall((:fq_poly_powmod_fmpz_binexp, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fmpz}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, n, y, base_ring(parent(x)))
   return z
@@ -467,7 +467,7 @@ end
 function gcd(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_gcd, :libflint), Nothing,
+   ccall((:fq_poly_gcd, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -478,7 +478,7 @@ function gcdinv(x::fq_poly, y::fq_poly)
    z = parent(x)()
    s = parent(x)()
    t = parent(x)()
-   ccall((:fq_poly_xgcd, :libflint), Nothing,
+   ccall((:fq_poly_xgcd, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s
@@ -489,7 +489,7 @@ function gcdx(x::fq_poly, y::fq_poly)
    z = parent(x)()
    s = parent(x)()
    t = parent(x)()
-   ccall((:fq_poly_xgcd, :libflint), Nothing,
+   ccall((:fq_poly_xgcd, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, s, t, x, y, base_ring(parent(x)))
    return z, s, t
@@ -504,7 +504,7 @@ end
 function evaluate(x::fq_poly, y::fq)
    base_ring(parent(x)) != parent(y) && error("Incompatible coefficient rings")
    z = parent(y)()
-   ccall((:fq_poly_evaluate_fq, :libflint), Nothing,
+   ccall((:fq_poly_evaluate_fq, libflint), Nothing,
          (Ref{fq}, Ref{fq_poly}, Ref{fq},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -519,7 +519,7 @@ end
 function compose(x::fq_poly, y::fq_poly)
    check_parent(x,y)
    z = parent(x)()
-   ccall((:fq_poly_compose, :libflint), Nothing,
+   ccall((:fq_poly_compose, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -533,7 +533,7 @@ end
 
 function derivative(x::fq_poly)
    z = parent(x)()
-   ccall((:fq_poly_derivative, :libflint), Nothing,
+   ccall((:fq_poly_derivative, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
          z, x, base_ring(parent(x)))
    return z
@@ -547,7 +547,7 @@ end
 
 function inflate(x::fq_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_poly_inflate, :libflint), Nothing, (Ref{fq_poly},
+   ccall((:fq_poly_inflate, libflint), Nothing, (Ref{fq_poly},
          Ref{fq_poly}, Culong, Ref{FqFiniteField}),
          z, x, UInt(n), base_ring(parent(x)))
    return z
@@ -555,7 +555,7 @@ end
 
 function deflate(x::fq_poly, n::Int)
    z = parent(x)()
-   ccall((:fq_poly_deflate, :libflint), Nothing,
+   ccall((:fq_poly_deflate, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Culong, Ref{FqFiniteField}),
          z, x, UInt(n), base_ring(parent(x)))
   return z
@@ -572,7 +572,7 @@ end
 > Return `true` if $x$ is irreducible, otherwise return `false`.
 """
 function isirreducible(x::fq_poly)
-  return Bool(ccall((:fq_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:fq_poly_is_irreducible, libflint), Int32,
                     (Ref{fq_poly}, Ref{FqFiniteField} ),
                     x, base_ring(parent(x))))
 end
@@ -588,7 +588,7 @@ end
 > Return `true` if $x$ is squarefree, otherwise return `false`.
 """
 function issquarefree(x::fq_poly)
-   return Bool(ccall((:fq_poly_is_squarefree, :libflint), Int32,
+   return Bool(ccall((:fq_poly_is_squarefree, libflint), Int32,
        (Ref{fq_poly}, Ref{FqFiniteField}), x, base_ring(parent(x))))
 end
 
@@ -612,13 +612,13 @@ function _factor(x::fq_poly)
    F = base_ring(R)
    a = F()
    fac = fq_poly_factor(F)
-   ccall((:fq_poly_factor, :libflint), Nothing, (Ref{fq_poly_factor},
+   ccall((:fq_poly_factor, libflint), Nothing, (Ref{fq_poly_factor},
          Ref{fq}, Ref{fq_poly}, Ref{FqFiniteField}),
          fac, a, x, F)
    res = Dict{fq_poly,Int}()
    for i in 1:fac.num
       f = R()
-      ccall((:fq_poly_factor_get_poly, :libflint), Nothing,
+      ccall((:fq_poly_factor_get_poly, libflint), Nothing,
             (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
             Ref{FqFiniteField}), f, fac, i-1, F)
       e = unsafe_load(fac.exp,i)
@@ -639,12 +639,12 @@ end
 function _factor_squarefree(x::fq_poly)
   F = base_ring(parent(x))
   fac = fq_poly_factor(F)
-  ccall((:fq_poly_factor_squarefree, :libflint), UInt,
+  ccall((:fq_poly_factor_squarefree, libflint), UInt,
         (Ref{fq_poly_factor}, Ref{fq_poly}, Ref{FqFiniteField}), fac, x, F)
   res = Dict{fq_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fq_poly_factor_get_poly, :libflint), Nothing,
+    ccall((:fq_poly_factor_get_poly, libflint), Nothing,
           (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
           Ref{FqFiniteField}), f, fac, i-1, F)
     e = unsafe_load(fac.exp, i)
@@ -662,13 +662,13 @@ function factor_distinct_deg(x::fq_poly)
    F = base_ring(R)
    fac = fq_poly_factor(F)
    degrees = Vector{Int}(undef, degree(x))
-   ccall((:fq_poly_factor_distinct_deg, :libflint), Nothing,
+   ccall((:fq_poly_factor_distinct_deg, libflint), Nothing,
          (Ref{fq_poly_factor}, Ref{fq_poly}, Ref{Vector{Int}},
          Ref{FqFiniteField}), fac, x, degrees, F)
    res = Dict{Int, fq_poly}()
    for i in 1:fac.num
       f = R()
-      ccall((:fq_poly_factor_get_poly, :libflint), Nothing,
+      ccall((:fq_poly_factor_get_poly, libflint), Nothing,
             (Ref{fq_poly}, Ref{fq_poly_factor}, Int,
             Ref{FqFiniteField}), f, fac, i-1, F)
       res[degrees[i]] = f
@@ -683,42 +683,42 @@ end
 ################################################################################
 
 function zero!(z::fq_poly)
-   ccall((:fq_poly_zero, :libflint), Nothing,
+   ccall((:fq_poly_zero, libflint), Nothing,
          (Ref{fq_poly}, Ref{FqFiniteField}),
          z, base_ring(parent(z)))
    return z
 end
 
 function fit!(z::fq_poly, n::Int)
-   ccall((:fq_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_poly_fit_length, libflint), Nothing,
          (Ref{fq_poly}, Int, Ref{FqFiniteField}),
          z, n, base_ring(parent(z)))
    return nothing
 end
 
 function setcoeff!(z::fq_poly, n::Int, x::fq)
-   ccall((:fq_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_poly_set_coeff, libflint), Nothing,
          (Ref{fq_poly}, Int, Ref{fq}, Ref{FqFiniteField}),
          z, n, x, base_ring(parent(z)))
    return z
 end
 
 function mul!(z::fq_poly, x::fq_poly, y::fq_poly)
-   ccall((:fq_poly_mul, :libflint), Nothing,
+   ccall((:fq_poly_mul, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function add!(z::fq_poly, x::fq_poly, y::fq_poly)
-   ccall((:fq_poly_add, :libflint), Nothing,
+   ccall((:fq_poly_add, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
 end
 
 function sub!(z::fq_poly, x::fq_poly, y::fq_poly)
-   ccall((:fq_poly_sub, :libflint), Nothing,
+   ccall((:fq_poly_sub, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, x, y, base_ring(parent(x)))
    return z
@@ -726,7 +726,7 @@ end
 
 
 function addeq!(z::fq_poly, x::fq_poly)
-   ccall((:fq_poly_add, :libflint), Nothing,
+   ccall((:fq_poly_add, libflint), Nothing,
          (Ref{fq_poly}, Ref{fq_poly}, Ref{fq_poly},
          Ref{FqFiniteField}), z, z, x, base_ring(parent(x)))
    return z

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -40,14 +40,14 @@ function normalise(a::fq_rel_series, len::Int)
    ctx = base_ring(a)
    if len > 0
       c = base_ring(a)()
-      ccall((:fq_poly_get_coeff, :libflint), Nothing,
+      ccall((:fq_poly_get_coeff, libflint), Nothing,
          (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                                                          c, a, len - 1, ctx)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         ccall((:fq_poly_get_coeff, :libflint), Nothing,
+         ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                                                          c, a, len - 1, ctx)
       end
@@ -56,7 +56,7 @@ function normalise(a::fq_rel_series, len::Int)
 end
 
 function pol_length(x::fq_rel_series)
-   return ccall((:fq_poly_length, :libflint), Int,
+   return ccall((:fq_poly_length, libflint), Int,
                 (Ref{fq_rel_series}, Ref{FqFiniteField}), x, base_ring(x))
 end
 
@@ -67,7 +67,7 @@ function polcoeff(x::fq_rel_series, n::Int)
    if n < 0
       return z
    end
-   ccall((:fq_poly_get_coeff, :libflint), Nothing,
+   ccall((:fq_poly_get_coeff, libflint), Nothing,
          (Ref{fq}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                                                       z, x, n, base_ring(x))
    return z
@@ -104,7 +104,7 @@ function renormalize!(z::fq_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:fq_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_poly_shift_right, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                                                       z, z, i, base_ring(z))
    end
@@ -134,7 +134,7 @@ show_minus_one(::Type{fq_rel_series}) = show_minus_one(fq)
 
 function -(x::fq_rel_series)
    z = parent(x)()
-   ccall((:fq_poly_neg, :libflint), Nothing,
+   ccall((:fq_poly_neg, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}),
                z, x, base_ring(x))
    z.prec = x.prec
@@ -160,31 +160,31 @@ function +(a::fq_rel_series, b::fq_rel_series)
    ctx = base_ring(a)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, z, a.val - b.val, ctx)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, ctx)
@@ -208,34 +208,34 @@ function -(a::fq_rel_series, b::fq_rel_series)
    ctx = base_ring(a)
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_poly_neg, :libflint), Nothing,
+      ccall((:fq_poly_neg, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{FqFiniteField}),
             z, z, ctx)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, z, a, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, z, a.val - b.val, ctx)
-      ccall((:fq_poly_sub_series, :libflint), Nothing,
+      ccall((:fq_poly_sub_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, z, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_poly_sub_series, :libflint), Nothing,
+      ccall((:fq_poly_sub_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, ctx)
@@ -262,7 +262,7 @@ function *(a::fq_rel_series, b::fq_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:fq_poly_mullow, :libflint), Nothing,
+   ccall((:fq_poly_mullow, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(a))
@@ -279,7 +279,7 @@ function *(x::fq, y::fq_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:fq_poly_scalar_mul_fq, :libflint), Nothing,
+   ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq}, Ref{FqFiniteField}),
                z, y, x, base_ring(y))
@@ -316,7 +316,7 @@ function shift_right(x::fq_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:fq_poly_shift_right, :libflint), Nothing,
+      ccall((:fq_poly_shift_right, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Int, Ref{FqFiniteField}),
                z, x, xlen - zlen, base_ring(x))
@@ -347,7 +347,7 @@ function truncate(x::fq_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Int, Ref{FqFiniteField}),
                z, x, min(prec - xval, xlen), base_ring(x))
@@ -415,7 +415,7 @@ function ==(x::fq_rel_series, y::fq_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:fq_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Int, Ref{FqFiniteField}),
                x, y, xlen, base_ring(x)))
@@ -428,7 +428,7 @@ function isequal(x::fq_rel_series, y::fq_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:fq_poly_equal, :libflint), Cint,
+   return Bool(ccall((:fq_poly_equal, libflint), Cint,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Int, Ref{FqFiniteField}),
                x, y, pol_length(x), base_ring(x)))
@@ -457,7 +457,7 @@ function divexact(x::fq_rel_series, y::fq_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:fq_poly_div_series, :libflint), Nothing,
+      ccall((:fq_poly_div_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, x, y, prec, base_ring(x))
@@ -477,7 +477,7 @@ function divexact(x::fq_rel_series, y::fq)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   ccall((:fq_poly_scalar_div_fq, :libflint), Nothing,
+   ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq}, Ref{FqFiniteField}),
                z, x, y, base_ring(x))
@@ -496,7 +496,7 @@ function inv(a::fq_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:fq_poly_inv_series, :libflint), Nothing,
+   ccall((:fq_poly_inv_series, libflint), Nothing,
          (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                ainv, a, a.prec, base_ring(a))
    return ainv
@@ -509,28 +509,28 @@ end
 ###############################################################################
 
 function zero!(x::fq_rel_series)
-  ccall((:fq_poly_zero, :libflint), Nothing,
+  ccall((:fq_poly_zero, libflint), Nothing,
                    (Ref{fq_rel_series}, Ref{FqFiniteField}), x, base_ring(x))
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(z::fq_rel_series, n::Int)
-   ccall((:fq_poly_fit_length, :libflint), Nothing,
+   ccall((:fq_poly_fit_length, libflint), Nothing,
          (Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
          z, n, base_ring(z))
    return nothing
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fmpz)
-   ccall((:fq_poly_set_coeff_fmpz, :libflint), Nothing,
+   ccall((:fq_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fq_rel_series}, Int, Ref{fmpz}, Ref{FqFiniteField}),
                z, n, x, base_ring(z))
    return z
 end
 
 function setcoeff!(z::fq_rel_series, n::Int, x::fq)
-   ccall((:fq_poly_set_coeff, :libflint), Nothing,
+   ccall((:fq_poly_set_coeff, libflint), Nothing,
                 (Ref{fq_rel_series}, Int, Ref{fq}, Ref{FqFiniteField}),
                z, n, x, base_ring(z))
    return z
@@ -550,7 +550,7 @@ function mul!(z::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:fq_poly_mullow, :libflint), Nothing,
+   ccall((:fq_poly_mullow, libflint), Nothing,
          (Ref{fq_rel_series}, Ref{fq_rel_series},
           Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                z, a, b, lenz, base_ring(z))
@@ -568,31 +568,31 @@ function addeq!(a::fq_rel_series, b::fq_rel_series)
    if a.val < b.val
       z = fq_rel_series(base_ring(a))
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:fq_poly_set_trunc, :libflint), Nothing,
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, b, max(0, lenz - b.val + a.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             z, z, b.val - a.val, ctx)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                a, a, z, lenz, ctx)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:fq_poly_truncate, :libflint), Nothing,
+      ccall((:fq_poly_truncate, libflint), Nothing,
             (Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             a, max(0, lenz - a.val + b.val), ctx)
-      ccall((:fq_poly_shift_left, :libflint), Nothing,
+      ccall((:fq_poly_shift_left, libflint), Nothing,
             (Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
             a, a, a.val - b.val, ctx)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                a, a, b, lenz, ctx)
    else
       lenz = max(lena, lenb)
-      ccall((:fq_poly_add_series, :libflint), Nothing,
+      ccall((:fq_poly_add_series, libflint), Nothing,
                 (Ref{fq_rel_series}, Ref{fq_rel_series},
                  Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                a, a, b, lenz, ctx)
@@ -615,7 +615,7 @@ function add!(c::fq_rel_series, a::fq_rel_series, b::fq_rel_series)
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:fq_poly_add_series, :libflint), Nothing,
+   ccall((:fq_poly_add_series, libflint), Nothing,
      (Ref{fq_rel_series}, Ref{fq_rel_series}, Ref{fq_rel_series}, Int, Ref{FqFiniteField}),
                c, a, b, lenc, ctx)
    return c

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -146,7 +146,7 @@ end
 function *(x::gfp_elem, y::gfp_elem)
    check_parent(x, y)
    R = parent(x)
-   d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+   d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              x.data, y.data, R.n, R.ninv)
    return gfp_elem(d, R)
 end
@@ -167,11 +167,11 @@ end
 function *(x::Int, y::gfp_elem)
    R = parent(y)
    if x < 0
-      d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+      d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(-x), y.data, R.n, R.ninv)
       return -gfp_elem(d, R)
    else
-      d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+      d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(x), y.data, R.n, R.ninv)
       return gfp_elem(d, R)
    end
@@ -181,7 +181,7 @@ end
 
 function *(x::UInt, y::gfp_elem)
    R = parent(y)
-   d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+   d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(x), y.data, R.n, R.ninv)
    return gfp_elem(d, R)
 end
@@ -220,7 +220,7 @@ function ^(x::gfp_elem, y::Int)
       x = inv(x)
       y = -y
    end
-   d = ccall((:n_powmod2_preinv, :libflint), UInt, (UInt, Int, UInt, UInt),
+   d = ccall((:n_powmod2_preinv, libflint), UInt, (UInt, Int, UInt, UInt),
              UInt(x.data), y, R.n, R.ninv)
    return gfp_elem(d, R)
 end
@@ -259,7 +259,7 @@ end
 function inv(x::gfp_elem)
    R = parent(x)
    iszero(x) && throw(DivideError())
-   xinv = ccall((:n_invmod, :libflint), UInt, (UInt, UInt),
+   xinv = ccall((:n_invmod, libflint), UInt, (UInt, UInt),
             x.data, R.n)
    return gfp_elem(xinv, R)
 end
@@ -274,9 +274,9 @@ function divexact(x::gfp_elem, y::gfp_elem)
    check_parent(x, y)
    y == 0 && throw(DivideError())
    R = parent(x)
-   yinv = ccall((:n_invmod, :libflint), UInt, (UInt, UInt),
+   yinv = ccall((:n_invmod, libflint), UInt, (UInt, UInt),
            y.data, R.n)
-   d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+   d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              x.data, yinv, R.n, R.ninv)
    return gfp_elem(d, R)
 end
@@ -369,7 +369,7 @@ function (R::GaloisField)(a::Int)
       d += n
    end
    if d >= n
-      d = ccall((:n_mod2_preinv, :libflint), UInt, (UInt, UInt, UInt),
+      d = ccall((:n_mod2_preinv, libflint), UInt, (UInt, UInt, UInt),
              d, n, ninv)
    end
    return gfp_elem(d, R)
@@ -378,13 +378,13 @@ end
 function (R::GaloisField)(a::UInt)
    n = R.n
    ninv = R.ninv
-   a = ccall((:n_mod2_preinv, :libflint), UInt, (UInt, UInt, UInt),
+   a = ccall((:n_mod2_preinv, libflint), UInt, (UInt, UInt, UInt),
              a, n, ninv)
    return gfp_elem(a, R)
 end
 
 function (R::GaloisField)(a::fmpz)
-   d = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt),
+   d = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt),
              a, R.n)
    return gfp_elem(d, R)
 end

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -149,7 +149,7 @@ function *(x::gfp_fmpz_elem, y::gfp_fmpz_elem)
    check_parent(x, y)
    R = parent(x)
    d = fmpz()
-   ccall((:fmpz_mod_mul, :libflint), Nothing,
+   ccall((:fmpz_mod_mul, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 				                d, x.data, y.data, R.ninv)
    return gfp_fmpz_elem(d, R)
@@ -201,7 +201,7 @@ function ^(x::gfp_fmpz_elem, y::Int)
       y = -y
    end
    d = fmpz()
-   ccall((:fmpz_mod_pow_ui, :libflint), Nothing,
+   ccall((:fmpz_mod_pow_ui, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, UInt, Ref{fmpz_mod_ctx_struct}),
 						 d, x.data, y, R.ninv)
    return gfp_fmpz_elem(d, R)
@@ -243,7 +243,7 @@ function inv(x::gfp_fmpz_elem)
    iszero(x) && throw(DivideError())
    s = fmpz()
    g = fmpz()
-   ccall((:fmpz_gcdinv, :libflint), Nothing,
+   ccall((:fmpz_gcdinv, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
 					         g, s, x.data, R.n)
    return gfp_fmpz_elem(s, R)
@@ -279,14 +279,14 @@ end
 ###############################################################################
 
 function zero!(z::gfp_fmpz_elem)
-   ccall((:fmpz_set_ui, :libflint), Nothing,
+   ccall((:fmpz_set_ui, libflint), Nothing,
 	 (Ref{fmpz}, UInt), z.data, UInt(0))
    return z
 end
 
 function mul!(z::gfp_fmpz_elem, x::gfp_fmpz_elem, y::gfp_fmpz_elem)
    R = parent(z)
-   ccall((:fmpz_mod_mul, :libflint), Nothing,
+   ccall((:fmpz_mod_mul, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 					   z.data, x.data, y.data, R.ninv)
    return z
@@ -294,7 +294,7 @@ end
 
 function addeq!(z::gfp_fmpz_elem, x::gfp_fmpz_elem)
    R = parent(z)
-   ccall((:fmpz_mod_add, :libflint), Nothing,
+   ccall((:fmpz_mod_add, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 		                          z.data, z.data, x.data, R.ninv)
    return z
@@ -302,7 +302,7 @@ end
 
 function add!(z::gfp_fmpz_elem, x::gfp_fmpz_elem, y::gfp_fmpz_elem)
    R = parent(z)
-   ccall((:fmpz_mod_add, :libflint), Nothing,
+   ccall((:fmpz_mod_add, libflint), Nothing,
 	 (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
 					 z.data, x.data, y.data, R.ninv)
    return z
@@ -355,7 +355,7 @@ end
 
 function (R::GaloisFmpzField)(a::fmpz)
    d = fmpz()
-   ccall((:fmpz_mod, :libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
+   ccall((:fmpz_mod, libflint), Nothing, (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}),
 				              d, a, R.n)
    return gfp_fmpz_elem(d, R)
 end

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -34,7 +34,7 @@ characteristic(R::GFPFmpzPolyRing) = characteristic(base_ring(R))
 
 function *(x::gfp_fmpz_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_mul_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
           (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -54,7 +54,7 @@ end
 
 function +(x::gfp_fmpz_poly, y::Int)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_add_si, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add_si, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Int), z, x, y)
   return z
 end
@@ -63,7 +63,7 @@ end
 
 function +(x::gfp_fmpz_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_add_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_add_fmpz, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Ref{fmpz}), z, x, y)
   return z
 end
@@ -83,28 +83,28 @@ end
 
 function -(x::gfp_fmpz_poly, y::Int)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_sub_si, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub_si, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Int), z, x, y)
   return z
 end
 
 function -(x::Int, y::gfp_fmpz_poly)
   z = parent(y)()
-  ccall((:fmpz_mod_poly_si_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_si_sub, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Int, Ref{gfp_fmpz_poly}), z, x, y)
   return z
 end
 
 function -(x::gfp_fmpz_poly, y::fmpz)
   z = parent(x)()
-  ccall((:fmpz_mod_poly_sub_fmpz, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_sub_fmpz, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Ref{fmpz}), z, x, y)
   return z
 end
 
 function -(x::fmpz, y::gfp_fmpz_poly)
   z = parent(y)()
-  ccall((:fmpz_mod_poly_fmpz_sub, :libflint), Nothing,
+  ccall((:fmpz_mod_poly_fmpz_sub, libflint), Nothing,
     (Ref{gfp_fmpz_poly}, Ref{fmpz}, Ref{gfp_fmpz_poly}), z, x, y)
   return z
 end
@@ -135,7 +135,7 @@ function ==(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
      return false
   elseif length(x) == 1 
      u = fmpz()
-     ccall((:fmpz_mod_poly_get_coeff_fmpz, :libflint), Nothing, 
+     ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing, 
             (Ref{fmpz}, Ref{gfp_fmpz_poly}, Int), u, x, 0)
      return u == y
   else
@@ -155,7 +155,7 @@ function divexact(x::gfp_fmpz_poly, y::gfp_fmpz_elem)
   base_ring(x) != parent(y) && error("Elements must have same parent")
   iszero(y) && throw(DivideError())
   q = parent(x)()
-  ccall((:fmpz_mod_poly_scalar_div_fmpz, :libflint), Nothing, 
+  ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing, 
           (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly}, Ref{fmpz}), 
                q, x, y.data)
   return q
@@ -191,7 +191,7 @@ end
 """
 function lift(R::FmpzPolyRing, y::gfp_fmpz_poly)
    z = fmpz_poly()
-   ccall((:fmpz_mod_poly_get_fmpz_poly, :libflint), Nothing,
+   ccall((:fmpz_mod_poly_get_fmpz_poly, libflint), Nothing,
           (Ref{fmpz_poly}, Ref{gfp_fmpz_poly}), z, y)
    z.parent = R
   return z
@@ -208,7 +208,7 @@ end
 > Return `true` if $x$ is irreducible, otherwise return `false`.
 """
 function isirreducible(x::gfp_fmpz_poly)
-  return Bool(ccall((:fmpz_mod_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:fmpz_mod_poly_is_irreducible, libflint), Int32,
           (Ref{gfp_fmpz_poly}, ), x))
 end
 
@@ -223,7 +223,7 @@ end
 > Return `true` if $x$ is squarefree, otherwise return `false`.
 """
 function issquarefree(x::gfp_fmpz_poly)
-   return Bool(ccall((:fmpz_mod_poly_is_squarefree, :libflint), Int32, 
+   return Bool(ccall((:fmpz_mod_poly_is_squarefree, libflint), Int32, 
       (Ref{gfp_fmpz_poly}, ), x))
 end
 
@@ -244,12 +244,12 @@ end
 
 function _factor(x::gfp_fmpz_poly)
   fac = gfp_fmpz_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor, libflint), UInt,
           (Ref{gfp_fmpz_poly_factor}, Ref{gfp_fmpz_poly}), fac, x)
   res = Dict{gfp_fmpz_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
@@ -268,12 +268,12 @@ end
 
 function _factor_squarefree(x::gfp_fmpz_poly)
   fac = gfp_fmpz_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor_squarefree, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor_squarefree, libflint), UInt,
           (Ref{gfp_fmpz_poly_factor}, Ref{gfp_fmpz_poly}), fac, x)
   res = Dict{gfp_fmpz_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly_factor}, Int), f, fac, i - 1)
     e = unsafe_load(fac.exp, i)
     res[f] = e
@@ -290,13 +290,13 @@ function factor_distinct_deg(x::gfp_fmpz_poly)
   degs = Vector{Int}(undef, degree(x))
   degss = [ pointer(degs) ]
   fac = gfp_fmpz_poly_factor(parent(x).n)
-  ccall((:fmpz_mod_poly_factor_distinct_deg, :libflint), UInt,
+  ccall((:fmpz_mod_poly_factor_distinct_deg, libflint), UInt,
           (Ref{gfp_fmpz_poly_factor}, Ref{gfp_fmpz_poly}, Ptr{Ptr{Int}}),
           fac, x, degss)
   res = Dict{Int, gfp_fmpz_poly}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, :libflint), Nothing,
+    ccall((:fmpz_mod_poly_factor_get_fmpz_mod_poly, libflint), Nothing,
          (Ref{gfp_fmpz_poly}, Ref{gfp_fmpz_poly_factor}, Int), f, fac, i - 1)
     res[degs[i]] = f
   end

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -40,7 +40,7 @@ zero(m::gfp_mat, R::GaloisField, r::Int, c::Int) = similar(m, R, r, c)
 
 @inline function getindex(a::gfp_mat, i::Int, j::Int)
   @boundscheck Generic._checkbounds(a, i, j)
-  u = ccall((:nmod_mat_get_entry, :libflint), UInt,
+  u = ccall((:nmod_mat_get_entry, libflint), UInt,
             (Ref{gfp_mat}, Int, Int), a, i - 1 , j - 1)
   return gfp_elem(u, base_ring(a)) # no reduction needed
 end
@@ -56,7 +56,7 @@ function deepcopy_internal(a::gfp_mat, dict::IdDict)
   if isdefined(a, :base_ring)
     z.base_ring = a.base_ring
   end
-  ccall((:nmod_mat_set, :libflint), Nothing,
+  ccall((:nmod_mat_set, libflint), Nothing,
           (Ref{gfp_mat}, Ref{gfp_mat}), z, a)
   return z
 end
@@ -72,7 +72,7 @@ zero(a::GFPMatSpace) = a()
 function one(a::GFPMatSpace)
   (nrows(a) != ncols(a)) && error("Matrices must be square")
   z = a()
-  ccall((:nmod_mat_one, :libflint), Nothing, (Ref{gfp_mat}, ), z)
+  ccall((:nmod_mat_one, libflint), Nothing, (Ref{gfp_mat}, ), z)
   return z
 end
 
@@ -97,12 +97,12 @@ end
 
 function rref(a::gfp_mat)
   z = deepcopy(a)
-  r = ccall((:nmod_mat_rref, :libflint), Int, (Ref{gfp_mat}, ), z)
+  r = ccall((:nmod_mat_rref, libflint), Int, (Ref{gfp_mat}, ), z)
   return r, z
 end
 
 function rref!(a::gfp_mat)
-  r = ccall((:nmod_mat_rref, :libflint), Int, (Ref{gfp_mat}, ), a)
+  r = ccall((:nmod_mat_rref, libflint), Int, (Ref{gfp_mat}, ), a)
   return r
 end
 
@@ -154,7 +154,7 @@ end
 
 function det(a::gfp_mat)
   !issquare(a) && error("Matrix must be a square matrix")
-  r = ccall((:nmod_mat_det, :libflint), UInt, (Ref{gfp_mat}, ), a)
+  r = ccall((:nmod_mat_det, libflint), UInt, (Ref{gfp_mat}, ), a)
   return base_ring(a)(r)
 end
 
@@ -184,7 +184,7 @@ function Base.view(x::gfp_mat, r1::Int, c1::Int, r2::Int, c2::Int)
   z = gfp_mat()
   z.base_ring = x.base_ring
   z.view_parent = x
-  ccall((:nmod_mat_window_init, :libflint), Nothing,
+  ccall((:nmod_mat_window_init, libflint), Nothing,
           (Ref{gfp_mat}, Ref{gfp_mat}, Int, Int, Int, Int),
           z, x, r1 - 1, c1 - 1, r2, c2)
   finalizer(_gfp_mat_window_clear_fn, z)
@@ -192,7 +192,7 @@ function Base.view(x::gfp_mat, r1::Int, c1::Int, r2::Int, c2::Int)
 end
 
 function _gfp_mat_window_clear_fn(a::gfp_mat)
-  ccall((:nmod_mat_window_clear, :libflint), Nothing, (Ref{gfp_mat}, ), a)
+  ccall((:nmod_mat_window_clear, libflint), Nothing, (Ref{gfp_mat}, ), a)
 end
 
 ################################################################################
@@ -225,7 +225,7 @@ end
 function lift(a::gfp_mat)
   z = fmpz_mat(nrows(a), ncols(a))
   z.base_ring = FlintZZ
-  ccall((:fmpz_mat_set_nmod_mat, :libflint), Nothing,
+  ccall((:fmpz_mat_set_nmod_mat, libflint), Nothing,
           (Ref{fmpz_mat}, Ref{gfp_mat}), z, a)
   return z
 end
@@ -239,7 +239,7 @@ end
 function charpoly(R::GFPPolyRing, a::gfp_mat)
   m = deepcopy(a)
   p = R()
-  ccall((:nmod_mat_charpoly, :libflint), Nothing,
+  ccall((:nmod_mat_charpoly, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_mat}), p, m)
   return p
 end
@@ -252,7 +252,7 @@ end
 
 function minpoly(R::GFPPolyRing, a::gfp_mat)
   p = R()
-  ccall((:nmod_mat_minpoly, :libflint), Nothing,
+  ccall((:nmod_mat_minpoly, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_mat}), p, a)
   return p
 end

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -35,7 +35,7 @@ lead_isunit(a::gfp_poly) = !iszero(a)
 function Base.hash(a::gfp_poly, h::UInt)
    b = 0x74cec61d2911ace3%UInt
    for i in 0:length(a) - 1
-      u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt, (Ref{gfp_poly}, Int), a, i)
+      u = ccall((:nmod_poly_get_coeff_ui, libflint), UInt, (Ref{gfp_poly}, Int), a, i)
       b = xor(b, xor(hash(u, h), h))
       b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
    end
@@ -119,7 +119,7 @@ function ==(x::gfp_poly, y::gfp_elem)
   if length(x) > 1
     return false
   elseif length(x) == 1
-    u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+    u = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
             (Ref{gfp_poly}, Int), x, 0)
     return u == y
   else
@@ -139,7 +139,7 @@ function divexact(x::gfp_poly, y::gfp_poly)
   check_parent(x, y)
   iszero(y) && throw(DivideError())
   z = parent(x)()
-  ccall((:nmod_poly_div, :libflint), Nothing,
+  ccall((:nmod_poly_div, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}), z, x, y)
   return z
 end
@@ -167,7 +167,7 @@ function divrem(x::gfp_poly, y::gfp_poly)
   iszero(y) && throw(DivideError())
   q = parent(x)()
   r = parent(x)()
-  ccall((:nmod_poly_divrem, :libflint), Nothing,
+  ccall((:nmod_poly_divrem, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}),
           q, r, x, y)
   return q, r
@@ -177,7 +177,7 @@ function div(x::gfp_poly, y::gfp_poly)
   check_parent(x,y)
   iszero(y) && throw(DivideError())
   q = parent(x)()
-  ccall((:nmod_poly_div, :libflint), Nothing,
+  ccall((:nmod_poly_div, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}),
           q, x, y)
   return q
@@ -193,7 +193,7 @@ function rem(x::gfp_poly, y::gfp_poly)
   check_parent(x,y)
   iszero(y) && throw(DivideError())
   z = parent(x)()
-  ccall((:nmod_poly_rem, :libflint), Nothing,
+  ccall((:nmod_poly_rem, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}), z, x, y)
   return z
 end
@@ -207,7 +207,7 @@ end
 function gcd(x::gfp_poly, y::gfp_poly)
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_gcd, :libflint), Nothing,
+  ccall((:nmod_poly_gcd, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}), z, x, y)
   return z
 end
@@ -217,7 +217,7 @@ function gcdx(x::gfp_poly, y::gfp_poly)
   g = parent(x)()
   s = parent(x)()
   t = parent(x)()
-  ccall((:nmod_poly_xgcd, :libflint), Nothing,
+  ccall((:nmod_poly_xgcd, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly},
            Ref{gfp_poly}), g, s, t, x, y)
   return g,s,t
@@ -228,7 +228,7 @@ function gcdinv(x::gfp_poly, y::gfp_poly)
   length(y) <= 1 && error("Length of second argument must be >= 2")
   g = parent(x)()
   s = parent(x)()
-  ccall((:nmod_poly_gcdinv, :libflint), Nothing,
+  ccall((:nmod_poly_gcdinv, libflint), Nothing,
           (Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}, Ref{gfp_poly}),
           g, s, x, y)
   return g,s
@@ -244,7 +244,7 @@ function resultant(x::gfp_poly, y::gfp_poly,  check::Bool = true)
   if check
     check_parent(x,y)
   end
-  r = ccall((:nmod_poly_resultant, :libflint), UInt,
+  r = ccall((:nmod_poly_resultant, libflint), UInt,
           (Ref{gfp_poly}, Ref{gfp_poly}), x, y)
   return base_ring(x)(r)
 end
@@ -257,7 +257,7 @@ end
 
 function evaluate(x::gfp_poly, y::gfp_elem)
   base_ring(x) != parent(y) && error("Elements must have same parent")
-  z = ccall((:nmod_poly_evaluate_nmod, :libflint), UInt,
+  z = ccall((:nmod_poly_evaluate_nmod, libflint), UInt,
               (Ref{gfp_poly}, UInt), x, y.data)
   return parent(y)(z)
 end
@@ -280,7 +280,7 @@ function interpolate(R::GFPPolyRing, x::Array{gfp_elem, 1},
 
     ay[i] = y[i].data
   end
-  ccall((:nmod_poly_interpolate_nmod_vec, :libflint), Nothing,
+  ccall((:nmod_poly_interpolate_nmod_vec, libflint), Nothing,
           (Ref{gfp_poly}, Ptr{UInt}, Ptr{UInt}, Int),
           z, ax, ay, length(x))
   return z
@@ -300,7 +300,7 @@ end
 """
 function lift(R::FmpzPolyRing, y::gfp_poly)
   z = fmpz_poly()
-  ccall((:fmpz_poly_set_nmod_poly, :libflint), Nothing,
+  ccall((:fmpz_poly_set_nmod_poly, libflint), Nothing,
           (Ref{fmpz_poly}, Ref{gfp_poly}), z, y)
   z.parent = R
   return z
@@ -317,7 +317,7 @@ end
 > Return `true` if $x$ is irreducible, otherwise return `false`.
 """
 function isirreducible(x::gfp_poly)
-  return Bool(ccall((:nmod_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:nmod_poly_is_irreducible, libflint), Int32,
           (Ref{gfp_poly}, ), x))
 end
 
@@ -332,7 +332,7 @@ end
 > Return `true` if $x$ is squarefree, otherwise return `false`.
 """
 function issquarefree(x::gfp_poly)
-   return Bool(ccall((:nmod_poly_is_squarefree, :libflint), Int32,
+   return Bool(ccall((:nmod_poly_is_squarefree, libflint), Int32,
        (Ref{gfp_poly}, ), x))
 end
 
@@ -353,12 +353,12 @@ end
 
 function _factor(x::gfp_poly)
   fac = gfp_poly_factor(x.mod_n)
-  z = ccall((:nmod_poly_factor, :libflint), UInt,
+  z = ccall((:nmod_poly_factor, libflint), UInt,
           (Ref{gfp_poly_factor}, Ref{gfp_poly}), fac, x)
   res = Dict{gfp_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{gfp_poly}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -376,12 +376,12 @@ end
 
 function _factor_squarefree(x::gfp_poly)
   fac = gfp_poly_factor(x.mod_n)
-  ccall((:nmod_poly_factor_squarefree, :libflint), UInt,
+  ccall((:nmod_poly_factor_squarefree, libflint), UInt,
           (Ref{gfp_poly_factor}, Ref{gfp_poly}), fac, x)
   res = Dict{gfp_poly, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{gfp_poly}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -398,13 +398,13 @@ function factor_distinct_deg(x::gfp_poly)
   degs = Vector{Int}(undef, degree(x))
   degss = [ pointer(degs) ]
   fac = gfp_poly_factor(x.mod_n)
-  ccall((:nmod_poly_factor_distinct_deg, :libflint), UInt,
+  ccall((:nmod_poly_factor_distinct_deg, libflint), UInt,
           (Ref{gfp_poly_factor}, Ref{gfp_poly}, Ptr{Ptr{Int}}),
           fac, x, degss)
   res = Dict{Int, gfp_poly}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{gfp_poly}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     res[degs[i]] = f
   end
@@ -428,7 +428,7 @@ function remove(z::gfp_poly, p::gfp_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
-   v = ccall((:nmod_poly_remove, :libflint), Int,
+   v = ccall((:nmod_poly_remove, libflint), Int,
                (Ref{gfp_poly}, Ref{gfp_poly}), z,  p)
    return v, z
 end
@@ -479,7 +479,7 @@ function (R::GFPPolyRing)()
 end
 
 function (R::GFPPolyRing)(x::fmpz)
-  r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, R.n)
+  r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), x, R.n)
   z = gfp_poly(R.n, r)
   z.parent = R
   return z

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -156,7 +156,7 @@ end
 function *(x::nmod, y::nmod)
    check_parent(x, y)
    R = parent(x)
-   d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+   d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              x.data, y.data, R.n, R.ninv)
    return nmod(d, R)
 end
@@ -177,11 +177,11 @@ end
 function *(x::Int, y::nmod)
    R = parent(y)
    if x < 0
-      d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+      d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(-x), y.data, R.n, R.ninv)
       return -nmod(d, R)
    else
-      d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+      d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(x), y.data, R.n, R.ninv)
       return nmod(d, R)
    end
@@ -191,7 +191,7 @@ end
 
 function *(x::UInt, y::nmod)
    R = parent(y)
-   d = ccall((:n_mulmod2_preinv, :libflint), UInt, (UInt, UInt, UInt, UInt),
+   d = ccall((:n_mulmod2_preinv, libflint), UInt, (UInt, UInt, UInt, UInt),
              UInt(x), y.data, R.n, R.ninv)
    return nmod(d, R)
 end
@@ -218,7 +218,7 @@ function ^(x::nmod, y::Int)
       x = inv(x)
       y = -y
    end
-   d = ccall((:n_powmod2_preinv, :libflint), UInt, (UInt, Int, UInt, UInt),
+   d = ccall((:n_powmod2_preinv, libflint), UInt, (UInt, Int, UInt, UInt),
              UInt(x.data), y, R.n, R.ninv)
    return nmod(d, R)
 end
@@ -262,7 +262,7 @@ function inv(x::nmod)
    end
    #s = [UInt(0)]
    s = Ref{UInt}()
-   g = ccall((:n_gcdinv, :libflint), UInt, (Ptr{UInt}, UInt, UInt),
+   g = ccall((:n_gcdinv, libflint), UInt, (Ptr{UInt}, UInt, UInt),
          s, x.data, R.n)
    g != 1 && error("Impossible inverse in ", R)
    return nmod(s[], R)
@@ -299,7 +299,7 @@ function divides(a::nmod, b::nmod)
    end
    ub = divexact(B, gb)
    # The Julia invmod function does not give the correct result for me
-   b1 = ccall((:n_invmod, :libflint), UInt, (UInt, UInt),
+   b1 = ccall((:n_invmod, libflint), UInt, (UInt, UInt),
            ub, divexact(m, gb))
    rr = R(q)*b1
    return true, rr
@@ -412,7 +412,7 @@ function (R::NmodRing)(a::Int)
       d += n
    end
    if d >= n
-      d = ccall((:n_mod2_preinv, :libflint), UInt, (UInt, UInt, UInt),
+      d = ccall((:n_mod2_preinv, libflint), UInt, (UInt, UInt, UInt),
              d, n, ninv)
    end
    return nmod(d, R)
@@ -421,13 +421,13 @@ end
 function (R::NmodRing)(a::UInt)
    n = R.n
    ninv = R.ninv
-   a = ccall((:n_mod2_preinv, :libflint), UInt, (UInt, UInt, UInt),
+   a = ccall((:n_mod2_preinv, libflint), UInt, (UInt, UInt, UInt),
              a, n, ninv)
    return nmod(a, R)
 end
 
 function (R::NmodRing)(a::fmpz)
-   d = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt),
+   d = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt),
              a, R.n)
    return nmod(d, R)
 end

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -35,7 +35,7 @@ base_ring(f::nmod_mpoly) = f.parent.base_ring
 
 function ordering(a::NmodMPolyRing)
 b = a.ord
-#   b = ccall((:nmod_mpoly_ctx_ord, :libflint), Cint, (Ref{NmodMPolyRing}, ), a)
+#   b = ccall((:nmod_mpoly_ctx_ord, libflint), Cint, (Ref{NmodMPolyRing}, ), a)
    return flint_orderings[b + 1]
 end
 
@@ -43,7 +43,7 @@ function gens(R::NmodMPolyRing)
    A = Vector{nmod_mpoly}(undef, R.nvars)
    for i = 1:R.nvars
       z = R()
-      ccall((:nmod_mpoly_gen, :libflint), Nothing,
+      ccall((:nmod_mpoly_gen, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), z, i - 1, R)
       A[i] = z
    end
@@ -54,7 +54,7 @@ function gen(R::NmodMPolyRing, i::Int)
    n = nvars(R)
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = R()
-   ccall((:nmod_mpoly_gen, :libflint), Nothing,
+   ccall((:nmod_mpoly_gen, libflint), Nothing,
          (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), z, i - 1, R)
    return z
 end
@@ -63,7 +63,7 @@ function isgen(a::nmod_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    R = parent(a)
-#   return Bool(ccall((:nmod_mpoly_is_gen, :libflint), Cint,
+#   return Bool(ccall((:nmod_mpoly_is_gen, libflint), Cint,
 #                     (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
 #                     a, i - 1, R))
    g = gen(parent(a), i)
@@ -80,40 +80,40 @@ end
 
 function deepcopy_internal(a::nmod_mpoly, dict::IdDict)
    z = parent(a)()
-   ccall((:nmod_mpoly_set, :libflint), Nothing,
+   ccall((:nmod_mpoly_set, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          z, a, a.parent)
    return z
 end
 
 function length(a::nmod_mpoly)
-   n = ccall((:nmod_mpoly_length, :libflint), Int, (Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
+   n = ccall((:nmod_mpoly_length, libflint), Int, (Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          a, a.parent)
    return n
 end
 
 function one(R::NmodMPolyRing)
    z = R()
-   ccall((:nmod_mpoly_one, :libflint), Nothing,
+   ccall((:nmod_mpoly_one, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, R)
    return z
 end
 
 function zero(R::NmodMPolyRing)
    z = R()
-   ccall((:nmod_mpoly_zero, :libflint), Nothing,
+   ccall((:nmod_mpoly_zero, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), z, R)
    return z
 end
 
 function isone(a::nmod_mpoly)
-   b = ccall((:nmod_mpoly_is_one, :libflint), Cint,
+   b = ccall((:nmod_mpoly_is_one, libflint), Cint,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return Bool(b)
 end
 
 function iszero(a::nmod_mpoly)
-   b = ccall((:nmod_mpoly_is_zero, :libflint), Cint,
+   b = ccall((:nmod_mpoly_is_zero, libflint), Cint,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -131,7 +131,7 @@ function isunit(a::nmod_mpoly)
 end
 
 function isconstant(a::nmod_mpoly)
-   b = ccall((:nmod_mpoly_is_ui, :libflint), Cint,
+   b = ccall((:nmod_mpoly_is_ui, libflint), Cint,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, parent(a))
    return Bool(b)
 end
@@ -147,7 +147,7 @@ characteristic(R::NmodMPolyRing) = characteristic(base_ring(R))
 function coeff(a::nmod_mpoly, i::Int)
    n = length(a)
    (i < 1 || i > n) && error("Index must be between 1 and $(length(a))")
-   z = ccall((:nmod_mpoly_get_term_coeff_ui, :libflint), UInt,
+   z = ccall((:nmod_mpoly_get_term_coeff_ui, libflint), UInt,
          (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          a, i - 1, a.parent)
    return base_ring(parent(a))(z)
@@ -156,7 +156,7 @@ end
 function coeff(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    !isone(length(b)) && error("Second argument must be a monomial")
-   z = ccall((:nmod_mpoly_get_coeff_ui_monomial, :libflint), UInt,
+   z = ccall((:nmod_mpoly_get_coeff_ui_monomial, libflint), UInt,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          a, b, parent(a))
    return base_ring(parent(a))(z)
@@ -172,7 +172,7 @@ end
 function degree(a::nmod_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
-   d = ccall((:nmod_mpoly_degree_si, :libflint), Int,
+   d = ccall((:nmod_mpoly_degree_si, libflint), Int,
              (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, i - 1, a.parent)
    return d
 end
@@ -182,7 +182,7 @@ function degree_fmpz(a::nmod_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    d = fmpz()
-   ccall((:nmod_mpoly_degree_fmpz, :libflint), Nothing,
+   ccall((:nmod_mpoly_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          d, a, i - 1, a.parent)
    return d
@@ -190,7 +190,7 @@ end
 
 # Return true if degrees fit into an Int
 function degrees_fit_int(a::nmod_mpoly)
-   b = ccall((:nmod_mpoly_degrees_fit_si, :libflint), Cint,
+   b = ccall((:nmod_mpoly_degrees_fit_si, libflint), Cint,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return Bool(b)
 end
@@ -198,7 +198,7 @@ end
 # Return an array of the max degrees in each variable
 function degrees(a::nmod_mpoly)
    degs = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:nmod_mpoly_degrees_si, :libflint), Nothing,
+   ccall((:nmod_mpoly_degrees_si, libflint), Nothing,
          (Ptr{Int}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -211,7 +211,7 @@ function degrees_fmpz(a::nmod_mpoly)
    for i in 1:n
       degs[i] = fmpz()
    end
-   ccall((:nmod_mpoly_degrees_fmpz, :libflint), Nothing,
+   ccall((:nmod_mpoly_degrees_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          degs, a, a.parent)
    return degs
@@ -219,14 +219,14 @@ end
 
 # Return true if degree fits into an Int
 function total_degree_fits_int(a::nmod_mpoly)
-      b = ccall((:nmod_mpoly_total_degree_fits_si, :libflint), Cint,
+      b = ccall((:nmod_mpoly_total_degree_fits_si, libflint), Cint,
                 (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
       return Bool(b)
    end
 
 # Total degree as an Int
 function total_degree(a::nmod_mpoly)
-   d = ccall((:nmod_mpoly_total_degree_si, :libflint), Int,
+   d = ccall((:nmod_mpoly_total_degree_si, libflint), Int,
              (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return d
 end
@@ -234,7 +234,7 @@ end
 # Total degree as an fmpz
 function total_degree_fmpz(a::nmod_mpoly)
    d = fmpz()
-   ccall((:nmod_mpoly_total_degree_fmpz, :libflint), Nothing,
+   ccall((:nmod_mpoly_total_degree_fmpz, libflint), Nothing,
          (Ref{fmpz}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
             d, a, a.parent)
    return d
@@ -260,7 +260,7 @@ function coeff(a::nmod_mpoly, vars::Vector{Int}, exps::Vector{Int})
          error("Exponent cannot be negative")
       end
    end
-   ccall((:nmod_mpoly_get_coeff_vars_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_coeff_vars_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ptr{Int},
           Ptr{Int}, Int, Ref{NmodMPolyRing}),
           z, a, vars, exps, length(vars), a.parent)
@@ -277,12 +277,12 @@ function show(io::IO, x::nmod_mpoly)
    if length(x) == 0
       print(io, "0")
    else
-      cstr = ccall((:nmod_mpoly_get_str_pretty, :libflint), Ptr{UInt8},
+      cstr = ccall((:nmod_mpoly_get_str_pretty, libflint), Ptr{UInt8},
           (Ref{nmod_mpoly}, Ptr{Ptr{UInt8}}, Ref{NmodMPolyRing}),
           x, [string(s) for s in symbols(parent(x))], x.parent)
       print(io, unsafe_string(cstr))
 
-      ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    end
 end
 
@@ -313,7 +313,7 @@ end
 
 function -(a::nmod_mpoly)
    z = parent(a)()
-   ccall((:nmod_mpoly_neg, :libflint), Nothing,
+   ccall((:nmod_mpoly_neg, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        z, a, a.parent)
    return z
@@ -322,7 +322,7 @@ end
 function +(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:nmod_mpoly_add, :libflint), Nothing,
+   ccall((:nmod_mpoly_add, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -331,7 +331,7 @@ end
 function -(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:nmod_mpoly_sub, :libflint), Nothing,
+   ccall((:nmod_mpoly_sub, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -340,7 +340,7 @@ end
 function *(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   ccall((:nmod_mpoly_mul, :libflint), Nothing,
+   ccall((:nmod_mpoly_mul, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        z, a, b, a.parent)
    return z
@@ -356,7 +356,7 @@ for (jT, cN, cT) in ((UInt, :ui, UInt),)
    @eval begin
       function +(a::nmod_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:nmod_mpoly_add_, cN)), :libflint), Nothing,
+         ccall(($(string(:nmod_mpoly_add_, cN)), libflint), Nothing,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, ($cT), Ref{NmodMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -366,7 +366,7 @@ for (jT, cN, cT) in ((UInt, :ui, UInt),)
 
       function -(a::nmod_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:nmod_mpoly_sub_, cN)), :libflint), Nothing,
+         ccall(($(string(:nmod_mpoly_sub_, cN)), libflint), Nothing,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, ($cT), Ref{NmodMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -376,7 +376,7 @@ for (jT, cN, cT) in ((UInt, :ui, UInt),)
 
       function *(a::nmod_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:nmod_mpoly_scalar_mul_, cN)), :libflint), Nothing,
+         ccall(($(string(:nmod_mpoly_scalar_mul_, cN)), libflint), Nothing,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, ($cT), Ref{NmodMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -386,7 +386,7 @@ for (jT, cN, cT) in ((UInt, :ui, UInt),)
 
       function divexact(a::nmod_mpoly, b::($jT))
          z = parent(a)()
-         ccall(($(string(:nmod_mpoly_scalar_div_, cN)), :libflint), Nothing,
+         ccall(($(string(:nmod_mpoly_scalar_div_, cN)), libflint), Nothing,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, ($cT), Ref{NmodMPolyRing}),
                z, a, b, parent(a))
          return z
@@ -417,7 +417,7 @@ divexact(a::nmod_mpoly, b::Integer) = divexact(a, base_ring(parent(a))(b))
 function ^(a::nmod_mpoly, b::Int)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:nmod_mpoly_pow_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_pow_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -426,7 +426,7 @@ end
 function ^(a::nmod_mpoly, b::fmpz)
    b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
    z = parent(a)()
-   ccall((:nmod_mpoly_pow_fmpz, :libflint), Nothing,
+   ccall((:nmod_mpoly_pow_fmpz, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{fmpz}, Ref{NmodMPolyRing}),
          z, a, b, parent(a))
    return z
@@ -441,7 +441,7 @@ end
 function gcd(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    z = parent(a)()
-   r = Bool(ccall((:nmod_mpoly_gcd, :libflint), Cint,
+   r = Bool(ccall((:nmod_mpoly_gcd, libflint), Cint,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
          z, a, b, a.parent))
    r == false && error("Unable to compute gcd")
@@ -456,14 +456,14 @@ end
 
 function ==(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
-   return Bool(ccall((:nmod_mpoly_equal, :libflint), Cint,
+   return Bool(ccall((:nmod_mpoly_equal, libflint), Cint,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
                a, b, a.parent))
 end
 
 function Base.isless(a::nmod_mpoly, b::nmod_mpoly)
    (!ismonomial(a) || !ismonomial(b)) && error("Not monomials in comparison")
-   return ccall((:nmod_mpoly_cmp, :libflint), Cint,
+   return ccall((:nmod_mpoly_cmp, libflint), Cint,
                (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
                a, b, a.parent) < 0
 end
@@ -475,7 +475,7 @@ end
 ###############################################################################
 
 function ==(a::nmod_mpoly, b::nmod)
-   return Bool(ccall((:nmod_mpoly_equal_ui, :libflint), Cint,
+   return Bool(ccall((:nmod_mpoly_equal_ui, libflint), Cint,
                      (Ref{nmod_mpoly}, UInt, Ref{NmodMPolyRing}),
                      a, b.data, a.parent))
 end
@@ -483,7 +483,7 @@ end
 ==(a::nmod, b::nmod_mpoly) = b == a
 
 function ==(a::nmod_mpoly, b::UInt)
-   return Bool(ccall((:nmod_mpoly_equal_ui, :libflint), Cint,
+   return Bool(ccall((:nmod_mpoly_equal_ui, libflint), Cint,
                (Ref{nmod_mpoly}, UInt, Ref{NmodMPolyRing}),
                a, b, a.parent))
 end
@@ -513,7 +513,7 @@ function divides(a::nmod_mpoly, b::nmod_mpoly)
       return false, zero(parent(a))
    end
    z = parent(a)()
-   d = ccall((:nmod_mpoly_divides, :libflint), Cint,
+   d = ccall((:nmod_mpoly_divides, libflint), Cint,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        z, a, b, a.parent)
    return isone(d), z
@@ -528,7 +528,7 @@ end
 function div(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    q = parent(a)()
-   ccall((:nmod_mpoly_div, :libflint), Nothing,
+   ccall((:nmod_mpoly_div, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly},
         Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        q, a, b, a.parent)
@@ -539,7 +539,7 @@ function divrem(a::nmod_mpoly, b::nmod_mpoly)
    check_parent(a, b)
    q = parent(a)()
    r = parent(a)()
-   ccall((:nmod_mpoly_divrem, :libflint), Nothing,
+   ccall((:nmod_mpoly_divrem, libflint), Nothing,
        (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Ref{nmod_mpoly},
         Ref{nmod_mpoly}, Ref{NmodMPolyRing}),
        q, r, a, b, a.parent)
@@ -550,7 +550,7 @@ function divrem(a::nmod_mpoly, b::Array{nmod_mpoly, 1})
    len = length(b)
    q = [parent(a)() for i in 1:len]
    r = parent(a)()
-   ccall((:nmod_mpoly_divrem_ideal, :libflint), Nothing,
+   ccall((:nmod_mpoly_divrem_ideal, libflint), Nothing,
          (Ptr{Ref{nmod_mpoly}}, Ref{nmod_mpoly}, Ref{nmod_mpoly},
           Ptr{Ref{nmod_mpoly}}, Int, Ref{NmodMPolyRing}),
        q, r, a, b, len, a.parent)
@@ -580,7 +580,7 @@ function derivative(a::nmod_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = parent(a)()
-   ccall((:nmod_mpoly_derivative, :libflint), Nothing,
+   ccall((:nmod_mpoly_derivative, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -590,7 +590,7 @@ function integral(a::nmod_mpoly, i::Int)
    n = nvars(parent(a))
    (i <= 0 || i > n) && error("Index must be between 1 and $n")
    z = parent(a)()
-   ccall((:nmod_mpoly_integral, :libflint), Nothing,
+   ccall((:nmod_mpoly_integral, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -605,7 +605,7 @@ end
 function evaluate(a::nmod_mpoly, b::Vector{nmod})
    length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
    b2 = [d.data for d in b]
-   z = ccall((:nmod_mpoly_evaluate_all_ui, :libflint), UInt,
+   z = ccall((:nmod_mpoly_evaluate_all_ui, libflint), UInt,
          (Ref{nmod_mpoly}, Ptr{UInt}, Ref{NmodMPolyRing}),
             a, b2, parent(a))
    return base_ring(parent(a))(z)
@@ -699,27 +699,27 @@ end
 ###############################################################################
 
 function zero!(a::nmod_mpoly)
-    ccall((:nmod_mpoly_zero, :libflint), Nothing,
+    ccall((:nmod_mpoly_zero, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
     return a
 end
 
 function add!(a::nmod_mpoly, b::nmod_mpoly, c::nmod_mpoly)
-   ccall((:nmod_mpoly_add, :libflint), Nothing,
+   ccall((:nmod_mpoly_add, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly},
           Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, b, c, a.parent)
    return a
 end
 
 function addeq!(a::nmod_mpoly, b::nmod_mpoly)
-   ccall((:nmod_mpoly_add, :libflint), Nothing,
+   ccall((:nmod_mpoly_add, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly},
           Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a, b, a.parent)
    return a
 end
 
 function mul!(a::nmod_mpoly, b::nmod_mpoly, c::nmod_mpoly)
-   ccall((:nmod_mpoly_mul, :libflint), Nothing,
+   ccall((:nmod_mpoly_mul, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly},
           Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, b, c, a.parent)
    return a
@@ -729,10 +729,10 @@ end
 # must be removed with combine_like_terms!
 function setcoeff!(a::nmod_mpoly, n::Int, c::nmod)
    if n > length(a)
-      ccall((:nmod_mpoly_resize, :libflint), Nothing,
+      ccall((:nmod_mpoly_resize, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, n, a.parent)
    end
-   ccall((:nmod_mpoly_set_term_coeff_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_set_term_coeff_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, Int, UInt, Ref{NmodMPolyRing}),
          a, n - 1, c.data, a.parent)
    return a
@@ -749,7 +749,7 @@ setcoeff!(a::nmod_mpoly, i::Int, c::fmpz) = setcoeff!(a, i, base_ring(parent(a))
 # Remove zero terms and combine adjacent terms if they have the same monomial
 # no sorting is performed
 function combine_like_terms!(a::nmod_mpoly)
-   ccall((:nmod_mpoly_combine_like_terms, :libflint), Nothing,
+   ccall((:nmod_mpoly_combine_like_terms, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return a
 end
@@ -762,14 +762,14 @@ end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_ui(a::nmod_mpoly, i::Int)
-   b = ccall((:nmod_mpoly_term_exp_fits_ui, :libflint), Cint,
+   b = ccall((:nmod_mpoly_term_exp_fits_ui, libflint), Cint,
              (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, i - 1, a.parent)
       return Bool(b)
 end
 
 # Return true if the exponents of the i-th exp. vector fit into UInts
 function exponent_vector_fits_int(a::nmod_mpoly, i::Int)
-   b = ccall((:nmod_mpoly_term_exp_fits_si, :libflint), Cint,
+   b = ccall((:nmod_mpoly_term_exp_fits_si, libflint), Cint,
              (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, i - 1, a.parent)
    return Bool(b)
 end
@@ -777,7 +777,7 @@ end
 # Return Julia array of UInt's corresponding to exponent vector of i-th term
 function exponent_vector_ui(a::nmod_mpoly, i::Int)
    z = Vector{UInt}(undef, nvars(parent(a)))
-   ccall((:nmod_mpoly_get_term_exp_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term_exp_ui, libflint), Nothing,
          (Ptr{UInt}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -788,7 +788,7 @@ function exponent_vector(a::nmod_mpoly, i::Int)
    exponent_vector_fits_int(a, i) ||
       throw(DomainError(term(a, i), "exponents don't fit in `Int` (try exponent_vector_fmpz)"))
    z = Vector{Int}(undef, nvars(parent(a)))
-   ccall((:nmod_mpoly_get_term_exp_si, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term_exp_si, libflint), Nothing,
          (Ptr{Int}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
       z, a, i - 1, parent(a))
    return z
@@ -801,7 +801,7 @@ function exponent_vector_fmpz(a::nmod_mpoly, i::Int)
    for j in 1:n
       z[j] = fmpz()
    end
-   ccall((:nmod_mpoly_get_term_exp_fmpz, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term_exp_fmpz, libflint), Nothing,
          (Ptr{Ref{fmpz}}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
          z, a, i - 1, parent(a))
    return z
@@ -817,10 +817,10 @@ end
 # they don't fit into 31/63 bits
 function set_exponent_vector!(a::nmod_mpoly, n::Int, exps::Vector{UInt})
    if n > length(a)
-      ccall((:nmod_mpoly_resize, :libflint), Nothing,
+      ccall((:nmod_mpoly_resize, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, n, a.parent)
    end
-   ccall((:nmod_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, Int, Ptr{UInt}, Ref{NmodMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -831,10 +831,10 @@ end
 # no check is performed
 function set_exponent_vector!(a::nmod_mpoly, n::Int, exps::Vector{Int})
    if n > length(a)
-      ccall((:nmod_mpoly_resize, :libflint), Nothing,
+      ccall((:nmod_mpoly_resize, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, n, a.parent)
    end
-   ccall((:nmod_mpoly_set_term_exp_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_set_term_exp_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, Int, Ptr{Int}, Ref{NmodMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -844,10 +844,10 @@ end
 # No sort is performed, so this is unsafe
 function set_exponent_vector!(a::nmod_mpoly, n::Int, exps::Vector{fmpz})
    if n > length(a)
-      ccall((:nmod_mpoly_resize, :libflint), Nothing,
+      ccall((:nmod_mpoly_resize, libflint), Nothing,
             (Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}), a, n, a.parent)
    end
-   @GC.preserve exps ccall((:nmod_mpoly_set_term_exp_fmpz, :libflint), Nothing,
+   @GC.preserve exps ccall((:nmod_mpoly_set_term_exp_fmpz, libflint), Nothing,
          (Ref{nmod_mpoly}, Int, Ptr{fmpz}, Ref{NmodMPolyRing}),
       a, n - 1, exps, parent(a))
    return a
@@ -856,7 +856,7 @@ end
 # Return j-th coordinate of i-th exponent vector
 function exponent(a::nmod_mpoly, i::Int, j::Int)
    (j < 1 || j > nvars(parent(a))) && error("Invalid variable index")
-   return ccall((:nmod_mpoly_get_term_var_exp_ui, :libflint), Int,
+   return ccall((:nmod_mpoly_get_term_var_exp_ui, libflint), Int,
                 (Ref{nmod_mpoly}, Int, Int, Ref{NmodMPolyRing}),
                  a, i - 1, j - 1, a.parent)
 end
@@ -864,7 +864,7 @@ end
 # Return the coefficient of the term with the given exponent vector
 # Return zero if there is no such term
 function coeff(a::nmod_mpoly, exps::Vector{UInt})
-   z = ccall((:nmod_mpoly_get_coeff_ui_ui, :libflint), UInt,
+   z = ccall((:nmod_mpoly_get_coeff_ui_ui, libflint), UInt,
          (Ref{nmod_mpoly}, Ptr{UInt}, Ref{NmodMPolyRing}),
       a, exps, parent(a))
    return base_ring(parent(a))(z)
@@ -873,7 +873,7 @@ end
 # Return the coefficient of the term with the given exponent vector
 # Return zero if there is no such term
 function coeff(a::nmod_mpoly, exps::Vector{Int})
-   z = ccall((:nmod_mpoly_get_coeff_ui_ui, :libflint), UInt,
+   z = ccall((:nmod_mpoly_get_coeff_ui_ui, libflint), UInt,
          (Ref{nmod_mpoly}, Ptr{Int}, Ref{NmodMPolyRing}),
       a, exps, parent(a))
    return base_ring(parent(a))(z)
@@ -882,7 +882,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpz. Removal of a zero term is performed.
 function setcoeff!(a::nmod_mpoly, exps::Vector{UInt}, b::nmod)
-   ccall((:nmod_mpoly_set_coeff_ui_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_set_coeff_ui_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, UInt, Ptr{UInt}, Ref{NmodMPolyRing}),
       a, b.data, exps, parent(a))
    return a
@@ -891,7 +891,7 @@ end
 # Set the coefficient of the term with the given exponent vector to the
 # given fmpz. Removal of a zero term is performed.
 function setcoeff!(a::nmod_mpoly, exps::Vector{Int}, b::nmod)
-   ccall((:nmod_mpoly_set_coeff_fmpz_ui, :libflint), Nothing,
+   ccall((:nmod_mpoly_set_coeff_fmpz_ui, libflint), Nothing,
          (Ref{nmod_mpoly}, UInt, Ptr{Int}, Ref{NmodMPolyRing}),
       a, b.data, exps, parent(a))
    return a
@@ -907,7 +907,7 @@ setcoeff!(a::nmod_mpoly, exps::Vector{Int}, b::Integer) =
 # out of order. Note that like terms are not combined and zeros are not
 # removed. For that, call combine_like_terms!
 function sort_terms!(a::nmod_mpoly)
-   ccall((:nmod_mpoly_sort_terms, :libflint), Nothing,
+   ccall((:nmod_mpoly_sort_terms, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{NmodMPolyRing}), a, a.parent)
    return a
 end
@@ -915,7 +915,7 @@ end
 # Return the i-th term of the polynomial, as a polynomial
 function term(a::nmod_mpoly, i::Int)
    z = parent(a)()
-   ccall((:nmod_mpoly_get_term, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -924,7 +924,7 @@ end
 # Return the i-th monomial of the polynomial, as a polynomial
 function monomial(a::nmod_mpoly, i::Int)
    z = parent(a)()
-   ccall((:nmod_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
           z, a, i - 1, a.parent)
    return z
@@ -932,7 +932,7 @@ end
 
 # Sets the given polynomial m to the i-th monomial of the polynomial
 function monomial!(m::nmod_mpoly, a::nmod_mpoly, i::Int)
-   ccall((:nmod_mpoly_get_term_monomial, :libflint), Nothing,
+   ccall((:nmod_mpoly_get_term_monomial, libflint), Nothing,
          (Ref{nmod_mpoly}, Ref{nmod_mpoly}, Int, Ref{NmodMPolyRing}),
           m, a, i - 1, a.parent)
    return m

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -44,15 +44,15 @@ end
 
 function lead_isunit(a::nmod_poly)
   d = degree(a)
-  u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt, (Ref{nmod_poly}, Int), a, d)
-  n = ccall((:n_gcd, :libflint), UInt, (UInt, UInt), u, modulus(a))
+  u = ccall((:nmod_poly_get_coeff_ui, libflint), UInt, (Ref{nmod_poly}, Int), a, d)
+  n = ccall((:n_gcd, libflint), UInt, (UInt, UInt), u, modulus(a))
   return n==1
 end
 
 function Base.hash(a::nmod_poly, h::UInt)
    b = 0x53dd43cd511044d1%UInt
    for i in 0:length(a) - 1
-      u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt, (Ref{nmod_poly}, Int), a, i)
+      u = ccall((:nmod_poly_get_coeff_ui, libflint), UInt, (Ref{nmod_poly}, Int), a, i)
       b = xor(b, xor(hash(u, h), h))
       b = (b << 1) | (b >> (sizeof(Int)*8 - 1))
    end
@@ -65,20 +65,20 @@ end
 #
 ################################################################################
 
-length(x::T) where T <: Zmodn_poly = ccall((:nmod_poly_length, :libflint), Int,
+length(x::T) where T <: Zmodn_poly = ccall((:nmod_poly_length, libflint), Int,
                                (Ref{T}, ), x)
 
-degree(x::T) where T <: Zmodn_poly = ccall((:nmod_poly_degree, :libflint), Int,
+degree(x::T) where T <: Zmodn_poly = ccall((:nmod_poly_degree, libflint), Int,
                                (Ref{T}, ), x)
 
 function coeff(x::T, n::Int) where T <: Zmodn_poly
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
-  return base_ring(x)(ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+  return base_ring(x)(ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
           (Ref{T}, Int), x, n))
 end
 
 function coeff_raw(x::T, n::Int) where T <: Zmodn_poly
-  return ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+  return ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                 (Ref{T}, Int), x, n)
 end
 
@@ -91,7 +91,7 @@ gen(R::NmodPolyRing) = R([zero(base_ring(R)), one(base_ring(R))])
 isgen(a::T) where T <: Zmodn_poly = (degree(a) == 1 &&
                               iszero(coeff(a,0)) && isone(coeff(a,1)))
 
-iszero(a::T) where T <: Zmodn_poly = Bool(ccall((:nmod_poly_is_zero, :libflint), Int32,
+iszero(a::T) where T <: Zmodn_poly = Bool(ccall((:nmod_poly_is_zero, libflint), Int32,
                               (Ref{T}, ), a))
 
 modulus(a::T) where T <: Zmodn_poly = a.parent.n
@@ -118,10 +118,10 @@ function show(io::IO, x::T) where T <: Zmodn_poly
   if length(x) == 0
     print(io, "0")
   else
-    cstr = ccall((:nmod_poly_get_str_pretty, :libflint), Ptr{UInt8},
+    cstr = ccall((:nmod_poly_get_str_pretty, libflint), Ptr{UInt8},
             (Ref{T}, Ptr{UInt8}), x, string(var(parent(x))))
     print(io, unsafe_string(cstr))
-    ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8}, ), cstr)
+    ccall((:flint_free, libflint), Nothing, (Ptr{UInt8}, ), cstr)
   end
 end
 
@@ -150,7 +150,7 @@ canonical_unit(a::T) where T <: Zmodn_poly = canonical_unit(lead(a))
 
 function -(x::T) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_neg, :libflint), Nothing,
+  ccall((:nmod_poly_neg, libflint), Nothing,
           (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -164,7 +164,7 @@ end
 function +(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_add, :libflint), Nothing,
+  ccall((:nmod_poly_add, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -172,7 +172,7 @@ end
 function -(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_sub, :libflint), Nothing,
+  ccall((:nmod_poly_sub, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -180,7 +180,7 @@ end
 function *(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_mul, :libflint), Nothing,
+  ccall((:nmod_poly_mul, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
@@ -193,7 +193,7 @@ end
 
 function *(x::T, y::UInt) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+  ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
           (Ref{T}, Ref{T}, UInt), z, x, y)
   return z
 end
@@ -204,9 +204,9 @@ function *(x::T, y::fmpz) where T <: Zmodn_poly
   z = parent(x)()
   t = fmpz()
   tt = UInt(0)
-  ccall((:fmpz_mod_ui, :libflint), UInt,
+  ccall((:fmpz_mod_ui, libflint), UInt,
                 (Ref{fmpz}, Ref{fmpz}, UInt), t, y, parent(x).n)
-  tt = ccall((:fmpz_get_ui, :libflint), UInt, (Ref{fmpz}, ), t)
+  tt = ccall((:fmpz_get_ui, libflint), UInt, (Ref{fmpz}, ), t)
   return x*tt
 end
 
@@ -225,7 +225,7 @@ end
 
 function +(x::T, y::UInt) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_add_ui, :libflint), Nothing,
+  ccall((:nmod_poly_add_ui, libflint), Nothing,
     (Ref{T}, Ref{T}, UInt), z, x, y)
   return z
 end
@@ -236,9 +236,9 @@ function +(x::T, y::fmpz) where T <: Zmodn_poly
   z = parent(x)()
   t = fmpz()
   tt = UInt(0)
-  ccall((:fmpz_mod_ui, :libflint), UInt,
+  ccall((:fmpz_mod_ui, libflint), UInt,
                 (Ref{fmpz}, Ref{fmpz}, UInt), t, y, parent(x).n)
-  tt = ccall((:fmpz_get_ui, :libflint), UInt, (Ref{fmpz}, ), t)
+  tt = ccall((:fmpz_get_ui, libflint), UInt, (Ref{fmpz}, ), t)
   return +(x,tt)
 end
 
@@ -257,7 +257,7 @@ end
 
 function -(x::T, y::UInt) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_sub_ui, :libflint), Nothing,
+  ccall((:nmod_poly_sub_ui, libflint), Nothing,
     (Ref{T}, Ref{T}, UInt), z, x, y)
   return z
 end
@@ -268,9 +268,9 @@ function -(x::T, y::fmpz) where T <: Zmodn_poly
   z = parent(x)()
   t = fmpz()
   tt = UInt(0)
-  ccall((:fmpz_mod_ui, :libflint), UInt,
+  ccall((:fmpz_mod_ui, libflint), UInt,
                 (Ref{fmpz}, Ref{fmpz}, UInt), t, y, parent(x).n)
-  tt = ccall((:fmpz_get_ui, :libflint), UInt, (Ref{fmpz}, ), t)
+  tt = ccall((:fmpz_get_ui, libflint), UInt, (Ref{fmpz}, ), t)
   return -(x,tt)
 end
 
@@ -296,7 +296,7 @@ end
 function ^(x::T, y::Int) where T <: Zmodn_poly
   y < 0 && throw(DomainError(y, "Exponent must be nonnegative"))
   z = parent(x)()
-  ccall((:nmod_poly_pow, :libflint), Nothing,
+  ccall((:nmod_poly_pow, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, y)
   return z
 end
@@ -309,7 +309,7 @@ end
 
 function ==(x::T, y::T) where T <: Zmodn_poly
   check_parent(x, y)
-  return Bool(ccall((:nmod_poly_equal, :libflint), Int32,
+  return Bool(ccall((:nmod_poly_equal, libflint), Int32,
           (Ref{T}, Ref{T}), x, y))
 end
 
@@ -326,7 +326,7 @@ function ==(x::nmod_poly, y::nmod)
   if length(x) > 1
     return false
   elseif length(x) == 1
-    u = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+    u = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
             (Ref{nmod_poly}, Int), x, 0)
     return u == y
   else
@@ -348,7 +348,7 @@ function truncate(a::T, n::Int) where T <: Zmodn_poly
   if length(z) <= n
     return z
   end
-  ccall((:nmod_poly_truncate, :libflint), Nothing,
+  ccall((:nmod_poly_truncate, libflint), Nothing,
           (Ref{T}, Int), z, n)
   return z
 end
@@ -357,7 +357,7 @@ function mullow(x::T, y::T, n::Int) where T <: Zmodn_poly
   check_parent(x, y)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   z = parent(x)()
-  ccall((:nmod_poly_mullow, :libflint), Nothing,
+  ccall((:nmod_poly_mullow, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}, Int), z, x, y, n)
   return z
 end
@@ -371,7 +371,7 @@ end
 function reverse(x::T, len::Int) where T <: Zmodn_poly
   len < 0 && throw(DomainError(n, "Index must be non-negative"))
   z = parent(x)()
-  ccall((:nmod_poly_reverse, :libflint), Nothing,
+  ccall((:nmod_poly_reverse, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -385,7 +385,7 @@ end
 function shift_left(x::T, len::Int) where T <: Zmodn_poly
   len < 0 && throw(DomainError(len, "Shift must be nonnegative."))
   z = parent(x)()
-  ccall((:nmod_poly_shift_left, :libflint), Nothing,
+  ccall((:nmod_poly_shift_left, libflint), Nothing,
           (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -393,7 +393,7 @@ end
 function shift_right(x::T, len::Int) where T <: Zmodn_poly
   len < 0 && throw(DomainError(len, "Shift must be nonnegative."))
   z = parent(x)()
-  ccall((:nmod_poly_shift_right, :libflint), Nothing,
+  ccall((:nmod_poly_shift_right, libflint), Nothing,
             (Ref{T}, Ref{T}, Int), z, x, len)
   return z
 end
@@ -409,7 +409,7 @@ function divexact(x::nmod_poly, y::nmod_poly)
   iszero(y) && throw(DivideError())
   !lead_isunit(y) && error("Impossible inverse in divexact")
   z = parent(x)()
-  ccall((:nmod_poly_div, :libflint), Nothing,
+  ccall((:nmod_poly_div, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}), z, x, y)
   return z
 end
@@ -448,7 +448,7 @@ function divrem(x::nmod_poly, y::nmod_poly)
   !lead_isunit(y) && error("Impossible inverse in divrem")
   q = parent(x)()
   r = parent(x)()
-  ccall((:nmod_poly_divrem, :libflint), Nothing,
+  ccall((:nmod_poly_divrem, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}),
           q, r, x, y)
   return q, r
@@ -459,7 +459,7 @@ function div(x::nmod_poly, y::nmod_poly)
   iszero(y) && throw(DivideError())
   !lead_isunit(y) && error("Impossible inverse in div")
   q = parent(x)()
-  ccall((:nmod_poly_div, :libflint), Nothing,
+  ccall((:nmod_poly_div, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}),
           q, x, y)
   return q
@@ -476,7 +476,7 @@ function rem(x::nmod_poly, y::nmod_poly)
   iszero(y) && throw(DivideError())
   !lead_isunit(y) && error("Impossible inverse in rem")
   z = parent(x)()
-  ccall((:nmod_poly_rem, :libflint), Nothing,
+  ccall((:nmod_poly_rem, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}), z, x, y)
   return z
 end
@@ -493,7 +493,7 @@ function gcd(x::nmod_poly, y::nmod_poly)
   check_parent(x,y)
   !isprime(modulus(x)) && error("Modulus not prime in gcd")
   z = parent(x)()
-  ccall((:nmod_poly_gcd, :libflint), Nothing,
+  ccall((:nmod_poly_gcd, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}), z, x, y)
   return z
 end
@@ -504,7 +504,7 @@ function gcdx(x::nmod_poly, y::nmod_poly)
   g = parent(x)()
   s = parent(x)()
   t = parent(x)()
-  ccall((:nmod_poly_xgcd, :libflint), Nothing,
+  ccall((:nmod_poly_xgcd, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly},
            Ref{nmod_poly}), g, s, t, x, y)
   return g,s,t
@@ -516,7 +516,7 @@ function gcdinv(x::nmod_poly, y::nmod_poly)
   length(y) <= 1 && error("Length of second argument must be >= 2")
   g = parent(x)()
   s = parent(x)()
-  ccall((:nmod_poly_gcdinv, :libflint), Nothing,
+  ccall((:nmod_poly_gcdinv, libflint), Nothing,
           (Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}, Ref{nmod_poly}),
           g, s, x, y)
   return g,s
@@ -535,7 +535,7 @@ function invmod(x::T, y::T) where T <: Zmodn_poly
     return parent(x)(inv(eval(x, coeff(y, 0))))
   end
   z = parent(x)()
-  r = ccall((:nmod_poly_invmod, :libflint), Int32,
+  r = ccall((:nmod_poly_invmod, libflint), Int32,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   r == 0 ? error("Impossible inverse in invmod") : return z
 end
@@ -544,7 +544,7 @@ function mulmod(x::T, y::T, z::T) where T <: Zmodn_poly
   check_parent(x,y)
   check_parent(y,z)
   w = parent(x)()
-  ccall((:nmod_poly_mulmod, :libflint), Nothing,
+  ccall((:nmod_poly_mulmod, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{T}, Ref{T}),
         w, x, y, z)
   return w
@@ -562,7 +562,7 @@ function powmod(x::T, e::Int, y::T) where T <: Zmodn_poly
     e = -e
   end
 
-  ccall((:nmod_poly_powmod_ui_binexp, :libflint), Nothing,
+  ccall((:nmod_poly_powmod_ui_binexp, libflint), Nothing,
         (Ref{T}, Ref{T}, Int, Ref{T}), z, x, e, y)
 
   return z
@@ -579,7 +579,7 @@ function resultant(x::nmod_poly, y::nmod_poly,  check::Bool = true)
     check_parent(x,y)
     !isprime(modulus(x)) && error("Modulus not prime in resultant")
   end
-  r = ccall((:nmod_poly_resultant, :libflint), UInt,
+  r = ccall((:nmod_poly_resultant, libflint), UInt,
           (Ref{nmod_poly}, Ref{nmod_poly}), x, y)
   return base_ring(x)(r)
 end
@@ -592,7 +592,7 @@ end
 
 function evaluate(x::nmod_poly, y::nmod)
   base_ring(x) != parent(y) && error("Elements must have same parent")
-  z = ccall((:nmod_poly_evaluate_nmod, :libflint), UInt,
+  z = ccall((:nmod_poly_evaluate_nmod, libflint), UInt,
               (Ref{nmod_poly}, UInt), x, y.data)
   return parent(y)(z)
 end
@@ -605,7 +605,7 @@ end
 
 function derivative(x::T) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_derivative, :libflint), Nothing,
+  ccall((:nmod_poly_derivative, libflint), Nothing,
         (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -618,7 +618,7 @@ end
 
 function integral(x::T) where T <: Zmodn_poly
   z = parent(x)()
-  ccall((:nmod_poly_integral, :libflint), Nothing,
+  ccall((:nmod_poly_integral, libflint), Nothing,
         (Ref{T}, Ref{T}), z, x)
   return z
 end
@@ -632,7 +632,7 @@ end
 function compose(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
-  ccall((:nmod_poly_compose, :libflint), Nothing,
+  ccall((:nmod_poly_compose, libflint), Nothing,
           (Ref{T}, Ref{T}, Ref{T}), z, x, y)
   return z
 end
@@ -655,7 +655,7 @@ function interpolate(R::NmodPolyRing, x::Array{nmod, 1},
 
     ay[i] = y[i].data
   end
-  ccall((:nmod_poly_interpolate_nmod_vec, :libflint), Nothing,
+  ccall((:nmod_poly_interpolate_nmod_vec, libflint), Nothing,
           (Ref{nmod_poly}, Ptr{UInt}, Ptr{UInt}, Int),
           z, ax, ay, length(x))
   return z
@@ -670,7 +670,7 @@ end
 function inflate(x::T, n::Int) where T <: Zmodn_poly
   n < 0 && throw(DomainError(n, "Cannot inflate by a negative number."))
   z = parent(x)()
-  ccall((:nmod_poly_inflate, :libflint), Nothing,
+  ccall((:nmod_poly_inflate, libflint), Nothing,
           (Ref{T}, Ref{T}, UInt), z, x, UInt(n))
   return z
 end
@@ -678,7 +678,7 @@ end
 function deflate(x::T, n::Int) where T <: Zmodn_poly
   n < 0 && throw(DomainError(n, "Cannot deflate by a negative number."))
   z = parent(x)()
-  ccall((:nmod_poly_deflate, :libflint), Nothing,
+  ccall((:nmod_poly_deflate, libflint), Nothing,
           (Ref{T}, Ref{T}, UInt), z, x, UInt(n))
   return z
 end
@@ -697,7 +697,7 @@ end
 """
 function lift(R::FmpzPolyRing, y::nmod_poly)
   z = fmpz_poly()
-  ccall((:fmpz_poly_set_nmod_poly, :libflint), Nothing,
+  ccall((:fmpz_poly_set_nmod_poly, libflint), Nothing,
           (Ref{fmpz_poly}, Ref{nmod_poly}), z, y)
   z.parent = R
   return z
@@ -715,7 +715,7 @@ end
 """
 function isirreducible(x::nmod_poly)
   !isprime(modulus(x)) && error("Modulus not prime in isirreducible")
-  return Bool(ccall((:nmod_poly_is_irreducible, :libflint), Int32,
+  return Bool(ccall((:nmod_poly_is_irreducible, libflint), Int32,
           (Ref{nmod_poly}, ), x))
 end
 
@@ -731,7 +731,7 @@ end
 """
 function issquarefree(x::nmod_poly)
    !isprime(modulus(x)) && error("Modulus not prime in issquarefree")
-   return Bool(ccall((:nmod_poly_is_squarefree, :libflint), Int32,
+   return Bool(ccall((:nmod_poly_is_squarefree, libflint), Int32,
        (Ref{nmod_poly}, ), x))
 end
 
@@ -753,12 +753,12 @@ end
 function _factor(x::nmod_poly)
   !isprime(modulus(x)) && error("Modulus not prime in factor")
   fac = nmod_poly_factor(x.mod_n)
-  z = ccall((:nmod_poly_factor, :libflint), UInt,
+  z = ccall((:nmod_poly_factor, libflint), UInt,
           (Ref{nmod_poly_factor}, Ref{nmod_poly}), fac, x)
   res = Dict{nmod_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{nmod_poly}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -777,12 +777,12 @@ end
 
 function _factor_squarefree(x::nmod_poly)
   fac = nmod_poly_factor(x.mod_n)
-  ccall((:nmod_poly_factor_squarefree, :libflint), UInt,
+  ccall((:nmod_poly_factor_squarefree, libflint), UInt,
           (Ref{nmod_poly_factor}, Ref{nmod_poly}), fac, x)
   res = Dict{nmod_poly,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{nmod_poly}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -800,13 +800,13 @@ function factor_distinct_deg(x::nmod_poly)
   degs = Vector{Int}(undef, degree(x))
   degss = [ pointer(degs) ]
   fac = nmod_poly_factor(x.mod_n)
-  ccall((:nmod_poly_factor_distinct_deg, :libflint), UInt,
+  ccall((:nmod_poly_factor_distinct_deg, libflint), UInt,
           (Ref{nmod_poly_factor}, Ref{nmod_poly}, Ptr{Ptr{Int}}),
           fac, x, degss)
   res = Dict{Int,nmod_poly}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, :libflint), Nothing,
+    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
             (Ref{nmod_poly}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     res[degs[i]] = f
   end
@@ -847,7 +847,7 @@ function remove(z::nmod_poly, p::nmod_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")
    z = deepcopy(z)
-   v = ccall((:nmod_poly_remove, :libflint), Int,
+   v = ccall((:nmod_poly_remove, libflint), Int,
                (Ref{nmod_poly}, Ref{nmod_poly}), z,  p)
    return v, z
 end
@@ -890,37 +890,37 @@ end
 ################################################################################
 
 function zero!(x::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_zero, :libflint), Nothing,
+  ccall((:nmod_poly_zero, libflint), Nothing,
                    (Ref{T},), x)
   return x
 end
 
 function one!(a::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_one, :libflint), Nothing, (Ref{T}, ), a)
+  ccall((:nmod_poly_one, libflint), Nothing, (Ref{T}, ), a)
   return a
 end
 
 function fit!(x::T, n::Int) where T <: Zmodn_poly
-  ccall((:nmod_poly_fit_length, :libflint), Nothing,
+  ccall((:nmod_poly_fit_length, libflint), Nothing,
                    (Ref{T}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(x::T, n::Int, y::UInt) where T <: Zmodn_poly
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+  ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, y)
   return x
 end
 
 function setcoeff!(x::T, n::Int, y::Int) where T <: Zmodn_poly
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+  ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, mod(y, x.mod_n))
   return x
 end
 
 function setcoeff!(x::T, n::Int, y::fmpz) where T <: Zmodn_poly
-  r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, x.mod_n)
-  ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+  r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), y, x.mod_n)
+  ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                    (Ref{T}, Int, UInt), x, n, r)
   return x
 end
@@ -930,31 +930,31 @@ setcoeff!(x::T, n::Int, y::Integer) where T <: Zmodn_poly = setcoeff!(x, n, fmpz
 setcoeff!(x::nmod_poly, n::Int, y::nmod) = setcoeff!(x, n, y.data)
 
 function add!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_add, :libflint), Nothing,
+  ccall((:nmod_poly_add, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
 
 function addeq!(z::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_add, :libflint), Nothing,
+  ccall((:nmod_poly_add, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, z, y)
   return z
 end
 
 function sub!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_sub, :libflint), Nothing,
+  ccall((:nmod_poly_sub, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
 
 function mul!(z::T, x::T, y::T) where T <: Zmodn_poly
-  ccall((:nmod_poly_mul, :libflint), Nothing,
+  ccall((:nmod_poly_mul, libflint), Nothing,
           (Ref{T}, Ref{T},  Ref{T}), z, x, y)
   return z
 end
 
 function mul!(z::T, x::T, y::UInt) where T <: Zmodn_poly
-  ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+  ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{T}, Ref{T}, UInt), z, x, y)
   return z
 end
@@ -997,7 +997,7 @@ function (R::NmodPolyRing)()
 end
 
 function (R::NmodPolyRing)(x::fmpz)
-  r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, R.n)
+  r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), x, R.n)
   z = nmod_poly(R.n, r)
   z.parent = R
   return z

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -38,13 +38,13 @@ max_precision(R::NmodRelSeriesRing) = R.prec_max
 
 function normalise(a::nmod_rel_series, len::Int)
    if len > 0
-      c = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+      c = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
          (Ref{nmod_rel_series}, Int), a, len - 1)
    end
    while len > 0 && iszero(c)
       len -= 1
       if len > 0
-         c = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+         c = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
             (Ref{nmod_rel_series}, Int), a, len - 1)
       end
    end
@@ -52,7 +52,7 @@ function normalise(a::nmod_rel_series, len::Int)
 end
 
 function pol_length(x::nmod_rel_series)
-   return ccall((:nmod_poly_length, :libflint), Int, (Ref{nmod_rel_series},), x)
+   return ccall((:nmod_poly_length, libflint), Int, (Ref{nmod_rel_series},), x)
 end
 
 precision(x::nmod_rel_series) = x.prec
@@ -62,7 +62,7 @@ function polcoeff(x::nmod_rel_series, n::Int)
    if n < 0
       return R(0)
    end
-   z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+   z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
          (Ref{nmod_rel_series}, Int), x, n)
    return R(z)
 end
@@ -100,7 +100,7 @@ function renormalize!(z::nmod_rel_series)
       z.val = zprec
    else
       z.val = zval + i
-      ccall((:nmod_poly_shift_right, :libflint), Nothing,
+      ccall((:nmod_poly_shift_right, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int), z, z, i)
    end
    return nothing
@@ -129,7 +129,7 @@ show_minus_one(::Type{nmod_rel_series}) = true
 
 function -(x::nmod_rel_series)
    z = parent(x)()
-   ccall((:nmod_poly_neg, :libflint), Nothing,
+   ccall((:nmod_poly_neg, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}),
                z, x)
    z.prec = x.prec
@@ -154,29 +154,29 @@ function +(a::nmod_rel_series, b::nmod_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -198,31 +198,31 @@ function -(a::nmod_rel_series, b::nmod_rel_series)
    z = parent(a)()
    if a.val < b.val
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:nmod_poly_neg, :libflint), Nothing,
+      ccall((:nmod_poly_neg, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}), z, z)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, z, a, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, a, max(0, lenz - a.val + b.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, z, a.val - b.val)
-      ccall((:nmod_poly_sub_series, :libflint), Nothing,
+      ccall((:nmod_poly_sub_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, z, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:nmod_poly_sub_series, :libflint), Nothing,
+      ccall((:nmod_poly_sub_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, a, b, lenz)
    end
@@ -248,7 +248,7 @@ function *(a::nmod_rel_series, b::nmod_rel_series)
       return z
    end
    lenz = min(lena + lenb - 1, prec)
-   ccall((:nmod_poly_mullow, :libflint), Nothing,
+   ccall((:nmod_poly_mullow, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, a, b, lenz)
    renormalize!(z)
@@ -265,7 +265,7 @@ function *(x::nmod, y::nmod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, y, data(x))
    renormalize!(z)
@@ -278,8 +278,8 @@ function *(x::fmpz, y::nmod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, modulus(y))
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), x, modulus(y))
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, y, r)
    renormalize!(z)
@@ -290,7 +290,7 @@ function *(x::UInt, y::nmod_rel_series)
    z = parent(y)()
    z.prec = y.prec
    z.val = y.val
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, y, mod(x, modulus(y)))
    renormalize!(z)
@@ -333,7 +333,7 @@ function shift_right(x::nmod_rel_series, len::Int)
       z.prec = max(0, x.prec - len)
       z.val = max(0, xval - len)
       zlen = min(xlen + xval - len, xlen)
-      ccall((:nmod_poly_shift_right, :libflint), Nothing,
+      ccall((:nmod_poly_shift_right, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, x, xlen - zlen)
       renormalize!(z)
@@ -363,7 +363,7 @@ function truncate(x::nmod_rel_series, prec::Int)
       z.prec = prec
    else
       z.val = xval
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, x, min(prec - xval, xlen))
    end
@@ -398,7 +398,7 @@ function ^(a::nmod_rel_series, b::Int)
       z = parent(a)()
       z.prec = a.prec + (b - 1)*valuation(a)
       z.val = b*valuation(a)
-      ccall((:nmod_poly_pow_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_pow_trunc, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int, Int),
                z, a, b, z.prec - z.val)
    end
@@ -426,7 +426,7 @@ function ==(x::nmod_rel_series, y::nmod_rel_series)
    if xlen != ylen
       return false
    end
-   return Bool(ccall((:nmod_poly_equal_trunc, :libflint), Cint,
+   return Bool(ccall((:nmod_poly_equal_trunc, libflint), Cint,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                x, y, xlen))
 end
@@ -438,7 +438,7 @@ function isequal(x::nmod_rel_series, y::nmod_rel_series)
    if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
       return false
    end
-   return Bool(ccall((:nmod_poly_equal, :libflint), Cint,
+   return Bool(ccall((:nmod_poly_equal, libflint), Cint,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                x, y, pol_length(x)))
 end
@@ -456,7 +456,7 @@ function ==(x::nmod_rel_series, y::nmod)
       return false
    elseif pol_length(x) == 1
       if x.val == 0
-         z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+         z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                        (Ref{nmod_rel_series}, Int), x, 0)
          return data(y) == z
       else
@@ -476,15 +476,15 @@ function ==(x::nmod_rel_series, y::fmpz)
       return false
    elseif pol_length(x) == 1
       if x.val == 0
-         r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
-         z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+         r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
+         z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                        (Ref{nmod_rel_series}, Int), x, 0)
          return r == z
       else
          return false
       end
    else
-      r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
+      r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
       return r == UInt(0)
    end
 end
@@ -499,7 +499,7 @@ function ==(x::nmod_rel_series, y::UInt)
    elseif pol_length(x) == 1
       if x.val == 0
          r = mod(y, modulus(x))
-         z = ccall((:nmod_poly_get_coeff_ui, :libflint), UInt,
+         z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                        (Ref{nmod_rel_series}, Int), x, 0)
          return r == z
       else
@@ -540,7 +540,7 @@ function divexact(x::nmod_rel_series, y::nmod_rel_series)
    z.val = xval - yval
    z.prec = prec + z.val
    if prec != 0
-      ccall((:nmod_poly_div_series, :libflint), Nothing,
+      ccall((:nmod_poly_div_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, x, y, prec)
    end
@@ -559,7 +559,7 @@ function divexact(x::nmod_rel_series, y::nmod)
    z.prec = x.prec
    z.val = x.val
    r = inv(y)
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, x, data(r))
    return z
@@ -571,9 +571,9 @@ function divexact(x::nmod_rel_series, y::fmpz)
    z.prec = x.prec
    z.prec = x.prec
    z.val = x.val
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
+   r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), y, modulus(x))
    rinv = inv(base_ring(x)(r))
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, x, data(rinv))
    return z
@@ -587,7 +587,7 @@ function divexact(x::nmod_rel_series, y::UInt)
    z.val = x.val
    r = mod(y, modulus(x))
    rinv = inv(base_ring(x)(r))
-   ccall((:nmod_poly_scalar_mul_nmod, :libflint), Nothing,
+   ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, UInt),
                z, x, data(rinv))
    return z
@@ -607,7 +607,7 @@ function inv(a::nmod_rel_series)
    ainv = parent(a)()
    ainv.prec = a.prec
    ainv.val = 0
-   ccall((:nmod_poly_inv_series, :libflint), Nothing,
+   ccall((:nmod_poly_inv_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                ainv, a, a.prec)
    return ainv
@@ -645,7 +645,7 @@ function Base.exp(a::nmod_rel_series)
       d[k + 1] = divexact(base_ring(a)(s), k)
    end
    z = parent(a)(d, preca, preca, 0)
-   ccall((:_nmod_poly_set_length, :libflint), Nothing,
+   ccall((:_nmod_poly_set_length, libflint), Nothing,
          (Ref{nmod_rel_series}, Int), z, normalise(z, preca))
    return z
 end
@@ -657,21 +657,21 @@ end
 ###############################################################################
 
 function zero!(x::nmod_rel_series)
-  ccall((:nmod_poly_zero, :libflint), Nothing,
+  ccall((:nmod_poly_zero, libflint), Nothing,
                    (Ref{nmod_rel_series},), x)
   x.prec = parent(x).prec_max
   return x
 end
 
 function fit!(x::nmod_rel_series, n::Int)
-  ccall((:nmod_poly_fit_length, :libflint), Nothing,
+  ccall((:nmod_poly_fit_length, libflint), Nothing,
                    (Ref{nmod_rel_series}, Int), x, n)
   return nothing
 end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::fmpz)
-   r = ccall((:fmpz_fdiv_ui, :libflint), UInt, (Ref{fmpz}, UInt), x, modulus(z))
-   ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+   r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{fmpz}, UInt), x, modulus(z))
+   ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                 (Ref{nmod_rel_series}, Int, UInt),
                z, n, r)
    return z
@@ -679,14 +679,14 @@ end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::UInt)
    r = mod(x, modulus(z))
-   ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+   ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                 (Ref{nmod_rel_series}, Int, UInt),
                z, n, r)
    return z
 end
 
 function setcoeff!(z::nmod_rel_series, n::Int, x::nmod)
-   ccall((:nmod_poly_set_coeff_ui, :libflint), Nothing,
+   ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
                 (Ref{nmod_rel_series}, Int, UInt),
                z, n, data(x))
    return z
@@ -706,7 +706,7 @@ function mul!(z::nmod_rel_series, a::nmod_rel_series, b::nmod_rel_series)
    if lena <= 0 || lenb <= 0
       lenz = 0
    end
-   ccall((:nmod_poly_mullow, :libflint), Nothing,
+   ccall((:nmod_poly_mullow, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                z, a, b, lenz)
    renormalize!(z)
@@ -724,29 +724,29 @@ function addeq!(a::nmod_rel_series, b::nmod_rel_series)
    if a.val < b.val
       z = nmod_rel_series(modulus)
       lenz = max(lena, lenb + b.val - a.val)
-      ccall((:nmod_poly_set_trunc, :libflint), Nothing,
+      ccall((:nmod_poly_set_trunc, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, b, max(0, lenz - b.val + a.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             z, z, b.val - a.val)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                a, a, z, lenz)
    elseif b.val < a.val
       lenz = max(lena + a.val - b.val, lenb)
-      ccall((:nmod_poly_truncate, :libflint), Nothing,
+      ccall((:nmod_poly_truncate, libflint), Nothing,
             (Ref{nmod_rel_series}, Int),
             a, max(0, lenz - a.val + b.val))
-      ccall((:nmod_poly_shift_left, :libflint), Nothing,
+      ccall((:nmod_poly_shift_left, libflint), Nothing,
             (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
             a, a, a.val - b.val)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                a, a, b, lenz)
    else
       lenz = max(lena, lenb)
-      ccall((:nmod_poly_add_series, :libflint), Nothing,
+      ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                a, a, b, lenz)
    end
@@ -767,7 +767,7 @@ function add!(c::nmod_rel_series, a::nmod_rel_series, b::nmod_rel_series)
 
    lenc = max(lena, lenb)
    c.prec = prec
-   ccall((:nmod_poly_add_series, :libflint), Nothing,
+   ccall((:nmod_poly_add_series, libflint), Nothing,
                 (Ref{nmod_rel_series}, Ref{nmod_rel_series}, Ref{nmod_rel_series}, Int),
                c, a, b, lenc)
    return c

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -104,7 +104,7 @@ parent_type(::Type{padic}) = FlintPadicField
 
 function Base.deepcopy_internal(a::padic, dict::IdDict)
    z = parent(a)()
-   ccall((:padic_set, :libflint), Nothing,
+   ccall((:padic_set, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, parent(a))
    z.N = a.N      # set does not transfer N - neither should it.
    return z
@@ -120,7 +120,7 @@ end
 """
 function prime(R::FlintPadicField)
    z = fmpz()
-   ccall((:padic_ctx_pow_ui, :libflint), Nothing,
+   ccall((:padic_ctx_pow_ui, libflint), Nothing,
          (Ref{fmpz}, Int, Ref{FlintPadicField}), z, 1, R)
    return z
 end
@@ -147,7 +147,7 @@ valuation(a::padic) = iszero(a) ? a.N : a.v
 function lift(R::FlintRationalField, a::padic)
     ctx = parent(a)
     r = fmpq()
-    ccall((:padic_get_fmpq, :libflint), Nothing,
+    ccall((:padic_get_fmpq, libflint), Nothing,
           (Ref{fmpq}, Ref{padic}, Ref{FlintPadicField}), r, a, ctx)
     return r
 end
@@ -159,7 +159,7 @@ end
 function lift(R::FlintIntegerRing, a::padic)
     ctx = parent(a)
     r = fmpz()
-    ccall((:padic_get_fmpz, :libflint), Nothing,
+    ccall((:padic_get_fmpz, libflint), Nothing,
           (Ref{fmpz}, Ref{padic}, Ref{FlintPadicField}), r, a, ctx)
     return r
 end
@@ -170,7 +170,7 @@ end
 """
 function zero(R::FlintPadicField)
    z = padic(R.prec_max)
-   ccall((:padic_zero, :libflint), Nothing, (Ref{padic},), z)
+   ccall((:padic_zero, libflint), Nothing, (Ref{padic},), z)
    z.parent = R
    return z
 end
@@ -181,7 +181,7 @@ end
 """
 function one(R::FlintPadicField)
    z = padic(R.prec_max)
-   ccall((:padic_one, :libflint), Nothing, (Ref{padic},), z)
+   ccall((:padic_one, libflint), Nothing, (Ref{padic},), z)
    z.parent = R
    return z
 end
@@ -191,7 +191,7 @@ end
 > Return `true` if the given p-adic field element is zero, otherwise return
 > `false`.
 """
-iszero(a::padic) = Bool(ccall((:padic_is_zero, :libflint), Cint,
+iszero(a::padic) = Bool(ccall((:padic_is_zero, libflint), Cint,
                               (Ref{padic},), a))
 
 @doc Markdown.doc"""
@@ -199,7 +199,7 @@ iszero(a::padic) = Bool(ccall((:padic_is_zero, :libflint), Cint,
 > Return `true` if the given p-adic field element is one, otherwise return
 > `false`.
 """
-isone(a::padic) = Bool(ccall((:padic_is_one, :libflint), Cint,
+isone(a::padic) = Bool(ccall((:padic_is_one, libflint), Cint,
                              (Ref{padic},), a))
 
 @doc Markdown.doc"""
@@ -207,7 +207,7 @@ isone(a::padic) = Bool(ccall((:padic_is_one, :libflint), Cint,
 > Return `true` if the given p-adic field element is invertible, i.e. nonzero,
 > otherwise return `false`.
 """
-isunit(a::padic) = !Bool(ccall((:padic_is_zero, :libflint), Cint,
+isunit(a::padic) = !Bool(ccall((:padic_is_zero, libflint), Cint,
                               (Ref{padic},), a))
 
 characteristic(R::FlintPadicField) = 0
@@ -253,13 +253,13 @@ function show(io::IO, x::padic)
 
    pmode = PADIC_PRINTING_MODE[]
 
-   cstr = ccall((:_padic_get_str, :libflint), Ptr{UInt8},
+   cstr = ccall((:_padic_get_str, libflint), Ptr{UInt8},
                 (Ptr{Nothing}, Ref{padic}, Ref{fmpz}, Cint),
                  C_NULL, x, p, pmode)
 
    print(io, unsafe_string(cstr))
 
-   ccall((:flint_free, :libflint), Nothing, (Ptr{UInt8},), cstr)
+   ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
    print(io, " + O(")
    print(io, p)
    print(io, "^$(x.N))")
@@ -295,7 +295,7 @@ function -(x::padic)
    end
    ctx = parent(x)
    z = padic(x.N)
-   ccall((:padic_neg, :libflint), Nothing,
+   ccall((:padic_neg, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                      z, x, ctx)
    z.parent = ctx
@@ -313,7 +313,7 @@ function +(x::padic, y::padic)
    ctx = parent(x)
    z = padic(min(x.N, y.N))
    z.parent = ctx
-   ccall((:padic_add, :libflint), Nothing,
+   ccall((:padic_add, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, x, y, ctx)
    return z
@@ -324,7 +324,7 @@ function -(x::padic, y::padic)
    ctx = parent(x)
    z = padic(min(x.N, y.N))
    z.parent = ctx
-   ccall((:padic_sub, :libflint), Nothing,
+   ccall((:padic_sub, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                   z, x, y, ctx)
    return z
@@ -335,7 +335,7 @@ function *(x::padic, y::padic)
    ctx = parent(x)
    z = padic(min(x.N + y.v, y.N + x.v))
    z.parent = ctx
-   ccall((:padic_mul, :libflint), Nothing,
+   ccall((:padic_mul, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, x, y, ctx)
    return z
@@ -393,10 +393,10 @@ function ==(a::padic, b::padic)
    check_parent(a, b)
    ctx = parent(a)
    z = padic(min(a.N, b.N))
-   ccall((:padic_sub, :libflint), Nothing,
+   ccall((:padic_sub, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, a, b, ctx)
-   return Bool(ccall((:padic_is_zero, :libflint), Cint,
+   return Bool(ccall((:padic_is_zero, libflint), Cint,
                 (Ref{padic},), z))
 end
 
@@ -435,7 +435,7 @@ function ^(a::padic, n::Int)
    ctx = parent(a)
    z = padic(a.N + (n - 1)*a.v)
    z.parent = ctx
-   ccall((:padic_pow_si, :libflint), Nothing,
+   ccall((:padic_pow_si, libflint), Nothing,
                 (Ref{padic}, Ref{padic}, Int, Ref{FlintPadicField}),
                z, a, n, ctx)
    return z
@@ -453,7 +453,7 @@ function divexact(a::padic, b::padic)
    ctx = parent(a)
    z = padic(min(a.N - b.v, b.N - 2*b.v + a.v))
    z.parent = ctx
-   ccall((:padic_div, :libflint), Cint,
+   ccall((:padic_div, libflint), Cint,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, a, b, ctx)
    return z
@@ -492,7 +492,7 @@ function inv(a::padic)
    ctx = parent(a)
    z = padic(a.N - 2*a.v)
    z.parent = ctx
-   ccall((:padic_inv, :libflint), Cint,
+   ccall((:padic_inv, libflint), Cint,
          (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx)
    return z
 end
@@ -558,7 +558,7 @@ function Base.sqrt(a::padic)
    ctx = parent(a)
    z = padic(a.N - div(a.v, 2))
    z.parent = ctx
-   res = Bool(ccall((:padic_sqrt, :libflint), Cint,
+   res = Bool(ccall((:padic_sqrt, libflint), Cint,
                     (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Square root of p-adic does not exist")
    return z
@@ -582,7 +582,7 @@ function Base.exp(a::padic)
    ctx = parent(a)
    z = padic(a.N)
    z.parent = ctx
-   res = Bool(ccall((:padic_exp, :libflint), Cint,
+   res = Bool(ccall((:padic_exp, libflint), Cint,
                     (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Unable to compute exponential")
    return z
@@ -600,7 +600,7 @@ function log(a::padic)
    ctx = parent(a)
    z = padic(a.N)
    z.parent = ctx
-   res = Bool(ccall((:padic_log, :libflint), Cint,
+   res = Bool(ccall((:padic_log, libflint), Cint,
                     (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
    !res && error("Unable to compute logarithm")
    return z
@@ -619,7 +619,7 @@ function teichmuller(a::padic)
    ctx = parent(a)
    z = padic(a.N)
    z.parent = ctx
-   ccall((:padic_teichmuller, :libflint), Nothing,
+   ccall((:padic_teichmuller, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx)
    return z
 end
@@ -633,7 +633,7 @@ end
 function zero!(z::padic)
    z.N = parent(z).prec_max
    ctx = parent(z)
-   ccall((:padic_zero, :libflint), Nothing,
+   ccall((:padic_zero, libflint), Nothing,
          (Ref{padic}, Ref{FlintPadicField}), z, ctx)
    return z
 end
@@ -641,7 +641,7 @@ end
 function mul!(z::padic, x::padic, y::padic)
    z.N = min(x.N + y.v, y.N + x.v)
    ctx = parent(x)
-   ccall((:padic_mul, :libflint), Nothing,
+   ccall((:padic_mul, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, x, y, ctx)
    return z
@@ -650,7 +650,7 @@ end
 function addeq!(x::padic, y::padic)
    x.N = min(x.N, y.N)
    ctx = parent(x)
-   ccall((:padic_add, :libflint), Nothing,
+   ccall((:padic_add, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                x, x, y, ctx)
    return x
@@ -659,7 +659,7 @@ end
 function add!(z::padic, x::padic, y::padic)
    z.N = min(x.N, y.N)
    ctx = parent(x)
-   ccall((:padic_add, :libflint), Nothing,
+   ccall((:padic_add, libflint), Nothing,
          (Ref{padic}, Ref{padic}, Ref{padic}, Ref{FlintPadicField}),
                z, x, y, ctx)
    return z
@@ -697,7 +697,7 @@ function (R::FlintPadicField)(n::fmpz)
       N, = remove(n, p)
    end
    z = padic(N + R.prec_max)
-   ccall((:padic_set_fmpz, :libflint), Nothing,
+   ccall((:padic_set_fmpz, libflint), Nothing,
          (Ref{padic}, Ref{fmpz}, Ref{FlintPadicField}), z, n, R)
    z.parent = R
    return z
@@ -715,7 +715,7 @@ function (R::FlintPadicField)(n::fmpq)
      N = -remove(m, p)[1]
    end
    z = padic(N + R.prec_max)
-   ccall((:padic_set_fmpq, :libflint), Nothing,
+   ccall((:padic_set_fmpq, libflint), Nothing,
          (Ref{padic}, Ref{fmpq}, Ref{FlintPadicField}), z, n, R)
    z.parent = R
    return z

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -103,7 +103,7 @@ parent_type(::Type{qadic}) = FlintQadicField
 
 function Base.deepcopy_internal(a::qadic, dict::IdDict{Any, Any})
    z = parent(a)()
-   ccall((:qadic_set, :libflint), Nothing,
+   ccall((:qadic_set, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, parent(a))
    z.N = a.N
    return z
@@ -115,7 +115,7 @@ function Base.hash(a::qadic, h::UInt)
 end
 
 function degree(R::FlintQadicField)
-   return ccall((:qadic_ctx_degree, :libflint), Int, (Ref{FlintQadicField}, ), R)
+   return ccall((:qadic_ctx_degree, libflint), Int, (Ref{FlintQadicField}, ), R)
 end
 
 @doc Markdown.doc"""
@@ -124,7 +124,7 @@ end
 """
 function prime(R::FlintQadicField)
    z = fmpz()
-   ccall((:padic_ctx_pow_ui, :libflint), Nothing,
+   ccall((:padic_ctx_pow_ui, libflint), Nothing,
          (Ref{fmpz}, UInt, Ref{FlintQadicField}), z, 1, R)
    return z
 end
@@ -143,7 +143,7 @@ precision(a::qadic) = a.N
 > will return $n$.
 """
 function valuation(a::qadic)
-    iszero(a) ? precision(a) : ccall((:qadic_val, :libflint), Int, (Ref{qadic}, ), a)
+    iszero(a) ? precision(a) : ccall((:qadic_val, libflint), Int, (Ref{qadic}, ), a)
 end
 
 @doc Markdown.doc"""
@@ -153,7 +153,7 @@ end
 function lift(R::FmpqPolyRing, a::qadic)
    ctx = parent(a)
    r = R()
-   ccall((:padic_poly_get_fmpq_poly, :libflint), Nothing,
+   ccall((:padic_poly_get_fmpq_poly, libflint), Nothing,
          (Ref{fmpq_poly}, Ref{qadic}, Ref{FlintQadicField}), r, a, ctx)
    return r
 end
@@ -165,7 +165,7 @@ end
 function lift(R::FmpzPolyRing, a::qadic)
    ctx = parent(a)
    r = R()
-   res = Bool(ccall((:padic_poly_get_fmpz_poly, :libflint), Cint,
+   res = Bool(ccall((:padic_poly_get_fmpz_poly, libflint), Cint,
                     (Ref{fmpz_poly}, Ref{qadic}, Ref{FlintQadicField}), r, a, ctx))
    !res && error("Unable to lift")
    return r
@@ -177,7 +177,7 @@ end
 """
 function zero(R::FlintQadicField)
    z = qadic(R.prec_max)
-   ccall((:qadic_zero, :libflint), Nothing, (Ref{qadic},), z)
+   ccall((:qadic_zero, libflint), Nothing, (Ref{qadic},), z)
    z.parent = R
    return z
 end
@@ -188,7 +188,7 @@ end
 """
 function one(R::FlintQadicField)
    z = qadic(R.prec_max)
-   ccall((:qadic_one, :libflint), Nothing, (Ref{qadic},), z)
+   ccall((:qadic_one, libflint), Nothing, (Ref{qadic},), z)
    z.parent = R
    return z
 end
@@ -198,7 +198,7 @@ end
 > Return `true` if the given p-adic field element is zero, otherwise return
 > `false`.
 """
-iszero(a::qadic) = Bool(ccall((:qadic_is_zero, :libflint), Cint,
+iszero(a::qadic) = Bool(ccall((:qadic_is_zero, libflint), Cint,
                               (Ref{qadic},), a))
 
 @doc Markdown.doc"""
@@ -206,7 +206,7 @@ iszero(a::qadic) = Bool(ccall((:qadic_is_zero, :libflint), Cint,
 > Return `true` if the given p-adic field element is one, otherwise return
 > `false`.
 """
-isone(a::qadic) = Bool(ccall((:qadic_is_one, :libflint), Cint,
+isone(a::qadic) = Bool(ccall((:qadic_is_one, libflint), Cint,
                              (Ref{qadic},), a))
 
 @doc Markdown.doc"""
@@ -214,7 +214,7 @@ isone(a::qadic) = Bool(ccall((:qadic_is_one, :libflint), Cint,
 > Return `true` if the given p-adic field element is invertible, i.e. nonzero,
 > otherwise return `false`.
 """
-isunit(a::qadic) = !Bool(ccall((:qadic_is_zero, :libflint), Cint,
+isunit(a::qadic) = !Bool(ccall((:qadic_is_zero, libflint), Cint,
                               (Ref{qadic},), a))
 
 characteristic(R::FlintQadicField) = 0
@@ -233,14 +233,14 @@ function show(io::IO, x::qadic)
    end
    len = degree(parent(x)) + 1
    c = R()
-   ccall((:padic_poly_get_coeff_padic, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len, parent(x))
+   ccall((:padic_poly_get_coeff_padic, libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len, parent(x))
    while iszero(c)
      len = len - 1
-     ccall((:padic_poly_get_coeff_padic, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len, parent(x))
+     ccall((:padic_poly_get_coeff_padic, libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len, parent(x))
    end
 
    for i = 1:len
-     ccall((:padic_poly_get_coeff_padic, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len - i + 1, parent(x))
+     ccall((:padic_poly_get_coeff_padic, libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, len - i + 1, parent(x))
      bracket = true
      if !iszero(c)
        if i != 1
@@ -257,7 +257,7 @@ function show(io::IO, x::qadic)
        end
      end
    end
-   ccall((:padic_poly_get_coeff_padic, :libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, 0, parent(x))
+   ccall((:padic_poly_get_coeff_padic, libflint), Nothing, (Ref{padic}, Ref{qadic}, Int, Ref{FlintQadicField}), c, x, 0, parent(x))
    if !iszero(c)
      if len + 1 != 1
        print(io, " + ")
@@ -298,7 +298,7 @@ function -(x::qadic)
    end
    ctx = parent(x)
    z = qadic(x.N)
-   ccall((:qadic_neg, :libflint), Nothing,
+   ccall((:qadic_neg, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                      z, x, ctx)
    z.parent = ctx
@@ -316,7 +316,7 @@ function +(x::qadic, y::qadic)
    ctx = parent(x)
    z = qadic(min(x.N, y.N))
    z.parent = ctx
-   ccall((:qadic_add, :libflint), Nothing,
+   ccall((:qadic_add, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                z, x, y, ctx)
    return z
@@ -327,7 +327,7 @@ function -(x::qadic, y::qadic)
    ctx = parent(x)
    z = qadic(min(x.N, y.N))
    z.parent = ctx
-   ccall((:qadic_sub, :libflint), Nothing,
+   ccall((:qadic_sub, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                   z, x, y, ctx)
    return z
@@ -338,7 +338,7 @@ function *(x::qadic, y::qadic)
    ctx = parent(x)
    z = qadic(min(x.N + valuation(y), y.N + valuation(x)))
    z.parent = ctx
-   ccall((:qadic_mul, :libflint), Nothing,
+   ccall((:qadic_mul, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                z, x, y, ctx)
    return z
@@ -396,10 +396,10 @@ function ==(a::qadic, b::qadic)
    check_parent(a, b)
    ctx = parent(a)
    z = qadic(min(a.N, b.N))
-   ccall((:qadic_sub, :libflint), Nothing,
+   ccall((:qadic_sub, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                z, a, b, ctx)
-   return Bool(ccall((:qadic_is_zero, :libflint), Cint,
+   return Bool(ccall((:qadic_is_zero, libflint), Cint,
                 (Ref{qadic},), z))
 end
 
@@ -443,7 +443,7 @@ function ^(a::qadic, n::fmpz)
    end
    z = qadic(a.N + (Int(n) - 1)*valuation(a))
    z.parent = ctx
-   ccall((:qadic_pow, :libflint), Nothing,
+   ccall((:qadic_pow, libflint), Nothing,
                  (Ref{qadic}, Ref{qadic}, Ref{fmpz}, Ref{FlintQadicField}),
                z, a, n, ctx)
    return z
@@ -493,7 +493,7 @@ function inv(a::qadic)
    ctx = parent(a)
    z = qadic(a.N - 2*valuation(a))
    z.parent = ctx
-   ccall((:qadic_inv, :libflint), Cint,
+   ccall((:qadic_inv, libflint), Cint,
          (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx)
    return z
 end
@@ -560,7 +560,7 @@ function Base.sqrt(a::qadic)
    ctx = parent(a)
    z = qadic(a.N - div(av, 2))
    z.parent = ctx
-   res = Bool(ccall((:qadic_sqrt, :libflint), Cint,
+   res = Bool(ccall((:qadic_sqrt, libflint), Cint,
                     (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx))
    !res && error("Square root of p-adic does not exist")
    return z
@@ -584,7 +584,7 @@ function Base.exp(a::qadic)
    ctx = parent(a)
    z = qadic(a.N)
    z.parent = ctx
-   res = Bool(ccall((:qadic_exp, :libflint), Cint,
+   res = Bool(ccall((:qadic_exp, libflint), Cint,
                     (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx))
    !res && error("Unable to compute exponential")
    return z
@@ -603,7 +603,7 @@ function log(a::qadic)
    ctx = parent(a)
    z = qadic(a.N)
    z.parent = ctx
-   res = Bool(ccall((:qadic_log, :libflint), Cint,
+   res = Bool(ccall((:qadic_log, libflint), Cint,
                     (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx))
    !res && error("Unable to compute logarithm")
    return z
@@ -622,7 +622,7 @@ function teichmuller(a::qadic)
    ctx = parent(a)
    z = qadic(a.N)
    z.parent = ctx
-   ccall((:qadic_teichmuller, :libflint), Nothing,
+   ccall((:qadic_teichmuller, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx)
    return z
 end
@@ -636,7 +636,7 @@ function frobenius(a::qadic, e::Int = 1)
    ctx = parent(a)
    z = qadic(a.N)
    z.parent = ctx
-   ccall((:qadic_frobenius, :libflint), Nothing,
+   ccall((:qadic_frobenius, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Int, Ref{FlintQadicField}), z, a, e, ctx)
    return z
 end
@@ -650,7 +650,7 @@ end
 function zero!(z::qadic)
    z.N = parent(z).prec_max
    ctx = parent(z)
-   ccall((:qadic_zero, :libflint), Nothing,
+   ccall((:qadic_zero, libflint), Nothing,
          (Ref{qadic}, Ref{FlintQadicField}), z, ctx)
    return z
 end
@@ -658,7 +658,7 @@ end
 function mul!(z::qadic, x::qadic, y::qadic)
    z.N = min(x.N + valuation(y), y.N + valuation(x))
    ctx = parent(x)
-   ccall((:qadic_mul, :libflint), Nothing,
+   ccall((:qadic_mul, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                z, x, y, ctx)
    return z
@@ -667,7 +667,7 @@ end
 function addeq!(x::qadic, y::qadic)
    x.N = min(x.N, y.N)
    ctx = parent(x)
-   ccall((:qadic_add, :libflint), Nothing,
+   ccall((:qadic_add, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                x, x, y, ctx)
    return x
@@ -676,7 +676,7 @@ end
 function add!(z::qadic, x::qadic, y::qadic)
    z.N = min(x.N, y.N)
    ctx = parent(x)
-   ccall((:qadic_add, :libflint), Nothing,
+   ccall((:qadic_add, libflint), Nothing,
          (Ref{qadic}, Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}),
                z, x, y, ctx)
    return z
@@ -712,7 +712,7 @@ end
 
 function gen(R::FlintQadicField)
    z = qadic(R.prec_max)
-   ccall((:qadic_gen, :libflint), Nothing,
+   ccall((:qadic_gen, libflint), Nothing,
          (Ref{qadic}, Ref{FlintQadicField}), z, R)
    z.parent = R
    return z
@@ -726,7 +726,7 @@ function (R::FlintQadicField)(a::UInt)
    end
    v = valuation(a, prime(R))
    z = qadic(R.prec_max + v)
-   ccall((:qadic_set_ui, :libflint), Nothing,
+   ccall((:qadic_set_ui, libflint), Nothing,
          (Ref{qadic}, UInt, Ref{FlintQadicField}), z, a, R)
    z.parent = R
    return z
@@ -740,7 +740,7 @@ function (R::FlintQadicField)(a::Int)
    end
    v = valuation(a, prime(R))
    z = qadic(R.prec_max + v)
-   ccall((:padic_poly_set_si, :libflint), Nothing,
+   ccall((:padic_poly_set_si, libflint), Nothing,
          (Ref{qadic}, Int, Ref{FlintQadicField}), z,a, R)
    z.parent = R
    return z
@@ -754,7 +754,7 @@ function (R::FlintQadicField)(n::fmpz)
       N = valuation(n, p)
    end
    z = qadic(N + R.prec_max)
-   ccall((:padic_poly_set_fmpz, :libflint), Nothing,
+   ccall((:padic_poly_set_fmpz, libflint), Nothing,
          (Ref{qadic}, Ref{fmpz}, Ref{FlintQadicField}), z, n, R)
    z.parent = R
    return z
@@ -772,7 +772,7 @@ function (R::FlintQadicField)(n::fmpq)
      N = -remove(m, p)[1]
    end
    z = qadic(N + R.prec_max)
-   ccall((:padic_poly_set_fmpq, :libflint), Nothing,
+   ccall((:padic_poly_set_fmpq, libflint), Nothing,
          (Ref{qadic}, Ref{fmpq}, Ref{FlintQadicField}), z, n, R)
    z.parent = R
    return z
@@ -780,7 +780,7 @@ end
 
 function (R::FlintQadicField)(n::fmpz_poly)
    z = qadic(R.prec_max)
-   ccall((:padic_poly_set_fmpz_poly, :libflint), Nothing,
+   ccall((:padic_poly_set_fmpz_poly, libflint), Nothing,
          (Ref{qadic}, Ref{fmpz_poly}, Ref{FlintQadicField}), z, n, R)
    z.parent = R
    return z
@@ -799,7 +799,7 @@ function (R::FlintQadicField)(n::fmpq_poly)
      N = -remove(m, p)[1]
    end
    z = qadic(N + R.prec_max)
-   ccall((:padic_poly_set_fmpq_poly, :libflint), Nothing,
+   ccall((:padic_poly_set_fmpq_poly, libflint), Nothing,
          (Ref{qadic}, Ref{fmpq_poly}, Ref{FlintQadicField}), z, n, R)
    z.parent = R
    return z


### PR DESCRIPTION
  :libflint -> libflin
  :libarb   -> libarb
  :libantic -> libantic

To uniquely and uniformely specify the library that has to be used.
We were already doing this for gmp to not use the Julia one.