### PR TITLE
add degree(::GaloisField)

### DIFF
--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -72,6 +72,8 @@ Return the characteristic of the given Galois field.
 """
 characteristic(R::GaloisField) = fmpz(R.n)
 
+degree(::GaloisField) = 1
+
 ###############################################################################
 #
 #   Canonicalisation

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -71,6 +71,8 @@ Return the order, i.e. the number of elements in, the given Galois field.
 """
 order(F::GaloisFmpzField) = modulus(F)
 
+degree(::GaloisFmpzField) = 1
+
 function deepcopy_internal(a::gfp_fmpz_elem, dict::IdDict)
    R = parent(a)
    return gfp_fmpz_elem(deepcopy(a.data), R)

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -93,6 +93,7 @@ end
    @test R === R1
 
    @test characteristic(R) == 13
+   @test degree(R) == 1
 end
 
 @testset "gfp.unary_ops..." begin

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -89,6 +89,8 @@ end
    @test R === R1
 
    @test characteristic(R) == 13
+
+   @test degree(R) == 1
 end
 
 @testset "gfp_fmpz.unary_ops..." begin


### PR DESCRIPTION
Both AbstractAlgebra's finite fields and Nemo's finite fields with degree > 1 define it. This is useful for the implementation of iteration in https://github.com/Nemocas/AbstractAlgebra.jl/pull/698.