### PR TITLE
Use Flint's gcdx

### DIFF
--- a/benchmarks/gcdx.jl
+++ b/benchmarks/gcdx.jl
@@ -1,0 +1,62 @@
+function gcdx_bigint(a::fmpz, b::fmpz)
+  g, s, t = gcdx(BigInt(a), BigInt(b))
+  return fmpz(g), fmpz(s), fmpz(t)
+end
+
+function gcdx_fmpz(a::fmpz, b::fmpz)
+  d = ZZ()
+  x = ZZ()
+  y = ZZ()
+  ccall((:fmpz_xgcd_canonical_bezout, :libflint), Nothing,
+        (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), d, x, y, a, b)
+  return d, x, y
+end
+
+function run_gcdx_bigint(x::Vector{fmpz}, y::Vector{fmpz})
+  for ix in x, iy in y
+    gcdx_bigint(ix, iy)
+  end
+end
+    
+function run_gcdx_fmpz(x::Vector{fmpz}, y::Vector{fmpz})
+  for ix in x, iy in y
+    gcdx_fmpz(ix, iy)
+  end
+end
+
+function benchmark_gcdx()
+  print("benchmark_gcdx ...\n")
+
+  # small size
+  sp = Random.Sampler(Random.MersenneTwister(),
+                      ZZ(0):ZZ(2)^(Sys.WORD_SIZE - 2) - 1)
+  x = [rand(sp) for _ in 1:100]
+  y = [rand(sp) for _ in 1:100]
+
+  tt = @elapsed run_gcdx_bigint(x, y)
+  println("Small sized integers for BigInt-solution: $tt")
+  tt = @elapsed run_gcdx_fmpz(x, y)
+  println("Small sized integers for fmpz-solution:   $tt")
+
+  # mixed integers
+  sp = Random.Sampler(Random.MersenneTwister(),
+                      ZZ(0):ZZ(2)^Sys.WORD_SIZE)
+  x = [rand(sp) for _ in 1:100]
+  y = [rand(sp) for _ in 1:100]
+
+  tt = @elapsed run_gcdx_bigint(x, y)
+  println("Mixed sized integers for BigInt-solution: $tt")
+  tt = @elapsed run_gcdx_fmpz(x, y)
+  println("Mixed sized integers for fmpz-solution:   $tt")
+
+  # big integers
+  sp = Random.Sampler(Random.MersenneTwister(),
+                      ZZ(0):ZZ(2)^512)
+  x = [rand(sp) for _ in 1:100]
+  y = [rand(sp) for _ in 1:100]
+
+  tt = @elapsed run_gcdx_bigint(x, y)
+  println("Large sized integers for BigInt-solution: $tt")
+  tt = @elapsed run_gcdx_fmpz(x, y)
+  println("Large sized integers for fmpz-solution:   $tt")
+end

--- a/benchmarks/gcdx.jl
+++ b/benchmarks/gcdx.jl
@@ -28,10 +28,9 @@ function benchmark_gcdx()
   print("benchmark_gcdx ...\n")
 
   # small size
-  sp = Random.Sampler(Random.MersenneTwister(),
-                      ZZ(0):ZZ(2)^(Sys.WORD_SIZE - 2) - 1)
-  x = [rand(sp) for _ in 1:100]
-  y = [rand(sp) for _ in 1:100]
+  range = ZZ(0):ZZ(2)^(Sys.WORD_SIZE - 2) - 1
+  x = [rand(range) for _ in 1:100]
+  y = [rand(range) for _ in 1:100]
 
   tt = @elapsed run_gcdx_bigint(x, y)
   println("Small sized integers for BigInt-solution: $tt")
@@ -39,10 +38,9 @@ function benchmark_gcdx()
   println("Small sized integers for fmpz-solution:   $tt")
 
   # mixed integers
-  sp = Random.Sampler(Random.MersenneTwister(),
-                      ZZ(0):ZZ(2)^Sys.WORD_SIZE)
-  x = [rand(sp) for _ in 1:100]
-  y = [rand(sp) for _ in 1:100]
+  range = ZZ(0):ZZ(2)^Sys.WORD_SIZE
+  x = [rand(range) for _ in 1:100]
+  y = [rand(range) for _ in 1:100]
 
   tt = @elapsed run_gcdx_bigint(x, y)
   println("Mixed sized integers for BigInt-solution: $tt")
@@ -50,10 +48,9 @@ function benchmark_gcdx()
   println("Mixed sized integers for fmpz-solution:   $tt")
 
   # big integers
-  sp = Random.Sampler(Random.MersenneTwister(),
-                      ZZ(0):ZZ(2)^512)
-  x = [rand(sp) for _ in 1:100]
-  y = [rand(sp) for _ in 1:100]
+  range = ZZ(0):ZZ(2)^512
+  x = [rand(range) for _ in 1:100]
+  y = [rand(range) for _ in 1:100]
 
   tt = @elapsed run_gcdx_bigint(x, y)
   println("Large sized integers for BigInt-solution: $tt")

--- a/benchmarks/gcdx.jl
+++ b/benchmarks/gcdx.jl
@@ -7,7 +7,7 @@ function gcdx_fmpz(a::fmpz, b::fmpz)
   d = ZZ()
   x = ZZ()
   y = ZZ()
-  ccall((:fmpz_xgcd_canonical_bezout, :libflint), Nothing,
+  ccall((:fmpz_xgcd_canonical_bezout, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), d, x, y, a, b)
   return d, x, y
 end

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -1,9 +1,13 @@
+using Nemo
+import Random
+
 include("bernoulli_polynomials.jl")
 include("charpoly_integers.jl")
 include("det_commutative_ring.jl")
 include("det_field.jl")
 include("det_polynomials.jl")
 include("fateman.jl")
+include("gcdx.jl")
 include("minpoly_integers.jl")
 include("minpoly_finite_field.jl")
 include("minpoly_gcd_domain.jl")
@@ -14,6 +18,7 @@ include("solve_polynomials.jl")
 
 function benchmark_all()
    benchmark_fateman()
+   benchmark_gcdx()
    benchmark_pearce()
    benchmark_resultant()
    benchmark_poly_nf_elem()

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1056,7 +1056,7 @@ function gcdx(a::fmpz, b::fmpz)
   d = FlintZZ()
   x = FlintZZ()
   y = FlintZZ()
-  ccall((:fmpz_xgcd_canonical_bezout, :libflint), Nothing,
+  ccall((:fmpz_xgcd_canonical_bezout, libflint), Nothing,
         (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), d, x, y, a, b)
   return d, x, y
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1050,8 +1050,15 @@ Return a tuple $g, s, t$ such that $g$ is the greatest common divisor of $a$
 and $b$ and integers $s$ and $t$ such that $g = as + bt$.
 """
 function gcdx(a::fmpz, b::fmpz)
-   g, s, t = gcdx(BigInt(a), BigInt(b))
-   return fmpz(g), fmpz(s), fmpz(t)
+  # Just to conform with Julia's definition
+  a == b == 0 && return zero(FlintZZ), one(FlintZZ), zero(FlintZZ)
+
+  d = FlintZZ()
+  x = FlintZZ()
+  y = FlintZZ()
+  ccall((:fmpz_xgcd_canonical_bezout, :libflint), Nothing,
+        (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), d, x, y, a, b)
+  return d, x, y
 end
 
 @doc Markdown.doc"""


### PR DESCRIPTION
It is faster, which can be seen from the benchmarks (around twice as fast for small `fmpz`).

I have defined `gcdx(0, 0) == (0, 1, 0)` in order to conform with Julia's definition.

Will remove draft when FLINT_jll gets updated.

Edit: Resolves #921 