### PR TITLE
Adjust all Nemo links to AbstractAlgebra docs after docs rearrangement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "^0.19.0"
+AbstractAlgebra = "^0.20.0"
 Antic_jll = "~0.200.400"
 Arb_jll = "~200.1900.0"
 BinaryProvider = "0.4, 0.5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 
 [compat]
-AbstractAlgebra = "^0.19.0"
+AbstractAlgebra = "^0.20.0"
 Documenter = "~0.26"

--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -33,9 +33,9 @@ elements in this field, i.e. complex boxes in this case, belong to the
 
 ## Complex ball functionality
 
-The complex balls in Nemo implement the AbstractAlgebra.jl field interface.
+The complex balls in Nemo provide all the field functionality defined by AbstractAlgebra:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Below, we document the additional functionality provided for complex balls.
 

--- a/docs/src/arb.md
+++ b/docs/src/arb.md
@@ -33,9 +33,9 @@ abstract type.
 
 ## Real ball functionality
 
-Real balls in Nemo implement the full AbstractAlgebra.jl field interface.
+Real balls in Nemo provide all the field functionality described in AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Below, we document the additional functionality provided for real balls.
 

--- a/docs/src/finitefield.md
+++ b/docs/src/finitefield.md
@@ -44,11 +44,11 @@ provided for the `fq_nmod` finite field type, we simply document the former.
 
 ## Finite field functionality
 
-Finite fields in Nemo implement the entire AbstractAlgebra.jl field interface.
+Finite fields in Nemo provide all the field functionality described in AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
-Below we describe the functionality that is provided in addition to this interface.
+Below we describe the functionality that is provided in addition to this.
 
 ### Constructors
 

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -51,16 +51,15 @@ one to write generic functions that can accept any Nemo fraction type.
 
 ## Fraction functionality
 
-All fraction types in Nemo implement the AbstractAlgebra.jl fraction field interface:
+All fraction types in Nemo provide funtionality for fields described in
+AbstractAlgebra.jl:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fraction_fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
-In addition, generic fractions fields are implemented in AbstractAlgebra.jl, with the
-following functionality:
+In addition all the fraction field functionality of AbstractAlgebra.jl is provided,
+along with generic fractions fields as described here:
 
 <https://nemocas.github.io/AbstractAlgebra.jl/latest/fraction>
-
-All fraction types in Nemo also implement this generic functionality.
 
 ### Basic manipulation
 

--- a/docs/src/gfp.md
+++ b/docs/src/gfp.md
@@ -41,15 +41,15 @@ belong to the abstract type `FinField`.
 
 ## Galois field functionality
 
-Galois fields in Nemo implement the residue ring interface of AbstractAlgebra.jl:
-
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue_rings>
-
-In addition, all the functionality for generic residue rings is available:
+Galois fields in Nemo provide all the residue ring functionality of AbstractAlgebra.jl:
 
 <https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
 
-Below we describe the functionality that is provided in addition to this interface.
+In addition, all the functionality for rings is available:
+
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
+
+Below we describe the functionality that is provided in addition to these.
 
 ## Basic manipulation
 

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -29,12 +29,12 @@ all the integer ring parent object types belong to the abstract type `Ring`.
 
 ## Integer functionality
 
-Nemo integers implement the whole of the ring and Euclidean ring interfaces of
+Nemo integers provide all of the ring and Euclidean ring functionality of
 AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/rings>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean.>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Nemo/Flint integer ring.
 

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -36,20 +36,17 @@ one to write generic functions that can accept any Nemo matrix type.
 
 Note that the preferred way to create matrices is not to use the type
 constructors but to use the `matrix` function, see also the
-[Constructors](https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix_spaces/#Constructors)
+[Matrix element constructors](https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix_spaces/#Matrix-element-constructors)
 section of the AbstractAlgebra manual.
 
 ## Matrix functionality
 
-All matrix spaces in Nemo follow the AbstractAlgebra.jl matrix interface:
-
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix_spaces>
-
-In addition, AbstractAlgebra.jl provides a great deal of generic functionality for
-matrices. Some of this functionality is also provided by C libraries, such as Flint,
-for various specific rings.
+All matrix spaces in Nemo provide the matrix functionality of AbstractAlgebra:
 
 <https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix>
+
+Some of this functionality is provided in Nemo by C libraries, such as Flint,
+for various specific rings.
 
 In the following, we list the functionality which is provided in addition to the generic
 matrix functionality, for specific rings in Nemo.

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -39,15 +39,12 @@ one to write generic functions that can accept any Nemo multivariate polynomial 
 
 ## Polynomial functionality
 
-All multivariate polynomial types in Nemo follow the AbstractAlgebra.jl multivariate
-polynomial interface:
+All multivariate polynomial types in Nemo provide the multivariate polynomial
+functionality described by AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial_rings>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial>
 
-Generic multivariate polynomials are also available, and Nemo multivariate polynomial
-types also implement all of the same functionality.
-
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial>.
+Generic multivariate polynomials are also available.
 
 We describe here only functions that are in addition to that guaranteed by
 AbstractAlgebra.jl, for specific coefficient rings.

--- a/docs/src/numberfield.md
+++ b/docs/src/numberfield.md
@@ -38,9 +38,9 @@ element type, making the two libraries tightly integrated.
 
 ## Number field functionality
 
-The number fields in Nemo implement the full AbstractAlgebra.jl field interface.
+The number fields in Nemo provide all of the AbstractAlgebra field functionality:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Below, we document the additional functionality provided for number field elements.
 

--- a/docs/src/padic.md
+++ b/docs/src/padic.md
@@ -31,9 +31,9 @@ $p$-adic field element types belong to the `FieldElem` abstract type.
 
 ## P-adic functionality
 
-P-adic fields in Nemo implement the AbstractAlgebra.jl field interface.
+P-adic fields in Nemo implement all the AbstractAlgebra field functionality:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Below, we document all the additional function that is provide by Nemo for p-adic
 fields.

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -39,13 +39,12 @@ one to write generic functions that can accept any Nemo univariate polynomial ty
 
 ## Polynomial functionality
 
-All univariate polynomial types in Nemo follow the AbstractAlgebra.jl univariate
-polynomial interface:
+All univariate polynomial types in Nemo provide the AbstractAlgebra univariate
+polynomial functionality:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/polynomial_rings>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/polynomial>
 
-Generic polynomials are also available, and Nemo univariate polynomial types also
-implement all of the same functionality.
+Generic polynomials are also available.
 
 We describe here only functions that are in addition to that guaranteed by
 AbstractAlgebra.jl, for specific coefficient rings.

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -48,18 +48,16 @@ series in general in AbstractAlgebra.jl for details.
 
 ## Puiseux series functionality
 
-Puiseux series rings in Nemo implement the AbstractAlgebra.jl series interface, with the
-exception of the `pol_length` and `polcoeff` functions:
+Puiseux series rings in Nemo implement all the same functionality that is available for
+AbstractAlgebra series rings, with the exception of the `pol_length` and `polcoeff`
+functions:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/series_rings>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/series>
 
-In addition, generic Puiseux series are provided by AbstractAlgebra.jl:
+In addition, generic Puiseux series are provided by AbstractAlgebra.jl
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/puiseux.>
-
-Puiseux series rings in Nemo also implement this generic functionality. We list below only
-the functionality that differs from this generic functionality, for specific rings
-provided by Nemo.
+We list below only the functionality that differs from that described in AbstractAlgebra,
+for specific rings provided by Nemo.
 
 ### Special functions
 

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -32,11 +32,12 @@ $q$-adic field element types belong to the `FieldElem` abstract type.
 
 ## P-adic functionality
 
-Q-adic fields in Nemo implement the AbstractAlgebra.jl field interface.
+Q-adic fields in Nemo provide all the functionality described in AbstractAlgebra
+for fields:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fields>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
-Below, we document all the additional function that is provide by Nemo for p-adic
+Below, we document all the additional function that is provide by Nemo for q-adic
 fields.
 
 ### Constructors

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -33,15 +33,14 @@ This enables one to write generic functions that accept any Nemo residue type.
 
 ## Residue functionality
 
-All the residue rings in Nemo implement the residue ring interface of AbstractAlgebra.jl:
-
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue_rings>
-
-In addition, functionality for generic residue rings is available:
+All the residue rings in Nemo provide the functionality described in AbstractAlgebra
+for residue rings:
 
 <https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
 
-The other residue types in Nemo also implement this functionality.
+In addition, generic residue rings are available.
+
+We describe Nemo specific residue ring functionality below.
 
 ### GCD
 

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -145,17 +145,15 @@ very much like the quotient $R[x]/(x^p)$ of the polynomial ring over $R$.
 
 ## Power series functionality
 
-Power series rings in Nemo implement the AbstractAlgebra.jl series interface:
-
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/series_rings>
-
-In addition, generic power series and Laurent series are provided by AbstractAlgebra.jl:
+Power series rings in Nemo provide all the functionality described for power
+series in AbstractAlgebra:
 
 <https://nemocas.github.io/AbstractAlgebra.jl/latest/series>
 
-Power series rings in Nemo also implement this generic functionality. We list below only
-the functionality that differs from this generic functionality, for specific rings
-provided by Nemo.
+In addition, generic power series and Laurent series are provided by AbstractAlgebra.
+
+We list below only the functionality that is Nemo specific for power series
+rings.
 
 ### Special functions
 


### PR DESCRIPTION
This is the Nemo counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/pull/930

That PR has to be merged before these links will be valid.