### PR TITLE
fix spurious `>` in docstring for modulus(::FqNmodFiniteField)

### DIFF
--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -562,7 +562,7 @@ end
 @doc Markdown.doc"""
     modulus(k::FqNmodFiniteField)
 
->Returns the modulus defining the finite field $k$.
+Return the modulus defining the finite field $k$.
 """
 function modulus(k::FqNmodFiniteField)
     p::Int = characteristic(k)


### PR DESCRIPTION
Must have escaped previous fixes because of the absence of space after `>`.