### PR TITLE
minor cahnges to qadics

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2647,7 +2647,8 @@ mutable struct FlintQadicField <: FlintLocalField
    var::Cstring   # char*
    prec_max::Int
 
-   function FlintQadicField(p::fmpz, d::Int, prec::Int; cached::Bool = true, check::Bool = true)
+   function FlintQadicField(p::fmpz, d::Int, prec::Int, var::String = "a"; cached::Bool = true, check::Bool = true)
+
       check && !isprobable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
 
       if cached
@@ -2660,7 +2661,7 @@ mutable struct FlintQadicField <: FlintLocalField
       z = new()
       ccall((:qadic_ctx_init, libflint), Nothing,
            (Ref{FlintQadicField}, Ref{fmpz}, Int, Int, Int, Cstring, Cint),
-                                     z, p, d, 0, 0, "a", 0)
+                                     z, p, d, 0, 0, var, 0)
       finalizer(_qadic_ctx_clear_fn, z)
       z.prec_max = prec
 

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -241,7 +241,11 @@ characteristic(R::FlintQadicField) = 0
 #
 ###############################################################################
 
-function expressify(b::qadic, x = :a; context = nothing)
+function var(Q::FlintQadicField)
+  return Symbol(unsafe_string(Q.var))
+end
+
+function expressify(b::qadic, x = var(parent(b)); context = nothing)
    R = FlintPadicField(prime(parent(b)), parent(b).prec_max)
    if iszero(b)
       return 0
@@ -795,8 +799,8 @@ function (R::FlintQadicField)(n::fmpq)
    return z
 end
 
-function (R::FlintQadicField)(n::fmpz_poly)
-   z = qadic(R.prec_max)
+function (R::FlintQadicField)(n::fmpz_poly, pr::Int = R.prec_max)
+   z = qadic(pr)
    ccall((:qadic_set_fmpz_poly, libflint), Nothing,
          (Ref{qadic}, Ref{fmpz_poly}, Ref{FlintQadicField}), z, n, R)
    z.parent = R
@@ -842,12 +846,12 @@ end
 # inner constructor is also used directly
 
 @doc Markdown.doc"""
-    FlintQadicField(p::Integer, d::Int, prec::Int)
+    FlintQadicField(p::Integer, d::Int, prec::Int, var::String = "a")
 
 Returns the parent object for the $q$-adic field for given prime $p$ and
 degree $d$, where the default absolute precision of elements of the field
-is given by `prec`.
+is given by `prec` and the generator is printed as `var`.
 """
-function FlintQadicField(p::Integer, d::Int, prec::Int)
-   return FlintQadicField(fmpz(p), d, prec)
+function FlintQadicField(p::Integer, d::Int, prec::Int, var::String = "a"; cached::Bool = true)
+   return FlintQadicField(fmpz(p), d, prec, var, cached = cached)
 end


### PR DESCRIPTION
- allow naming of the generator (and use in printing)
- allow setting of precision when creating an element from fmpz_poly

(more complex, breaking, changes later)