### PR TITLE
remove trivial doc strings

### DIFF
--- a/docs/src/finitefield.md
+++ b/docs/src/finitefield.md
@@ -96,14 +96,6 @@ degree(::FqFiniteField)
 ```
 
 ```@docs
-characteristic(::FqFiniteField)
-```
-
-```@docs
-order(::FqFiniteField)
-```
-
-```@docs
 modulus(::FqFiniteField)
 ```
 

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -64,10 +64,6 @@ along with generic fractions fields as described here:
 ### Basic manipulation
 
 ```@docs
-abs(::fmpq)
-```
-
-```@docs
 sign(::fmpq)
 ```
 
@@ -85,18 +81,6 @@ height_bits(::fmpq)
 
 ```@docs
 >>(::fmpq, ::Int)
-```
-
-Rational fractions can be compared with each other and with integers. Julia
-provides the full range of operators $<, >, \leq, \geq$ which depend on the
-following functions.
-
-```@docs
-isless(::fmpq, ::fmpq)
-isless(::Integer, ::fmpq)
-isless(::fmpq, ::Integer)
-isless(::fmpq, ::fmpz)
-isless(::fmpz, ::fmpq)
 ```
 
 ```@docs
@@ -205,9 +189,6 @@ bernoulli_cache(::Int)
 
 ```@docs
 dedekind_sum(::fmpz, ::fmpz)
-dedekind_sum(::fmpz, ::Integer)
-dedekind_sum(::Integer, ::fmpz)
-dedekind_sum(::Integer, ::Integer)
 ```
 
 **Examples**

--- a/docs/src/gfp.md
+++ b/docs/src/gfp.md
@@ -53,16 +53,6 @@ Below we describe the functionality that is provided in addition to these.
 
 ## Basic manipulation
 
-```@docs
-characteristic(::GaloisField)
-characteristic(::GaloisFmpzField)
-```
-
-```@docs
-order(::GaloisField)
-order(::GaloisFmpzField)
-```
-
 **Examples**
 
 ```julia

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -65,10 +65,6 @@ can be exactly represented as an integer.
 ### Basic manipulation
 
 ```@docs
-isunit(::fmpz)
-```
-
-```@docs
 sign(::fmpz)
 ```
 

--- a/src/flint/adhoc.jl
+++ b/src/flint/adhoc.jl
@@ -4,11 +4,6 @@
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::AbsSeriesElem)
-
-Return $a\times b$.
-"""
 function *(a::fmpz, b::AbsSeriesElem)
    len = length(b)
    z = parent(b)()
@@ -21,11 +16,6 @@ function *(a::fmpz, b::AbsSeriesElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::AbsSeriesElem, b::fmpz)
-
-Return $a\times b$.
-"""
 *(a::AbsSeriesElem, b::fmpz) = b*a
 
 @doc Markdown.doc"""
@@ -43,11 +33,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 ==(x::fmpz, y::AbsSeriesElem) = y == x
 
-@doc Markdown.doc"""
-    divexact(x::AbsSeriesElem, y::fmpz; check::Bool=true)
-
-Return $x/y$.
-"""
 function divexact(x::AbsSeriesElem, y::fmpz; check::Bool=true)
    iszero(y) && throw(DivideError())
    lenx = length(x)
@@ -76,11 +61,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::RelSeriesElem)
-
-Return $a\times b$.
-"""
 function *(a::fmpz, b::RelSeriesElem)
    len = pol_length(b)
    z = parent(b)()
@@ -95,11 +75,6 @@ function *(a::fmpz, b::RelSeriesElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::RelSeriesElem, b::fmpz)
-
-Return $a\times b$.
-"""
 *(a::RelSeriesElem, b::fmpz) = b*a
 
 @doc Markdown.doc"""
@@ -118,11 +93,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 ==(x::fmpz, y::RelSeriesElem) = y == x
 
-@doc Markdown.doc"""
-    divexact(x::RelSeriesElem, y::fmpz; check::Bool=true)
-
-Return $x/y$.
-"""
 function divexact(x::RelSeriesElem, y::fmpz; check::Bool=true)
    iszero(y) && throw(DivideError())
    lenx = pol_length(x)
@@ -152,11 +122,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::PolyElem)
-
-Return $a\times b$.
-"""
 function *(a::fmpz, b::PolyElem)
    len = length(b)
    z = parent(b)()
@@ -168,11 +133,6 @@ function *(a::fmpz, b::PolyElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::PolyElem, b::fmpz)
-
-Return $a\times b$.
-"""
 *(a::PolyElem, b::fmpz) = b*a
 
 @doc Markdown.doc"""
@@ -190,11 +150,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 ==(x::fmpz, y::PolyElem) = y == x
 
-@doc Markdown.doc"""
-    divexact(a::PolyElem, b::fmpz; check::Bool=true)
-
-Return $a/b$.
-"""
 function divexact(a::PolyElem, b::fmpz; check::Bool=true)
    iszero(b) && throw(DivideError())
    z = parent(a)()
@@ -243,46 +198,16 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::ResElem, b::fmpz)
-
-Return $a\times b$.
-"""
 *(a::ResElem, b::fmpz) = parent(a)(data(a) * b)
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::ResElem)
-
-Return $a\times b$.
-"""
 *(a::fmpz, b::ResElem) = parent(b)(a * data(b))
 
-@doc Markdown.doc"""
-    +(a::ResElem, b::fmpz)
-
-Return $a + b$.
-"""
 +(a::ResElem, b::fmpz) = parent(a)(data(a) + b)
 
-@doc Markdown.doc"""
-    +(a::fmpz, b::ResElem)
-
-Return $a + b$.
-"""
 +(a::fmpz, b::ResElem) = parent(b)(a + data(b))
 
-@doc Markdown.doc"""
-    -(a::ResElem, b::fmpz)
-
-Return $a - b$.
-"""
 -(a::ResElem, b::fmpz) = parent(a)(data(a) - b)
 
-@doc Markdown.doc"""
-    -(a::fmpz, b::ResElem)
-
-Return $a - b$.
-"""
 -(a::fmpz, b::ResElem) = parent(b)(a - data(b))
 
 @doc Markdown.doc"""
@@ -437,11 +362,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(x::fmpz, y::MatElem)
-
-Return $x\times y$.
-"""
 function *(x::fmpz, y::MatElem)
    z = similar(y)
    for i = 1:nrows(y)
@@ -452,18 +372,8 @@ function *(x::fmpz, y::MatElem)
    return z
 end
 
-@doc Markdown.doc"""
-    *(x::MatElem, y::fmpz)
-
-Return $x\times y$.
-"""
 *(x::MatElem, y::fmpz) = y*x
 
-@doc Markdown.doc"""
-    +(x::fmpz, y::MatElem)
-
-Return $S(x) + y$ where $S$ is the parent of $y$.
-"""
 function +(x::fmpz, y::MatElem)
    z = similar(y)
    R = base_ring(y)
@@ -479,18 +389,8 @@ function +(x::fmpz, y::MatElem)
    return z
 end
 
-@doc Markdown.doc"""
-    +(x::MatElem, y::fmpz)
-
-Return $x + S(y)$ where $S$ is the parent of $x$.
-"""
 +(x::MatElem, y::fmpz) = y + x
 
-@doc Markdown.doc"""
-    -(x::fmpz, y::MatElem)
-
-Return $S(x) - y$ where $S$ is the parent of $y$.
-"""
 function -(x::fmpz, y::MatElem)
    z = similar(y)
    R = base_ring(y)
@@ -506,11 +406,6 @@ function -(x::fmpz, y::MatElem)
    return z
 end
 
-@doc Markdown.doc"""
-    -(x::MatElem, y::fmpz)
-
-Return $x - S(y)$, where $S$ is the parent of $x$
-"""
 function -(x::MatElem, y::fmpz)
    z = similar(x)
    R = base_ring(x)
@@ -602,11 +497,6 @@ end
 
 //(x::fmpz, y::T) where {T <: RingElem} = parent(y)(x)//y
 
-@doc Markdown.doc"""
-    *(a::FracElem, b::fmpz)
-
-Return $a\times b$.
-"""
 function *(a::FracElem, b::fmpz)
    c = base_ring(a)(b)
    g = gcd(denominator(a), c)
@@ -615,11 +505,6 @@ function *(a::FracElem, b::fmpz)
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::FracElem)
-
-Return $a\times b$.
-"""
 function *(a::fmpz, b::FracElem)
    c = base_ring(b)(a)
    g = gcd(denominator(b), c)
@@ -628,11 +513,6 @@ function *(a::fmpz, b::FracElem)
    return parent(b)(n, d)
 end
 
-@doc Markdown.doc"""
-    +(a::FracElem, b::fmpz)
-
-Return $a + b$.
-"""
 function +(a::FracElem, b::fmpz)
    n = numerator(a) + denominator(a)*b
    d = denominator(a)
@@ -640,11 +520,6 @@ function +(a::FracElem, b::fmpz)
    return parent(a)(divexact(n, g), divexact(d, g))
 end
 
-@doc Markdown.doc"""
-    -(a::FracElem, b::fmpz)
-
-Return $a - b$.
-"""
 function -(a::FracElem, b::fmpz)
    n = numerator(a) - denominator(a)*b
    d = denominator(a)
@@ -652,18 +527,8 @@ function -(a::FracElem, b::fmpz)
    return parent(a)(divexact(n, g), divexact(d, g))
 end
 
-@doc Markdown.doc"""
-    +(a::fmpz, b::FracElem)
-
-Return $a + b$.
-"""
 +(a::fmpz, b::FracElem) = b + a
 
-@doc Markdown.doc"""
-    -(a::fmpz, b::FracElem)
-
-Return $a - b$.
-"""
 function -(a::fmpz, b::FracElem)
    n = a*denominator(b) - numerator(b)
    d = denominator(b)
@@ -687,11 +552,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 """
 ==(x::fmpz, y::FracElem) = y == x
 
-@doc Markdown.doc"""
-    divexact(a::FracElem, b::fmpz; check::Bool=true)
-
-Return $a/b$.
-"""
 function divexact(a::FracElem, b::fmpz; check::Bool=true)
    iszero(b) && throw(DivideError())
    c = base_ring(a)(b)
@@ -701,11 +561,6 @@ function divexact(a::FracElem, b::fmpz; check::Bool=true)
    return parent(a)(n, d)
 end
 
-@doc Markdown.doc"""
-    divexact(a::fmpz, b::FracElem; check::Bool=true)
-
-Return $a/b$.
-"""
 function divexact(a::fmpz, b::FracElem; check::Bool=true)
    iszero(b) && throw(DivideError())
    c = base_ring(b)(a)

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -14,18 +14,8 @@ export FlintPuiseuxSeriesRing, FlintPuiseuxSeriesField,
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    laurent_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem
-
-Return the `LaurentSeriesRing` underlying the given `PuiseuxSeriesRing`.
-"""
 laurent_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = R.laurent_ring::parent_type(T)
 
-@doc Markdown.doc"""
-    laurent_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem
-
-Return the `LaurentSeriesField` underlying the given `PuiseuxSeriesField`.
-"""
 laurent_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = R.laurent_ring::parent_type(T)
 
 @doc Markdown.doc"""
@@ -48,51 +38,20 @@ parent_type(::Type{T}) where {S <: RingElem, T <: FlintPuiseuxSeriesRingElem{S}}
 
 parent_type(::Type{T}) where {S <: FieldElem, T <: FlintPuiseuxSeriesFieldElem{S}} = FlintPuiseuxSeriesField{S}
 
-@doc Markdown.doc"""
-    parent(a::FlintPuiseuxSeriesElem)
-
-Return the parent of the given Puiseux series.
-"""
 parent(a::FlintPuiseuxSeriesElem) = a.parent
 
 elem_type(::Type{T}) where {S <: RingElem, T <: FlintPuiseuxSeriesRing{S}} = FlintPuiseuxSeriesRingElem{S}
 
 elem_type(::Type{T}) where {S <: FieldElem, T <: FlintPuiseuxSeriesField{S}} = FlintPuiseuxSeriesFieldElem{S}
 
-@doc Markdown.doc"""
-    base_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem
-
-Return the base (coefficient) ring of the given Puiseux series ring.
-"""
 base_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = base_ring(laurent_ring(R))
 
-@doc Markdown.doc"""
-    base_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem
-
-Return the base (coefficient) ring of the given Puiseux series field.
-"""
 base_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = base_ring(laurent_ring(R))
 
-@doc Markdown.doc"""
-    base_ring(a::FlintPuiseuxSeriesElem)
-
-Return the base (coefficient) ring of the Puiseux series ring of the given Puiseux
-series.
-"""
 base_ring(a::FlintPuiseuxSeriesElem) = base_ring(parent(a))
 
-@doc Markdown.doc"""
-    max_precision(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem
-
-Return the maximum precision of the underlying Laurent series ring.
-"""
 max_precision(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = max_precision(laurent_ring(R))
 
-@doc Markdown.doc"""
-    max_precision(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem
-
-Return the maximum precision of the underlying Laurent series field.
-"""
 max_precision(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = max_precision(laurent_ring(R))
 
 function isdomain_type(::Type{T}) where {S <: RingElem, T <: FlintPuiseuxSeriesElem{S}}
@@ -127,38 +86,17 @@ function Base.hash(a::FlintPuiseuxSeriesElem, h::UInt)
    return b
 end
 
-@doc Markdown.doc"""
-    precision(a::FlintPuiseuxSeriesElem)
-
-Return the precision of the given Puiseux series in absolute terms.
-"""
 precision(a::FlintPuiseuxSeriesElem) = precision(a.data)//a.scale
 
-@doc Markdown.doc"""
-    valuation(a::FlintPuiseuxSeriesElem)
-
-Return the valuation of the given Puiseux series, i.e. the exponent of the first
-nonzero term (or the precision if it is arithmetically zero).
-"""
 valuation(a::FlintPuiseuxSeriesElem) = valuation(a.data)//a.scale
 
 scale(a::FlintPuiseuxSeriesElem) = a.scale
 
-@doc Markdown.doc"""
-    coeff(a::FlintPuiseuxSeriesElem, n::Int)
-
-Return the coefficient of the term of exponent $n$ of the given Puiseux series.
-"""
 function coeff(a::FlintPuiseuxSeriesElem, n::Int)
    s = scale(a)
    return coeff(a.data, n*s)
 end
 
-@doc Markdown.doc"""
-    coeff(a::FlintPuiseuxSeriesElem, r::Rational{Int})
-
-Return the coefficient of the term of exponent $r$ of the given Puiseux series.
-"""
 function coeff(a::FlintPuiseuxSeriesElem, r::Rational{Int})
    s = scale(a)
    n = numerator(r)
@@ -169,55 +107,19 @@ function coeff(a::FlintPuiseuxSeriesElem, r::Rational{Int})
    return coeff(a.data, n*div(s, d))
 end
 
-@doc Markdown.doc"""
-    zero(R::FlintPuiseuxSeriesRing)
-
-Return $0 + O(x^n)$ where $n$ is the maximum precision of the Puiseux series
-ring $R$.
-"""
 zero(R::FlintPuiseuxSeriesRing) = R(0)
 
-@doc Markdown.doc"""
-    zero(R::FlintPuiseuxSeriesField)
-
-Return $0 + O(x^n)$ where $n$ is the maximum precision of the Puiseux series
-ring $R$.
-"""
 zero(R::FlintPuiseuxSeriesField) = R(0)
 
-@doc Markdown.doc"""
-    one(R::FlintPuiseuxSeriesField)
-
-Return $1 + O(x^n)$ where $n$ is the maximum precision of the Puiseux series
-ring $R$.
-"""
 one(R::FlintPuiseuxSeriesField) = R(1)
 
-@doc Markdown.doc"""
-    one(R::FlintPuiseuxSeriesRing)
-
-Return $1 + O(x^n)$ where $n$ is the maximum precision of the Puiseux series
-ring $R$.
-"""
 one(R::FlintPuiseuxSeriesRing) = R(1)
 
-@doc Markdown.doc"""
-    gen(R::FlintPuiseuxSeriesRing)
-
-Return the generator of the Puiseux series ring, i.e. $x + O(x^{n + 1})$ where
-$n$ is the maximum precision of the Puiseux series ring $R$.
-"""
 function gen(R::FlintPuiseuxSeriesRing)
    S = laurent_ring(R)
    return R(gen(S), 1)
 end
 
-@doc Markdown.doc"""
-    gen(R::FlintPuiseuxSeriesField)
-
-Return the generator of the Puiseux series ring, i.e. $x + O(x^{n + 1})$ where
-$n$ is the maximum precision of the Puiseux series ring $R$.
-"""
 function gen(R::FlintPuiseuxSeriesField)
    S = laurent_ring(R)
    return R(gen(S), 1)
@@ -505,11 +407,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    sqrt(a::FlintPuiseuxSeriesElem{T}; check::Bool=true) where T <: RingElem
-
-Return the square root of the given Puiseux series.
-"""
 function sqrt(a::FlintPuiseuxSeriesElem{T}; check::Bool=true) where T <: RingElem
    val = valuation(a.data)
    S = parent(a)
@@ -526,11 +423,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    exp(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
-
-Return the exponential of the given Puiseux series.
-"""
 function exp(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
    z = parent(a)(exp(a.data), a.scale)
    z = rescale!(z)

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -96,11 +96,6 @@ Return the sign of $a$ ($-1$, $0$ or $1$) as a fraction.
 """
 sign(a::fmpq) = fmpq(sign(numerator(a)))
 
-@doc Markdown.doc"""
-    abs(a::fmpq)
-
-Return the absolute value of $a$.
-"""
 function abs(a::fmpq)
    z = fmpq()
    ccall((:fmpq_abs, libflint), Nothing, (Ref{fmpq}, Ref{fmpq}), z, a)
@@ -322,11 +317,6 @@ function ==(a::fmpq, b::fmpq)
                 (Ref{fmpq}, Ref{fmpq}), a, b)
 end
 
-@doc Markdown.doc"""
-    isless(a::fmpq, b::fmpq)
-
-Return `true` if $a < b$, otherwise return `false`.
-"""
 function isless(a::fmpq, b::fmpq)
    return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, b) < 0
@@ -355,44 +345,24 @@ end
 
 ==(a::Rational{T}, b::fmpq) where {T <: Integer} = b == a
 
-@doc Markdown.doc"""
-    isless(a::fmpq, b::Integer)
-
-Return `true` if $a < b$, otherwise return `false`.
-"""
 function isless(a::fmpq, b::Integer)
    z = fmpq(b)
    return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
-@doc Markdown.doc"""
-    isless(a::Integer, b::fmpq)
-
-Return `true` if $a < b$, otherwise return `false`.
-"""
 function isless(a::Integer, b::fmpq)
    z = fmpq(a)
    return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), z, b) < 0
 end
 
-@doc Markdown.doc"""
-    isless(a::fmpq, b::fmpz)
-
-Return `true` if $a < b$, otherwise return `false`.
-"""
 function isless(a::fmpq, b::fmpz)
    z = fmpq(b)
    return ccall((:fmpq_cmp, libflint), Cint,
                 (Ref{fmpq}, Ref{fmpq}), a, z) < 0
 end
 
-@doc Markdown.doc"""
-    isless(a::fmpz, b::fmpq)
-
-Return `true` if $a < b$, otherwise return `false`.
-"""
 function isless(a::fmpz, b::fmpq)
    z = fmpq(a)
    return ccall((:fmpq_cmp, libflint), Cint,
@@ -765,6 +735,8 @@ end
 
 @doc Markdown.doc"""
     dedekind_sum(h::fmpz, k::fmpz)
+
+Return the Dedekind sum $s(h,k)$ for arbitrary $h$ and $k$.
 """
 function dedekind_sum(h::fmpz, k::fmpz)
    c = fmpq()
@@ -773,25 +745,10 @@ function dedekind_sum(h::fmpz, k::fmpz)
    return c
 end
 
-@doc Markdown.doc"""
-    dedekind_sum(h::fmpz, k::Integer)
-
-Return the Dedekind sum $s(h,k)$ for arbitrary $h$ and $k$.
-"""
 dedekind_sum(h::fmpz, k::Integer) = dedekind_sum(h, fmpz(k))
 
-@doc Markdown.doc"""
-    dedekind_sum(h::Integer, k::fmpz)
-
-Return the Dedekind sum $s(h,k)$ for arbitrary $h$ and $k$.
-"""
 dedekind_sum(h::Integer, k::fmpz) = dedekind_sum(fmpz(h), k)
 
-@doc Markdown.doc"""
-    dedekind_sum(h::Integer, k::Integer)
-
-Return the Dedekind sum $s(h,k)$ for arbitrary $h$ and $k$.
-"""
 dedekind_sum(h::Integer, k::Integer) = dedekind_sum(fmpz(h), fmpz(k))
 
 ###############################################################################

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -749,12 +749,6 @@ function atanh(a::fmpq_abs_series)
    return z
 end
 
-@doc Markdown.doc"""
-    sqrt(a::fmpq_abs_series; check::Bool=true)
-
-Return the power series square root of $a$. Requires a constant term equal to
-one.
-"""
 function Base.sqrt(a::fmpq_abs_series; check::Bool=true)
    !isone(coeff(a, 0)) && error("Constant term not one in sqrt")
    z = parent(a)()

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -930,12 +930,6 @@ function atanh(a::fmpq_rel_series)
    return z
 end
 
-@doc Markdown.doc"""
-    sqrt(a::fmpq_rel_series; check::Bool=true)
-
-Return the power series square root of $a$. Requires a constant term equal to
-one.
-"""
 function Base.sqrt(a::fmpq_rel_series; check::Bool=true)
    (a.val != 0 || coeff(a, 0) != 1) && error("Constant term not one in sqrt")
    z = parent(a)()

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -155,18 +155,8 @@ end
 
 characteristic(R::FlintIntegerRing) = 0
 
-@doc Markdown.doc"""
-    one(R::FlintIntegerRing)
-
-Return the integer $1$.
-"""
 one(R::FlintIntegerRing) = fmpz(1)
 
-@doc Markdown.doc"""
-    zero(R::FlintIntegerRing)
-
-Return the integer $0$.
-"""
 zero(R::FlintIntegerRing) = fmpz(0)
 
 # Exists only to support Julia functionality (no guarantees)
@@ -202,25 +192,10 @@ Return the number of limbs required to store the absolute value of $a$.
 """
 size(a::fmpz) = Int(ccall((:fmpz_size, libflint), Cint, (Ref{fmpz},), a))
 
-@doc Markdown.doc"""
-    isunit(a::fmpz)
-
-Return `true` if $a$ is a unit, i.e. $\pm 1$, otherwise return `false`.
-"""
 isunit(a::fmpz) = ccall((:fmpz_is_pm1, libflint), Bool, (Ref{fmpz},), a)
 
-@doc Markdown.doc"""
-    iszero(a::fmpz)
-
-Return `true` if $a$ is zero, otherwise return `false`.
-"""
 iszero(a::fmpz) = ccall((:fmpz_is_zero, libflint), Bool, (Ref{fmpz},), a)
 
-@doc Markdown.doc"""
-    isone(a::fmpz)
-
-Return `true` if $a$ is one, otherwise return `false`.
-"""
 isone(a::fmpz) = ccall((:fmpz_is_one, libflint), Bool, (Ref{fmpz},), a)
 
 @doc Markdown.doc"""
@@ -804,12 +779,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    mod(x::fmpz, y::fmpz)
-
-Return the remainder after division of $x$ by $y$. The remainder will be
-closer to zero than $y$ and have the same sign, or it will be zero.
-"""
 function mod(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
    r = fmpz()
@@ -818,12 +787,6 @@ function mod(x::fmpz, y::fmpz)
    return r
 end
 
-@doc Markdown.doc"""
-    mod(x::fmpz, y::UInt)
-
-Return the remainder after division of $x$ by $y$. The remainder will be the
-least nonnegative remainder.
-"""
 function mod(x::fmpz, c::UInt)
     c == 0 && throw(DivideError())
     ccall((:fmpz_fdiv_ui, libflint), Base.GMP.Limb, (Ref{fmpz}, Base.GMP.Limb), x, c)
@@ -1178,12 +1141,6 @@ function isqrtrem(x::fmpz)
     return s, r
 end
 
-@doc Markdown.doc"""
-    sqrt(x::fmpz)
-
-Return the square root $s$ of $x$. By default the function will raise an
-exception if the input is not square. If `check=false` this check is omitted.
-"""
 function Base.sqrt(x::fmpz; check=true)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     if check
@@ -1203,20 +1160,9 @@ function Base.sqrt(x::fmpz; check=true)
     return s
 end
 
-@doc Markdown.doc"""
-    issquare(x::fmpz)
-
-Return `true` if $x$ is a square, otherwise return `false`.
-"""
 issquare(x::fmpz) = Bool(ccall((:fmpz_is_square, libflint), Cint,
                                (Ref{fmpz},), x))
 
-@doc Markdown.doc"""
-    issquare_with_sqrt(x::fmpz)
-
-Return `(flag, s)` where `flag = true` and `s` is the square root of `x`
-if `x` is a perfect square and where `flag = false` and `s = 0` otherwise.
-"""
 function issquare_with_sqrt(x::fmpz)
     x < 0 && throw(DomainError(x, "Argument must be non-negative"))
     for i = 1:length(sqrt_moduli)
@@ -1520,11 +1466,6 @@ function next_prime(x::Int, proved::Bool = true)
    return x < 2 ? 2 : Int(next_prime(x % UInt, proved))
 end
 
-@doc Markdown.doc"""
-    remove(x::fmpz, y::fmpz)
-
-Return the tuple $n, z$ such that $x = y^nz$ where $y$ and $z$ are coprime.
-"""
 function remove(x::fmpz, y::fmpz)
    iszero(y) && throw(DivideError())
    z = fmpz()

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -26,39 +26,18 @@ end
 
 parent_type(::Type{fmpz_laurent_series}) = FmpzLaurentSeriesRing
 
-@doc Markdown.doc"""
-    parent(a::fmpz_laurent_series)
-
-Return the parent of the given power series.
-"""
 parent(a::fmpz_laurent_series) = a.parent
 
 elem_type(::Type{FmpzLaurentSeriesRing}) = fmpz_laurent_series
 
-@doc Markdown.doc"""
-    base_ring(R::FmpzLaurentSeriesRing)
-
-Return the base ring of the given power series ring.
-"""
 base_ring(R::FmpzLaurentSeriesRing) = R.base_ring
 
-@doc Markdown.doc"""
-    base_ring(a::fmpz_laurent_series)
-
-Return the base ring of the power series ring of the given power series.
-"""
 base_ring(a::fmpz_laurent_series) = base_ring(parent(a))
 
 isdomain_type(::Type{fmpz_laurent_series}) = true
 
 isexact_type(a::Type{fmpz_laurent_series}) = false
 
-@doc Markdown.doc"""
-    var(a::FmpzLaurentSeriesRing)
-
-Return the internal name of the generator of the power series ring. Note that
-this is returned as a `Symbol` not a `String`.
-`"""
 var(a::FmpzLaurentSeriesRing) = a.S
 
 function check_parent(a::fmpz_laurent_series, b::fmpz_laurent_series)
@@ -113,12 +92,6 @@ Return the scale factor of the polynomial underlying the given power series.
 """
 scale(a::fmpz_laurent_series) = a.scale
 
-@doc Markdown.doc"""
-    max_precision(R::FmpzLaurentSeriesRing)
-
-Return the maximum relative precision of power series in the given power
-series ring.
-"""
 max_precision(R::FmpzLaurentSeriesRing) = R.prec_max
 
 @doc Markdown.doc"""
@@ -263,28 +236,10 @@ function upscale(a::fmpz_laurent_series, n::Int)
    return d
 end
 
-@doc Markdown.doc"""
-    zero(R::FmpzLaurentSeriesRing)
-
-Return $0 + O(x^n)$ where $n$ is the maximum precision of the power series
-ring $R$.
-"""
 zero(R::FmpzLaurentSeriesRing) = R(0)
 
-@doc Markdown.doc"""
-    one(R::FmpzLaurentSeriesRing)
-
-Return $1 + O(x^n)$ where $n$ is the maximum precision of the power series
-ring $R$.
-"""
 one(R::FmpzLaurentSeriesRing) = R(1)
 
-@doc Markdown.doc"""
-    gen(R::FmpzLaurentSeriesRing)
-
-Return the generator of the power series ring, i.e. $x + O(x^{n + 1})$ where
-$n$ is the maximum precision of the power series ring $R$.
-"""
 function gen(R::FmpzLaurentSeriesRing)
    S = base_ring(R)
    return R([S(1)], 1, max_precision(R) + 1, 1, 1)
@@ -407,11 +362,6 @@ needs_parentheses(x::fmpz_laurent_series) = pol_length(x) > 1
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    -(a::fmpz_laurent_series)
-
-Return $-a$.
-"""
 function -(a::fmpz_laurent_series)
    len = pol_length(a)
    z = parent(a)()
@@ -430,11 +380,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    +(a::fmpz_laurent_series, b::fmpz_laurent_series)
-
-Return $a + b$.
-"""
 function +(a::fmpz_laurent_series, b::fmpz_laurent_series)
    check_parent(a, b)
    lena = pol_length(a)
@@ -487,11 +432,6 @@ function +(a::fmpz_laurent_series, b::fmpz_laurent_series)
    return z
 end
 
-@doc Markdown.doc"""
-    -(a::fmpz_laurent_series, b::fmpz_laurent_series)
-
-Return $a - b$.
-"""
 function -(a::fmpz_laurent_series, b::fmpz_laurent_series)
    check_parent(a, b)
    lena = pol_length(a)
@@ -544,11 +484,6 @@ function -(a::fmpz_laurent_series, b::fmpz_laurent_series)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::fmpz_laurent_series, b::fmpz_laurent_series)
-
-Return $a\times b$.
-"""
 function *(a::fmpz_laurent_series, b::fmpz_laurent_series)
    check_parent(a, b)
    lena = pol_length(a)
@@ -598,11 +533,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    *(a::fmpz, b::fmpz_laurent_series)
-
-Return $a\times b$.
-"""
 function *(a::fmpz, b::fmpz_laurent_series)
    len = pol_length(b)
    z = parent(b)()
@@ -616,11 +546,6 @@ function *(a::fmpz, b::fmpz_laurent_series)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::Integer, b::fmpz_laurent_series)
-
-Return $a\times b$.
-"""
 function *(a::Integer, b::fmpz_laurent_series)
    len = pol_length(b)
    z = parent(b)()
@@ -634,18 +559,8 @@ function *(a::Integer, b::fmpz_laurent_series)
    return z
 end
 
-@doc Markdown.doc"""
-    *(a::fmpz_laurent_series, b::fmpz)
-
-Return $a\times b$.
-"""
 *(a::fmpz_laurent_series, b::fmpz) = b*a
 
-@doc Markdown.doc"""
-    *(a::fmpz_laurent_series, b::Integer)
-
-Return $a\times b$.
-"""
 *(a::fmpz_laurent_series, b::Integer) = b*a
 
 ###############################################################################
@@ -654,12 +569,6 @@ Return $a\times b$.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    shift_left(x::fmpz_laurent_series, n::Int)
-
-Return the power series $x$ shifted left by $n$ terms, i.e. multiplied by
-$x^n$.
-"""
 function shift_left(x::fmpz_laurent_series, n::Int)
    z = deepcopy(x)
    z = set_precision!(z, precision(x) + n)
@@ -667,12 +576,6 @@ function shift_left(x::fmpz_laurent_series, n::Int)
    return z
 end
 
-@doc Markdown.doc"""
-    shift_right(x::fmpz_laurent_series, n::Int)
-
-Return the power series $x$ shifted right by $n$ terms, i.e. divided by
-$x^n$.
-"""
 function shift_right(x::fmpz_laurent_series, n::Int)
    z = deepcopy(x)
    z = set_precision!(z, precision(x) - n)
@@ -686,11 +589,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    truncate(a::fmpz_laurent_series, n::Int)
-
-Return $a$ truncated to (absolute) precision $n$.
-"""
 function truncate(a::fmpz_laurent_series, n::Int)
    alen = pol_length(a)
    aprec = precision(a)
@@ -773,11 +671,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    ^(a::fmpz_laurent_series, b::Int)
-
-Return $a^b$. We require $b \geq 0$.
-"""
 function ^(a::fmpz_laurent_series, b::Int)
    # special case powers of x for constructing power series efficiently
    if pol_length(a) == 0
@@ -969,11 +862,6 @@ Return `true` if $x == y$ arithmetically, otherwise return `false`.
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(a::fmpz_laurent_series, b::fmpz_laurent_series; check::Bool=true)
-
-Return $a/b$.
-"""
 function divexact(a::fmpz_laurent_series, b::fmpz_laurent_series; check::Bool=true)
    check_parent(a, b)
    lena = pol_length(a)
@@ -1021,11 +909,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divexact(x::fmpz_laurent_series, y::Union{Integer, Rational, AbstractFloat}; check::Bool=true)
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::fmpz_laurent_series, y::Union{Integer, Rational, AbstractFloat})
    y == 0 && throw(DivideError())
    lenx = pol_length(x)
@@ -1039,11 +922,6 @@ function divexact(x::fmpz_laurent_series, y::Union{Integer, Rational, AbstractFl
    return z
 end
 
-@doc Markdown.doc"""
-    divexact(x::fmpz_laurent_series, y::T) where {T <: RingElem}
-
-Return $x/y$ where the quotient is expected to be exact.
-"""
 function divexact(x::fmpz_laurent_series, y::T; check::Bool=true) where {T <: RingElem}
    iszero(y) && throw(DivideError())
    lenx = pol_length(x)
@@ -1063,11 +941,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    inv(a::fmpz_laurent_series)
-
-Return the inverse of the power series $a$, i.e. $1/a$.
-"""
 function inv(a::fmpz_laurent_series)
    iszero(a) && throw(DivideError())
    a1 = polcoeff(a, 0)
@@ -1092,11 +965,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    sqrt(a::fmpz_laurent_series; check::Bool=true)
-
-Return the square root of the power series $a$.
-"""
 function sqrt(a::fmpz_laurent_series; check::Bool=true)
    aval = valuation(a)
    check && !iseven(aval) && error("Not a square in sqrt")

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -611,11 +611,6 @@ function powermod(x::T, e::Int, y::T) where {T <: Zmodn_fmpz_poly}
   return z
 end
 
-@doc Markdown.doc"""
-    powermod(x::T, e::fmpz, y::T) where {T <: Zmodn_fmpz_poly}
-
-Return $x^e \pmod{y}$.
-"""
 function powermod(x::T, e::fmpz, y::T) where {T <: Zmodn_fmpz_poly}
   z = parent(x)()
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -31,11 +31,6 @@ Returns `Union{}` as this field is not dependent on another field.
 """
 base_ring(a::fq) = Union{}
 
-@doc Markdown.doc"""
-    parent(a::fq)
-
-Returns the parent of the given finite field element.
-"""
 parent(a::fq) = a.parent
 
 isdomain_type(::Type{fq}) = true
@@ -73,22 +68,12 @@ function coeff(x::fq, n::Int)
    return z
 end
 
-@doc Markdown.doc"""
-    zero(a::FqFiniteField)
-
-Return the additive identity, zero, in the given finite field.
-"""
 function zero(a::FqFiniteField)
    d = a()
    ccall((:fq_zero, libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
    return d
 end
 
-@doc Markdown.doc"""
-    one(a::FqFiniteField)
-
-Return the multiplicative identity, one, in the given finite field.
-"""
 function one(a::FqFiniteField)
    d = a()
    ccall((:fq_one, libflint), Nothing, (Ref{fq}, Ref{FqFiniteField}), d, a)
@@ -108,21 +93,9 @@ function gen(a::FqFiniteField)
    return d
 end
 
-@doc Markdown.doc"""
-    iszero(a::fq)
-
-Return `true` if the given finite field element is zero, otherwise return
-`false`.
-"""
 iszero(a::fq) = ccall((:fq_is_zero, libflint), Bool,
                      (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
-@doc Markdown.doc"""
-    isone(a::fq)
-
-Return `true` if the given finite field element is one, otherwise return
-`false`.
-"""
 isone(a::fq) = ccall((:fq_is_one, libflint), Bool,
                     (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
@@ -134,20 +107,9 @@ finite field, otherwise return `false`.
 """
 isgen(a::fq) = a == gen(parent(a))
 
-@doc Markdown.doc"""
-    isunit(a::fq)
-
-Return `true` if the given finite field element is invertible, i.e. nonzero,
-otherwise return `false`.
-"""
 isunit(a::fq) = ccall((:fq_is_invertible, libflint), Bool,
                      (Ref{fq}, Ref{FqFiniteField}), a, a.parent)
 
-@doc Markdown.doc"""
-    characteristic(a::FqFiniteField)
-
-Return the characteristic of the given finite field.
-"""
 function characteristic(a::FqFiniteField)
    d = fmpz()
    ccall((:__fq_ctx_prime, libflint), Nothing,
@@ -155,11 +117,6 @@ function characteristic(a::FqFiniteField)
    return d
 end
 
-@doc Markdown.doc"""
-    order(a::FqFiniteField)
-
-Return the order, i.e. the number of elements in, the given finite field.
-"""
 function order(a::FqFiniteField)
    d = fmpz()
    ccall((:fq_ctx_order, libflint), Nothing,
@@ -407,11 +364,6 @@ divexact(x::fmpz, y::fq; check::Bool=true) = divexact(parent(y)(x), y; check=che
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    inv(x::fq)
-
-Return $x^{-1}$.
-"""
 function inv(x::fq)
    iszero(x) && throw(DivideError())
    z = parent(x)()
@@ -426,12 +378,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    sqrt(x::fq)
-
-Return a square root of $x$ in the finite field. If $x$ is not a square
-an exception is raised.
-"""
 function sqrt(x::fq; check::Bool=true)
    z = parent(x)()
    res = Bool(ccall((:fq_sqrt, libflint), Cint,
@@ -441,24 +387,12 @@ function sqrt(x::fq; check::Bool=true)
    return z
 end
 
-@doc Markdown.doc"""
-    issquare(x::fq)
-
-Return `true` if $x$ is a square in the finite field (includes zero).
-"""
 function issquare(x::fq)
    return Bool(ccall((:fq_is_square, libflint), Cint,
                      (Ref{fq}, Ref{FqFiniteField}),
                      x, x.parent))
 end
 
-@doc Markdown.doc"""
-    issquare_with_sqrt(x::fq)
-
-If $x$ is a square, return the tuple of `true` and a square root of $x$.
-Otherwise, return the tuple of `false` and an unspecified element of the
-finite field.
-"""
 function issquare_with_sqrt(x::fq)
    z = parent(x)()
    flag = ccall((:fq_sqrt, libflint), Cint,

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -30,11 +30,6 @@ Returns `Union{}` as this field is not dependent on another field.
 """
 base_ring(a::fq_default) = Union{}
 
-@doc Markdown.doc"""
-    parent(a::fq_default)
-
-Returns the parent of the given finite field element.
-"""
 parent(a::fq_default) = a.parent
 
 isdomain_type(::Type{fq_default}) = true
@@ -73,22 +68,12 @@ function coeff(x::fq_default, n::Int)
    return z
 end
 
-@doc Markdown.doc"""
-    zero(a::FqDefaultFiniteField)
-
-Return the additive identity, zero, in the given finite field.
-"""
 function zero(a::FqDefaultFiniteField)
    d = a()
    ccall((:fq_default_zero, libflint), Nothing, (Ref{fq_default}, Ref{FqDefaultFiniteField}), d, a)
    return d
 end
 
-@doc Markdown.doc"""
-    one(a::FqDefaultFiniteField)
-
-Return the multiplicative identity, one, in the given finite field.
-"""
 function one(a::FqDefaultFiniteField)
    d = a()
    ccall((:fq_default_one, libflint), Nothing, (Ref{fq_default}, Ref{FqDefaultFiniteField}), d, a)
@@ -108,21 +93,9 @@ function gen(a::FqDefaultFiniteField)
    return d
 end
 
-@doc Markdown.doc"""
-    iszero(a::fq_default)
-
-Return `true` if the given finite field element is zero, otherwise return
-`false`.
-"""
 iszero(a::fq_default) = ccall((:fq_default_is_zero, libflint), Bool,
                      (Ref{fq_default}, Ref{FqDefaultFiniteField}), a, a.parent)
 
-@doc Markdown.doc"""
-    isone(a::fq_default)
-
-Return `true` if the given finite field element is one, otherwise return
-`false`.
-"""
 isone(a::fq_default) = ccall((:fq_default_is_one, libflint), Bool,
                     (Ref{fq_default}, Ref{FqDefaultFiniteField}), a, a.parent)
 
@@ -134,20 +107,9 @@ finite field, otherwise return `false`.
 """
 isgen(a::fq_default) = a == gen(parent(a))
 
-@doc Markdown.doc"""
-    isunit(a::fq_default)
-
-Return `true` if the given finite field element is invertible, i.e. nonzero,
-otherwise return `false`.
-"""
 isunit(a::fq_default) = ccall((:fq_default_is_invertible, libflint), Bool,
                      (Ref{fq_default}, Ref{FqDefaultFiniteField}), a, a.parent)
 
-@doc Markdown.doc"""
-    characteristic(a::FqDefaultFiniteField)
-
-Return the characteristic of the given finite field.
-"""
 function characteristic(a::FqDefaultFiniteField)
    d = fmpz()
    ccall((:fq_default_ctx_prime, libflint), Nothing,
@@ -155,11 +117,6 @@ function characteristic(a::FqDefaultFiniteField)
    return d
 end
 
-@doc Markdown.doc"""
-    order(a::FqDefaultFiniteField)
-
-Return the order, i.e. the number of elements in, the given finite field.
-"""
 function order(a::FqDefaultFiniteField)
    d = fmpz()
    ccall((:fq_default_ctx_order, libflint), Nothing,
@@ -453,11 +410,6 @@ divexact(x::fmpz, y::fq_default; check::Bool=true) = divexact(parent(y)(x), y; c
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    inv(x::fq_default)
-
-Return $x^{-1}$.
-"""
 function inv(x::fq_default)
    iszero(x) && throw(DivideError())
    z = parent(x)()
@@ -472,12 +424,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    sqrt(x::fq_default)
-
-Return a square root of $x$ in the finite field. If $x$ is not a square
-an exception is raised.
-"""
 function sqrt(x::fq_default)
    z = parent(x)()
    res = Bool(ccall((:fq_default_sqrt, libflint), Cint,
@@ -487,24 +433,12 @@ function sqrt(x::fq_default)
    return z
 end
 
-@doc Markdown.doc"""
-    issquare(x::fq_default)
-
-Return `true` if $x$ is a square in the finite field (includes zero).
-"""
 function issquare(x::fq_default)
    return Bool(ccall((:fq_default_is_square, libflint), Cint,
                      (Ref{fq_default}, Ref{FqDefaultFiniteField}),
                      x, x.parent))
 end
 
-@doc Markdown.doc"""
-    issquare_with_sqrt(x::fq_default)
-
-If $x$ is a square, return the tuple of `true` and a square root of $x$.
-Otherwise, return the tuple of `false` and an unspecified element of the
-finite field.
-"""
 function issquare_with_sqrt(x::fq_default)
    z = parent(x)()
    flag = ccall((:fq_default_sqrt, libflint), Cint,

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -376,14 +376,6 @@ end
 #
 ################################################################################
 
-@doc Markdown.doc"""
-    remove(z::fq_default_poly, p::fq_default_poly)
-
-Computes the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::fq_default_poly, p::fq_default_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -403,14 +403,6 @@ end
 #
 ################################################################################
 
-@doc Markdown.doc"""
-    remove(z::fq_poly, p::fq_poly)
-
-Computes the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::fq_poly, p::fq_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -64,18 +64,8 @@ function deepcopy_internal(a::gfp_elem, dict::IdDict)
    return gfp_elem(deepcopy(a.data), R)
 end
 
-@doc Markdown.doc"""
-    order(R::GaloisField) -> fmpz
-
-Return the order, i.e. the number of elements in, the given Galois field.
-"""
 order(R::GaloisField) = fmpz(R.n)
 
-@doc Markdown.doc"""
-    characteristic(R::GaloisField) -> fmpz
-
-Return the characteristic of the given Galois field.
-"""
 characteristic(R::GaloisField) = fmpz(R.n)
 
 degree(::GaloisField) = 1

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -63,18 +63,8 @@ isunit(a::gfp_fmpz_elem) = a.data != 0
 
 modulus(R::GaloisFmpzField) = R.n
 
-@doc Markdown.doc"""
-    characteristic(F::GaloisFmpzField)
-
-Return the characteristic of the given Galois field.
-"""
 characteristic(F::GaloisFmpzField) = modulus(F)
 
-@doc Markdown.doc"""
-    order(F::GaloisFmpzField)
-
-Return the order, i.e. the number of elements in, the given Galois field.
-"""
 order(F::GaloisFmpzField) = modulus(F)
 
 degree(::GaloisFmpzField) = 1

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -454,14 +454,6 @@ end
 #
 ################################################################################
 
-@doc Markdown.doc"""
-    remove(z::gfp_poly, p::gfp_poly)
-
-Computes the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::gfp_poly, p::gfp_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -864,14 +864,6 @@ end
 #
 ################################################################################
 
-@doc Markdown.doc"""
-    remove(z::nmod_poly, p::nmod_poly)
-
-Computes the valuation of $z$ at $p$, that is, the largest $k$ such that
-$p^k$ divides $z$. Additionally, $z/p^k$ is returned as well.
-
-See also `valuation`, which only returns the valuation.
-"""
 function remove(z::nmod_poly, p::nmod_poly)
    check_parent(z,p)
    iszero(z) && error("Not yet implemented")

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -175,11 +175,6 @@ function lift(R::FlintIntegerRing, a::padic)
     return r
 end
 
-@doc Markdown.doc"""
-    zero(R::FlintPadicField)
-
-Return zero in the given $p$-adic field, to the default precision.
-"""
 function zero(R::FlintPadicField)
    z = padic(R.prec_max)
    ccall((:padic_zero, libflint), Nothing, (Ref{padic},), z)
@@ -187,11 +182,6 @@ function zero(R::FlintPadicField)
    return z
 end
 
-@doc Markdown.doc"""
-    one(R::FlintPadicField)
-
-Return zero in the given $p$-adic field, to the default precision.
-"""
 function one(R::FlintPadicField)
    z = padic(R.prec_max)
    ccall((:padic_one, libflint), Nothing, (Ref{padic},), z)
@@ -199,30 +189,12 @@ function one(R::FlintPadicField)
    return z
 end
 
-@doc Markdown.doc"""
-    iszero(a::padic)
-
-Return `true` if the given p-adic field element is zero, otherwise return
-`false`.
-"""
 iszero(a::padic) = Bool(ccall((:padic_is_zero, libflint), Cint,
                               (Ref{padic},), a))
 
-@doc Markdown.doc"""
-    isone(a::padic)
-
-Return `true` if the given p-adic field element is one, otherwise return
-`false`.
-"""
 isone(a::padic) = Bool(ccall((:padic_is_one, libflint), Cint,
                              (Ref{padic},), a))
 
-@doc Markdown.doc"""
-    isunit(a::padic)
-
-Return `true` if the given p-adic field element is invertible, i.e. nonzero,
-otherwise return `false`.
-"""
 isunit(a::padic) = !Bool(ccall((:padic_is_zero, libflint), Cint,
                               (Ref{padic},), a))
 
@@ -509,11 +481,6 @@ divexact(a::fmpq, b::padic; check::Bool=true) = inv(inv(a)*b)
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    inv(a::padic)
-
-Returns $a^{-1}$. If $a = 0$ a `DivideError()` is thrown.
-"""
 function inv(a::padic)
    iszero(a) && throw(DivideError())
    ctx = parent(a)
@@ -530,13 +497,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divides(a::padic, b::padic)
-
-Returns a pair consisting of a flag which is set to `true` if $b$ divides
-$a$ and `false` otherwise, and a value $h$ such that $a = bh$ if
-such a value exists. If not, the value of $h$ is undetermined.
-"""
 function divides(a::padic, b::padic)
    if iszero(a)
       return true, zero(parent(a))
@@ -553,12 +513,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    gcd(x::padic, y::padic)
-
-Returns the greatest common divisor of $x$ and $y$, i.e. the function returns
-$1$ unless both $a$ and $b$ are $0$, in which case it returns $0$.
-"""
 function gcd(x::padic, y::padic)
    check_parent(x, y)
    if iszero(x) && iszero(y)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -83,11 +83,6 @@ Returns `Union{}` as this field is not dependent on another field.
 """
 base_ring(a::qadic) = Union{}
 
-@doc Markdown.doc"""
-    parent(a::qadic)
-
-Returns the parent of the given p-adic field element.
-"""
 parent(a::qadic) = a.parent
 
 isdomain_type(::Type{qadic}) = true
@@ -182,11 +177,6 @@ function lift(R::FmpzPolyRing, a::qadic)
    return r
 end
 
-@doc Markdown.doc"""
-    zero(R::FlintQadicField)
-
-Return zero in the given $q$-adic field, to the default precision.
-"""
 function zero(R::FlintQadicField)
    z = qadic(R.prec_max)
    ccall((:qadic_zero, libflint), Nothing, (Ref{qadic},), z)
@@ -194,11 +184,6 @@ function zero(R::FlintQadicField)
    return z
 end
 
-@doc Markdown.doc"""
-    one(R::FlintQadicField)
-
-Return zero in the given $q$-adic field, to the default precision.
-"""
 function one(R::FlintQadicField)
    z = qadic(R.prec_max)
    ccall((:qadic_one, libflint), Nothing, (Ref{qadic},), z)
@@ -206,30 +191,12 @@ function one(R::FlintQadicField)
    return z
 end
 
-@doc Markdown.doc"""
-    iszero(a::qadic)
-
-Return `true` if the given p-adic field element is zero, otherwise return
-`false`.
-"""
 iszero(a::qadic) = Bool(ccall((:qadic_is_zero, libflint), Cint,
                               (Ref{qadic},), a))
 
-@doc Markdown.doc"""
-    isone(a::qadic)
-
-Return `true` if the given p-adic field element is one, otherwise return
-`false`.
-"""
 isone(a::qadic) = Bool(ccall((:qadic_is_one, libflint), Cint,
                              (Ref{qadic},), a))
 
-@doc Markdown.doc"""
-    isunit(a::qadic)
-
-Return `true` if the given p-adic field element is invertible, i.e. nonzero,
-otherwise return `false`.
-"""
 isunit(a::qadic) = !Bool(ccall((:qadic_is_zero, libflint), Cint,
                               (Ref{qadic},), a))
 
@@ -486,11 +453,6 @@ divexact(a::fmpq, b::qadic; check::Bool=true) = inv(inv(a)*b)
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    inv(a::qadic)
-
-Returns $a^{-1}$. If $a = 0$ a `DivideError()` is thrown.
-"""
 function inv(a::qadic)
    iszero(a) && throw(DivideError())
    ctx = parent(a)
@@ -507,13 +469,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    divides(f::qadic, g::qadic)
-
-Returns a pair consisting of a flag which is set to `true` if $g$ divides
-$f$ and `false` otherwise, and a value $h$ such that $f = gh$ if
-such a value exists. If not, the value of $h$ is undetermined.
-"""
 function divides(a::qadic, b::qadic)
    if iszero(a)
      return true, zero(parent(a))
@@ -530,12 +485,6 @@ end
 #
 ###############################################################################
 
-@doc Markdown.doc"""
-    gcd(x::qadic, y::qadic)
-
-Returns the greatest common divisor of $x$ and $y$, i.e. the function returns
-$1$ unless both $a$ and $b$ are $0$, in which case it returns $0$.
-"""
 function gcd(x::qadic, y::qadic)
    check_parent(x, y)
    if iszero(x) && iszero(y)


### PR DESCRIPTION
Here is a bit of my rationale:
- `sign(::fmpq)` Does it return `Int`, `fmpz`, or `fmpq`? Keep it.
- `abs(::fmpq)` can only do one reasonable thing: Dust bin.

It seems that the docs strings are being used on a per-argument type to indicate
that the function exists/is implemented. Once a function is in Base, this is a
mistake in my view. Let's take the `exp` function for example.
When I type into julia, I get

```julia
help?> exp
search: exp exp2 Expr exp10 expm1 export exppii expint exp_gcd exponent exp_pi_i expanduser exp_integral_e exponent_vector

  exp(x)

  Compute the natural base exponential of x, in other words e^x.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> exp(1.0)
  2.718281828459045

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  exp(A::AbstractMatrix)

  Compute the matrix exponential of A, defined by

  e^A = \sum_{n=0}^{\infty} \frac{A^n}{n!}.
```

and this is sufficient. All of nemo methods for `exp` in my view do *not*
need to be documented (`fmpq_poly_series`, `arb`, `acb`, `acb_mat`, ...), unless they
are doing something tricky, like the p-adic stuff. I would really like to
(but didn't) remove the useless doc strings for `f(x)` that just say "return f(x)":

```

  exp(x::arb_mat)

  Returns the exponential of the matrix x.


  exp(x::acb_mat)

  Returns the exponential of the matrix x.
```

If I want to know what functions I can call on an `arb`, there is

```julia
julia> methodswith(arb)
```

and maybe *this* is worth documenting.


I also wanted to (but didn't) delete the doc strings for `isirreducible`,
`issquarefree`, `factor`, `factor_squarefree`, ... . These should in my view be
documented *once* in AA under an optional section for the rings. A specific
factor function worth documenting would be, say, one that factors a polynomial
over ZZ[x] into factors over ZZ_p[x] or some other inexact ring.
