### PR TITLE
Disable a test of a heuristic function which is sometimes allowed to fail.

### DIFF
--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -405,8 +405,8 @@ end
 
 @testset "acb.lindep..." begin
    CC = ComplexField(512)
-   tau1 = CC(rand(), abs(rand()) + eps())
-   tau2 = CC(rand(), abs(rand()) + eps())
+   tau1 = CC(1//3, 8//7)
+   tau2 = CC(1//5, 9//8)
    A1 = modweber_f1(tau1)^8; B1 = modweber_f1(2*tau1)^8
 
    vals1 = [A1^i*B1^j for i in 0:2 for j in 0:2];


### PR DESCRIPTION
This test would fail about 1 time in 20 due to the fact that it is testing a heuristic function which can sometimes return a different answer.

It's safe to ignore such outputs, but as such it is a nuisance for our CI, so I disable it here. 