### PR TITLE
Fix exp for ordo power series

### DIFF
--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -621,9 +621,9 @@ end
 
 function Base.exp(a::nmod_rel_series)
    if iszero(a)
+      precision(a) == 0 && return deepcopy(a)
       z = one(parent(a))
       z.prec = precision(a)
-      z.val = valuation(a)
       return z
    end
    z = parent(a)()


### PR DESCRIPTION
When `exp` is called with an ordo power serie of type `nmod_rel_series`, it apparently generates the wrong answer. I suspect that this solution generates the right answer, both for ordo of a constant and of higher degrees.

Since I am new to these things, please take this with a big grain of salt.

Resolves #927 