### PR TITLE
fix empty polylog docstring

### DIFF
--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -619,11 +619,7 @@ risingfac2(::acb, ::Int)
 ```
 
 ```@docs
-polylog(::acb, ::acb)
-```
-
-```@docs
-polylog(::Int, ::acb)
+polylog(::Union{acb,Int}, ::acb)
 ```
 
 ```@docs

--- a/docs/src/arb.md
+++ b/docs/src/arb.md
@@ -614,11 +614,7 @@ risingfac2(::arb, ::Int)
 ```
 
 ```@docs
-polylog(::arb, ::arb)
-```
-
-```@docs
-polylog(::Int, ::arb)
+polylog(::Union{arb,Int}, ::arb)
 ```
 
 ```@docs

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1362,9 +1362,9 @@ function risingfac2(x::acb, n::Int)
 end
 
 @doc Markdown.doc"""
-    polylog(s::acb, a::acb)
+    polylog(s::Union{acb,Int}, a::acb)
 
-
+Return the polylogarithm Li$_s(a)$.
 """
 function polylog(s::acb, a::acb)
   z = parent(s)()
@@ -1373,11 +1373,6 @@ function polylog(s::acb, a::acb)
   return z
 end
 
-@doc Markdown.doc"""
-    polylog(s::Int, a::acb)
-
-Return the polylogarithm Li$_s(a)$.
-"""
 function polylog(s::Int, a::acb)
   z = parent(a)()
   ccall((:acb_polylog_si, libarb), Nothing,

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1361,11 +1361,6 @@ function risingfac2(x::acb, n::Int)
   return risingfac2(x, UInt(n))
 end
 
-@doc Markdown.doc"""
-    polylog(s::Union{acb,Int}, a::acb)
-
-Return the polylogarithm Li$_s(a)$.
-"""
 function polylog(s::acb, a::acb)
   z = parent(s)()
   ccall((:acb_polylog, libarb), Nothing,
@@ -1379,6 +1374,12 @@ function polylog(s::Int, a::acb)
               (Ref{acb}, Int, Ref{acb}, Int), z, s, a, parent(a).prec)
   return z
 end
+
+@doc Markdown.doc"""
+    polylog(s::Union{acb,Int}, a::acb)
+
+Return the polylogarithm Li$_s(a)$.
+""" polylog(s::Union{acb,Int}, ::acb)
 
 @doc Markdown.doc"""
     li(x::acb)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1783,11 +1783,6 @@ and its derivative.
 """
 risingfac2(x::arb, n::Int) = n < 0 ? throw(DomainError(n, "Index must be non-negative")) : risingfac2(x, UInt(n))
 
-@doc Markdown.doc"""
-    polylog(s::Union{arb,Int}, a::arb)
-
-Return the polylogarithm Li$_s(a)$.
-"""
 function polylog(s::arb, a::arb)
   z = parent(s)()
   ccall((:arb_polylog, libarb), Nothing,
@@ -1801,6 +1796,12 @@ function polylog(s::Int, a::arb)
               (Ref{arb}, Int, Ref{arb}, Int), z, s, a, parent(a).prec)
   return z
 end
+
+@doc Markdown.doc"""
+    polylog(s::Union{arb,Int}, a::arb)
+
+Return the polylogarithm Li$_s(a)$.
+""" polylog(s::Union{arb,Int}, a::arb)
 
 function chebyshev_t(n::UInt, x::arb)
   z = parent(x)()

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1784,7 +1784,7 @@ and its derivative.
 risingfac2(x::arb, n::Int) = n < 0 ? throw(DomainError(n, "Index must be non-negative")) : risingfac2(x, UInt(n))
 
 @doc Markdown.doc"""
-    polylog(s::arb, a::arb)
+    polylog(s::Union{arb,Int}, a::arb)
 
 Return the polylogarithm Li$_s(a)$.
 """
@@ -1795,11 +1795,6 @@ function polylog(s::arb, a::arb)
   return z
 end
 
-@doc Markdown.doc"""
-    polylog(s::Int, a::arb)
-
-Return the polylogarithm Li$_s(a)$.
-"""
 function polylog(s::Int, a::arb)
   z = parent(a)()
   ccall((:arb_polylog_si, libarb), Nothing,


### PR DESCRIPTION
Also, factor the docstrings out into one, for arb and acb.