### PR TITLE
implement faster rand(::StepRange{fmpz, fmpz})

### DIFF
--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -64,6 +64,28 @@ end
    @test_throws DomainError rand_bits_prime(FlintZZ, 0)
    @test_throws DomainError rand_bits_prime(FlintZZ, 1)
 
+   # in a range
+   for e in [0, 1, 2, 3, 32, 64, 65, 100, 129, 500]
+      for b in [fmpz(2) .^ e ; fmpz(2) .^ e .+ e;]
+         for r in [fmpz(1):fmpz(1):b, fmpz(3):fmpz(1):b, fmpz(1):fmpz(3):b]
+            if isempty(r)
+               @test_throws ArgumentError rand(r)
+            else
+               rb = map(BigInt, r) # in(::fmpz, StepRange{fmpz}) no working
+               @test BigInt(rand(r)) in rb
+               @test rand(r) isa fmpz
+               @test all(in(rb), map(BigInt, rand(r, 9)))
+               @test rand(r, 9) isa Vector{fmpz}
+               seed = rand(rng, UInt128)
+               Random.seed!(rng, seed)
+               x = rand(rng, r)
+               Random.seed!(rng, seed)
+               @test x == rand(rng, r)
+            end
+         end
+      end
+   end
+
    @testset "Nemo seeding" begin
       for seed in (rand(UInt128), abs(rand(Int8)))
          Nemo.randseed!(seed)


### PR DESCRIPTION
This was already working via the generic implentation for arrays:
sample from `1:length(range)` and index the range with the result.
This new implementation mirrors the one for `BigInt`, and matches
its speed (so we get a speedup which can be e.g. 3x).

```julia
julia> rng = MersenneTwister();

julia> r = ZZ(1):ZZ(2)^1000;

julia> r2 = ZZ(1):ZZ(2):ZZ(2)^1000;

# master branch

julia> @btime rand($rng, $r);
  1.612 μs (30 allocations: 1.10 KiB)

julia> @btime rand($rng, $r2);
  1.604 μs (30 allocations: 1.10 KiB)

# PR
julia> @btime rand($rng, $r);
  485.733 ns (7 allocations: 200 bytes)

julia> @btime rand($rng, $r2);
  807.000 ns (11 allocations: 256 bytes)
```