### PR TITLE
Finite field sqrt

### DIFF
--- a/docs/src/finitefield.md
+++ b/docs/src/finitefield.md
@@ -132,6 +132,14 @@ frobenius(::fq, ::Int)
 ```
 
 ```@docs
+sqrt(::fq)
+```
+
+```@docs
+issquare(::fq)
+```
+
+```@docs
 pth_root(::fq)
 ```
 
@@ -147,4 +155,6 @@ c = norm(a)
 d = frobenius(a)
 f = frobenius(a, 3)
 g = pth_root(a)
+h = sqrt(a^2)
+j = issquare(a)
 ```

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1600,6 +1600,7 @@ mutable struct FqNmodFiniteField <: FinField
    ninv :: Int
    norm :: Int
    sparse_modulus :: Int
+   is_conway::Int
    a :: Ptr{Nothing}
    j :: Ptr{Nothing}
    len :: Int
@@ -1753,6 +1754,7 @@ end
 mutable struct FqFiniteField <: FinField
    p::Int # fmpz
    sparse_modulus::Int
+   is_conway::Int
    a::Ptr{Nothing}
    j::Ptr{Nothing}
    len::Int

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1599,8 +1599,8 @@ mutable struct FqNmodFiniteField <: FinField
    n :: Int
    ninv :: Int
    norm :: Int
-   sparse_modulus :: Int
-   is_conway::Int
+   sparse_modulus :: Cint
+   is_conway::Cint
    a :: Ptr{Nothing}
    j :: Ptr{Nothing}
    len :: Int
@@ -1753,8 +1753,8 @@ end
 
 mutable struct FqFiniteField <: FinField
    p::Int # fmpz
-   sparse_modulus::Int
-   is_conway::Int
+   sparse_modulus::Cint
+   is_conway::Cint
    a::Ptr{Nothing}
    j::Ptr{Nothing}
    len::Int

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -406,8 +406,29 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
+    sqrt(x::fq)
+> Return the square root of $x$ in the finite field. If $x$ is not a square
+> an exception is raised.
+"""
+function sqrt(x::fq)
+   z = parent(x)()
+   ccall((:fq_sqrt, libflint), Nothing,
+         (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
+   return z
+end
+
+@doc Markdown.doc"""
+    issquare(x::fq)
+> Returns `true` if $x$ is a square in the finite field (includes zero).
+"""
+function issquare(x::fq)
+   ccall((:fq_is_square, libflint), Bool,
+         (Ref{fq}, Ref{FqFiniteField}), x, x.parent)
+end
+
+@doc Markdown.doc"""
     pth_root(x::fq)
-> Return the $p$-th root of $a$ in the finite field of characteristic $p$. This
+> Return the $p$-th root of $x$ in the finite field of characteristic $p$. This
 > is the inverse operation to the Frobenius map $\sigma_p$.
 """
 function pth_root(x::fq)

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -412,8 +412,9 @@ end
 """
 function sqrt(x::fq)
    z = parent(x)()
-   ccall((:fq_sqrt, libflint), Nothing,
+   res = ccall((:fq_sqrt, libflint), Bool,
          (Ref{fq}, Ref{fq}, Ref{FqFiniteField}), z, x, x.parent)
+   res || error("Not a square in sqrt") 
    return z
 end
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -350,8 +350,9 @@ divexact(x::fmpz, y::fq_nmod) = divexact(parent(y)(x), y)
 
 function sqrt(x::fq_nmod)
    z = parent(x)()
-   ccall((:fq_nmod_sqrt, libflint), Nothing,
+   res = ccall((:fq_nmod_sqrt, libflint), Bool,
          (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
+   res || error("Not a square in sqrt")
    return z
 end
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -348,6 +348,18 @@ divexact(x::fmpz, y::fq_nmod) = divexact(parent(y)(x), y)
 #
 ###############################################################################
 
+function sqrt(x::fq_nmod)
+   z = parent(x)()
+   ccall((:fq_nmod_sqrt, libflint), Nothing,
+         (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}), z, x, x.parent)
+   return z
+end
+
+function issquare(x::fq_nmod)
+   ccall((:fq_nmod_is_square, libflint), Bool,
+         (Ref{fq_nmod}, Ref{FqNmodFiniteField}), x, x.parent)
+end
+
 function pth_root(x::fq_nmod)
    z = parent(x)()
    ccall((:fq_nmod_pth_root, libflint), Nothing,

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -182,6 +182,10 @@ end
    @test frobenius(a, 3) == 3*x^4+3*x^3+3*x^2+x+4
 
    @test pth_root(a) == 4*x^4+3*x^3+4*x^2+5*x+2
+
+   @test sqrt(a^2) == a
+
+   @test issquare(a^2)
 end
 
 @testset "fq.rand..." begin

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -185,6 +185,8 @@ end
 
    @test sqrt(a^2) == a
 
+   @test_throws ErrorException sqrt(x*a^2)
+
    @test issquare(a^2)
 end
 

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -182,4 +182,8 @@ end
    @test frobenius(a, 3) == 3*x^4+3*x^3+3*x^2+x+4
 
    @test pth_root(a) == 4*x^4+3*x^3+4*x^2+5*x+2
+
+   @test sqrt(a^2) == a
+
+   @test issquare(a^2)
 end

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -185,5 +185,7 @@ end
 
    @test sqrt(a^2) == a
 
+   @test_throws ErrorException sqrt(x*a^2)
+
    @test issquare(a^2)
 end


### PR DESCRIPTION
Note that this requires Flint-2.7 which will be released later this year, hence the breaking label. Tests will fail until then.

It also changes the actual finite field structs in line with Flint-2.7.

It adds sqrt and is_square.