### PR TITLE
Consistent caching for all polynomial rings

### DIFF
--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -174,7 +174,7 @@ end
 > in case it is, otherwise sets $t$ to `false`.
 """
 function unique_integer(x::acb_poly)
-  z = FmpzPolyRing(var(parent(x)))()
+  z = FmpzPolyRing(FlintZZ, var(parent(x)))()
   unique = ccall((:acb_poly_get_unique_fmpz_poly, libarb), Int,
     (Ref{fmpz_poly}, Ref{acb_poly}), z, x)
   return (unique != 0, z)

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -160,7 +160,7 @@ end
 > In the former case, $z$ is set to the integer polynomial.
 """
 function unique_integer(x::arb_poly)
-  z = FmpzPolyRing(var(parent(x)))()
+  z = FmpzPolyRing(FlintZZ, var(parent(x)))()
   unique = ccall((:arb_poly_get_unique_fmpz_poly, libarb), Int,
     (Ref{fmpz_poly}, Ref{arb_poly}), z, x)
   return (unique != 0, z)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -171,20 +171,20 @@ mutable struct FmpzPolyRing <: PolyRing{fmpz}
    base_ring::FlintIntegerRing
    S::Symbol
 
-   function FmpzPolyRing(s::Symbol, cached::Bool = true)
-      if cached && haskey(FmpzPolyID, s)
-         return FmpzPolyID[s]
+   function FmpzPolyRing(R::FlintIntegerRing, s::Symbol, cached::Bool = true)
+      if cached && haskey(FmpzPolyID, (R, s))
+         return FmpzPolyID[R, s]
       else
-         z = new(FlintZZ, s)
+         z = new(R, s)
          if cached
-            FmpzPolyID[s] = z
+            FmpzPolyID[R, s] = z
          end
          return z
       end
    end
 end
 
-const FmpzPolyID = Dict{Symbol, FmpzPolyRing}()
+const FmpzPolyID = Dict{Tuple{FlintIntegerRing, Symbol}, FmpzPolyRing}()
 
 mutable struct fmpz_poly <: PolyElem{fmpz}
    coeffs::Ptr{Nothing}
@@ -275,19 +275,19 @@ mutable struct FmpqPolyRing <: PolyRing{fmpq}
    S::Symbol
 
    function FmpqPolyRing(R::FlintRationalField, s::Symbol, cached::Bool = true)
-      if cached && haskey(FmpqPolyID, s)
-         return FmpqPolyID[s]
+      if cached && haskey(FmpqPolyID, (R, s))
+         return FmpqPolyID[R, s]
       else
          z = new(R, s)
          if cached
-            FmpqPolyID[s] = z
+            FmpqPolyID[R, s] = z
          end
          return z
       end
    end
 end
 
-const FmpqPolyID = Dict{Symbol, FmpqPolyRing}()
+const FmpqPolyID = Dict{Tuple{FlintRationalField, Symbol}, FmpqPolyRing}()
 
 mutable struct fmpq_poly <: PolyElem{fmpq}
    coeffs::Ptr{Int}

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -896,7 +896,7 @@ end
 function PolynomialRing(R::FlintIntegerRing, s::AbstractString; cached = true)
    S = Symbol(s)
 
-   parent_obj = FmpzPolyRing(S, cached)
+   parent_obj = FmpzPolyRing(R, S, cached)
 
    return parent_obj, parent_obj([fmpz(0), fmpz(1)])
 end

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -74,6 +74,11 @@
    p = S([ZZ(1), ZZ(2), ZZ(3)])
 
    @test isa(p, PolyElem)
+   
+   @test PolynomialRing(FlintRationalField(), "x")[1] != PolynomialRing(FlintRationalField(), "y")[1]
+
+   R = FlintRationalField()
+   @test PolynomialRing(R, "x", cached = true)[1] === PolynomialRing(R, "x", cached = true)[1]
 end
 
 @testset "fmpq_poly.printing..." begin

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -28,6 +28,11 @@
    l = R([1, 2, 3])
 
    @test isa(l, PolyElem)
+
+   @test PolynomialRing(FlintIntegerRing(), "x")[1] != PolynomialRing(FlintIntegerRing(), "y")[1]
+
+   R = FlintIntegerRing()
+   @test PolynomialRing(R, "x", cached = true)[1] === PolynomialRing(R, "x", cached = true)[1]
 end
 
 @testset "fmpz_poly.printing..." begin


### PR DESCRIPTION
We had two (again inconsistent) different implementations
for caching of polynomial rings over the rationals and the
integers. But since we allow two different instances of
rationals, we should also allow two different instances
of polynomial rings over rationals.

Closes #783.

I am marking this as breaking, since it requires (minor) adjustments in Hecke.