### PR TITLE
fix ndigits for bases > 62, and make it way faster

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -88,10 +88,6 @@ function Base.length(r::StepRange{fmpz,fmpz})
     isempty(r) ? zero(BigInt) : BigInt(n)
 end
 
-using Base.GMP: BITS_PER_LIMB
-
-coeff_is_mpz(x::fmpz) = x.d >>> (BITS_PER_LIMB - 2) == 1
-
 ################################################################################
 #
 #   Hashing
@@ -1641,11 +1637,11 @@ end
 > Return the number of digits of $x$ in the base $b$ (default is $b = 10$).
 """
 function ndigits(x::fmpz, b::Integer = 10)::Int
-   if coeff_is_mpz(x)
+   if _fmpz_is_small(x)
+      ndigits(x.d, base=b)
+   else
       # GMP/Flint's sizeinbase is not reliable for b > 62, so use Julia's implementation
       GC.@preserve x ndigits(unsafe_load(Ptr{BigInt}(x.d << 2)), base=b)
-   else
-      ndigits(x.d, base=b)
    end
 end
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -545,6 +545,10 @@ end
    @test nbits(a) == 4
 
    @test ndigits(a, 3) == 3
+
+   a = fmpz(4611686837384281896) # must not be an "immediate" integer (but a GMP int)
+
+   @test ndigits(a, 257) == 8
 end
 
 @testset "fmpz.string_io..." begin


### PR DESCRIPTION
The C library function `sizeinbase` is valid only for bases <= 62.
So use Julia's implementation, which is valid for all bases,
and happens to be quite faster, e.g. by 5x or 10x
(the reason is in its faster workaround to the fact that even
for correct bases, `sizeinbase` can return a value which is "one too big".)

For an example of speed improvement,
```julia
julia> n = ZZ(2)^1234; m = ZZ(2)^51;

# master branch
julia> @btime ndigits($n, 61)
347.557 ns (3 allocations: 48 bytes)
209

julia> @btime ndigits($m, 12)
 291.242 ns (3 allocations: 48 bytes)
15

# PR
julia> @btime ndigits($n, 61)
 75.372 ns (1 allocation: 32 bytes)
209

julia> @btime ndigits($m, 12)
27.360 ns (0 allocations: 0 bytes)
15
```