### PR TITLE
Define and test lift for Z/nZ and GF(p) types.

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -37,6 +37,8 @@ function Base.hash(a::fmpz_mod, h::UInt)
    return xor(xor(hash(a.data), h), b)
 end
 
+lift(a::fmpz_mod) = data(a)
+
 function zero(R::FmpzModRing)
    return fmpz_mod(fmpz(0), R)
 end

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -41,6 +41,8 @@ end
 
 data(a::gfp_elem) = a.data
 
+lift(a::gfp_elem) = fmpz(data(a))
+
 function zero(R::GaloisField)
    return gfp_elem(UInt(0), R)
 end

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -41,6 +41,8 @@ end
 
 data(a::gfp_fmpz_elem) = a.data
 
+lift(a::gfp_fmpz_elem) = data(a)
+
 iszero(a::gfp_fmpz_elem) = a.data == 0
 
 isone(a::gfp_fmpz_elem) = a.data == 1

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -37,6 +37,8 @@ function Base.hash(a::nmod, h::UInt)
    return xor(xor(hash(a.data), h), b)
 end
 
+lift(a::nmod) = fmpz(data(a))
+
 function zero(R::NmodRing)
    return nmod(UInt(0), R)
 end

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -78,6 +78,10 @@ end
    @test isunit(S())
 
    @test characteristic(R) == 13
+
+   @test data(R(3)) == 3
+   @test lift(R(3)) == 3
+   @test isa(lift(R(3)), fmpz)
 end
 
 @testset "fmpz_mod.unary_ops" begin

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -94,6 +94,10 @@ end
 
    @test characteristic(R) == 13
    @test degree(R) == 1
+
+   @test data(R(3)) == 3
+   @test lift(R(3)) == 3
+   @test isa(lift(R(3)), fmpz)
 end
 
 @testset "gfp.unary_ops" begin

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -91,6 +91,10 @@ end
    @test characteristic(R) == 13
 
    @test degree(R) == 1
+
+   @test data(R(3)) == 3
+   @test lift(R(3)) == 3
+   @test isa(lift(R(3)), fmpz)
 end
 
 @testset "gfp_fmpz.unary_ops" begin

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -78,6 +78,10 @@ end
    @test isunit(S())
 
    @test characteristic(S) == 1
+
+   @test data(R(3)) == 3
+   @test lift(R(3)) == 3
+   @test isa(lift(R(3)), fmpz)
 end
 
 @testset "nmod.unary_ops" begin


### PR DESCRIPTION
Fixes #1069 

I will document these in AbstractAlgebra after defining a generic fallback version there.