### PR TITLE
Sqrt functions

### DIFF
--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -785,11 +785,11 @@ end
 # complex - complex functions
 
 @doc Markdown.doc"""
-    Base.sqrt(x::acb)
+    Base.sqrt(x::acb; check::Bool=true)
 
 Return the square root of $x$.
 """
-function Base.sqrt(x::acb)
+function Base.sqrt(x::acb; check::Bool=true)
    z = parent(x)()
    ccall((:acb_sqrt, libarb), Nothing, (Ref{acb}, Ref{acb}, Int), z, x, parent(x).prec)
    return z

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1181,11 +1181,11 @@ ceil(::Type{fmpz}, x::arb) = fmpz(ceil(x))
 ceil(::Type{T}, x::arb) where {T <: Integer} = T(ceil(x))
 
 @doc Markdown.doc"""
-    sqrt(x::arb)
+    sqrt(x::arb; check::Bool=true)
 
 Return the square root of $x$.
 """
-function Base.sqrt(x::arb)
+function Base.sqrt(x::arb; check::Bool=true)
    z = parent(x)()
    ccall((:arb_sqrt, libarb), Nothing, (Ref{arb}, Ref{arb}, Int), z, x, parent(x).prec)
    return z

--- a/src/calcium/ca.jl
+++ b/src/calcium/ca.jl
@@ -958,11 +958,11 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::ca)
+    Base.sqrt(a::ca; check::Bool=true)
 
 Return the principal square root of `a`.
 """
-function Base.sqrt(a::ca)
+function Base.sqrt(a::ca; check::Bool=true)
    C = a.parent
    r = C()
    ccall((:ca_sqrt, libcalcium), Nothing,

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -867,11 +867,11 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::qqbar)
+    sqrt(a::qqbar; check::Bool=true)
 
 Return the principal square root of `a`.
 """
-function sqrt(a::qqbar)
+function sqrt(a::qqbar; check::Bool=true)
    z = qqbar()
    ccall((:qqbar_sqrt, libcalcium),
         Nothing, (Ref{qqbar}, Ref{qqbar}), z, a)

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -506,17 +506,17 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
+    sqrt(a::FlintPuiseuxSeriesElem{T}; check::Bool=true) where T <: RingElem
 
 Return the square root of the given Puiseux series.
 """
-function sqrt(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
+function sqrt(a::FlintPuiseuxSeriesElem{T}; check::Bool=true) where T <: RingElem
    val = valuation(a.data)
    S = parent(a)
    if mod(val, 2) != 0
-      return S(sqrt(inflate(a.data, 2)), a.scale*2)
+      return S(sqrt(inflate(a.data, 2); check=check), a.scale*2)
    else
-      return S(sqrt(a.data), a.scale)
+      return S(sqrt(a.data; check=check), a.scale)
    end
 end
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -453,9 +453,9 @@ end
 #
 ###############################################################################
 
-function Base.sqrt(a::fmpq)
-    snum = sqrt(numerator(a))
-    sden = sqrt(denominator(a))
+function Base.sqrt(a::fmpq; check::Bool=true)
+    snum = sqrt(numerator(a); check=check)
+    sden = sqrt(denominator(a); check=check)
     return fmpq(snum, sden)
  end
 

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -750,12 +750,12 @@ function atanh(a::fmpq_abs_series)
 end
 
 @doc Markdown.doc"""
-    sqrt(a::fmpq_abs_series)
+    sqrt(a::fmpq_abs_series; check::Bool=true)
 
 Return the power series square root of $a$. Requires a constant term equal to
 one.
 """
-function Base.sqrt(a::fmpq_abs_series)
+function Base.sqrt(a::fmpq_abs_series; check::Bool=true)
    !isone(coeff(a, 0)) && error("Constant term not one in sqrt")
    z = parent(a)()
    z.prec = a.prec

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -535,9 +535,9 @@ function factor_squarefree(a::fmpq_mpoly)
 end
 
 
-function sqrt(a::fmpq_mpoly)
+function sqrt(a::fmpq_mpoly; check::Bool=true)
    (flag, q) = issquare_with_sqrt(a)
-   !flag && error("Not a square")
+   check && !flag && error("Not a square")
    return q
 end
 

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -535,9 +535,9 @@ function factor_squarefree(a::fmpq_mpoly)
 end
 
 
-function square_root(a::fmpq_mpoly)
-   (flag, q) = issquare_with_square_root(a)
-   !flag && error("Not a square in square_root")
+function sqrt(a::fmpq_mpoly)
+   (flag, q) = issquare_with_sqrt(a)
+   !flag && error("Not a square")
    return q
 end
 
@@ -547,7 +547,7 @@ function issquare(a::fmpq_mpoly)
                      a, a.parent))
 end
 
-function issquare_with_square_root(a::fmpq_mpoly)
+function issquare_with_sqrt(a::fmpq_mpoly)
    q = parent(a)()
    flag = ccall((:fmpq_mpoly_sqrt, libflint), Cint,
                 (Ref{fmpq_mpoly}, Ref{fmpq_mpoly}, Ref{FmpqMPolyRing}),

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -931,12 +931,12 @@ function atanh(a::fmpq_rel_series)
 end
 
 @doc Markdown.doc"""
-    sqrt(a::fmpq_rel_series)
+    sqrt(a::fmpq_rel_series; check::Bool=true)
 
 Return the power series square root of $a$. Requires a constant term equal to
 one.
 """
-function Base.sqrt(a::fmpq_rel_series)
+function Base.sqrt(a::fmpq_rel_series; check::Bool=true)
    (a.val != 0 || coeff(a, 0) != 1) && error("Constant term not one in sqrt")
    z = parent(a)()
    z.prec = a.prec

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -502,14 +502,14 @@ end
 #
 ###############################################################################
 
-function Base.sqrt(a::fmpz_abs_series)
+function Base.sqrt(a::fmpz_abs_series; check::Bool=true)
     asqrt = parent(a)()
     v = valuation(a)
     asqrt.prec = a.prec - div(v, 2)
     flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
                (Ref{fmpz_abs_series}, Ref{fmpz_abs_series}, Int),
                   asqrt, a, a.prec))
-    flag == false && error("Not a square in sqrt")
+    check && !flag && error("Not a square")
     return asqrt
 end
 

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -1093,13 +1093,13 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::fmpz_laurent_series)
+    sqrt(a::fmpz_laurent_series; check::Bool=true)
 
 Return the square root of the power series $a$.
 """
-function sqrt(a::fmpz_laurent_series)
+function sqrt(a::fmpz_laurent_series; check::Bool=true)
    aval = valuation(a)
-   !iseven(aval) && error("Not a square in sqrt")
+   check && !iseven(aval) && error("Not a square in sqrt")
    R = base_ring(a)
    !isdomain_type(elem_type(R)) && error("Sqrt not implemented over non-integral domains")
    aval2 = div(aval, 2)
@@ -1119,7 +1119,7 @@ function sqrt(a::fmpz_laurent_series)
    flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
           (Ref{fmpz_laurent_series}, Ref{fmpz_laurent_series}, Int),
                 asqrt, a, zlen))
-   flag == false && error("Not a square in sqrt")
+   check && flag == false && error("Not a square in sqrt")
    asqrt = set_scale!(asqrt, s)
    asqrt = rescale!(asqrt)
    return asqrt

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -503,9 +503,12 @@ function factor_squarefree(a::fmpz_mpoly)
 end
 
 
-function sqrt(a::fmpz_mpoly)
-   (flag, q) = issquare_with_sqrt(a)
-   !flag && error("Not a square")
+function sqrt(a::fmpz_mpoly; check::Bool=true)
+   q = parent(a)()
+   flag = Bool(ccall((:fmpz_mpoly_sqrt_heap, libflint), Cint,
+         (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}, Cint),
+                     q, a, a.parent, Cint(check)))
+   check && !flag && error("Not a square")
    return q
 end
 

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -503,9 +503,9 @@ function factor_squarefree(a::fmpz_mpoly)
 end
 
 
-function square_root(a::fmpz_mpoly)
-   (flag, q) = issquare_with_square_root(a)
-   !flag && error("Not a square in square_root")
+function sqrt(a::fmpz_mpoly)
+   (flag, q) = issquare_with_sqrt(a)
+   !flag && error("Not a square")
    return q
 end
 
@@ -515,7 +515,7 @@ function issquare(a::fmpz_mpoly)
                      a, a.parent))
 end
 
-function issquare_with_square_root(a::fmpz_mpoly)
+function issquare_with_sqrt(a::fmpz_mpoly)
    q = parent(a)()
    flag = ccall((:fmpz_mpoly_sqrt, libflint), Cint,
                 (Ref{fmpz_mpoly}, Ref{fmpz_mpoly}, Ref{FmpzMPolyRing}),

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -500,11 +500,11 @@ end
 #
 ###############################################################################
 
-function Base.sqrt(x::fmpz_poly)
+function Base.sqrt(x::fmpz_poly; check::Bool=true)
     z = parent(x)()
     flag = Bool(ccall((:fmpz_poly_sqrt, libflint), Cint,
           (Ref{fmpz_poly}, Ref{fmpz_poly}), z, x))
-    flag == false && error("Not a square in sqrt")
+    check && flag == false && error("Not a square in sqrt")
     return z
  end
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -578,7 +578,7 @@ end
 #
 ###############################################################################
 
-function Base.sqrt(a::fmpz_rel_series)
+function Base.sqrt(a::fmpz_rel_series; check::Bool=true)
     asqrt = parent(a)()
     val = div(valuation(a), 2)
     asqrt.prec = a.prec - val
@@ -586,7 +586,7 @@ function Base.sqrt(a::fmpz_rel_series)
     flag = Bool(ccall((:fmpz_poly_sqrt_series, libflint), Cint,
           (Ref{fmpz_rel_series}, Ref{fmpz_rel_series}, Int),
                 asqrt, a, a.prec - 2*val))
-    flag == false && error("Not a square in sqrt")
+    check && flag == false && error("Not a square in sqrt")
     return asqrt
 end
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -432,12 +432,12 @@ end
 Return a square root of $x$ in the finite field. If $x$ is not a square
 an exception is raised.
 """
-function sqrt(x::fq)
+function sqrt(x::fq; check::Bool=true)
    z = parent(x)()
    res = Bool(ccall((:fq_sqrt, libflint), Cint,
                     (Ref{fq}, Ref{fq}, Ref{FqFiniteField}),
                     z, x, x.parent))
-   res || error("Not a square")
+   check && !res && error("Not a square")
    return z
 end
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -427,17 +427,17 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    square_root(x::fq)
+    sqrt(x::fq)
 
 Return a square root of $x$ in the finite field. If $x$ is not a square
 an exception is raised.
 """
-function square_root(x::fq)
+function sqrt(x::fq)
    z = parent(x)()
    res = Bool(ccall((:fq_sqrt, libflint), Cint,
                     (Ref{fq}, Ref{fq}, Ref{FqFiniteField}),
                     z, x, x.parent))
-   res || error("Not a square in square_root")
+   res || error("Not a square")
    return z
 end
 
@@ -453,13 +453,13 @@ function issquare(x::fq)
 end
 
 @doc Markdown.doc"""
-    issquare_with_square_root(x::fq)
+    issquare_with_sqrt(x::fq)
 
 If $x$ is a square, return the tuple of `true` and a square root of $x$.
 Otherwise, return the tuple of `false` and an unspecified element of the
 finite field.
 """
-function issquare_with_square_root(x::fq)
+function issquare_with_sqrt(x::fq)
    z = parent(x)()
    flag = ccall((:fq_sqrt, libflint), Cint,
                 (Ref{fq}, Ref{fq}, Ref{FqFiniteField}),

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -473,17 +473,17 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    square_root(x::fq_default)
+    sqrt(x::fq_default)
 
 Return a square root of $x$ in the finite field. If $x$ is not a square
 an exception is raised.
 """
-function square_root(x::fq_default)
+function sqrt(x::fq_default)
    z = parent(x)()
    res = Bool(ccall((:fq_default_sqrt, libflint), Cint,
                     (Ref{fq_default}, Ref{fq_default}, Ref{FqDefaultFiniteField}),
                     z, x, x.parent))
-   res || error("Not a square in square_root")
+   res || error("Not a square")
    return z
 end
 
@@ -499,13 +499,13 @@ function issquare(x::fq_default)
 end
 
 @doc Markdown.doc"""
-    issquare_with_square_root(x::fq_default)
+    issquare_with_sqrt(x::fq_default)
 
 If $x$ is a square, return the tuple of `true` and a square root of $x$.
 Otherwise, return the tuple of `false` and an unspecified element of the
 finite field.
 """
-function issquare_with_square_root(x::fq_default)
+function issquare_with_sqrt(x::fq_default)
    z = parent(x)()
    flag = ccall((:fq_default_sqrt, libflint), Cint,
                 (Ref{fq_default}, Ref{fq_default}, Ref{FqDefaultFiniteField}),

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -354,7 +354,7 @@ divexact(x::fmpz, y::fq_nmod; check::Bool=true) = divexact(parent(y)(x), y; chec
 #
 ###############################################################################
 
-function square_root(x::fq_nmod)
+function sqrt(x::fq_nmod)
    z = parent(x)()
    res = Bool(ccall((:fq_nmod_sqrt, libflint), Cint,
                     (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
@@ -369,7 +369,7 @@ function issquare(x::fq_nmod)
                      x, x.parent))
 end
 
-function issquare_with_square_root(x::fq_nmod)
+function issquare_with_sqrt(x::fq_nmod)
    z = parent(x)()
    flag = ccall((:fq_nmod_sqrt, libflint), Cint,
                 (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -354,12 +354,12 @@ divexact(x::fmpz, y::fq_nmod; check::Bool=true) = divexact(parent(y)(x), y; chec
 #
 ###############################################################################
 
-function sqrt(x::fq_nmod)
+function sqrt(x::fq_nmod; check::Bool=true)
    z = parent(x)()
    res = Bool(ccall((:fq_nmod_sqrt, libflint), Cint,
                     (Ref{fq_nmod}, Ref{fq_nmod}, Ref{FqNmodFiniteField}),
                     z, x, x.parent))
-   res || error("Not a square in sqrt")
+   check && !res && error("Not a square")
    return z
 end
 

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -471,9 +471,9 @@ function factor_squarefree(a::fq_nmod_mpoly)
 end
 
 
-function sqrt(a::fq_nmod_mpoly)
+function sqrt(a::fq_nmod_mpoly; check::Bool=true)
    (flag, q) = issquare_with_sqrt(a)
-   !flag && error("Not a square")
+   check && !flag && error("Not a square")
    return q
 end
 

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -471,9 +471,9 @@ function factor_squarefree(a::fq_nmod_mpoly)
 end
 
 
-function square_root(a::fq_nmod_mpoly)
-   (flag, q) = issquare_with_square_root(a)
-   !flag && error("Not a square in square_root")
+function sqrt(a::fq_nmod_mpoly)
+   (flag, q) = issquare_with_sqrt(a)
+   !flag && error("Not a square")
    return q
 end
 
@@ -483,7 +483,7 @@ function issquare(a::fq_nmod_mpoly)
                      a, a.parent))
 end
 
-function issquare_with_square_root(a::fq_nmod_mpoly)
+function issquare_with_sqrt(a::fq_nmod_mpoly)
    q = parent(a)()
    flag = ccall((:fq_nmod_mpoly_sqrt, libflint), Cint,
                 (Ref{fq_nmod_mpoly}, Ref{fq_nmod_mpoly}, Ref{FqNmodMPolyRing}),

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -513,9 +513,9 @@ function factor_squarefree(a::($etype))
 end
 
 
-function square_root(a::($etype))
-   (flag, q) = issquare_with_square_root(a)
-   !flag && error("Not a square in square_root")
+function sqrt(a::($etype))
+   (flag, q) = issquare_with_sqrt(a)
+   !flag && error("Not a square")
    return q
 end
 
@@ -525,7 +525,7 @@ function issquare(a::($etype))
                      a, a.parent))
 end
 
-function issquare_with_square_root(a::($etype))
+function issquare_with_sqrt(a::($etype))
    q = parent(a)()
    flag = ccall((:nmod_mpoly_sqrt, libflint), Cint,
                 (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -513,9 +513,9 @@ function factor_squarefree(a::($etype))
 end
 
 
-function sqrt(a::($etype))
+function sqrt(a::($etype); check::Bool=true)
    (flag, q) = issquare_with_sqrt(a)
-   !flag && error("Not a square")
+   check && !flag && error("Not a square")
    return q
 end
 

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -576,21 +576,21 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::padic)
+    sqrt(a::padic; check::Bool=true)
 
 Return the $p$-adic square root of $a$. We define this only when the
 valuation of $a$ is even. The precision of the output will be
-precision$(a) -$ valuation$(a)/2$. If the square root does not exist, an
-exception is thrown.
+precision$(a) -$ valuation$(a)/2$. By default if the square root does not
+exist, an exception is thrown. If `check=false` this test is not performed.
 """
-function Base.sqrt(a::padic)
-   (a.v % 2) != 0 && error("Unable to take padic square root")
+function Base.sqrt(a::padic; check::Bool=true)
+   check && (a.v % 2) != 0 && error("Unable to take padic square root")
    ctx = parent(a)
    z = padic(a.N - div(a.v, 2))
    z.parent = ctx
    res = Bool(ccall((:padic_sqrt, libflint), Cint,
                     (Ref{padic}, Ref{padic}, Ref{FlintPadicField}), z, a, ctx))
-   !res && error("Square root of p-adic does not exist")
+   check && !res && error("Square root of p-adic does not exist")
    return z
 end
 

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -553,22 +553,22 @@ end
 ###############################################################################
 
 @doc Markdown.doc"""
-    sqrt(a::qadic)
+    sqrt(a::qadic; check::Bool=true)
 
 Return the $q$-adic square root of $a$. We define this only when the
 valuation of $a$ is even. The precision of the output will be
 precision$(a) -$ valuation$(a)/2$. If the square root does not exist, an
 exception is thrown.
 """
-function Base.sqrt(a::qadic)
+function Base.sqrt(a::qadic; check::Bool=true)
    av = valuation(a)
-   (av % 2) != 0 && error("Unable to take qadic square root")
+   check && (av % 2) != 0 && error("Unable to take qadic square root")
    ctx = parent(a)
    z = qadic(a.N - div(av, 2))
    z.parent = ctx
    res = Bool(ccall((:qadic_sqrt, libflint), Cint,
                     (Ref{qadic}, Ref{qadic}, Ref{FlintQadicField}), z, a, ctx))
-   !res && error("Square root of p-adic does not exist")
+   check && !res && error("Square root of p-adic does not exist")
    return z
 end
 

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -356,7 +356,7 @@ end
    @test gcd(a, b) == fmpz(1)//6
 end
 
-@testset "fmpq.square_root" begin
+@testset "fmpq.sqrt" begin
    a = fmpz(4)//9
    b = fmpz(0)//1
 

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -507,14 +507,14 @@ end
       for iter = 1:10
          f = rand(S, 0:4, 0:5, -10:10)
 
-         g = square_root(f^2)
+         g = sqrt(f^2)
 
          @test g^2 == f^2
          @test issquare(f^2)
 
          if f != 0
             x = varlist[rand(1:num_vars)]
-            @test_throws ErrorException square_root(f^2*(x^2 - x))
+            @test_throws ErrorException sqrt(f^2*(x^2 - x))
             @test !issquare(f^2*(x^2 - x))
          end
       end

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -532,6 +532,17 @@ end
 end
 
 @testset "fmpz.roots" begin
+   @test sqrt(fmpz(16)) == 4
+   @test sqrt(fmpz()) == 0
+
+   @test_throws DomainError sqrt(-fmpz(1))
+   @test_throws ErrorException sqrt(fmpz(12))
+
+   @test issquare_with_sqrt(fmpz(5)) == (false, 0)
+   @test issquare_with_sqrt(fmpz(4)) == (true, 2)
+
+   @test_throws DomainError issquare_with_sqrt(-fmpz(1))
+   
    @test isqrt(fmpz(12)) == 3
 
    @test_throws DomainError isqrt(-fmpz(12))
@@ -821,8 +832,6 @@ end
    @test next_prime(UInt(11), false) == 13
    @test_throws Exception next_prime(typemax(UInt))
 
-   @test issquare(fmpz(36))
-
    @test factorial(ZZ(100)) == fmpz("93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000")
 
    @test divisor_sigma(fmpz(128), 10) == fmpz("1181745669222511412225")
@@ -907,10 +916,3 @@ end
    end
 end
 
-@testset "fmpz.square_root" begin
-   @test sqrt(fmpz(4)) == 2
-
-   @test_throws DomainError sqrt(-fmpz(4))
-
-   @test sqrt(fmpz(0)) == 0
-end

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -487,14 +487,14 @@ end
       for iter = 1:10
          f = rand(S, 0:4, 0:5, -10:10)
 
-         g = square_root(f^2)
+         g = sqrt(f^2)
 
          @test g^2 == f^2
          @test issquare(f^2)
 
          if f != 0
             x = varlist[rand(1:num_vars)]
-            @test_throws ErrorException square_root(f^2*(x^2 - x))
+            @test_throws ErrorException sqrt(f^2*(x^2 - x))
             @test !issquare(f^2*(x^2 - x))
          end
       end

--- a/test/flint/fq-test.jl
+++ b/test/flint/fq-test.jl
@@ -192,17 +192,17 @@ end
 
    @test issquare(a^2)
 
-   @test square_root(a^2)^2 == a^2
+   @test sqrt(a^2)^2 == a^2
 
-   @test issquare_with_square_root(a^2)[1]
+   @test issquare_with_sqrt(a^2)[1]
 
-   @test issquare_with_square_root(a^2)[2]^2 == a^2
+   @test issquare_with_sqrt(a^2)[2]^2 == a^2
 
    @test !issquare(x*a^2)
 
-   @test_throws ErrorException square_root(x*a^2)
+   @test_throws ErrorException sqrt(x*a^2)
 
-   @test !issquare_with_square_root(x*a^2)[1]
+   @test !issquare_with_sqrt(x*a^2)[1]
 end
 
 @testset "fq.rand" begin

--- a/test/flint/fq_default-test.jl
+++ b/test/flint/fq_default-test.jl
@@ -215,17 +215,17 @@ end
 
    @test issquare(a^2)
 
-   @test square_root(a^2)^2 == a^2
+   @test sqrt(a^2)^2 == a^2
 
-   @test issquare_with_square_root(a^2)[1]
+   @test issquare_with_sqrt(a^2)[1]
 
-   @test issquare_with_square_root(a^2)[2]^2 == a^2
+   @test issquare_with_sqrt(a^2)[2]^2 == a^2
 
    @test !issquare(x*a^2)
 
-   @test_throws ErrorException square_root(x*a^2)
+   @test_throws ErrorException sqrt(x*a^2)
 
-   @test !issquare_with_square_root(x*a^2)[1]
+   @test !issquare_with_sqrt(x*a^2)[1]
 end
 
 @testset "fq_default.rand" begin

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -187,17 +187,17 @@ end
 
    @test issquare(a^2)
 
-   @test square_root(a^2)^2 == a^2
+   @test sqrt(a^2)^2 == a^2
 
-   @test issquare_with_square_root(a^2)[1]
+   @test issquare_with_sqrt(a^2)[1]
 
-   @test issquare_with_square_root(a^2)[2]^2 == a^2
+   @test issquare_with_sqrt(a^2)[2]^2 == a^2
 
    @test !issquare(x*a^2)
 
-   @test_throws ErrorException square_root(x*a^2)
+   @test_throws ErrorException sqrt(x*a^2)
 
-   @test !issquare_with_square_root(x*a^2)[1]
+   @test !issquare_with_sqrt(x*a^2)[1]
 end
 
 @testset "fq_nmod.iteration" begin

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -507,14 +507,14 @@ end
       for iter = 1:10
          f = rand(S, 0:4, 0:5, -10:10)
 
-         g = square_root(f^2)
+         g = sqrt(f^2)
 
          @test g^2 == f^2
          @test issquare(f^2)
 
          if f != 0
             x = varlist[rand(1:num_vars)]
-            @test_throws ErrorException square_root(f^2*(x^2 - x))
+            @test_throws ErrorException sqrt(f^2*(x^2 - x))
             @test !issquare(f^2*(x^2 - x))
          end
       end

--- a/test/flint/gfp_mpoly-test.jl
+++ b/test/flint/gfp_mpoly-test.jl
@@ -520,14 +520,14 @@ end
       for iter = 1:10
          f = rand(S, 0:4, 0:5, -10:10)
 
-         g = square_root(f^2)
+         g = sqrt(f^2)
 
          @test g^2 == f^2
          @test issquare(f^2)
 
          if f != 0
             x = varlist[rand(1:num_vars)]
-            @test_throws ErrorException square_root(f^2*(x^2 - x))
+            @test_throws ErrorException sqrt(f^2*(x^2 - x))
             @test !issquare(f^2*(x^2 - x))
          end
       end

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -518,14 +518,14 @@ end
       for iter = 1:10
          f = rand(S, 0:4, 0:5, -10:10)
 
-         g = square_root(f^2)
+         g = sqrt(f^2)
 
          @test g^2 == f^2
          @test issquare(f^2)
 
          if f != 0
             x = varlist[rand(1:num_vars)]
-            @test_throws ErrorException square_root(f^2*(x^2 - x))
+            @test_throws ErrorException sqrt(f^2*(x^2 - x))
             @test !issquare(f^2*(x^2 - x))
          end
       end


### PR DESCRIPTION
* Adds issquare_sqrt
* Renames square_root to sqrt
* Adds check=true flag to all sqrt functions
* Make better fmpz_mpoly_sqrt function

This is the Nemo counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/pull/943

See https://github.com/Nemocas/Nemo.jl/issues/862

This is breaking in every possible way.