### PR TITLE
Add randm

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -472,6 +472,10 @@ combit!(a, 2)
 ### Random generation
 
 ```@docs
+randm(::fmpz)
+```
+
+```@docs
 rand_bits(::FlintIntegerRing, ::Int)
 ```
 
@@ -481,6 +485,12 @@ rand_bits_prime(::FlintIntegerRing, ::Int, ::Bool)
 
 **Examples**
 
+For random generation of `fmpz`, one can also use the standard function `rand`
+for generating uniformly distributed random numbers, like
+```julia
+a = rand(ZZ(0):ZZ(100))
+```
+which generates a number in the interval $[0, 100]$. Other examples include:
 ```julia
 a = rand_bits(ZZ, 23)
 b = rand_bits_prime(ZZ, 7)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -43,7 +43,7 @@ export fmpz, FlintZZ, FlintIntegerRing, parent, show, convert, hash,
        euler_phi, fibonacci, moebius_mu, primorial, rising_factorial,
        number_of_partitions, canonical_unit, isunit, isequal, addeq!, mul!,
        issquare, square_root, issquare_with_square_root,
-       iszero, rand, rand_bits, binomial, factorial, rand_bits_prime
+       iszero, rand, rand_bits, binomial, factorial, rand_bits_prime, randm
 
 ###############################################################################
 #
@@ -1974,6 +1974,19 @@ function rand_bits_prime(::FlintIntegerRing, n::Int, proved::Bool = true)
    ccall((:fmpz_randprime, libflint), Nothing,
 	 (Ref{fmpz}, Ptr{Cvoid}, Int, Cint),
 	  z, _flint_rand_states[Threads.threadid()].ptr, n, Cint(proved))
+   return z
+end
+
+@doc Markdown.doc"""
+    randm(a::fmpz)
+
+Return uniformly distributed random number in the range 0 to $a$, where $a$
+also can be negative.
+"""
+function randm(a::fmpz)
+   z = fmpz()
+   ccall((:fmpz_randm, libflint), Nothing,(Ref{fmpz}, Ptr{Cvoid}, Ref{fmpz}),
+         z, _flint_rand_states[Threads.threadid()].ptr, a)
    return z
 end
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -72,7 +72,7 @@ end
       @test abs(sa - saideal) < .04 * saideal
    end
 
-   in a range
+   # in a range
    for e in [0, 1, 2, 3, 32, 64, 65, 100, 129, 500]
       for b in [fmpz(2) .^ e ; fmpz(2) .^ e .+ e;]
          for r in [fmpz(1):fmpz(1):b, fmpz(3):fmpz(1):b, fmpz(1):fmpz(3):b]

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -51,7 +51,28 @@ end
    @test_throws DomainError rand_bits_prime(FlintZZ, 0)
    @test_throws DomainError rand_bits_prime(FlintZZ, 1)
 
-   # in a range
+   nn = 10000
+   RR = RealField(100)
+   for ia in ["-14627818", "-723", "-23", "2", "3", "71",
+              "1982", "112312321123928416"]
+      a = FlintZZ(ia)
+      ma, sa = RR(0), RR(0)
+      maideal = (RR(abs(a)) - 1) / 2
+      saideal = (RR(a)^2 - 1) / 12
+      for _ in 1:nn
+         xa = randm(a)
+         ma += RR(xa)
+         sa += (xa - sign(a) * maideal)^2
+      end
+      ma /= nn
+      sa /= nn
+      # 3% deviation from ideal mean
+      # 4% deviation from ideal variance
+      @test abs(ma - sign(a) * maideal) < .03 * maideal
+      @test abs(sa - saideal) < .04 * saideal
+   end
+
+   in a range
    for e in [0, 1, 2, 3, 32, 64, 65, 100, 129, 500]
       for b in [fmpz(2) .^ e ; fmpz(2) .^ e .+ e;]
          for r in [fmpz(1):fmpz(1):b, fmpz(3):fmpz(1):b, fmpz(1):fmpz(3):b]


### PR DESCRIPTION
Perhaps there is a reason why `fmpz_randm` hasn't been implemented in Nemo yet. I'm adding this because if speed is a priority, one might want to use this instead. Testing it with these functions
```julia
function test_randm_small(n::Int)
  a = ZZ(1237)
  for _ in 1:n
    x = randm(a)
  end
end

function test_randm_big(n::Int)
  a = ZZ("817239871628937618927369871629837691826192383")
  for _ in 1:n
    x = randm(a)
  end
end

function test_rand_small(n::Int)
  a = ZZ(1237)
  for _ in 1:n
    x = rand(ZZ(0):a-1)
  end
end

function test_rand_big(n::Int)
  a = ZZ("817239871628937618927369871629837691826192383")
  for _ in 1:n
    x = rand(ZZ(0):a-1)
  end
end
```
gives the output
```
julia> @time test_randm_small(10000000)
  0.682515 seconds (10.00 M allocations: 152.669 MiB, 32.76% gc time, 0.34% compilation time)

julia> @time test_randm_small(10000000)
  0.826861 seconds (10.00 M allocations: 152.588 MiB, 39.23% gc time)

julia> @time test_rand_small(10000000)
 13.600023 seconds (169.99 M allocations: 2.384 GiB, 36.25% gc time)

julia> @time test_rand_small(10000000)
 14.109840 seconds (169.99 M allocations: 2.384 GiB, 36.71% gc time)

julia> @time test_randm_big(10000000)
  2.912013 seconds (19.19 M allocations: 396.901 MiB, 25.30% gc time)

julia> @time test_randm_big(10000000)
  2.078919 seconds (12.98 M allocations: 210.958 MiB, 17.57% gc time)

julia> @time test_rand_big(10000000)
 22.631186 seconds (193.91 M allocations: 2.836 GiB, 22.53% gc time)
```