### PR TITLE
CI: reduce the number of macOS jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,15 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        exclude:
+          # Reduce the number of macOS jobs, as fewer can be run in parallel
+          - os: macos-latest
+            julia-version: '1.1'
+          - os: macos-latest
+            julia-version: '1.3'
+          - os: macos-latest
+            julia-version: '1.4'
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,8 +28,6 @@ jobs:
           - os: macos-latest
             julia-version: '1.1'
           - os: macos-latest
-            julia-version: '1.3'
-          - os: macos-latest
             julia-version: '1.4'
 
     steps:


### PR DESCRIPTION
GitHub Actions lets us run fewer macOS jobs than Linux jobs in parallel.
As a result, waiting for macOS jobs to finish is the primary bottleneck
for our CI runs (the jobs are not really slower, it just takes longer to
process them all).