### PR TITLE
Add non-ASCII ban to dev docs.

### DIFF
--- a/docs/src/developer/conventions.md
+++ b/docs/src/developer/conventions.md
@@ -58,6 +58,15 @@ have been making efforts to remove the most egregious cases from our codebase
 over time. As perfect consistency is not possible, work on this has to at
 times take a back seat.
 
+### Use of ASCII characters
+
+All code and printed output in Nemo should use ASCII characters only. This is
+because we have developers who are using versions of the WSL that cannot
+correctly display such characters.
+
+This extends to function and operator names, which saves people having to
+learn how to enter them to use the system.
+
 ### Spacing and tabs
 
 All function bodies and control blocks should be indented using spaces.

--- a/docs/src/developer/conventions.md
+++ b/docs/src/developer/conventions.md
@@ -62,7 +62,7 @@ times take a back seat.
 
 All code and printed output in Nemo should use ASCII characters only. This is
 because we have developers who are using versions of the WSL that cannot
-correctly display such characters.
+correctly display non-ASCII characters.
 
 This extends to function and operator names, which saves people having to
 learn how to enter them to use the system.


### PR DESCRIPTION
Let me know if the wording is ok, especially regarding the use of non-ASCII in operator names (which can technically be entered using only ASCII characters as far as I am aware).