### PR TITLE
Pretty printing for more types

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -291,19 +291,6 @@ end
 #
 ###############################################################################
 
-function show(io::IO, x::fmpq_mpoly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fmpq_mpoly_get_str_pretty, libflint), Ptr{UInt8},
-          (Ref{fmpq_mpoly}, Ptr{Ptr{UInt8}}, Ref{FmpqMPolyRing}),
-          x, [string(s) for s in symbols(parent(x))], x.parent)
-      print(io, unsafe_string(cstr))
-
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, p::FmpqMPolyRing)
    local max_vars = 5 # largest number of variables to print
    n = nvars(p)

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -84,22 +84,6 @@ canonical_unit(a::fmpq_poly) = canonical_unit(lead(a))
 #
 ###############################################################################
 
-#=
-#use the generic one to print //
-function show(io::IO, x::fmpq_poly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fmpq_poly_get_str_pretty, libflint), Ptr{UInt8},
-          (Ref{fmpq_poly}, Ptr{UInt8}), x, string(var(parent(x))))
-
-      print(io, unsafe_string(cstr))
-
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-=#
-
 function show(io::IO, p::FmpqPolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(p)))

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -84,57 +84,6 @@ characteristic(R::ZmodNFmpzPolyRing) = modulus(R)
 #
 ################################################################################
 
-function show(io::IO, x::Zmodn_fmpz_poly)
-   len = length(x)
-   S = var(parent(x))
-
-   if len == 0
-      print(io, base_ring(x)(0))
-   else
-      for i = 1:len - 1
-         c = coeff(x, len - i)
-         bracket = needs_parentheses(c)
-         if !iszero(c)
-            if i != 1 && !displayed_with_minus_in_front(c)
-               print(io, "+")
-            end
-            if !isone(c) && (c != -1 || show_minus_one(typeof(c)))
-               if bracket
-                  print(io, "(")
-               end
-               show(io, c)
-               if bracket
-                  print(io, ")")
-               end
-               print(io, "*")
-            end
-            if c == -1 && !show_minus_one(typeof(c))
-               print(io, "-")
-            end
-            print(io, string(S))
-            if len - i != 1
-               print(io, "^")
-               print(io, len - i)
-            end
-         end
-      end
-      c = coeff(x, 0)
-      bracket = needs_parentheses(c)
-      if !iszero(c)
-         if len != 1 && !displayed_with_minus_in_front(c)
-            print(io, "+")
-         end
-         if bracket
-            print(io, "(")
-         end
-         show(io, c)
-         if bracket
-            print(io, ")")
-         end
-      end
-   end
-end
-
 function show(io::IO, R::ZmodNFmpzPolyRing)
   print(io, "Univariate Polynomial Ring in ")
   print(io, string(var(R)))

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -272,19 +272,6 @@ end
 #
 ###############################################################################
 
-function show(io::IO, x::fmpz_mpoly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fmpz_mpoly_get_str_pretty, libflint), Ptr{UInt8},
-          (Ref{fmpz_mpoly}, Ptr{Ptr{UInt8}}, Ref{FmpzMPolyRing}),
-          x, [string(s) for s in symbols(parent(x))], x.parent)
-      print(io, unsafe_string(cstr))
-
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, p::FmpzMPolyRing)
    local max_vars = 5 # largest number of variables to print
    n = nvars(p)

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -71,19 +71,6 @@ canonical_unit(a::fmpz_poly) = canonical_unit(lead(a))
 #
 ###############################################################################
 
-function show(io::IO, x::fmpz_poly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fmpz_poly_get_str_pretty, libflint), Ptr{UInt8},
-          (Ref{fmpz_poly}, Ptr{UInt8}), x, string(var(parent(x))))
-
-      print(io, unsafe_string(cstr))
-
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, p::FmpzPolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(p)))

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -181,25 +181,31 @@ canonical_unit(x::fq) = x
 #
 ###############################################################################
 
-function show(io::IO, x::fq)
-   cstr = ccall((:fq_get_str_pretty, libflint), Ptr{UInt8},
-                (Ref{fq}, Ref{FqFiniteField}), x, x.parent)
+function AbstractAlgebra.expressify(a::fq; context = nothing)
+   x = unsafe_string(reinterpret(Cstring, a.parent.var))
+   d = degree(a.parent)
 
-   print(io, unsafe_string(cstr))
-
-   ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
+   sum = Expr(:call, :+)
+   for k in (d - 1):-1:0
+        c = coeff(a, k)
+        if !iszero(c)
+            xk = k < 1 ? 1 : k == 1 ? x : Expr(:call, :^, x, k)
+            if isone(c)
+                push!(sum.args, Expr(:call, :*, xk))
+            else
+                push!(sum.args, Expr(:call, :*, expressify(c, context = context), xk))
+            end
+        end
+    end
+    return sum
 end
+
+show(io::IO, a::fq) = print(io, AbstractAlgebra.obj_to_string(a, context = io))
 
 function show(io::IO, a::FqFiniteField)
    print(io, "Finite field of degree ", degree(a))
    print(io, " over F_", characteristic(a))
 end
-
-needs_parentheses(x::fq) = x.length > 1
-
-displayed_with_minus_in_front(x::fq) = false
-
-show_minus_one(::Type{fq}) = true
 
 ###############################################################################
 #

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -94,19 +94,6 @@ canonical_unit(a::fq_nmod_poly) = canonical_unit(lead(a))
 #
 ################################################################################
 
-function show(io::IO, x::fq_nmod_poly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fq_nmod_poly_get_str_pretty, libflint), Ptr{UInt8},
-                  (Ref{fq_nmod_poly}, Ptr{UInt8}, Ref{FqNmodFiniteField}),
-                  x, string(var(parent(x))),
-                  (x.parent).base_ring)
-      print(io, unsafe_string(cstr))
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, R::FqNmodPolyRing)
   print(io, "Univariate Polynomial Ring in ")
   print(io, string(var(R)))

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -94,19 +94,6 @@ canonical_unit(a::fq_poly) = canonical_unit(lead(a))
 #
 ################################################################################
 
-function show(io::IO, x::fq_poly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:fq_poly_get_str_pretty, libflint), Ptr{UInt8},
-                  (Ref{fq_poly}, Ptr{UInt8}, Ref{FqFiniteField}),
-                  x, string(var(parent(x))),
-                  (x.parent).base_ring)
-      print(io, unsafe_string(cstr))
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, R::FqPolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(R)))

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -273,19 +273,6 @@ end
 #
 ###############################################################################
 
-function show(io::IO, x::nmod_mpoly)
-   if length(x) == 0
-      print(io, "0")
-   else
-      cstr = ccall((:nmod_mpoly_get_str_pretty, libflint), Ptr{UInt8},
-          (Ref{nmod_mpoly}, Ptr{Ptr{UInt8}}, Ref{NmodMPolyRing}),
-          x, [string(s) for s in symbols(parent(x))], x.parent)
-      print(io, unsafe_string(cstr))
-
-      ccall((:flint_free, libflint), Nothing, (Ptr{UInt8},), cstr)
-   end
-end
-
 function show(io::IO, p::NmodMPolyRing)
    local max_vars = 5 # largest number of variables to print
    n = nvars(p)

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -114,17 +114,6 @@ characteristic(R::NmodPolyRing) = modulus(R)
 #
 ################################################################################
 
-function show(io::IO, x::T) where T <: Zmodn_poly
-  if length(x) == 0
-    print(io, "0")
-  else
-    cstr = ccall((:nmod_poly_get_str_pretty, libflint), Ptr{UInt8},
-            (Ref{T}, Ptr{UInt8}), x, string(var(parent(x))))
-    print(io, unsafe_string(cstr))
-    ccall((:flint_free, libflint), Nothing, (Ptr{UInt8}, ), cstr)
-  end
-end
-
 function show(io::IO, R::NmodPolyRing)
   print(io, "Univariate Polynomial Ring in ")
   print(io, string(var(R)))

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -57,7 +57,7 @@ end
    S, x = PolynomialRing(R, "x")
    f = x^3 + 2x^2 + x + 1
 
-   @test string(f) == "x^3+2*x^2+x+1"
+   @test sprint(show, "text/plain", f) == "x^3 + 2*x^2 + x + 1"
 end
 
 @testset "fmpz_mod_poly.manipulation..." begin

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -39,7 +39,7 @@ end
    R, x = PolynomialRing(ZZ, "x")
    f = x^3 + 2x^2 + x + 1
 
-   @test string(f) == "x^3+2*x^2+x+1"
+   @test sprint(show, "text/plain", f) == "x^3 + 2*x^2 + x + 1"
 end
 
 @testset "fmpz_poly.manipulation..." begin

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -47,7 +47,7 @@ end
 
    a = 3x^4 + 2x^3 + 4x^2 + x + 1
 
-   @test string(a) == "3*x^4+2*x^3+4*x^2+x+1"
+   @test sprint(show, "text/plain", a) == "3*x^4 + 2*x^3 + 4*x^2 + x + 1"
 end
 
 @testset "fq.manipulation..." begin

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -47,7 +47,7 @@ end
 
    a = 3x^4 + 2x^3 + 4x^2 + x + 1
 
-   @test string(a) == "3*x^4+2*x^3+4*x^2+x+1"
+   @test sprint(show, "text/plain", a) == "3*x^4 + 2*x^3 + 4*x^2 + x + 1"
 end
 
 @testset "fq_nmod.manipulation..." begin

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -65,7 +65,7 @@ end
 
    f = x^2 + y^3 + 1
 
-   @test string(f) == "y^3+(x^2+1)"
+   @test sprint(show, "text/plain", f) == "y^3 + x^2 + 1"
 end
 
 @testset "fq_nmod_poly.manipulation..." begin

--- a/test/flint/fq_nmod_rel_series-test.jl
+++ b/test/flint/fq_nmod_rel_series-test.jl
@@ -39,7 +39,7 @@ end
 
    b = (t^2 + 1)*x^2 + (t + 3)x + O(x^4)
 
-   @test sprint(show, "text/plain", b) == "(t+3)*x + (t^2+1)*x^2 + O(x^4)"
+   @test sprint(show, "text/plain", b) == "(t + 3)*x + (t^2 + 1)*x^2 + O(x^4)"
 end
 
 @testset "fq_nmod_rel_series.manipulation..." begin

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -66,7 +66,7 @@ end
 
    f = x^2 + y^3 + z + 1
 
-   @test sprint(show, "text/plain", f) == "z + y^3 + (x^2+1)"
+   @test sprint(show, "text/plain", f) == "z + y^3 + x^2 + 1"
 end
 
 @testset "fq_poly.manipulation..." begin

--- a/test/flint/fq_rel_series-test.jl
+++ b/test/flint/fq_rel_series-test.jl
@@ -39,7 +39,7 @@ end
 
    b = (t^2 + 1)*x^2 + (t + 3)x + O(x^4)
 
-   @test sprint(show, "text/plain", b) == "(t+3)*x + (t^2+1)*x^2 + O(x^4)"
+   @test sprint(show, "text/plain", b) == "(t + 3)*x + (t^2 + 1)*x^2 + O(x^4)"
 end
 
 @testset "fq_rel_series.manipulation..." begin

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -55,7 +55,7 @@ end
    S, x = PolynomialRing(R, "x")
    f = x^3 + 2x^2 + x + 1
 
-   @test string(f) == "x^3+2*x^2+x+1"
+   @test sprint(show, "text/plain", f) == "x^3 + 2*x^2 + x + 1"
 end
 
 @testset "gfp_fmpz_poly.manipulation..." begin

--- a/test/flint/gfp_poly-test.jl
+++ b/test/flint/gfp_poly-test.jl
@@ -91,7 +91,7 @@ end
 
   a = x^3 + x + 1
 
-  @test string(a) == "x^3+x+1"
+  @test sprint(show, "text/plain", a) == "x^3 + x + 1"
 end
 
 @testset "gfp_poly.manipulation..." begin

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -91,7 +91,7 @@ end
 
   a = x^3 + x + 1
 
-  @test string(a) == "x^3+x+1"
+  @test sprint(show, "text/plain", a) == "x^3 + x + 1"
 end
 
 @testset "nmod_poly.manipulation..." begin


### PR DESCRIPTION
More pretty printing by deleting methods, hooray. Except for finite field elements we build the expression directly.

This does not touch the printing of `padic` or `arb/acb`. Not sure what we want to do for `padic`, since there are three different printing options which are all implemented in C. I will leave this for a later discussion/PR.