### PR TITLE
Update generic tests for changes in AbstractAlgebra.

### DIFF
--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -133,7 +133,12 @@ end
       M = randmat_with_rank(S, dim, -100:100)
       b = rand(T, -100:100)
 
-      flag, x, d = Generic.can_solve_with_solution_fflu(M, b)
+      if isdefined(Generic, :can_solve_with_solution_fflu) 
+         flag, x, d = Generic.can_solve_with_solution_fflu(M, b)
+         @test flag
+      else
+         x, d = Generic.solve_fflu(M, b)
+      end       
 
       @test flag && divexact(M, d)*x == b
    end

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -140,7 +140,7 @@ end
          x, d = Generic.solve_fflu(M, b)
       end       
 
-      @test flag && divexact(M, d)*x == b
+      @test divexact(M, d)*x == b
    end
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -133,9 +133,9 @@ end
       M = randmat_with_rank(S, dim, -100:100)
       b = rand(T, -100:100)
 
-      x, d = Generic.solve_fflu(M, b)
+      flag, x, d = Generic.can_solve_with_solution_fflu(M, b)
 
-      @test divexact(M, d)*x == b
+      @test flag && divexact(M, d)*x == b
    end
 end
 
@@ -150,9 +150,9 @@ end
       M = randmat_with_rank(S, dim, -100:100)
       b = rand(T, -100:100)
 
-      x = Generic.solve_lu(M, b)
+      flag, x = Generic.can_solve_with_solution_lu(M, b)
 
-      @test M*x == b
+      @test flag && M*x == b
    end
 end
 

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -155,7 +155,12 @@ end
       M = randmat_with_rank(S, dim, -100:100)
       b = rand(T, -100:100)
 
-      flag, x = Generic.can_solve_with_solution_lu(M, b)
+      if isdefined(Generic, :can_solve_with_solution_lu)
+         flag, x = Generic.can_solve_with_solution_lu(M, b)
+         @test flag
+      else
+         x = Generic.solve_lu(M, b)
+      end     
 
       @test flag && M*x == b
    end

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -162,7 +162,7 @@ end
          x = Generic.solve_lu(M, b)
       end     
 
-      @test flag && M*x == b
+      @test M*x == b
    end
 end
 


### PR DESCRIPTION
This probably shouldn't be strictly necessary, but the Nemo generic tests were calling the internal AbstractAlgebra functions which changed. Therefore this PR is necessary to adjust for the changes over there.

This probably has a bearing on #909 