### PR TITLE
Fix caching in fmpz_mod_poly/gfp_fmpz_poly constructors

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -852,8 +852,9 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz)
-      return fmpz_mod_poly(FmpzModRing(n).ninv)
+
+   function fmpz_mod_poly(R::FmpzModRing)
+      return fmpz_mod_poly(R.ninv)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, a::fmpz)
@@ -868,8 +869,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, a::fmpz)
-      return fmpz_mod_poly(FmpzModRing(n).ninv, a)
+   function fmpz_mod_poly(R::FmpzModRing, a::fmpz)
+      return fmpz_mod_poly(R.ninv, a)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, a::UInt)
@@ -884,8 +885,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, a::UInt)
-      return fmpz_mod_poly(FmpzModRing(n).ninv, a)
+   function fmpz_mod_poly(R::FmpzModRing, a::UInt)
+      return fmpz_mod_poly(R.ninv, a)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, arr::Array{fmpz, 1})
@@ -903,8 +904,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, arr::Array{fmpz, 1})
-      return fmpz_mod_poly(FmpzModRing(n).ninv, arr)
+   function fmpz_mod_poly(R::FmpzModRing, arr::Array{fmpz, 1})
+      return fmpz_mod_poly(R.ninv, arr)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, arr::Array{fmpz_mod, 1})
@@ -921,8 +922,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, arr::Array{fmpz_mod, 1})
-      return fmpz_mod_poly(FmpzModRing(n).ninv, arr)
+   function fmpz_mod_poly(R::FmpzModRing, arr::Array{fmpz_mod, 1})
+      return fmpz_mod_poly(R.ninv, arr)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, f::fmpz_poly)
@@ -937,8 +938,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, f::fmpz_poly)
-      return fmpz_mod_poly(FmpzModRing(n).ninv, f)
+   function fmpz_mod_poly(R::FmpzModRing, f::fmpz_poly)
+      return fmpz_mod_poly(R.ninv, f)
    end
 
    function fmpz_mod_poly(n::fmpz_mod_ctx_struct, f::fmpz_mod_poly)
@@ -953,8 +954,8 @@ mutable struct fmpz_mod_poly <: PolyElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_poly(n::fmpz, f::fmpz_mod_poly)
-      return fmpz_mod_poly(FmpzModRing(n).ninv, f)
+   function fmpz_mod_poly(R::FmpzModRing, f::fmpz_mod_poly)
+      return fmpz_mod_poly(R.ninv, f)
    end
 end
 
@@ -983,8 +984,8 @@ mutable struct fmpz_mod_poly_factor
       return z
    end
 
-   function fmpz_mod_poly_factor(n::fmpz)
-      return fmpz_mod_poly_factor(FmpzModRing(n).ninv)
+   function fmpz_mod_poly_factor(R::FmpzModRing)
+      return fmpz_mod_poly_factor(R.ninv)
    end
 end
 
@@ -1040,8 +1041,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz)
-      return gfp_fmpz_poly(FmpzModRing(n).ninv)
+   function gfp_fmpz_poly(R::GaloisFmpzField)
+      return gfp_fmpz_poly(R.ninv)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, a::fmpz)
@@ -1056,8 +1057,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, a::fmpz)
-      return gfp_fmpz_poly(FmpzModRing(n).ninv, a)
+   function gfp_fmpz_poly(R::GaloisFmpzField, a::fmpz)
+      return gfp_fmpz_poly(R.ninv, a)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, a::UInt)
@@ -1072,8 +1073,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, a::UInt)
-      return gfp_fmpz_poly(FmpzModRing(n).ninv, a)
+   function gfp_fmpz_poly(R::GaloisFmpzField, a::UInt)
+      return gfp_fmpz_poly(R.ninv, a)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, arr::Array{fmpz, 1})
@@ -1091,8 +1092,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, arr::Array{fmpz, 1})
-      gfp_fmpz_poly(FmpzModRing(n).ninv, arr)
+   function gfp_fmpz_poly(R::GaloisFmpzField, arr::Array{fmpz, 1})
+      gfp_fmpz_poly(R.ninv, arr)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, arr::Array{gfp_fmpz_elem, 1})
@@ -1109,8 +1110,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, arr::Array{gfp_fmpz_elem, 1})
-      return gfp_fmpz_poly(FmpzModRing(n).ninv, arr)
+   function gfp_fmpz_poly(R::GaloisFmpzField, arr::Array{gfp_fmpz_elem, 1})
+      return gfp_fmpz_poly(R.ninv, arr)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, f::fmpz_poly)
@@ -1125,8 +1126,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, f::fmpz_poly)
-      return gfp_fmpz_poly(FmpzModRing(n).ninv, f)
+   function gfp_fmpz_poly(R::GaloisFmpzField, f::fmpz_poly)
+      return gfp_fmpz_poly(R.ninv, f)
    end
 
    function gfp_fmpz_poly(n::fmpz_mod_ctx_struct, f::gfp_fmpz_poly)
@@ -1141,8 +1142,8 @@ mutable struct gfp_fmpz_poly <: PolyElem{gfp_fmpz_elem}
       return z
    end
 
-   function gfp_fmpz_poly(n::fmpz, f::gfp_fmpz_poly)
-      return gfp_fmpz_poly(FmpzModRing(n).ninv, f)
+   function gfp_fmpz_poly(R::GaloisFmpzField, f::gfp_fmpz_poly)
+      return gfp_fmpz_poly(R.ninv, f)
    end
 end
 
@@ -1171,8 +1172,8 @@ mutable struct gfp_fmpz_poly_factor
       return z
    end
 
-   function gfp_fmpz_poly_factor(n::fmpz)
-      return gfp_fmpz_poly_factor(FmpzModRing(n).ninv)
+   function gfp_fmpz_poly_factor(R::GaloisFmpzField)
+      return gfp_fmpz_poly_factor(R.ninv)
    end
 end
 
@@ -3273,8 +3274,8 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_rel_series(p::fmpz)
-      return fmpz_mod_rel_series(FmpzModRing(p).ninv)
+   function fmpz_mod_rel_series(R::FmpzModRing)
+      return fmpz_mod_rel_series(R.ninv)
    end
 
    function fmpz_mod_rel_series(p::fmpz_mod_ctx_struct, a::Array{fmpz, 1},
@@ -3295,9 +3296,9 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_rel_series(p::fmpz, a::Array{fmpz, 1},
+   function fmpz_mod_rel_series(R::FmpzModRing, a::Array{fmpz, 1},
                                 len::Int, prec::Int, val::Int)
-      return fmpz_mod_rel_series(FmpzModRing(p).ninv, a, len, prec, val)
+      return fmpz_mod_rel_series(R.ninv, a, len, prec, val)
    end
 
    function fmpz_mod_rel_series(p::fmpz_mod_ctx_struct, a::Array{fmpz_mod, 1},
@@ -3318,9 +3319,9 @@ mutable struct fmpz_mod_rel_series <: RelSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_rel_series(p::fmpz, a::Array{fmpz_mod, 1},
+   function fmpz_mod_rel_series(R::FmpzModRing, a::Array{fmpz_mod, 1},
                                 len::Int, prec::Int, val::Int)
-      return fmpz_mod_rel_series(FmpzModRing(p).ninv, a, len, prec, val)
+      return fmpz_mod_rel_series(R.ninv, a, len, prec, val)
    end
 
    function fmpz_mod_rel_series(a::fmpz_mod_rel_series)
@@ -3390,8 +3391,8 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_abs_series(p::fmpz)
-      return fmpz_mod_abs_series(FmpzModRing(p).ninv)
+   function fmpz_mod_abs_series(R::FmpzModRing)
+      return fmpz_mod_abs_series(R.ninv)
    end
 
    function fmpz_mod_abs_series(p::fmpz_mod_ctx_struct, a::Array{fmpz, 1},
@@ -3411,8 +3412,8 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_abs_series(p::fmpz, a::Array{fmpz, 1}, len::Int, prec::Int)
-      return fmpz_mod_abs_series(FmpzModRing(p).ninv, a, len, prec)
+   function fmpz_mod_abs_series(R::FmpzModRing, a::Array{fmpz, 1}, len::Int, prec::Int)
+      return fmpz_mod_abs_series(R.ninv, a, len, prec)
    end
 
    function fmpz_mod_abs_series(p::fmpz_mod_ctx_struct, a::Array{fmpz_mod, 1},
@@ -3430,9 +3431,9 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
       return z
    end
 
-   function fmpz_mod_abs_series(p::fmpz, a::Array{fmpz_mod, 1},
+   function fmpz_mod_abs_series(R::FmpzModRing, a::Array{fmpz_mod, 1},
                                 len::Int, prec::Int)
-      return fmpz_mod_abs_series(FmpzModRing(p).ninv, a, len, prec)
+      return fmpz_mod_abs_series(R.ninv, a, len, prec)
    end
 
    function fmpz_mod_abs_series(a::fmpz_mod_abs_series)

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -18,7 +18,7 @@ function O(a::fmpz_mod_abs_series)
    end
    prec = length(a) - 1
    prec < 0 && throw(DomainError(prec, "Precision must be non-negative"))
-   z = fmpz_mod_abs_series(modulus(a), Vector{fmpz}(undef, 0), 0, prec)
+   z = fmpz_mod_abs_series(base_ring(a), Vector{fmpz}(undef, 0), 0, prec)
    z.parent = parent(a)
    return z
 end
@@ -86,7 +86,7 @@ zero(R::FmpzModAbsSeriesRing) = R(0)
 one(R::FmpzModAbsSeriesRing) = R(1)
 
 function gen(R::FmpzModAbsSeriesRing)
-   z = fmpz_mod_abs_series(modulus(base_ring(R)), [fmpz(0), fmpz(1)], 2, max_precision(R))
+   z = fmpz_mod_abs_series(base_ring(R), [fmpz(0), fmpz(1)], 2, max_precision(R))
    z.parent = R
    return z
 end
@@ -595,7 +595,7 @@ promote_rule(::Type{fmpz_mod_abs_series}, ::Type{fmpz_mod}) = fmpz_mod_abs_serie
 ###############################################################################
 
 function (a::FmpzModAbsSeriesRing)()
-   m = modulus(base_ring(a))
+   m = base_ring(a)
    z = fmpz_mod_abs_series(m)
    z.prec = a.prec_max
    z.parent = a
@@ -603,7 +603,7 @@ function (a::FmpzModAbsSeriesRing)()
 end
 
 function (a::FmpzModAbsSeriesRing)(b::Integer)
-   m = modulus(base_ring(a))
+   m = base_ring(a)
    if b == 0
       z = fmpz_mod_abs_series(m)
       z.prec = a.prec_max
@@ -615,7 +615,7 @@ function (a::FmpzModAbsSeriesRing)(b::Integer)
 end
 
 function (a::FmpzModAbsSeriesRing)(b::fmpz)
-   m = modulus(base_ring(a))
+   m = base_ring(a)
    if iszero(b)
       z = fmpz_mod_abs_series(m)
       z.prec = a.prec_max
@@ -627,7 +627,7 @@ function (a::FmpzModAbsSeriesRing)(b::fmpz)
 end
 
 function (a::FmpzModAbsSeriesRing)(b::fmpz_mod)
-   m = modulus(base_ring(a))
+   m = base_ring(a)
    if iszero(b)
       z = fmpz_mod_abs_series(m)
       z.prec = a.prec_max
@@ -644,7 +644,7 @@ function (a::FmpzModAbsSeriesRing)(b::fmpz_mod_abs_series)
 end
 
 function (a::FmpzModAbsSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int)
-   m = modulus(base_ring(a))
+   m = base_ring(a)
    z = fmpz_mod_abs_series(m, b, len, prec)
    z.parent = a
    return z

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -77,7 +77,7 @@ modulus(a::Zmodn_fmpz_poly) = a.parent.n
 modulus(R::ZmodNFmpzPolyRing) = R.n
 
 function deepcopy_internal(a::T, dict::IdDict) where {T <: Zmodn_fmpz_poly}
-  z = T(modulus(a), a)
+  z = T(base_ring(parent(a)), a)
   z.parent = a.parent
   return z
 end
@@ -936,32 +936,32 @@ end
 ################################################################################
 
 function (R::FmpzModPolyRing)()
-  z = fmpz_mod_poly(R.n)
+  z = fmpz_mod_poly(base_ring(R))
   z.parent = R
   return z
 end
 
 function (R::FmpzModPolyRing)(x::fmpz)
-  z = fmpz_mod_poly(R.n, x)
+  z = fmpz_mod_poly(base_ring(R), x)
   z.parent = R
   return z
 end
 
 function (R::FmpzModPolyRing)(x::Integer)
-  z = fmpz_mod_poly(R.n, fmpz(x))
+  z = fmpz_mod_poly(base_ring(R), fmpz(x))
   z.parent = R
   return z
 end
 
 function (R::FmpzModPolyRing)(x::fmpz_mod)
   base_ring(R) != parent(x) && error("Wrong parents")
-  z = fmpz_mod_poly(R.n, x.data)
+  z = fmpz_mod_poly(base_ring(R), x.data)
   z.parent = R
   return z
 end
 
 function (R::FmpzModPolyRing)(arr::Array{fmpz, 1})
-  z = fmpz_mod_poly(R.n, arr)
+  z = fmpz_mod_poly(base_ring(R), arr)
   z.parent = R
   return z
 end
@@ -970,7 +970,7 @@ function (R::FmpzModPolyRing)(arr::Array{fmpz_mod, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
-  z = fmpz_mod_poly(R.n, arr)
+  z = fmpz_mod_poly(base_ring(R), arr)
   z.parent = R
   return z
 end
@@ -978,7 +978,7 @@ end
 (R::FmpzModPolyRing)(arr::Array{T, 1}) where {T <: Integer} = R(map(base_ring(R), arr))
 
 function (R::FmpzModPolyRing)(x::fmpz_poly)
-  z = fmpz_mod_poly(R.n, x)
+  z = fmpz_mod_poly(base_ring(R), x)
   z.parent = R
   return z
 end

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -15,7 +15,7 @@ export fmpz_mod_rel_series, FmpzModRelSeriesRing
 function O(a::fmpz_mod_rel_series)
    val = pol_length(a) + valuation(a) - 1
    val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
-   z = fmpz_mod_rel_series(modulus(a), Vector{fmpz}(undef, 0), 0, val, val)
+   z = fmpz_mod_rel_series(base_ring(a), Vector{fmpz}(undef, 0), 0, val, val)
    z.parent = parent(a)
    return z
 end
@@ -79,7 +79,7 @@ zero(R::FmpzModRelSeriesRing) = R(0)
 one(R::FmpzModRelSeriesRing) = R(1)
 
 function gen(R::FmpzModRelSeriesRing)
-   z = fmpz_mod_rel_series(modulus(R), [fmpz(1)], 1, max_precision(R) + 1, 1)
+   z = fmpz_mod_rel_series(base_ring(R), [fmpz(1)], 1, max_precision(R) + 1, 1)
    z.parent = R
    return z
 end
@@ -713,10 +713,9 @@ function addeq!(a::fmpz_mod_rel_series, b::fmpz_mod_rel_series)
    val = min(a.val, b.val)
    lena = min(lena, prec - a.val)
    lenb = min(lenb, prec - b.val)
-   modulus = modulus(a)
    p = a.parent.base_ring.ninv
    if a.val < b.val
-      z = fmpz_mod_rel_series(modulus)
+      z = fmpz_mod_rel_series(p)
       lenz = max(lena, lenb + b.val - a.val)
       ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{fmpz_mod_rel_series}, Ref{fmpz_mod_rel_series}, Int,
@@ -793,7 +792,7 @@ promote_rule(::Type{fmpz_mod_rel_series}, ::Type{fmpz_mod}) = fmpz_mod_rel_serie
 ###############################################################################
 
 function (a::FmpzModRelSeriesRing)()
-   z = fmpz_mod_rel_series(modulus(a))
+   z = fmpz_mod_rel_series(base_ring(a))
    z.prec = a.prec_max
    z.val = a.prec_max
    z.parent = a
@@ -802,11 +801,11 @@ end
 
 function (a::FmpzModRelSeriesRing)(b::Integer)
    if b == 0
-      z = fmpz_mod_rel_series(modulus(a))
+      z = fmpz_mod_rel_series(base_ring(a))
       z.prec = a.prec_max
       z.val = a.prec_max
    else
-      z = fmpz_mod_rel_series(modulus(a), [fmpz(b)], 1, a.prec_max, 0)
+      z = fmpz_mod_rel_series(base_ring(a), [fmpz(b)], 1, a.prec_max, 0)
    end
    z.parent = a
    return z
@@ -814,11 +813,11 @@ end
 
 function (a::FmpzModRelSeriesRing)(b::fmpz)
    if iszero(b)
-      z = fmpz_mod_rel_series(modulus(a))
+      z = fmpz_mod_rel_series(base_ring(a))
       z.prec = a.prec_max
       z.val = a.prec_max
    else
-      z = fmpz_mod_rel_series(modulus(a), [b], 1, a.prec_max, 0)
+      z = fmpz_mod_rel_series(base_ring(a), [b], 1, a.prec_max, 0)
    end
    z.parent = a
    return z
@@ -826,11 +825,11 @@ end
 
 function (a::FmpzModRelSeriesRing)(b::fmpz_mod)
    if iszero(b)
-      z = fmpz_mod_rel_series(modulus(a))
+      z = fmpz_mod_rel_series(base_ring(a))
       z.prec = a.prec_max
       z.val = a.prec_max
    else
-      z = fmpz_mod_rel_series(modulus(a), [b], 1, a.prec_max, 0)
+      z = fmpz_mod_rel_series(base_ring(a), [b], 1, a.prec_max, 0)
    end
    z.parent = a
    return z
@@ -842,13 +841,13 @@ function (a::FmpzModRelSeriesRing)(b::fmpz_mod_rel_series)
 end
 
 function (a::FmpzModRelSeriesRing)(b::Array{fmpz, 1}, len::Int, prec::Int, val::Int)
-   z = fmpz_mod_rel_series(modulus(a), b, len, prec, val)
+   z = fmpz_mod_rel_series(base_ring(a), b, len, prec, val)
    z.parent = a
    return z
 end
 
 function (a::FmpzModRelSeriesRing)(b::Array{fmpz_mod, 1}, len::Int, prec::Int, val::Int)
-   z = fmpz_mod_rel_series(modulus(a), b, len, prec, val)
+   z = fmpz_mod_rel_series(base_ring(a), b, len, prec, val)
    z.parent = a
    return z
 end

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -375,32 +375,32 @@ end
 ################################################################################
 
 function (R::GFPFmpzPolyRing)()
-  z = gfp_fmpz_poly(R.n)
+  z = gfp_fmpz_poly(base_ring(R))
   z.parent = R
   return z
 end
 
 function (R::GFPFmpzPolyRing)(x::fmpz)
-  z = gfp_fmpz_poly(R.n, x)
+  z = gfp_fmpz_poly(base_ring(R), x)
   z.parent = R
   return z
 end
 
 function (R::GFPFmpzPolyRing)(x::Integer)
-  z = gfp_fmpz_poly(R.n, fmpz(x))
+  z = gfp_fmpz_poly(base_ring(R), fmpz(x))
   z.parent = R
   return z
 end
 
 function (R::GFPFmpzPolyRing)(x::gfp_fmpz_elem)
   base_ring(R) != parent(x) && error("Wrong parents")
-  z = gfp_fmpz_poly(R.n, x.data)
+  z = gfp_fmpz_poly(base_ring(R), x.data)
   z.parent = R
   return z
 end
 
 function (R::GFPFmpzPolyRing)(arr::Array{fmpz, 1})
-  z = gfp_fmpz_poly(R.n, arr)
+  z = gfp_fmpz_poly(base_ring(R), arr)
   z.parent = R
   return z
 end
@@ -409,7 +409,7 @@ function (R::GFPFmpzPolyRing)(arr::Array{gfp_fmpz_elem, 1})
   if length(arr) > 0
      (base_ring(R) != parent(arr[1])) && error("Wrong parents")
   end
-  z = gfp_fmpz_poly(R.n, arr)
+  z = gfp_fmpz_poly(base_ring(R), arr)
   z.parent = R
   return z
 end
@@ -417,7 +417,7 @@ end
 (R::GFPFmpzPolyRing)(arr::Array{T, 1}) where {T <: Integer} = R(map(base_ring(R), arr))
 
 function (R::GFPFmpzPolyRing)(x::fmpz_poly)
-  z = gfp_fmpz_poly(R.n, x)
+  z = gfp_fmpz_poly(base_ring(R), x)
   z.parent = R
   return z
 end


### PR DESCRIPTION
The various `(R::FmpzModPolyRing)(...)` functions are currently constructing lots of cached `FmpzModRing`s, making Nemo fill your memory quickly for modular algorithms.

I will do a patch release once this is merged.