### PR TITLE
Add basic Airy function bindings

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -12,7 +12,8 @@ import Base: real, imag, abs, conj, angle, log, log1p, sin, cos,
 
 
 export one, onei, real, imag, conj, abs, inv, angle, isreal, polygamma, erf,
-       erfi, erfc, bessel_j, bessel_k, bessel_i, bessel_y
+       erfi, erfc, bessel_j, bessel_k, bessel_i, bessel_y, airy_ai, airy_bi,
+       airy_ai_prime, airy_bi_prime
 
 export rsqrt, log, log1p, exppii, sin, cos, tan, cot, sinpi, cospi, tanpi,
        cotpi, sincos, sincospi, sinh, cosh, tanh, coth, sinhcosh, atan,
@@ -1580,6 +1581,58 @@ function bessel_k(nu::acb, x::acb)
   ccall((:acb_hypgeom_bessel_k, libarb), Nothing,
               (Ref{acb}, Ref{acb}, Ref{acb}, Int), z, nu, x, parent(x).prec)
   return z
+end
+
+@doc Markdown.doc"""
+    airy_ai(x::acb)
+
+Return the Airy function $\operatorname{Ai}$ evaluated at $x$.
+"""
+function airy_ai(x::acb)
+  ai = parent(x)()
+  ccall((:acb_hypgeom_airy, libarb), Nothing,
+              (Ref{acb}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{acb}, Int),
+              ai, C_NULL, C_NULL, C_NULL, x, parent(x).prec)
+  return ai
+end
+
+@doc Markdown.doc"""
+    airy_bi(x::acb)
+
+Return the Airy function $\operatorname{Bi}$ evaluated at $x$.
+"""
+function airy_bi(x::acb)
+  bi = parent(x)()
+  ccall((:acb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ptr{Cvoid}, Ref{acb}, Ptr{Cvoid}, Ref{acb}, Int),
+              C_NULL, C_NULL, bi, C_NULL, x, parent(x).prec)
+  return bi
+end
+
+@doc Markdown.doc"""
+    airy_ai_prime(x::acb)
+
+Return the derivative of the Airy function $\operatorname{Ai}$ evaluated at $x$.
+"""
+function airy_ai_prime(x::acb)
+  ai_prime = parent(x)()
+  ccall((:acb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ref{acb}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{acb}, Int),
+              C_NULL, ai_prime, C_NULL, C_NULL, x, parent(x).prec)
+  return ai_prime
+end
+
+@doc Markdown.doc"""
+    airy_bi_prime(x::acb)
+
+Return the derivative of the Airy function $\operatorname{Bi}$ evaluated at $x$.
+"""
+function airy_bi_prime(x::acb)
+  bi_prime = parent(x)()
+  ccall((:acb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{acb}, Ref{acb}, Int),
+              C_NULL, C_NULL, C_NULL, bi_prime, x, parent(x).prec)
+  return bi_prime
 end
 
 @doc Markdown.doc"""

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -22,8 +22,8 @@ export ball, radius, midpoint, contains, contains_zero, contains_negative,
        gamma_lower_regularized, zeta, sincos, sincospi, sinhcosh, atan2, agm,
        factorial, binomial, fibonacci, bernoulli, rising_factorial,
        rising_factorial2, polylog, chebyshev_t, chebyshev_t2, chebyshev_u,
-       chebyshev_u2, bell, numpart, lindep, canonical_unit,
-       simplest_rational_inside
+       chebyshev_u2, bell, numpart, lindep, airy_ai, airy_bi, airy_ai_prime,
+       airy_bi_prime, canonical_unit, simplest_rational_inside
 
 ###############################################################################
 #
@@ -2001,6 +2001,64 @@ end
 Return the number of partitions $p(n)$ as an element of $r$.
 """
 numpart(n::Int, r::ArbField) = numpart(fmpz(n), r)
+
+################################################################################
+#
+#  Hypergeometric and related functions
+#
+################################################################################
+
+@doc Markdown.doc"""
+    airy_ai(x::arb)
+
+Return the Airy function $\operatorname{Ai}$ evaluated at $x$.
+"""
+function airy_ai(x::arb)
+  ai = parent(x)()
+  ccall((:arb_hypgeom_airy, libarb), Nothing,
+              (Ref{arb}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{arb}, Int),
+              ai, C_NULL, C_NULL, C_NULL, x, parent(x).prec)
+  return ai
+end
+
+@doc Markdown.doc"""
+    airy_bi(x::arb)
+
+Return the Airy function $\operatorname{Bi}$ evaluated at $x$.
+"""
+function airy_bi(x::arb)
+  bi = parent(x)()
+  ccall((:arb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ptr{Cvoid}, Ref{arb}, Ptr{Cvoid}, Ref{arb}, Int),
+              C_NULL, C_NULL, bi, C_NULL, x, parent(x).prec)
+  return bi
+end
+
+@doc Markdown.doc"""
+    airy_ai_prime(x::arb)
+
+Return the derivative of the Airy function $\operatorname{Ai}$ evaluated at $x$.
+"""
+function airy_ai_prime(x::arb)
+  ai_prime = parent(x)()
+  ccall((:arb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ref{arb}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{arb}, Int),
+              C_NULL, ai_prime, C_NULL, C_NULL, x, parent(x).prec)
+  return ai_prime
+end
+
+@doc Markdown.doc"""
+    airy_bi_prime(x::arb)
+
+Return the derivative of the Airy function $\operatorname{Bi}$ evaluated at $x$.
+"""
+function airy_bi_prime(x::arb)
+  bi_prime = parent(x)()
+  ccall((:arb_hypgeom_airy, libarb), Nothing,
+              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ref{arb}, Ref{arb}, Int),
+              C_NULL, C_NULL, C_NULL, bi_prime, x, parent(x).prec)
+  return bi_prime
+end
 
 ################################################################################
 #


### PR DESCRIPTION
Function names are provisional. I've run informal tests against the SpecialFunctions package, but I need guidance on how to write formal tests.

These bindings only compute individual Airy functions and derivatives. It might be nice to add more bindings that take advantage of Arb's simultaneous computation feature.

I don't know how to preview the new docstrings, so they may have Markdown or LaTeX errors.