### PR TITLE
doc: fix table in mpolynomial.md

### DIFF
--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -25,6 +25,8 @@ $\mathbb{Q}$                                | Flint               | `fmpq_mpoly`
 
 The following are not implemented yet, but will be available soon:
 
+Base ring                                   | Library             | Element type        | Parent type
+--------------------------------------------|---------------------|---------------------|----------------------
 $\mathbb{Z}/p\mathbb{Z}$ (small prime $p$)  | Flint               | `gfp_mpoly`         | `GFPMPolyRing`
 $\mathbb{F}_{p^n}$ (small $p$)              | Flint               | `fq_nmod_mpoly`     | `FqNmodMPolyRing`
 


### PR DESCRIPTION
A table in markdown needs to have a header line apparently.

Cf. https://nemocas.github.io/Nemo.jl/latest/mpolynomial.html#Introduction-1 to see the current rendering.