### PR TITLE
add "other" to all FiniteFields to start allowing disc_logs

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -404,6 +404,7 @@ end
 mutable struct GaloisField <: FinField
    n::UInt
    ninv::UInt
+   @declare_other
 
    function GaloisField(n::UInt, cached::Bool=true)
       if cached && haskey(GaloisFieldID, n)
@@ -483,6 +484,7 @@ end
 mutable struct GaloisFmpzField <: FinField
    n::fmpz
    ninv::fmpz_mod_ctx_struct
+   @declare_other
 
    function GaloisFmpzField(n::fmpz, cached::Bool=true)
       if cached && haskey(GaloisFmpzFieldID, n)
@@ -1622,6 +1624,7 @@ mutable struct FqNmodFiniteField <: FinField
    var :: Ptr{Nothing}
    overfields :: Dict{Int, Array{FinFieldMorphism, 1}}
    subfields :: Dict{Int, Array{FinFieldMorphism, 1}}
+   @declare_other
 
    function FqNmodFiniteField(c::fmpz, deg::Int, s::Symbol, cached::Bool = true)
       if cached && haskey(FqNmodFiniteFieldID, (c, deg, s))
@@ -1771,6 +1774,7 @@ mutable struct FqFiniteField <: FinField
    var::Ptr{Nothing}
    overfields :: Dict{Int, Array{FinFieldMorphism, 1}}
    subfields :: Dict{Int, Array{FinFieldMorphism, 1}}
+   @declare_other
 
    function FqFiniteField(char::fmpz, deg::Int, s::Symbol, cached::Bool = true)
       if cached && haskey(FqFiniteFieldID, (char, deg, s))


### PR DESCRIPTION
In order to allow (experimental, naive) disc log computations in finite fields, data needs to be stored. Thus I added the @declare_other that can be used to store anything (names, factorisation of q-1, disc log data)
For now, to experiment, the actual disc_log will be in Oscar (I think). Once we agree on some infrastructure we can move things around.

For now: we'll have BabyStep-GiantStep, Pohlig-Hellman
if one needs fancy stuff, it can be slotted in