### PR TITLE
Page three of developer docs: parent objects

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,7 +32,8 @@ makedocs(
              "matrix.md",
              "factor.md",
 	     "Developer" => [ "developer/conventions.md",
-			      "developer/typesystem.md" ]
+			      "developer/typesystem.md",
+			      "developer/parents.md" ]
          ]
 )
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,6 +27,7 @@ pages:
 - Factorization:                factor.md
 - Conventions:                  developer/conventions.md
 - Type System:                  developer/typesystem.md
+- Parent Objects:               developer/parents.md
 
 markdown_extensions:
   - extra

--- a/docs/src/developer/conventions.md
+++ b/docs/src/developer/conventions.md
@@ -20,38 +20,38 @@ the words, e.g. `zip` and `jacobi_symbol`.
 We follow these conventions in Nemo with some exceptions:
 
 * When interfacing C libraries the types use the same spelling and
-capitalisation in Nemo as they do in C, e.g. the Flint library's `fmpz_poly`
-remains uncapitalised in Nemo.
+  capitalisation in Nemo as they do in C, e.g. the Flint library's `fmpz_poly`
+  remains uncapitalised in Nemo.
 
 * Types such as `gfp_poly` which don't exist under that name on the C side
-also use the lowercase convention as they wrap an actual C type which must be
-split into more than one type on the Julia side. For example `nmod_poly` and
-`gfp_poly` on the Julia side both represent Flint `nmod_poly`'s on the C side.
+  also use the lowercase convention as they wrap an actual C type which must be
+  split into more than one type on the Julia side. For example `nmod_poly` and
+  `gfp_poly` on the Julia side both represent Flint `nmod_poly`'s on the C side.
 
 * Types of rings and fields, modules, maps, etc. are capitalised whether they
-correspond to a C type or not, e.g. `FqNmodFiniteField` for the type of an
-object representing the field that `fq_nmod`'s belong to.
+  correspond to a C type or not, e.g. `FqNmodFiniteField` for the type of an
+  object representing the field that `fq_nmod`'s belong to.
 .
 * We omit an underscore if the first word of a method is "is" or "has", e.g.
-`iseven`.
+  `iseven`.
 
 * Underscores are omitted if the method name is already well established
-without an underscore in Julia itself, e.g. `setindex`.
+  without an underscore in Julia itself, e.g. `setindex`.
 
 * Constructors with the same name as a type use the same spelling and
-capitalisation as that type, e.g. `fmpz(1)`.
+  capitalisation as that type, e.g. `fmpz(1)`.
 
 * Functions for creating rings, fields, modules, maps, etc. (rather than the
-elements thereof) use CamelCase, e.g. `PolynomialRing`. We refer to these 
-functions as parent constructors. Note that we do not follow the Julia
-convention here, e.g. `PolynomialRing` is a function and not a type constructor
-(in fact we often return a tuple consisting of a parent object and other
-objects such as generators with this type of function) yet we capitalise it.
+  elements thereof) use CamelCase, e.g. `PolynomialRing`. We refer to these 
+  functions as parent constructors. Note that we do not follow the Julia
+  convention here, e.g. `PolynomialRing` is a function and not a type constructor
+  (in fact we often return a tuple consisting of a parent object and other
+  objects such as generators with this type of function) yet we capitalise it.
 
 * We prefer words to not be abbreviated, e.g. `denominator` instead of `den`.
 
 * Exceptions always exist where the result would be offensive in any major
-spoken language (example omitted).
+  spoken language (example omitted).
 
 It is easy to find counterexamples to virtually all these rules. However we
 have been making efforts to remove the most egregious cases from our codebase
@@ -127,27 +127,27 @@ follows:
 * A header stating what the file is for, and if needed, any copyright notices
 
 * Functions applying to any "types" used in the file, e.g. `parent_type`,
-`elem_type`, `base_ring`, `parent`, `check_parent`.
+  `elem_type`, `base_ring`, `parent`, `check_parent`.
 
 * Basic manipulation, including hashes, predicates, getters/setters, functions
-for creating special values (e.g. `one`, `zero` and the like),
-`deepcopy_internal`. These are usually fairly short functions, often a single
-line.
+  for creating special values (e.g. `one`, `zero` and the like),
+  `deepcopy_internal`. These are usually fairly short functions, often a single
+  line.
 
 * Indexing (`getindex`, `setindex`), iteration, views.
 
 * String I/O (`expressify` and file access, etc.)
 
 * Arithmetic operations, usually in multiple sections, such as unary
-operations, binary operations, ad hoc binary operations (e.g. multiplication
-of a complex object by a scalar), comparisons, ad hoc comparisons, division,
-etc.
+  operations, binary operations, ad hoc binary operations (e.g. multiplication
+  of a complex object by a scalar), comparisons, ad hoc comparisons, division,
+  etc.
 
 * More complex functionality separated into sections based on functionality
-provided, e.g. gcd, interpolation, special functions, solving, etc.
+  provided, e.g. gcd, interpolation, special functions, solving, etc.
 
 * Functions for mapping between different types, coercion, changing base ring,
-etc.
+  etc.
 
 * Unsafe operators, e.g. `mul!`, `add!`, `addeq!` etc.
 
@@ -156,10 +156,10 @@ etc.
 * Promotion rules
 
 * Parent object call overload (e.g. for implementing `R(2)` where `R` is an
-object representing a ring or field, etc.)
+  object representing a ring or field, etc.)
 
 * Additional constructors, e.g. `matrix`, which might be used instead of a
-parent object to construct elements.
+  parent object to construct elements.
 
 * Parent object constructors, e.g. `PolynomialRing`, etc.
 

--- a/docs/src/developer/parents.md
+++ b/docs/src/developer/parents.md
@@ -1,0 +1,195 @@
+```@meta
+CurrentModule = Nemo
+```
+
+# Parent objects
+
+## The use of parent objects in Nemo
+
+### The parent/element model
+
+As for other major computer algebra projects such as Sage and Magma, Nemo uses
+the parent/element model to manage its mathematical objects.
+
+As explained in the appendix to the AbstractAlgebra documentation, the standard
+type/object model used in most programming languages is insufficient for much
+of mathematics which often requires mathematical structures parameterised by
+other objects.
+
+For example a quotient ring by an ideal would be parameterised by the ideal.
+The ideal is an object in the system and not a type and so parameterised types
+are not sufficient to represent such quotient rings.
+
+This means that each mathematical "domain" in the system (set, group, ring,
+field, module, etc.) must be represented by an object in the system, rather
+than a type. Such objects are called parent objects.
+
+Just as one would write `typeof(a)` to get the type of an object `a` in an
+object/type system of a standard programming language, we write `parent(a)`
+to return the parent of the object `a`.
+
+When talked about with reference to a parent in this way, the object `a` is
+referred to as an `element` of the parent. Thus the system is divided into
+elements and parents. For example a polynomial would be an element of a
+polynomial ring, the latter being the parent of the former.
+
+Naturally the parent/element system leads to some issues in a programming
+language not built around this model. We discuss some of these issues below.
+
+### Types in the parent/element model
+
+As all elements and parents in Nemo are objects, those objects have types
+which we refer to as the element type and parent type respectively.
+
+For example, Flint integers have type `fmpz` and the parent object they all
+belong to, `FlintZZ` has type `FlintIntegerRing`.
+
+More complex parents and elements are parameterised. For example, generic
+univariate polynomials over a base ring `R` are parameterised by `R`. The
+base ring of a ring `S` can be obtained by the call `base_ring(S)`.
+
+We have found it extremely useful to parameterise the type of both the parent
+and element objects of such a ring by the type of the base ring. Thus for
+example, a generic polynomial with Flint integer coefficients would have
+type `Poly{fmpz}`.
+
+In practice Flint already implements univariate polynomials over Flint
+integers, and these have type `fmpz_poly`. But both `fmpz_poly` and the
+generic polynomials `Poly{fmpz}` belong to the abstract type `PolyElem{fmpz}`
+making it possible to write functions for all univariate polynomials over
+Flint integers.
+
+Given a specific element type or parent type it is possible to compute one
+from the other with the functions `elem_type` and `parent_type`. For example
+`parent_type(fmpz_poly)` returns `FmpzPolyRing` and `elem_type(FmpzPolyRing)`
+returns `fmpz_poly`. Similarly `parent_type(Generic.Poly{fmpz})` returns
+`Generic.PolyRing{fmpz}` and so on.
+
+These functions are especially useful when writing type assertions or
+constructing arrays of elements insides function where only the parent object
+was passed.
+
+### Other functions for computing types
+
+Sometimes one needs to know the type of a polynomial or matrix one would
+obtain if it were constructed over a given ring or coefficients/entries of a
+given element type.
+
+This is especially important in generic code where it may not even be known
+which Julia package is being used. The user may be expecting an
+AbstractAlgebra, a Nemo or even some other kind of matrix or polynomial to be
+constructed, depending on which package they are using.
+
+The function for returning the correct type for a dense matrix is
+`dense_matrix_type` to which one can pass either a base ring or an element
+type. For example, if AbstractAlgebra is being used `dense_matrix_type(ZZ)`
+will return `Mat{BigInt}` whereas if Nemo is being used it will return
+`fmpz_mat`.
+
+In theory such functions should exist for all major object types, however they
+have in most cases not been implemented yet.
+
+### Functions for creating objects of a similar type
+
+A slightly more consistent interface for creating objects of a type that is
+suitable for the package currently in use is the `similar` interface.
+
+For example, given a matrix `M` one can create one with the same dimensions
+but over a different ring `R` by calling `similar(M, R)`. Likewise one can
+create one over the same ring with different dimensions `r x c` by calling
+`similar(M, r, c)`.
+
+The `similar` system is sophisticated enough to know that there is no native
+type provided by Flint/Antic for matrices and polynomials over a number field.
+The system knows that in such cases it must create a generic matrix or
+polynomial over the given number field.
+
+A great deal of thought went into the design of the `similar` system so that
+developers would not be required to implement similar for every pair of types
+in the package.
+
+Again this interface should exist for all major Nemo domains, but the
+functionality is still being implemented in some cases.
+
+### Changing base rings and map
+
+Given a polynomial, matrix or other composite object over a base ring, it is
+often convenient to create a similar object but with all the entries or
+coefficients coerced into a different ring.
+
+For this purpose the function `change_base_ring` is provided.
+
+Similarly it may be useful to create the matrix or polynomial that results by
+applying a given map/function/lambda to each of the entries or coefficients.
+
+For this purpose Julia's `map` function is overloaded. There are also functions
+specific to polynomials and matrices called `map_coeffs` and `map_entries`
+respectively, which essentially do the same thing.
+
+Note that the implementation of such functions must make use of the functions
+discussed above to ensure that a matrix/polynomial of the right type is output.
+
+### Parent checking
+
+When applying binary operations to a pair of elements of a given ring, it is
+useful to check that they are in fact elements of the same ring. This is not
+possible by checking the types alone. For example elements of $Z/7Z$ and
+$Z/3Z$ would have the same type but different parents (one parameterised by
+the integer 7, the other by the integer 3).
+
+In order to perform such a check in a function one uses `parent_check(a, b)`
+where `a` and `b` are the objects one wishes to assert must have the same
+parent. If not, an exception is raised by `parent_check`.
+
+### Parent object constructors
+
+Various functions are provided for constructing parent objects. For example
+a polynomial ring is constructed by calling a `PolynomialRing` function.
+Such functions are called parent object constructors.
+
+In general parent object constructors are intended for the user and should not
+be used in library code. There are a number of reasons for this.
+
+Firstly, inside the Generic submodule of AbstractAlgebra the only parent object
+constructors that are directly accessible are the ones inside Generic. Thus if
+a Nemo function calls a function inside generic and it creates a parent object
+using one of the parent object constructors, it will create a parent object for
+a generic ring rather than a Nemo one.
+
+One can work around this by calling `AbstractAlgebra.PolynomialRing` instead of
+simply `PolynomialRing` inside Generic, but even safer would be to find another
+way to construct the polynomials required.
+
+A second issue is that parent objects are allowed to be as large as one likes
+and they are cached by the system. They can also perform arbitrary
+precomputations for the ring/field/module etc. that is being constructed. Over
+time they tend to accumulate such precomputations, slowing down all generic
+code which made use of them. Both memory usage and performance may blow out in
+previously working code.
+
+Thirdly, parent objects must be unique across the system for a given set of
+parameters. This means they must be cached globally. This is problematic for
+any future attempts to parallelise library code.
+
+Most parent object constructors take a `cached` keyword which specifies whether
+the parent object should be cached or not, but again it is better overall to
+simply eschew the use of parent object constructors in libary code.
+
+Instead, it is recommended to use functions such as `similar`, `zero_matrix`,
+`identity_matrix`, `change_base_ring`, `map`, etc.
+
+There are also functions that provide alternative ways of constructing objects,
+e.g. `matrix` provides a means of creating a matrix over a given ring with
+given dimensions. These should be used in preference to parent object
+constructors where possible. Additional functions of this type should be added
+in future.
+
+Naturally many such functions are missing at present and it is hoped that
+developers will fill in such infrastructure rather than simply push the can
+down the road for someone else to fix. Forcing the creating of parent objects
+into as few bottlenecks as possible will make it much easier for developers to
+remove problems associated with such calls when they arise in future.
+
+
+
+

--- a/docs/src/developer/parents.md
+++ b/docs/src/developer/parents.md
@@ -49,9 +49,9 @@ univariate polynomials over a base ring `R` are parameterised by `R`. The
 base ring of a ring `S` can be obtained by the call `base_ring(S)`.
 
 We have found it extremely useful to parameterise the type of both the parent
-and element objects of such a ring by the type of the base ring. Thus for
-example, a generic polynomial with Flint integer coefficients would have
-type `Poly{fmpz}`.
+and element objects of such a ring by the type of the elements of the base
+ring. Thus for example, a generic polynomial with Flint integer coefficients
+would have type `Poly{fmpz}`.
 
 In practice Flint already implements univariate polynomials over Flint
 integers, and these have type `fmpz_poly`. But both `fmpz_poly` and the
@@ -77,7 +77,7 @@ of a given element type.
 
 This is especially important in generic code where it may not even be known
 which Julia package is being used. The user may be expecting an
-AbstractAlgebra, a Nemo or even some other kind of matrix or polynomial to be
+AbstractAlgebra object, a Nemo object or even some other kind of object to be
 constructed, depending on which package they are using.
 
 The function for returning the correct type for a dense matrix is

--- a/docs/src/developer/parents.md
+++ b/docs/src/developer/parents.md
@@ -72,8 +72,8 @@ was passed.
 ### Other functions for computing types
 
 Sometimes one needs to know the type of a polynomial or matrix one would
-obtain if it were constructed over a given ring or coefficients/entries of a
-given element type.
+obtain if it were constructed over a given ring or with coefficients/entries
+of a given element type.
 
 This is especially important in generic code where it may not even be known
 which Julia package is being used. The user may be expecting an
@@ -82,7 +82,7 @@ constructed, depending on which package they are using.
 
 The function for returning the correct type for a dense matrix is
 `dense_matrix_type` to which one can pass either a base ring or an element
-type. For example, if AbstractAlgebra is being used `dense_matrix_type(ZZ)`
+type. For example, if AbstractAlgebra is being used, `dense_matrix_type(ZZ)`
 will return `Mat{BigInt}` whereas if Nemo is being used it will return
 `fmpz_mat`.
 
@@ -152,7 +152,7 @@ be used in library code. There are a number of reasons for this.
 
 Firstly, inside the Generic submodule of AbstractAlgebra the only parent object
 constructors that are directly accessible are the ones inside Generic. Thus if
-a Nemo function calls a function inside generic and it creates a parent object
+a Nemo function calls a function inside Generic and it creates a parent object
 using one of the parent object constructors, it will create a parent object for
 a generic ring rather than a Nemo one.
 
@@ -173,7 +173,7 @@ any future attempts to parallelise library code.
 
 Most parent object constructors take a `cached` keyword which specifies whether
 the parent object should be cached or not, but again it is better overall to
-simply eschew the use of parent object constructors in libary code.
+simply eschew the use of parent object constructors in library code.
 
 Instead, it is recommended to use functions such as `similar`, `zero_matrix`,
 `identity_matrix`, `change_base_ring`, `map`, etc.
@@ -189,7 +189,4 @@ developers will fill in such infrastructure rather than simply push the can
 down the road for someone else to fix. Forcing the creating of parent objects
 into as few bottlenecks as possible will make it much easier for developers to
 remove problems associated with such calls when they arise in future.
-
-
-
 

--- a/docs/src/developer/typesystem.md
+++ b/docs/src/developer/typesystem.md
@@ -194,7 +194,7 @@ map types whose first two parameters are `D` and `C`, and where the remaining
 two parameters are arbitrary.
 
 However one can also pass a map class or a concrete type `U` to a `Map`
-function to compute the class of all maps of the given map class or type..
+function to compute the class of all maps of the given map class or type.
 
 For example, to write a function which accepts all maps of "type"
 `MyRingHomomorphism`, including all compositions of such maps, one inserts

--- a/docs/src/developer/typesystem.md
+++ b/docs/src/developer/typesystem.md
@@ -86,7 +86,7 @@ Nemo does not currently use type traits, though the map types in Nemo do make
 use of a custom analogue of this.
 
 Note that unlike class based systems that dispatch on the type of a (sometimes
-implicit) `this` or `self' parameter, Julia methods dispatch on the type of all
+implicit) `this` or `self` parameter, Julia methods dispatch on the type of all
 arguments. This is a natural fit for mathematics where all sorts of ad hoc left
 and right operations may be required.
 


### PR DESCRIPTION
I think this page is basically done. Here are the pages I plan to write next, for those playing along at home:

Intro to Nemo development:
  - basic layout of files in AbstractAlgebra and Nemo
  - relationship between AbstractAlgebra and Nemo
  - git, Github, PRs, review, branches, tickets
  - devel list
  - reporting bugs
  - roadmap ticket
  - limitations for external Julia users (e.g. Nemo has its own matrices)
  - binaries

Code conventions (exists):

Type system (exists, but I will add):
  - type tree diagrams (incl. abstract types and unions)

Parent objects (this page):

Interfaces:
  - julia interfaces we implement
  - interfaces defined in AbstractAlgebra docs
  - abstract vs generic functionality

Specialised topics for developers:
  - div, rem, divrem, mod, %
  - inv, sqrt (transc. functions)
  - Generic module
  - performance : unsafe operations
  - SparsePoly
  - functions which take an additional boolean argument
  - delayed reduction
  - aliasing rules
 
Expressify: (please help @tthsqe12)
  - this is like magnets; how do *they* work!!

Future plans:
  - CommRing
  - matrices and polys over number fields (antic C)
  - mono repo  
  - splitting abstract and generic functionality
  - moving stuff from Hecke