### PR TITLE
Bump AA version and add missing ad hoc method.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "^0.18.0"
+AbstractAlgebra = "^0.19.0"
 Antic_jll = "~0.200.400"
 Arb_jll = "~200.1900.0"
 BinaryProvider = "0.4, 0.5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 
 [compat]
-AbstractAlgebra = "^0.18.0"
+AbstractAlgebra = "^0.19.0"
 Documenter = "~0.26"

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -541,6 +541,30 @@ function divexact(a::qqbar, b::Int)
    return z
 end
 
+function divexact(a::fmpq, b::qqbar)
+   iszero(b) && throw(DivideError())
+   z = qqbar()
+   ccall((:qqbar_fmpq_div, libcalcium), Nothing,
+         (Ref{qqbar}, Ref{fmpq}, Ref{qqbar}), z, a, b)
+   return z
+end
+
+function divexact(a::fmpz, b::qqbar)
+   iszero(b) && throw(DivideError())
+   z = qqbar()
+   ccall((:qqbar_fmpz_div, libcalcium), Nothing,
+         (Ref{qqbar}, Ref{fmpz}, Ref{qqbar}), z, a, b)
+   return z
+end
+
+function divexact(a::Int, b::qqbar)
+   iszero(b) && throw(DivideError())
+   z = qqbar()
+   ccall((:qqbar_si_div, libcalcium), Nothing,
+         (Ref{qqbar}, Int, Ref{qqbar}), z, a, b)
+   return z
+end
+
 //(a::qqbar, b::qqbar) = divexact(a, b)
 //(a::qqbar, b::fmpq) = divexact(a, b)
 //(a::qqbar, b::fmpz) = divexact(a, b)


### PR DESCRIPTION
@wbhart Yes, this is tested. It worked before because it was using the `else` branch of the following method:
```julia
function divexact(x::S, y::T) where {S <: RingElem, T <: RingElem}
   if S == promote_rule(S, T)
      divexact(x, parent(x)(y))
   else
      divexact(parent(y)(x), y)
   end
end
```