### PR TITLE
Enable creating acb with inputs of two different datatypes

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1832,7 +1832,7 @@ for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
     if S != T
       @eval begin
         function (r::AcbField)(x::$(S), y::$(T))
-          RR = ArbField(r.prec)
+          RR = ArbField(r.prec, cached = false)
           z = acb(RR(x), RR(y), r.prec)
           z.parent = r
           return z
@@ -1845,13 +1845,13 @@ end
 for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
   @eval begin
     function (r::AcbField)(x::Rational{S}, y::$(T)) where {S <: Integer}
-      RR = ArbField(r.prec)
+      RR = ArbField(r.prec, cached = false)
       z = acb(RR(x), RR(y), r.prec)
       z.parent = r
       return z
     end
     function (r::AcbField)(x::$(T), y::Rational{S}) where {S <: Integer}
-      RR = ArbField(r.prec)
+      RR = ArbField(r.prec, cached = false)
       z = acb(RR(x), RR(y), r.prec)
       z.parent = r
       return z

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1821,7 +1821,7 @@ end
 
 (r::AcbField)(x::Rational{T}) where {T <: Integer} = r(fmpq(x))
 
-function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt,fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}
+function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString}}
   z = acb(x, y, r.prec)
   z.parent = r
   return z

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1827,8 +1827,8 @@ function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt, fmpz, fmpq, arb,
   return z
 end
 
-for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString)
-  for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString)
+for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
+  for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
     if S != T
       @eval begin
         function (r::AcbField)(x::$(S), y::$(T))
@@ -1838,6 +1838,23 @@ for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString)
           return z
         end
       end
+    end
+  end
+end
+
+for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString, BigInt)
+  @eval begin
+    function (r::AcbField)(x::Rational{S}, y::$(T)) where {S <: Integer}
+      RR = ArbField(r.prec)
+      z = acb(RR(x), RR(y), r.prec)
+      z.parent = r
+      return z
+    end
+    function (r::AcbField)(x::$(T), y::Rational{S}) where {S <: Integer}
+      RR = ArbField(r.prec)
+      z = acb(RR(x), RR(y), r.prec)
+      z.parent = r
+      return z
     end
   end
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1827,6 +1827,21 @@ function (r::AcbField)(x::T, y::T) where {T <: Union{Int, UInt, fmpz, fmpq, arb,
   return z
 end
 
+for S in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString)
+  for T in (Int, UInt, fmpz, fmpq, arb, Float64, BigFloat, AbstractString)
+    if S != T
+      @eval begin
+        function (r::AcbField)(x::$(S), y::$(T))
+          RR = ArbField(r.prec)
+          z = acb(RR(x), RR(y), r.prec)
+          z.parent = r
+          return z
+        end
+      end
+    end
+  end
+end
+
 (r::AcbField)(x::BigInt, y::BigInt) = r(fmpz(x), fmpz(y))
 
 (r::AcbField)(x::Rational{S}, y::Rational{T}) where {S <: Integer, T <: Integer} =

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -55,6 +55,7 @@ end
    @test CC(UInt(4), Int(2)) == CC(4.0, ZZ(2))
    @test CC("4 +/- 0", BigFloat(2)) == CC(RR(4), QQ(2))
    @test CC(UInt(8)//UInt(2), BigInt(2)) == CC(4, 2)
+@test CC(2, UInt(8)//UInt(2)) == CC(2, 4)
 
    @test characteristic(CC) == 0
 end

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -52,6 +52,10 @@ end
    @test real(b) == 2
    @test imag(b) == 3
 
+   @test CC(UInt(4), Int(2)) == CC(4.0, ZZ(2))
+   @test CC("4 +/- 0", BigFloat(2)) == CC(RR(4), QQ(2))
+   @test CC(UInt(8)//UInt(2), BigInt(2)) == CC(4, 2)
+
    @test characteristic(CC) == 0
 end
 


### PR DESCRIPTION
Earlier it was not possible to create an `acb` with two different input types when calling `AcbField`, for example `CC(1.0, 1)`.

This change adds methods for inputs whose types are not the same, by converting them to `arb`, of the same precision as the `AcbField`, before calling acb.

Furthermore it adds a space between types at the method before these additional methods.

Solves #933.