### PR TITLE
Disallow modulus zero

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -413,7 +413,9 @@ end
 ###############################################################################
 
 function ResidueRing(R::FlintIntegerRing, n::fmpz; cached::Bool=true)
-   n <= 0 && throw(DomainError(n, "Modulus must be non-negative"))
+   # Modulus of zero cannot be supported. E.g. Flint library could not be expected to
+   # do matrices over Z/0 using a Z/nZ type. The former is multiprecision, the latter not.
+   n <= 0 && throw(DomainError(n, "Modulus must be positive"))
    return FmpzModRing(n, cached)
 end
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -447,7 +447,9 @@ end
 ###############################################################################
 
 function ResidueRing(R::FlintIntegerRing, n::Int; cached::Bool=true)
-   n <= 0 && throw(DomainError(n, "Modulus must be non-negative"))
+   # Modulus of zero cannot be supported. E.g. Flint library could not be expected to
+   # do matrices over Z/0 using a Z/nZ type. The former is multiprecision, the latter not.
+   n <= 0 && throw(DomainError(n, "Modulus must be positive"))
    return NmodRing(UInt(n), cached)
 end
 

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -2,6 +2,7 @@
    R = ResidueRing(ZZ, ZZ(13))
 
    @test_throws DomainError ResidueRing(ZZ, -ZZ(13))
+   @test_throws DomainError ResidueRing(ZZ, ZZ(0))
 
    @test elem_type(R) == Nemo.fmpz_mod
    @test elem_type(Nemo.FmpzModRing) == Nemo.fmpz_mod

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -2,6 +2,7 @@
    R = ResidueRing(ZZ, 13)
 
    @test_throws DomainError ResidueRing(ZZ, -13)
+   @test_throws DomainError ResidueRing(ZZ, 0)
 
    @test elem_type(R) == Nemo.nmod
    @test elem_type(Nemo.NmodRing) == Nemo.nmod


### PR DESCRIPTION
This merely cleans up a little to make things more consistent with AbstractAlgebra https://github.com/Nemocas/AbstractAlgebra.jl/issues/365

Nothing is really changing here as we already disallowed Z/0. 