### PR TITLE
Fix link to documentation: latest -> dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nemo
 
-[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://nemocas.github.io/Nemo.jl/latest)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://nemocas.github.io/Nemo.jl/dev)
 [![Build status](https://ci.appveyor.com/api/projects/status/gc4mw5oixputntda/branch/master?svg=true)](https://ci.appveyor.com/project/thofma/nemo-jl-n5gdb/branch/master)
 [![Build Status](https://github.com/Nemocas/Nemo.jl/workflows/Run%20tests/badge.svg)](https://github.com/Nemocas/Nemo.jl/actions?query=workflow%3A%22Run%20tests%22+branch%3Amaster)
 [![Codecov](https://codecov.io/github/Nemocas/Nemo.jl/coverage.svg?branch=master&token=)](https://codecov.io/gh/Nemocas/Nemo.jl)
@@ -12,7 +12,7 @@ It is currently developed by William Hart, Tommy Hofmann, Fredrik Johansson and
 Claus Fieker with contributions from others.
 
 - <https://nemocas.org> (Website)
-- <https://nemocas.github.io/Nemo.jl/latest/> (Online documentation)
+- <https://nemocas.github.io/Nemo.jl/dev/> (Online documentation)
 
 The official Nemo repository is at:
 


### PR DESCRIPTION
Also the [website](https://nemocas.org/docs.html) points to the old version of the documentation.  I don't know if in general you'd prefer to point to the stable version instead.