### PR TITLE
Clarify documentation on expm1

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -843,7 +843,7 @@ end
 @doc Markdown.doc"""
     expm1(x::acb)
 
-Return $\exp(x)-1$, evaluated accurately for small $x$.
+Return $\exp(x)-1$, using a more accurate method when $x \approx 0$.
 """
 function Base.expm1(x::acb)
    z = parent(x)()

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1262,7 +1262,7 @@ end
 @doc Markdown.doc"""
     expm1(x::arb)
 
-Return $\exp(x)-1$, evaluated accurately for small $x$.
+Return $\exp(x)-1$, using a more accurate method when $x \approx 0$.
 """
 function expm1(x::arb)
    z = parent(x)()


### PR DESCRIPTION
Instead of "evaluated accurately for small x", say "using an accurate
method when z approximately 0".

Related MR: https://github.com/fredrik-johansson/arb/pull/370