### PR TITLE
Avoid \mbox, as MathJax does not like it

### DIFF
--- a/docs/src/constructors.md
+++ b/docs/src/constructors.md
@@ -63,12 +63,12 @@ they represent.
 | $R = \mathbb{F}_{p^n}$                | `R, a = FiniteField(p, n, "a")`               |
 | $R = \mathbb{Z}/n\mathbb{Z}$          | `R = ResidueRing(ZZ, n)`                      |
 | $S = R[x]$                            | `S, x = PolynomialRing(R, "x")`               |
-| $S = R[x, y]$                         | `S, (x, y, z) = PolynomialRing(R, ["x", "y"]) |
+| $S = R[x, y]$                         | `S, (x, y) = PolynomialRing(R, ["x", "y"])    |
 | $S = R[[x]]$ (to precision $n$)       | `S, x = PowerSeriesRing(R, n, "x")`           |
 | $S = R((x))$ (to precision $n$)       | `S, x = LaurentSeriesRing(R, n, "x")`         |
-| $S = \mbox{Frac}_R$                   | `S = FractionField(R)`                        |
+| $S = \mathrm{Frac}_R$                 | `S = FractionField(R)`                        |
 | $S = R/(f)$                           | `S = ResidueRing(R, f)`                       |
-| $S = \mbox{Mat}_{m\times n}(R)$       | `S = MatrixSpace(R, m, n)`                    |
+| $S = \mathrm{Mat}_{m\times n}(R)$     | `S = MatrixSpace(R, m, n)`                    |
 | $S = \mathbb{Q}[x]/(f)$               | `S, a = NumberField(f, "a")`                  |
 | $S = \mathbb{Q}_p$ (to precision $N$) | `S = PadicField(p, n)`                        |
 | $S = \mathbb{R}$ (to precision $n$)   | `S = RealField(n)`                            |

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -31,7 +31,7 @@ laurent_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = R.laurent_rin
 @doc Markdown.doc"""
     O(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
 
-Returns $0 + O(x^\mbox{val}(a))$. Usually this function is called with $x^n$
+Returns $0 + O(x^\mathrm{val}(a))$. Usually this function is called with $x^n$
 as parameter for some rational $n$. Then the function returns the Puiseux series
 $0 + O(x^n)$, which can be used to set the precision of a Puiseux series when
 constructing it.

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -15,7 +15,7 @@ export fmpz_laurent_series, FmpzLaurentSeriesRing
 @doc Markdown.doc"""
     O(a::fmpz_laurent_series)
 
-Returns $0 + O(x^\mbox{val}(a))$. Usually this function is called with $x^n$
+Returns $0 + O(x^\mathrm{val}(a))$. Usually this function is called with $x^n$
 as parameter. Then the function returns the power series $0 + O(x^n)$, which
 can be used to set the precision of a power series when constructing it.
 """


### PR DESCRIPTION
Use mathrm instead.

Also fix PolynomialRing example.

BTW, I noticed that the table in `constructors.md` here has diverged from that in `AbstractAlgebra.jl`. Not sure if it is realistic to keep them in sync -- perhaps better to remove the table here and just link to it in AA?