### PR TITLE
Adjust base ring of residue rings

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -14,9 +14,9 @@ parent_type(::Type{fmpz_mod}) = FmpzModRing
 
 elem_type(::Type{FmpzModRing}) = fmpz_mod
 
-base_ring(a::FmpzModRing) = Union{}
+base_ring(a::FmpzModRing) = FlintZZ
 
-base_ring(a::fmpz_mod) = Union{}
+base_ring(a::fmpz_mod) = FlintZZ
 
 parent(a::fmpz_mod) = a.parent
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -14,9 +14,9 @@ parent_type(::Type{nmod}) = NmodRing
 
 elem_type(::Type{NmodRing}) = nmod
 
-base_ring(a::NmodRing) = Union{}
+base_ring(a::NmodRing) = FlintZZ
 
-base_ring(a::nmod) = Union{}
+base_ring(a::nmod) = FlintZZ
 
 parent(a::nmod) = a.parent
 

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -7,6 +7,8 @@
    @test elem_type(Nemo.FmpzModRing) == Nemo.fmpz_mod
    @test parent_type(Nemo.fmpz_mod) == Nemo.FmpzModRing
 
+   @test base_ring(R) == FlintZZ
+
    @test isa(R, Nemo.FmpzModRing)
 
    @test isa(R(), Nemo.fmpz_mod)

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -7,6 +7,8 @@
    @test elem_type(Nemo.NmodRing) == Nemo.nmod
    @test parent_type(Nemo.nmod) == Nemo.NmodRing
 
+   @test base_ring(R) == FlintZZ
+
    @test isa(R, Nemo.NmodRing)
 
    @test isa(R(), Nemo.nmod)


### PR DESCRIPTION
I was a bit surprised to find out that `base_ring(ResidueRing(ZZ, 3)))` is not `ZZ`. This is contrary to all other `ResidueRing` things, see 
https://github.com/Nemocas/AbstractAlgebra.jl/blob/20b249b831a291e971e5c92955b930d01991826e/src/generic/Residue.jl#L23

This PR fixes this for both residue ring types.