### PR TITLE
Add test for unsafe fmpz methods

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1867,11 +1867,13 @@ function mul!(z::fmpz, x::fmpz, y::fmpz)
    return z
 end
 
-function addmul!(z::fmpz, x::fmpz, y::fmpz, c::fmpz)
+function addmul!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_addmul, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
+
+addmul!(z::fmpz, x::fmpz, y::fmpz, ::fmpz) = addmul!(z, x, y)
 
 function addeq!(z::fmpz, x::fmpz)
    ccall((:fmpz_add, libflint), Nothing,

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -566,6 +566,30 @@ end
    @test_throws DomainError clrbit!(a, -1)
 end
 
+@testset "fmpz.unsafe" begin
+  a = fmpz(32)
+  b = fmpz(23)
+  c = one(FlintZZ)
+  b_copy = deepcopy(b)
+  c_copy = deepcopy(c)
+
+  zero!(a)
+  @test iszero(a)
+  mul!(a, a, b)
+  @test iszero(a)
+  add!(a, a, b)
+  @test a == b
+  addeq!(a, b^2)
+  @test a == b + b^2
+  mul!(a, a, b)
+  @test a == (b + b^2) * b
+  addmul!(a, a, c)
+  @test a == 2 * (b + b^2) * b
+
+  @test b_copy == b
+  @test c_copy == c
+end
+
 @testset "fmpz.bases" begin
    a = fmpz(12)
 


### PR DESCRIPTION
Also remove unused input for `addmul!`.

Edit: One might consider this change in `addmul!` breaking.