### PR TITLE
update some rand methods according to the Random API

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@
 
 rand(x::Union{GaloisField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
 
-rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing,GaloisFmpzField}, v) =
+rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/common.jl
+++ b/src/common.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-rand(x::Union{GaloisField,FinField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
+rand(x::Union{GaloisField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
 
 rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing,GaloisFmpzField}, v) =
     rand(Random.GLOBAL_RNG, x, v)

--- a/src/common.jl
+++ b/src/common.jl
@@ -4,9 +4,9 @@
 #
 ###############################################################################
 
-rand(x::Union{GaloisField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
+rand(x::Union{GaloisField}) = rand(Random.GLOBAL_RNG, x)
 
-rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing}, v) =
+rand(x::Union{AnticNumberField,GaloisField,FlintIntegerRing}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@
 
 rand(x::Union{GaloisField,FinField,NmodRing}) = rand(Random.GLOBAL_RNG, x)
 
-rand(x::Union{AnticNumberField,GaloisField,NmodRing,FmpzModRing,FlintIntegerRing,GaloisFmpzField}, v) =
+rand(x::Union{AnticNumberField,GaloisField,NmodRing,FlintIntegerRing,GaloisFmpzField}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/common.jl
+++ b/src/common.jl
@@ -4,9 +4,7 @@
 #
 ###############################################################################
 
-rand(x::Union{GaloisField}) = rand(Random.GLOBAL_RNG, x)
-
-rand(x::Union{AnticNumberField,GaloisField,FlintIntegerRing}, v) =
+rand(x::Union{AnticNumberField,FlintIntegerRing}, v) =
     rand(Random.GLOBAL_RNG, x, v)
 
 rand(x::Union{FlintPuiseuxSeriesRing,FlintPuiseuxSeriesField}, v1, v2, v...) =

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -358,15 +358,22 @@ end
 #
 ###############################################################################
 
-function rand(r::Random.AbstractRNG, R::FmpzModRing)
-   n = rand(r, BigInt(0):BigInt(R.n) - 1)
-   return fmpz_mod(fmpz(n), R)
+Random.Sampler(::Type{RNG}, R::FmpzModRing, n::Random.Repetition) where {RNG<:AbstractRNG} =
+   Random.SamplerSimple(R, Random.Sampler(RNG, BigInt(0):BigInt(R.n)-1, n))
+
+function rand(rng::AbstractRNG, R::Random.SamplerSimple{FmpzModRing})
+   n = rand(rng, R.data)
+   fmpz_mod(fmpz(n), R[])
 end
+
+Random.gentype(::Type{FmpzModRing}) = elem_type(FmpzModRing)
 
 function rand(r::Random.AbstractRNG, R::FmpzModRing, b::UnitRange{Int})
    n = rand(r, b)
    return R(n)
 end
+
+rand(R::FmpzModRing, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -497,18 +497,22 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, K::FinField)
-	p = characteristic(K)
-	r = degree(K)
-	alpha = gen(K)
-	res = zero(K)
-  range = BigInt(0):BigInt(p - 1)
-	for i = 0 : (r-1)
-		c = rand(rng, range)
-		res += c * alpha^i
-	end
-	return res
+Random.Sampler(::Type{RNG}, K::FinField, n::Random.Repetition) where {RNG<:AbstractRNG} =
+   Random.SamplerSimple(K, Random.Sampler(RNG, BigInt(0):BigInt(characteristic(K) - 1), n))
+
+function rand(rng::AbstractRNG, Ksp::Random.SamplerSimple{<:FinField})
+   K = Ksp[]
+   r = degree(K)
+   alpha = gen(K)
+   res = zero(K)
+   for i = 0 : (r-1)
+      c = rand(rng, Ksp.data)
+      res += c * alpha^i
+   end
+   return res
 end
+
+Random.gentype(::Type{T}) where {T<:FinField} = elem_type(T)
 
 ###############################################################################
 #

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -327,15 +327,18 @@ end
 #
 ###############################################################################
 
-function rand(rng::AbstractRNG, R::GaloisField)
-   n = rand(rng, UInt(0):R.n - 1)
-   return gfp_elem(n, R)
-end
+Random.Sampler(::Type{RNG}, R::GaloisField, n::Random.Repetition) where {RNG<:AbstractRNG} =
+   Random.SamplerSimple(R, Random.Sampler(RNG, UInt(0):R.n - 1, n))
+
+rand(rng::AbstractRNG, R::Random.SamplerSimple{GaloisField}) =
+   gfp_elem(rand(rng, R.data), R[])
 
 function rand(rng::AbstractRNG, R::GaloisField, b::UnitRange{Int})
    n = rand(rng, b)
    return R(n)
 end
+
+rand(R::GaloisField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -316,15 +316,20 @@ end
 #
 ###############################################################################
 
-function rand(r::Random.AbstractRNG, R::GaloisFmpzField)
-   n = rand(r, BigInt(0):BigInt(R.n) - 1)
-   return gfp_fmpz_elem(fmpz(n), R)
+Random.Sampler(::Type{RNG}, R::GaloisFmpzField, n::Random.Repetition) where {RNG<:AbstractRNG} =
+   Random.SamplerSimple(R, Random.Sampler(RNG, BigInt(0):BigInt(R.n)-1, n))
+
+function rand(rng::AbstractRNG, R::Random.SamplerSimple{GaloisFmpzField})
+   n = rand(rng, R.data)
+   gfp_fmpz_elem(fmpz(n), R[])
 end
 
 function rand(r::Random.AbstractRNG, R::GaloisFmpzField, b::UnitRange{Int})
    n = rand(r, b)
    return R(n)
 end
+
+rand(R::GaloisFmpzField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -368,15 +368,19 @@ end
 #
 ###############################################################################
 
-function rand(r::Random.AbstractRNG, R::NmodRing)
-   n = rand(r, UInt(0):R.n - 1)
-   return nmod(n, R)
-end
+Random.Sampler(::Type{RNG}, R::NmodRing, n::Random.Repetition) where {RNG<:AbstractRNG} =
+   Random.SamplerSimple(R, Random.Sampler(RNG, UInt(0):R.n - 1, n))
+
+rand(rng::AbstractRNG, R::Random.SamplerSimple{NmodRing}) = nmod(rand(rng, R.data), R[])
+
+Random.gentype(::Type{NmodRing}) = elem_type(NmodRing)
 
 function rand(r::Random.AbstractRNG, R::NmodRing, b::UnitRange{Int})
    n = rand(r, b)
    return R(n)
 end
+
+rand(R::NmodRing, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -43,14 +43,27 @@ end
    R = ResidueRing(ZZ, ZZ(13))
    @test rand(R) isa Nemo.fmpz_mod
    @test rand(R, 1:9) isa Nemo.fmpz_mod
+   @test rand(R, 2) isa Vector{Nemo.fmpz_mod}
+   @test rand(R, 2, 3) isa Matrix{Nemo.fmpz_mod}
+
    Random.seed!(rng, 0)
+
    s = rand(rng, R)
    @test s isa Nemo.fmpz_mod
    t = rand(rng, R, 1:9)
    @test t isa Nemo.fmpz_mod
+   s2 = rand(rng, R, 2)
+   @test s2 isa Vector{Nemo.fmpz_mod}
+   @test length(s2) == 2
+   s3 = rand(rng, R, 2, 3)
+   @test s3 isa Matrix{Nemo.fmpz_mod}
+   @test size(s3) == (2, 3)
+
    Random.seed!(rng, 0)
    @test s == rand(rng, R)
    @test t == rand(rng, R, 1:9)
+   @test s2 == rand(rng, R, 2)
+   @test s3 == rand(rng, R, 2, 3)
 end
 
 @testset "fmpz_mod.printing..." begin

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -189,9 +189,21 @@ end
 
    @inferred rand(R)
    @test rand(R) isa fq
+   @test rand(R, 2) isa Vector{fq}
+   @test rand(R, 2, 3) isa Matrix{fq}
+
    Random.seed!(rng, 0)
    t = rand(rng, R)
    @test t isa fq
+   s2 = rand(rng, R, 2)
+   @test s2 isa Vector{fq}
+   @test length(s2) == 2
+   s3 = rand(rng, R, 2, 3)
+   @test s3 isa Matrix{fq}
+   @test size(s3) == (2, 3)
+
    Random.seed!(rng, 0)
    @test t == rand(rng, R)
+   @test s2 == rand(rng, R, 2)
+   @test s3 == rand(rng, R, 2, 3)
 end

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -66,14 +66,26 @@ end
    R = GF(13)
    @test rand(R) isa Nemo.gfp_elem
    @test rand(R, 1:9) isa Nemo.gfp_elem
+   @test rand(R, 2) isa Vector{Nemo.gfp_elem}
+   @test rand(R, 2, 3) isa Matrix{Nemo.gfp_elem}
+
    Random.seed!(rng, 0)
    s = rand(rng, R)
    @test s isa Nemo.gfp_elem
    t = rand(rng, R, 1:9)
    @test t isa Nemo.gfp_elem
+   s2 = rand(rng, R, 2)
+   @test s2 isa Vector{Nemo.gfp_elem}
+   @test size(s2) == (2,)
+   s3 = rand(rng, R, 2, 3)
+   @test s3 isa Matrix{Nemo.gfp_elem}
+   @test size(s3) == (2, 3)
+
    Random.seed!(rng, 0)
    @test s == rand(rng, R)
    @test t == rand(rng, R, 1:9)
+   @test s2 == rand(rng, R, 2)
+   @test s3 == rand(rng, R, 2, 3)
 end
 
 @testset "gfp.printing..." begin

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -62,14 +62,24 @@ end
    R = GF(ZZ(13))
    @test rand(R) isa Nemo.gfp_fmpz_elem
    @test rand(R, 1:9) isa Nemo.gfp_fmpz_elem
+
    Random.seed!(rng, 0)
    s = rand(rng, R)
    @test s isa Nemo.gfp_fmpz_elem
    t = rand(rng, R, 1:9)
    @test t isa Nemo.gfp_fmpz_elem
+   s2 = rand(rng, R, 2)
+   @test s2 isa Vector{Nemo.gfp_fmpz_elem}
+   @test size(s2) == (2,)
+   s3 = rand(rng, R, 2, 3)
+   @test s3 isa Matrix{Nemo.gfp_fmpz_elem}
+   @test size(s3) == (2, 3)
+
    Random.seed!(rng, 0)
    @test s == rand(rng, R)
    @test t == rand(rng, R, 1:9)
+   @test s2 == rand(rng, R, 2)
+   @test s3 == rand(rng, R, 2, 3)
 end
 
 @testset "gfp_fmpz.printing..." begin

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -43,14 +43,26 @@ end
    R = ResidueRing(ZZ, 13)
    @test rand(R) isa Nemo.nmod
    @test rand(R, 1:9) isa Nemo.nmod
+   @test rand(R, 2) isa Vector{Nemo.nmod}
+   @test rand(R, 2, 3) isa Matrix{Nemo.nmod}
+
    Random.seed!(rng, 0)
    s = rand(rng, R)
    @test s isa Nemo.nmod
    t = rand(rng, R, 1:9)
    @test t isa Nemo.nmod
+   s2 = rand(rng, R, 2)
+   @test s2 isa Vector{Nemo.nmod}
+   @test size(s2) == (2,)
+   s3 = rand(rng, R, 2, 3)
+   @test s3 isa Matrix{Nemo.nmod}
+   @test size(s3) == (2, 3)
+
    Random.seed!(rng, 0)
    @test s == rand(rng, R)
    @test t == rand(rng, R, 1:9)
+   @test s2 == rand(rng, R, 2)
+   @test s3 == rand(rng, R, 2, 3)
 end
 
 @testset "nmod.printing..." begin


### PR DESCRIPTION
Using the `Random` API is more composable in general, and allows for example to create arrays for free (the functionality is implemented in the `Random` module):

```julia
julia> R = GF(13)
Galois field with characteristic 13

julia> rand(R, 2, 3)
2×3 Array{Nemo.gfp_elem,2}:
 10  5  2
 6   5  4
```

When `rand` methods take more than 1 parameter, it's more complicated to conform to the `Random` API. I will submit a proposal for these cases separately.