### PR TITLE
Fixes missing fit! and setcoeff! methods for relative and absolute series.

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3426,7 +3426,8 @@ mutable struct fmpz_mod_abs_series <: AbsSeriesElem{fmpz_mod}
             z, len, p)
       for i = 1:len
          ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
-                     (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}), z, i - 1, data(a[i]))
+            (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
+		     z, i - 1, data(a[i]), p)
       end
       z.prec = prec
       finalizer(_fmpz_mod_abs_series_clear_fn, z)

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -739,6 +739,12 @@ function zero!(z::fmpq_abs_series)
    return z
 end
 
+function fit!(z::fmpq_abs_series, n::Int)
+   ccall((:fmpq_poly_fit_length, libflint), Nothing,
+                (Ref{fmpq_abs_series}, Int), z, n)
+   return nothing
+end
+
 function setcoeff!(z::fmpq_abs_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                 (Ref{fmpq_abs_series}, Int, Ref{fmpq}),

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -920,6 +920,12 @@ function zero!(z::fmpq_rel_series)
    return z
 end
 
+function fit!(z::fmpq_rel_series, n::Int)
+   ccall((:fmpq_poly_fit_length, libflint), Nothing,
+                 (Ref{fmpq_rel_series}, Int), z, n)
+   return nothing
+end
+
 function setcoeff!(z::fmpq_rel_series, n::Int, x::fmpq)
    ccall((:fmpq_poly_set_coeff_fmpq, libflint), Nothing,
                 (Ref{fmpq_rel_series}, Int, Ref{fmpq}),

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -488,6 +488,12 @@ function zero!(z::fmpz_abs_series)
    return z
 end
 
+function fit!(z::fmpz_abs_series, n::Int)
+   ccall((:fmpz_poly_fit_length, libflint), Nothing,
+                 (Ref{fmpz_abs_series}, Int), z, n)
+   return nothing
+end
+
 function setcoeff!(z::fmpz_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_abs_series}, Int, Ref{fmpz}),

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -523,11 +523,22 @@ function zero!(z::fmpz_mod_abs_series)
    return z
 end
 
+function fit!(z::fmpz_mod_abs_series, n::Int)
+   ccall((:fmpz_mod_poly_fit_length, libflint), Nothing,
+         (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz_mod_ctx_struct}),
+	 z, n, z.parent.base_ring.ninv)
+   return nothing
+end
+
 function setcoeff!(z::fmpz_mod_abs_series, n::Int, x::fmpz)
    ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
          (Ref{fmpz_mod_abs_series}, Int, Ref{fmpz}, Ref{fmpz_mod_ctx_struct}),
          z, n, x, z.parent.base_ring.ninv)
    return z
+end
+
+function setcoeff!(z::fmpz_mod_abs_series, n::Int, x::fmpz_mod)
+   return setcoeff!(z, n, data(x))
 end
 
 function mul!(z::fmpz_mod_abs_series, a::fmpz_mod_abs_series, b::fmpz_mod_abs_series)

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -564,6 +564,12 @@ function zero!(x::fmpz_rel_series)
   return x
 end
 
+function fit!(z::fmpz_rel_series, n::Int)
+   ccall((:fmpz_poly_fit_length, libflint), Nothing,
+                 (Ref{fmpz_rel_series}, Int), z, n)
+   return nothing
+end
+
 function setcoeff!(z::fmpz_rel_series, n::Int, x::fmpz)
    ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
                 (Ref{fmpz_rel_series}, Int, Ref{fmpz}),

--- a/test/flint/fmpq_abs_series-test.jl
+++ b/test/flint/fmpq_abs_series-test.jl
@@ -313,6 +313,16 @@ end
    @test inv(b) == -1
 end
 
+@testset "fmpq_abs_series.integral_derivative" begin
+   R, x = PowerSeriesRing(QQ, 10, "x"; model=:capped_absolute)
+
+   for iter = 1:100
+      f = rand(R, 0:0, -10:10)
+
+      @test integral(derivative(f)) == f - coeff(f, 0)
+   end
+end
+
 @testset "fmpq_abs_series.special" begin
    R, x = PowerSeriesRing(QQ, 30, "x", model=:capped_absolute)
 

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -391,6 +391,16 @@ end
    @test inv(b) == -1
 end
 
+@testset "fmpq_rel_series.integral_derivative" begin
+   R, x = PowerSeriesRing(QQ, 10, "x")
+
+   for iter = 1:100
+      f = rand(R, 0:0, -10:10)
+
+      @test integral(derivative(f)) == f - coeff(f, 0)
+   end
+end
+
 @testset "fmpq_rel_series.special" begin
    R, x = PowerSeriesRing(QQ, 30, "x")
 

--- a/test/flint/fmpz_abs_series-test.jl
+++ b/test/flint/fmpz_abs_series-test.jl
@@ -241,6 +241,16 @@ end
    @test inv(b) == -1
 end
 
+@testset "fmpz_abs_series.integral_derivative" begin
+   R, x = PowerSeriesRing(ZZ, 10, "x"; model=:capped_absolute)
+
+   for iter = 1:100
+      f = rand(R, 0:0, -10:10)
+
+      @test integral(derivative(f)) == f - coeff(f, 0)
+   end
+end
+
 @testset "fmpz_abs_series.square_root" begin
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
 

--- a/test/flint/fmpz_mod_abs_series-test.jl
+++ b/test/flint/fmpz_mod_abs_series-test.jl
@@ -253,3 +253,14 @@ end
 
    @test inv(b) == -1
 end
+
+@testset "fmpz_mod_abs_series.integral_derivative" begin
+   S = ResidueRing(ZZ, ZZ(31))
+   R, x = PowerSeriesRing(S, 10, "x"; model=:capped_absolute)
+
+   for iter = 1:100
+      f = rand(R, 0:0, -10:10)
+
+      @test integral(derivative(f)) == f - coeff(f, 0)
+   end
+end

--- a/test/flint/fmpz_rel_series-test.jl
+++ b/test/flint/fmpz_rel_series-test.jl
@@ -358,6 +358,16 @@ end
    @test inv(b) == -1
 end
 
+@testset "fmpz_rel_series.integral_derivative" begin
+   R, x = PowerSeriesRing(ZZ, 10, "x")
+
+   for iter = 1:100
+      f = rand(R, 0:0, -10:10)
+
+      @test integral(derivative(f)) == f - coeff(f, 0)
+   end
+end
+]
 @testset "fmpz_rel_series.square_root" begin
    R, x = PowerSeriesRing(ZZ, 30, "x")
 

--- a/test/flint/fmpz_rel_series-test.jl
+++ b/test/flint/fmpz_rel_series-test.jl
@@ -367,7 +367,7 @@ end
       @test integral(derivative(f)) == f - coeff(f, 0)
    end
 end
-]
+
 @testset "fmpz_rel_series.square_root" begin
    R, x = PowerSeriesRing(ZZ, 30, "x")
 


### PR DESCRIPTION
As the Series Ring Interface says these functions should be provided by series, I have added them for all the Flint series types where they were missing.

Indeed derivative called these functions, hence the added tests to make sure the new code works.