### PR TITLE
add iteration for finite fields

### DIFF
--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -486,8 +486,10 @@ rand(R::FqNmodFiniteField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
 #
 ###############################################################################
 
-Base.iterate(F::FqNmodFiniteField) = zero(F), zeros(UInt, degree(F))
-Base.iterate(F::FqFiniteField) = zero(F), zeros(fmpz, degree(F))
+# the two definitions are merged (with `Union`) so that this doesn't produce a compilation
+# warning due to similar definitions in Hecke
+Base.iterate(F::Union{FqNmodFiniteField,FqFiniteField}) =
+   zero(F), zeros(F isa FqNmodFiniteField ? UInt : fmpz, degree(F))
 
 function Base.iterate(F::Union{FqNmodFiniteField,FqFiniteField}, coeffs::Vector)
    deg = length(coeffs)

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -208,3 +208,13 @@ end
 
    test_rand(R)
 end
+
+@testset "fq.iteration..." begin
+   for n = [2, 3, 5, 13, 31]
+      R, _ = FiniteField(fmpz(n), 1, "x")
+      elts = Nemo.AbstractAlgebra.test_iterate(R)
+      @test elts == R.(0:n-1)
+      R, _ = FiniteField(fmpz(n), rand(2:9), "x")
+      Nemo.AbstractAlgebra.test_iterate(R)
+   end
+end

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -197,3 +197,13 @@ end
 
    @test !issquare_with_square_root(x*a^2)[1]
 end
+
+@testset "fq_nmod.iteration..." begin
+   for n = [2, 3, 5, 13, 31]
+      R, _ = FiniteField(n, 1, "x")
+      elts = Nemo.AbstractAlgebra.test_iterate(R)
+      @test elts == R.(0:n-1)
+      R, _ = FiniteField(n, rand(2:9), "x")
+      Nemo.AbstractAlgebra.test_iterate(R)
+   end
+end


### PR DESCRIPTION
This optimizes the generic version from AbstractAlgebra, using hints from the implementation in Hecke (in particular the `ccall` parts).
