### PR TITLE
Fix deploying docs for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ julia:
   
 branches:
   only:
-  - master
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/  # release tags
 
 notifications:
   - email: false


### PR DESCRIPTION
Restricting which branches are built also restricts the tags being built. See [the Travis docs](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) for details; it also suggests the fix I am trying here.

As a result of this, the latest version of the manuals shown on http://nemocas.github.io/Nemo.jl/latest/ is for v0.14.3; no docs for the 0.15 and 0.16 series are there.

I don't know if it is possible to get the older versions in there retroactively; but at least the next release should get docs (I hope, I'll try soon with GAP.jl which suffered from the same issue)