### PR TITLE
bump version 0.18.3 -> 0.18.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.18.3"
+version = "0.18.4"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
Nemo 0.18.3 is not compatible with AA 0.11.1, as a fix for "fflu"
(commit c5630fc0) is only in Nemo master, corresponding to an AA change
(commit 96455073) which happened between 0.11.0 and 0.11.1.