### PR TITLE
Fixes the use of AbstractAlgebra permutations in Flint functions.

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -591,17 +591,13 @@ function fflu(x::fmpz_mat, P = SymmetricGroup(nrows(x)))
    d = fmpz()
    p = P()
 
-   for i = 1:nrows(x)
-      p.d[i] -= 1
-   end
+   p.d .-= 1
 
    r = ccall((:fmpz_mat_fflu, libflint), Int,
                 (Ref{fmpz_mat}, Ref{fmpz}, Ptr{Int}, Ref{fmpz_mat}, Int),
                 U, d, p.d, x, 0)
 
-   for i = 1:nrows(x)
-      p.d[i] += 1
-   end
+   p.d .+= 1
 
    i = 1
    j = 1

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -480,12 +480,12 @@ end
 #= Not implemented in Flint yet
 
 function lu!(P::Generic.Perm, x::T) where T <: Zmod_fmpz_mat
+  P.d .-= 1
+
   rank = Int(ccall((:fmpz_mod_mat_lu, libflint), Cint, (Ptr{Int}, Ref{T}, Cint),
            P.d, x, 0))
 
-  for i in 1:length(P.d)
-    P.d[i] += 1
-  end
+  P.d .+= 1
 
   # flint does x == PLU instead of Px == LU (docs are wrong)
   inv!(P)
@@ -504,7 +504,7 @@ function lu(x::T, P = SymmetricGroup(nrows(x))) where T <: Zmod_fmpz_mat
   L = similar(x, m, m)
 
   rank = lu!(p, U)
-
+  
   for i = 1:m
     for j = 1:n
       if i > j

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -433,13 +433,13 @@ end
 ################################################################################
 
 function lu!(P::Generic.Perm, x::fq_mat)
+   P.d .-= 1
+
    rank = Int(ccall((:fq_mat_lu, libflint), Cint,
                 (Ptr{Int}, Ref{fq_mat}, Cint, Ref{FqFiniteField}),
                 P.d, x, 0, base_ring(x)))
 
-  for i in 1:length(P.d)
-    P.d[i] += 1
-  end
+  P.d .+= 1
 
   # flint does x == PLU instead of Px == LU (docs are wrong)
   inv!(P)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -433,13 +433,13 @@ end
 ################################################################################
 
 function lu!(P::Generic.Perm, x::fq_nmod_mat)
+   P.d .-= 1
+
    rank = Int(ccall((:fq_nmod_mat_lu, libflint), Cint,
                 (Ptr{Int}, Ref{fq_nmod_mat}, Cint, Ref{FqNmodFiniteField}),
                 P.d, x, 0, base_ring(x)))
 
-  for i in 1:length(P.d)
-    P.d[i] += 1
-  end
+  P.d .+= 1
 
   # flint does x == PLU instead of Px == LU (docs are wrong)
   inv!(P)

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -470,12 +470,12 @@ end
 ################################################################################
 
 function lu!(P::Generic.Perm, x::T) where T <: Zmodn_mat
+  P.d .-= 1
+
   rank = Int(ccall((:nmod_mat_lu, libflint), Cint, (Ptr{Int}, Ref{T}, Cint),
            P.d, x, 0))
 
-  for i in 1:length(P.d)
-    P.d[i] += 1
-  end
+  P.d .+= 1
 
   # flint does x == PLU instead of Px == LU (docs are wrong)
   inv!(P)


### PR DESCRIPTION
Fixes #896 