### PR TITLE
Add random generators for arb

### DIFF
--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2171,17 +2171,24 @@ end
 Return a random element in the given Arb field. The values are distributed
 non-uniformly in order to exercise corner cases.
 
-The `randtype` default is `:null` that return a finite midpoint and radius.
-The other options are `:exact` which return a radius that is zero, `precise`
-which return a radius around $2^{-\mathrm{prec}}$ the magnitude of the midpoint,
-`:wide` whose returned radius might be big relative to its midpoint, and
-`:special` which return a midpoint and radius that might be NaN or infinity.
+The `randtype` default is `:null` for which the midpoint and radius lie within
+$[0, 1]$. Another option is `:null_exact` which return a midpoint in $[0, 1]$
+with a zero radius. The rest of the options are based on the option `:randtype`
+whose only contraint is to return finite numbers. The options include `:exact`
+which return a radius that is zero, `precise` which return a radius around
+$2^{-\mathrm{prec}}$ the magnitude of the midpoint, `:wide` whose returned
+radius might be big relative to its midpoint, and `:special` which return a
+midpoint and radius that might be NaN or infinity.
 """
 function rand(r::ArbField; randtype::Symbol=:null)
   state = _flint_rand_states[Threads.threadid()]
   x = r()
 
   if randtype == :null
+    x = r(rand(BigFloat), rand(BigFloat))
+  elseif randtype == :null_exact
+    x = r(rand(BigFloat))
+  elseif randtype == :randtype
     ccall((:arb_randtest, libarb), Nothing,
           (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :exact

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2172,8 +2172,8 @@ Return a random element in the given Arb field. The values are distributed
 non-uniformly in order to exercise corner cases.
 
 The `randtype` default is `:null` that return a finite midpoint and radius.
-The other options are `:exact` which return a zero radius, `precise` which
-return a radius around $2^{-\mathrm{prec}}$ the magnitude of the midpoint,
+The other options are `:exact` which return a radius that is zero, `precise`
+which return a radius around $2^{-\mathrm{prec}}$ the magnitude of the midpoint,
 `:wide` whose returned radius might be big relative to its midpoint, and
 `:special` which return a midpoint and radius that might be NaN or infinity.
 """

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2185,7 +2185,8 @@ function rand(r::ArbField; randtype::Symbol=:null)
   x = r()
 
   if randtype == :null
-    x = r(rand(BigFloat), rand(BigFloat))
+    a = r.(rand(BigFloat, 2))
+    x = ball(a[1], a[2])
   elseif randtype == :null_exact
     x = r(rand(BigFloat))
   elseif randtype == :randtype

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2179,19 +2179,19 @@ function rand(rng::AbstractRNG, r::ArbField; randtype::Symbol=:null)
   x = r()
   if randtype == :null
     ccall((:arb_randtest, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :exact
     ccall((:arb_randtest_exact, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :precise
     ccall((:arb_randtest_precise, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :wide
     ccall((:arb_randtest_wide, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :special
     ccall((:arb_randtest_special, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   else
     error("randtype not defined")
   end
@@ -2208,19 +2208,19 @@ function rand(r::ArbField; randtype::Symbol=:null)
   x = r()
   if randtype == :null
     ccall((:arb_randtest, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :exact
     ccall((:arb_randtest_exact, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :precise
     ccall((:arb_randtest_precise, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :wide
     ccall((:arb_randtest_wide, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   elseif randtype == :special
     ccall((:arb_randtest_special, libarb), Nothing,
-          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
   else
     error("randtype not defined")
   end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2165,6 +2165,12 @@ end
 #
 ################################################################################
 
+@doc Markdown.doc"""
+    rand(rng::AbstractRNG, r::ArbField; randtype::Symbol=:null)
+
+Return a random element in the given Arb field. The values are distributed
+non-uniformly in order to exercise corner cases.
+"""
 function rand(rng::AbstractRNG, r::ArbField; randtype::Symbol=:null)
   state = rand_ctx()
   ccall((:flint_randseed, libarb), Nothing, (Ptr{Cvoid}, UInt, UInt),

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2158,3 +2158,66 @@ end
 ################################################################################
 
 # see inner constructor for ArbField
+
+################################################################################
+#
+#  Random generation
+#
+################################################################################
+
+function rand(rng::AbstractRNG, r::ArbField; randtype::Symbol=:null)
+  state = rand_ctx()
+  ccall((:flint_randseed, libarb), Nothing, (Ptr{Cvoid}, UInt, UInt),
+      state.ptr, rand(rng, UInt), rand(rng, UInt))
+
+  x = r()
+  if randtype == :null
+    ccall((:arb_randtest, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :exact
+    ccall((:arb_randtest_exact, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :precise
+    ccall((:arb_randtest_precise, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :wide
+    ccall((:arb_randtest_wide, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :special
+    ccall((:arb_randtest_special, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  else
+    error("randtype not defined")
+  end
+
+  return x
+end
+
+function rand(r::ArbField; randtype::Symbol=:null)
+  rng = Random.GLOBAL_RNG
+  state = rand_ctx()
+  ccall((:flint_randseed, libarb), Nothing, (Ptr{Cvoid}, UInt, UInt),
+      state.ptr, rand(rng, UInt), rand(rng, UInt))
+
+  x = r()
+  if randtype == :null
+    ccall((:arb_randtest, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :exact
+    ccall((:arb_randtest_exact, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :precise
+    ccall((:arb_randtest_precise, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :wide
+    ccall((:arb_randtest_wide, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  elseif randtype == :special
+    ccall((:arb_randtest_special, libarb), Nothing,
+          (Ref{arb}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 53)
+  else
+    error("randtype not defined")
+  end
+
+  return x
+end


### PR DESCRIPTION
I have thought about random generators for `arb` for a while, so I sat down and took a look at the C-code.

The seeding is probably wrong and maybe the `randtype` should be cut out. I couldn't figure out if it was possible to redirect the `GLOBAL_RNG` to the first function, so now the second method is basically a copy of the first one.

I also want to have a random generator that generates an `arb` between 0 and 1 that's uniformly distributed.