### PR TITLE
Fix 404-link to AbstractAlgebra

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -36,7 +36,7 @@ one to write generic functions that can accept any Nemo matrix type.
 
 Note that the preferred way to create matrices is not to use the type
 constructors but to use the `matrix` function, see also the
-[Constructors](https://nemocas.github.io/AbstractAlgebra.jl/latest/latest/matrix_spaces/#Constructors-1)
+[Constructors](https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix_spaces/#Constructors)
 section of the AbstractAlgebra manual.
 
 ## Matrix functionality


### PR DESCRIPTION
By grepping `AbstractAlgebra.jl/` and `github.io` in the docs, I found a 404-link which I replaced with the right one.

Resolves #656