### PR TITLE
allow seeding Flint's RNGs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -65,12 +65,14 @@ end
    @test_throws DomainError rand_bits_prime(FlintZZ, 1)
 
    @testset "Nemo seeding" begin
-      seed = rand(UInt128)
-      Nemo.randseed!(seed)
-      a = [rand_bits(ZZ, i) for i = 1:99] # must test for i > 64, to exercise
-                                          # both Flint's RNGs
-      Nemo.randseed!(seed)
-      @test a == [rand_bits(ZZ, i) for i = 1:99]
+      for seed in (rand(UInt128), abs(rand(Int8)))
+         Nemo.randseed!(seed)
+         a = [rand_bits(ZZ, i) for i = 1:99] # must test for i > 64, to exercise
+                                             # both Flint's RNGs
+         Nemo.randseed!(seed)
+         @test a == [rand_bits(ZZ, i) for i = 1:99]
+      end
+      @test_throws DomainError Nemo.randseed!(-rand(1:1234))
    end
 end
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -63,6 +63,15 @@ end
    @test_throws DomainError rand_bits_prime(FlintZZ, -1)
    @test_throws DomainError rand_bits_prime(FlintZZ, 0)
    @test_throws DomainError rand_bits_prime(FlintZZ, 1)
+
+   @testset "Nemo seeding" begin
+      seed = rand(UInt128)
+      Nemo.randseed!(seed)
+      a = [rand_bits(ZZ, i) for i = 1:99] # must test for i > 64, to exercise
+                                          # both Flint's RNGs
+      Nemo.randseed!(seed)
+      @test a == [rand_bits(ZZ, i) for i = 1:99]
+   end
 end
 
 @testset "fmpz.printing..." begin


### PR DESCRIPTION
* add `Random.seed!(::rand_ctx, seed)` to seed a `rand_ctx`
* add `Nemo.randseed!(seed)` to seed Nemo's global RNG (on current thread)

Here, the seed has to be an `UInt128` on 64-bits machines. Ideally, an integer would do, for example by applying a hash function (using e.g. `SHA`, which is a stdlib) to it before calling library routines.

A random `UInt128` seems good enough to initialize GMP's RNG which is stored in `rand_ctx`, but I don't know whether there are constraints on the seeds fed to `flint_randseed`.