### PR TITLE
Add "argument" to the description of angle(::acb)

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -741,8 +741,8 @@ end
 @doc Markdown.doc"""
     angle(x::acb)
 
-Return the angle in radians that the complex vector $x$ makes with the
-positive real axis in a counterclockwise direction.
+Return argument of $x$, the angle in radians that the complex vector $x$
+makes with the positive real axis in a counterclockwise direction.
 """
 function angle(x::acb)
   z = arb()

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -741,8 +741,10 @@ end
 @doc Markdown.doc"""
     angle(x::acb)
 
-Return argument of $x$, the angle in radians that the complex vector $x$
-makes with the positive real axis in a counterclockwise direction.
+Return complex argument of $x$, the angle in radians that the complex vector $x$
+makes with the positive real axis in a counterclockwise direction. It has a
+discontinuity on the non-positive real axis, with the special values
+$\arg(0) = 0$ and $\arg(a + 0 i) = \pi$ for $a < 0$.
 """
 function angle(x::acb)
   z = arb()


### PR DESCRIPTION
Thought Nemo didn't have the complex argument for a second since it wasn't searchable.