### PR TITLE
Update acb.md

### DIFF
--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -721,7 +721,7 @@ W = lindep(V1, 20)
 
 # ...or from two
 V2 = [CC(1), b, b^2, b^3, b^4, b^5];
-Vs = [V1 V2]'
+Vs = [V1 V2]
 X = lindep(Vs, 20)
 ```
 


### PR DESCRIPTION
Otherwise occurs the MethodError: no method matching lindep(::LinearAlgebra.Adjoint{acb,Array{acb,2}}, ::Int64)