### PR TITLE
Fix bug in gfp_mat constructor for negative entries

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3973,7 +3973,7 @@ mutable struct gfp_mat <: MatElem{gfp_elem}
     for i = 1:r
       for j = 1:c
         ccall((:fmpz_mod_ui, libflint), Nothing,
-              (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), t, arr[i, j], n)
+              (Ref{fmpz}, Ref{fmpz}, UInt), t, arr[i, j], n)
         setindex_raw!(z, t, i, j)
       end
     end

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -164,6 +164,10 @@
    @test !(a in [b])
    @test a in keys(Dict(a => 1))
    @test !(a in keys(Dict(b => 1)))
+
+   M = matrix(Z3, Z3.([-1 -2; -3 -4]))
+   @test M == matrix(Z3, [-1 -2; -3 -4])
+   @test M == matrix(Z3, 2, 2, [-1, -2, -3, -4])
 end
 
 @testset "gfp_mat.similar..." begin


### PR DESCRIPTION
Follow-up to https://github.com/Nemocas/Nemo.jl/issues/813: the fix in https://github.com/Nemocas/Nemo.jl/pull/814 made the following work correctly:
```
julia> matrix(GF(3), 2, 2, [-1, -1, -1, -1])
[2  2]
[2  2]
```
But if the entries are given as a two-dimensional array, the outcome is still somewhat random:
```
julia> matrix(GF(3), [-1 -1; -1 -1])
[0  2]
[1  0]
```
I adapted the fix for the one-dimensional case to this case and added a quick test for both cases.