### PR TITLE
fix corner-case in randseed! tests

### DIFF
--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -87,7 +87,7 @@ end
    end
 
    @testset "Nemo seeding" begin
-      for seed in (rand(UInt128), abs(rand(Int8)))
+      for seed in (rand(UInt128), rand(Int8(0):typemax(Int8)))
          Nemo.randseed!(seed)
          a = [rand_bits(ZZ, i) for i = 1:99] # must test for i > 64, to exercise
                                              # both Flint's RNGs


### PR DESCRIPTION
This should fix this CI error: https://github.com/Nemocas/Nemo.jl/pull/901/checks?check_run_id=1332125533
(as `abs(typemin(Int8)) < 0`, the seed can be negative even when taking `abs`)