### PR TITLE
Clarify balls in documentation

### DIFF
--- a/docs/src/arb.md
+++ b/docs/src/arb.md
@@ -69,7 +69,7 @@ parent object to coerce values into the resulting field.
 RR = RealField(64)
 
 a = RR("0.25")
-b = RR("0.1")
+b = RR("0.1 +/- 0.001")
 c = RR(0.5)
 d = RR(12)
 ```

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -567,10 +567,10 @@ end
 ################################################################################
 
 @doc Markdown.doc"""
-    ball(mid::arb, rad::arb)
+    ball(x::arb, y::arb)
 
-Constructs an `arb` enclosing the range $[m-|r|, m+|r|]$, given the pair
-$(m, r)$.
+Constructs an `arb` via $x_m \pm (|x_r| + |y_m| + |y_r|)$, given the pair
+$(x, y) = (x_m \pm x_r, y_m \pm y_r)$.
 """
 function ball(mid::arb, rad::arb)
   z = arb(mid, rad)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -569,8 +569,8 @@ end
 @doc Markdown.doc"""
     ball(x::arb, y::arb)
 
-Constructs an Arb ball $x_m \pm (|x_r| + |y_m| + |y_r|)$, given the pair
-$(x, y) = (x_m \pm x_r, y_m \pm y_r)$.
+Constructs an Arb ball enclosing $x_m \pm (|x_r| + |y_m| + |y_r|)$, given the
+pair $(x, y) = (x_m \pm x_r, y_m \pm y_r)$.
 """
 function ball(mid::arb, rad::arb)
   z = arb(mid, rad)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -569,7 +569,7 @@ end
 @doc Markdown.doc"""
     ball(x::arb, y::arb)
 
-Constructs an `arb` via $x_m \pm (|x_r| + |y_m| + |y_r|)$, given the pair
+Constructs an Arb ball $x_m \pm (|x_r| + |y_m| + |y_r|)$, given the pair
 $(x, y) = (x_m \pm x_r, y_m \pm y_r)$.
 """
 function ball(mid::arb, rad::arb)


### PR DESCRIPTION
By
```
julia> a = RR("1 +/- 0.1")
[1e+0 +/- 0.101]

julia> b = RR("0.1 +/- 0.1")
[+/- 0.201]

julia> c = ball(a, b)
[1e+0 +/- 0.301]

julia> radius(c)
[0.3000000007450581 +/- 4.04e-17]

julia> midpoint(c)
1.000000000000000
```
it is clear that the current docstring does not describe the cases for `ball(::arb, ::arb)` when the input balls have error bounds.

Edit: I also changed `RR("0.1")` to `RR("0.1 +/- 0.001")` in an early example in `arb.md`. This is to explain how to "naturally" construct an arb with error bounds before anything with `ball(::arb, ::arb)` or `isexact(::arb)` is mentioned.