### PR TITLE
Add lower and regularized gamma function

### DIFF
--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -651,6 +651,18 @@ gamma(::acb, ::acb)
 ```
 
 ```@docs
+gamma_regularized(::acb, ::acb)
+```
+
+```@docs
+gamma_lower(::acb, ::acb)
+```
+
+```@docs
+gamma_lower_regularized(::acb, ::acb)
+```
+
+```@docs
 besselj(::acb, ::acb)
 ```
 

--- a/docs/src/arb.md
+++ b/docs/src/arb.md
@@ -554,6 +554,22 @@ digamma(::arb)
 ```
 
 ```@docs
+gamma(::arb, ::arb)
+```
+
+```@docs
+gamma_regularized(::arb, ::arb)
+```
+
+```@docs
+gamma_lower(::arb, ::arb)
+```
+
+```@docs
+gamma_lower_regularized(::arb, ::arb)
+```
+
+```@docs
 zeta(::arb)
 ```
 

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -24,7 +24,10 @@ export rsqrt, log, log1p, exppii, sin, cos, tan, cot,
        modular_delta, modular_eta, modular_eisenstein_g, modular_j,
        modular_lambda, modular_weber_f, modular_weber_f1, modular_weber_f2,
        ellipwp, ellipk, ellipe,
-       canonical_unit, root_of_unity
+       canonical_unit, root_of_unity,
+       gamma_regularized, gamma_lower, gamma_lower_regularized
+       # These last three should be moved up to `gamma`.
+       # Temporarily here to ease the conflict later with the renaming merge.
 
 ###############################################################################
 #
@@ -1492,7 +1495,45 @@ Return the upper incomplete gamma function $\Gamma(s,x)$.
 function gamma(s::acb, x::acb)
   z = parent(s)()
   ccall((:acb_hypgeom_gamma_upper, libarb), Nothing,
-              (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 0, parent(s).prec)
+        (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 0, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_regularized(s::acb, x::acb)
+
+Return the regularized upper incomplete gamma function
+$\Gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_regularized(s::acb, x::acb)
+  z = parent(s)()
+  ccall((:acb_hypgeom_gamma_upper, libarb), Nothing,
+        (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 1, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_lower(s::acb, x::acb)
+
+Return the lower incomplete gamma function $\gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_lower(s::acb, x::acb)
+  z = parent(s)()
+  ccall((:acb_hypgeom_gamma_lower, libarb), Nothing,
+        (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 0, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_lower_regularized(s::acb, x::acb)
+
+Return the regularized lower incomplete gamma function
+$\gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_lower_regularized(s::acb, x::acb)
+  z = parent(s)()
+  ccall((:acb_hypgeom_gamma_lower, libarb), Nothing,
+        (Ref{acb}, Ref{acb}, Ref{acb}, Int, Int), z, s, x, 1, parent(s).prec)
   return z
 end
 

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -23,7 +23,10 @@ export ball, radius, midpoint, contains, contains_zero,
        sincos, sincospi, sinhcosh, atan2,
        agm, fac, binomial, fib, bernoulli, risingfac, risingfac2, polylog,
        chebyshev_t, chebyshev_t2, chebyshev_u, chebyshev_u2, bell, numpart,
-       lindep, canonical_unit, simplest_rational_inside
+       lindep, canonical_unit, simplest_rational_inside,
+       gamma_regularized, gamma_lower, gamma_lower_regularized
+       # These last three should be moved up to `gamma`.
+       # Temporarily here to ease the conflict later with the renaming merge.
 
 ###############################################################################
 #
@@ -1512,6 +1515,57 @@ function digamma(x::arb)
    ccall((:arb_digamma, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z
 end
+
+@doc Markdown.doc"""
+    gamma(s::arb, x::arb)
+
+Return the upper incomplete gamma function $\Gamma(s,x)$.
+"""
+function gamma(s::arb, x::arb)
+  z = parent(s)()
+  ccall((:arb_hypgeom_gamma_upper, libarb), Nothing,
+        (Ref{arb}, Ref{arb}, Ref{arb}, Int, Int), z, s, x, 0, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_regularized(s::arb, x::arb)
+
+Return the regularized upper incomplete gamma function
+$\Gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_regularized(s::arb, x::arb)
+  z = parent(s)()
+  ccall((:arb_hypgeom_gamma_upper, libarb), Nothing,
+        (Ref{arb}, Ref{arb}, Ref{arb}, Int, Int), z, s, x, 1, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_lower(s::arb, x::arb)
+
+Return the lower incomplete gamma function $\gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_lower(s::arb, x::arb)
+  z = parent(s)()
+  ccall((:arb_hypgeom_gamma_lower, libarb), Nothing,
+        (Ref{arb}, Ref{arb}, Ref{arb}, Int, Int), z, s, x, 0, parent(s).prec)
+  return z
+end
+
+@doc Markdown.doc"""
+    gamma_lower_regularized(s::arb, x::arb)
+
+Return the regularized lower incomplete gamma function
+$\gamma(s,x) / \Gamma(s)$.
+"""
+function gamma_lower_regularized(s::arb, x::arb)
+  z = parent(s)()
+  ccall((:arb_hypgeom_gamma_lower, libarb), Nothing,
+        (Ref{arb}, Ref{arb}, Ref{arb}, Int, Int), z, s, x, 1, parent(s).prec)
+  return z
+end
+
 
 @doc Markdown.doc"""
     zeta(x::arb)

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -354,6 +354,9 @@ end
                               "-1.34436596014834977342501 +/- 2.02e-24"))
    @test overlaps(gamma(a,z), CC("0.52015862665033430896480 +/- 6.25e-24",
                               "-0.45171359572912367448392 +/- 5.94e-24"))
+   @test overlaps(gamma_regularized(a,z), gamma(a,z) / gamma(a))
+   @test overlaps(gamma_lower(a,z), gamma(a) - gamma(a,z))
+   @test overlaps(gamma_lower_regularized(a,z), gamma_lower(a,z) / gamma(a))
    @test overlaps(besselj(a,z), CC("0.46117305056699182297843 +/- 5.61e-24",
                               "-0.172953644007776862353437 +/- 6.92e-25"))
    @test overlaps(bessely(a,z), CC("-1.18656154996325105251999 +/- 4.72e-24",

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -330,6 +330,10 @@ end
    @test overlaps(lgamma(x), RR("0.760991283500573821902224 +/- 5.01e-25"))
    @test overlaps(rgamma(x), RR("0.467203066695702292350541 +/- 3.65e-25"))
    @test overlaps(digamma(x), RR("-2.46112318864250355875288 +/- 2.51e-24"))
+   @test overlaps(gamma(x,y), RR("0.390850361255613677231063 +/- 4.29e-25"))
+   @test overlaps(gamma_regularized(x,y), gamma(x,y) / gamma(x))
+   @test overlaps(gamma_lower(x,y), gamma(x) - gamma(x,y))
+   @test overlaps(gamma_lower_regularized(x,y), gamma_lower(x,y) / gamma(x))
    @test overlaps(zeta(x), RR("-1.17412759881491813598600 +/- 5.46e-24"))
 
    a, b = sincos(x)


### PR DESCRIPTION
Edit: Added for `arb` as well, which includes the non-regularized upper incomplete gamma function.