### PR TITLE
Deploy documentation to website using GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,3 +48,28 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         uses: codecov/codecov-action@v1
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,8 @@
 [deps]
-Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 
 [compat]
-Documenter = "~0.19"
 AbstractAlgebra = "^0.11.0"
+Documenter = "~0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,12 @@
 using Documenter, Nemo, AbstractAlgebra
 
 makedocs(
-         format   = :html,
+         format = Documenter.HTML(),
          sitename = "Nemo.jl",
          modules = [Nemo, AbstractAlgebra],
          clean = true,
          checkdocs = :none,
-         doctest = false,
+         doctest = true,
          pages    = [
              "index.md",
              "about.md",
@@ -34,10 +34,6 @@ makedocs(
 )
 
 deploydocs(
-   julia = "1.0",
    repo   = "github.com/Nemocas/Nemo.jl.git",
-   target = "build",
-   deps = nothing,
-   make   = nothing,
-   osname = "linux"
+   target = "build"
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(
          clean = true,
          checkdocs = :none,
          doctest = true,
+         strict = true,
          pages    = [
              "index.md",
              "about.md",


### PR DESCRIPTION
... this was lost with the removal of Travis (resp. with Travis stopping to work).

However, for the final step (the actual deployment) to work, someone with admin rights for this repo may have to set a `DOCUMENTER_KEY`. To generate one, you can do this:
```julia
julia> using DocumenterTools, Nemo
julia> DocumenterTools.genkeys(Nemo)
```
Then go to "Settings" -> "Deploy Keys" (should be something like <https://github.com/Nemocas/Nemo.jl/settings/keys>) and add it there.
