### PR TITLE
Remove double exports

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -81,8 +81,7 @@ export error_dim_negative, ErrorConstrDimMismatch
 
 export iswindows64
 
-export CyclotomicField, MaximalRealSubfield, NumberField, ComplexField, PadicField,
-       QadicField
+export ComplexField, PadicField, QadicField
 
 # Things/constants which are also defined in AbstractAlgebra:
 export ZZ, QQ, RealField, FiniteField, NumberField

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -1192,7 +1192,7 @@ rand(K::AnticNumberField, r) = rand(Random.GLOBAL_RNG, K, r)
     NumberField(f::fmpq_poly, s::AbstractString; cached::Bool = true, check::Bool = true)
 
 Return a tuple $R, x$ consisting of the parent object $R$ and generator $x$
-of the number field $\mathbb{Q}/(f)$ where $f$ is the supplied polynomial.
+of the number field $\mathbb{Q}[x]/(f)$ where $f$ is the supplied polynomial.
 The supplied string `s` specifies how the generator of the number field
 should be printed.
 """


### PR DESCRIPTION
`CyclotomicField` and `MaximalRealSubfield` are exported under `/antic` and `NumberField` is exported couple of lines below.

Edit: Changed a docstring which I, with my limited knowledge, think contained a minor error. 