### PR TITLE
Remove uses of the adjoint operator x'

### DIFF
--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -639,8 +639,8 @@ end
 function can_solve_with_solution(a::fmpq_mat, b::fmpq_mat; side::Symbol = :right)
    if side == :left
       (ncols(a) != ncols(b)) && error("Matrices must have same number of columns")
-      (f, x) = can_solve_with_solution(a', b'; side=:right)
-      return (f, x')
+      (f, x) = can_solve_with_solution(transpose(a), transpose(b); side=:right)
+      return (f, transpose(x))
    elseif side == :right
       (nrows(a) != nrows(b)) && error("Matrices must have same number of rows")
       x = similar(a, ncols(a), ncols(b))

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -433,8 +433,8 @@ function can_solve_with_solution(a::fq_default_mat, b::fq_default_mat; side::Sym
    (base_ring(a) != base_ring(b)) && error("Matrices must have same base ring")
    if side == :left
       (ncols(a) != ncols(b)) && error("Matrices must have same number of columns")
-      (f, x) = can_solve_with_solution(a', b'; side=:right)
-      return (f, x')
+      (f, x) = can_solve_with_solution(transpose(a), transpose(b); side=:right)
+      return (f, transpose(x))
    elseif side == :right
       (nrows(a) != nrows(b)) && error("Matrices must have same number of rows")
       x = similar(a, ncols(a), ncols(b))

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -430,8 +430,8 @@ function can_solve_with_solution(a::fq_mat, b::fq_mat; side::Symbol = :right)
    (base_ring(a) != base_ring(b)) && error("Matrices must have same base ring")
    if side == :left
       (ncols(a) != ncols(b)) && error("Matrices must have same number of columns")
-      (f, x) = can_solve_with_solution(a', b'; side=:right)
-      return (f, x')
+      (f, x) = can_solve_with_solution(transpose(a), transpose(b); side=:right)
+      return (f, transpose(x))
    elseif side == :right
       (nrows(a) != nrows(b)) && error("Matrices must have same number of rows")
       x = similar(a, ncols(a), ncols(b))

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -430,8 +430,8 @@ function can_solve_with_solution(a::fq_nmod_mat, b::fq_nmod_mat; side::Symbol = 
    (base_ring(a) != base_ring(b)) && error("Matrices must have same base ring")
    if side == :left
       (ncols(a) != ncols(b)) && error("Matrices must have same number of columns")
-      (f, x) = can_solve_with_solution(a', b'; side=:right)
-      return (f, x')
+      (f, x) = can_solve_with_solution(transpose(a), transpose(b); side=:right)
+      return (f, transpose(x))
    elseif side == :right
       (nrows(a) != nrows(b)) && error("Matrices must have same number of rows")
       x = similar(a, ncols(a), ncols(b))

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -297,8 +297,8 @@ function can_solve_with_solution(a::gfp_mat, b::gfp_mat; side::Symbol = :right)
    (base_ring(a) != base_ring(b)) && error("Matrices must have same base ring")
    if side == :left
       (ncols(a) != ncols(b)) && error("Matrices must have same number of columns")
-      (f, x) = can_solve_with_solution(a', b'; side=:right)
-      return (f, x')
+      (f, x) = can_solve_with_solution(transpose(a), transpose(b); side=:right)
+      return (f, transpose(x))
    elseif side == :right
       (nrows(a) != nrows(b)) && error("Matrices must have same number of rows")
       x = similar(a, ncols(a), ncols(b))

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -568,28 +568,28 @@ end
    @test_throws ErrorException can_solve_with_solution(A, B)
 
    # Transpose
-   A = matrix(QQ, 2, 2, [1, 2, 2, 5])'
-   B = matrix(QQ, 2, 1, [1, 2])'
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(QQ, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(QQ, 2, 2, [1, 2, 2, 4])'
-   B = matrix(QQ, 2, 1, [1, 2])'
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(QQ, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(QQ, 2, 2, [1, 2, 2, 4])'
-   B = matrix(QQ, 2, 1, [1, 3])'
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(QQ, 2, 1, [1, 3]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test !fl
    @test !can_solve(A, B, side = :left)
 
-   A = zero_matrix(QQ, 2, 3)'
-   B = identity_matrix(QQ, 3)'
+   A = transpose(zero_matrix(QQ, 2, 3))
+   B = transpose(identity_matrix(QQ, 3))
    @test_throws ErrorException can_solve_with_solution(A, B, side = :left)
 
    @test_throws ErrorException can_solve_with_solution(A, B, side = :garbage)

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -612,28 +612,28 @@ end
    B = identity_matrix(F17, 3)
    @test_throws ErrorException can_solve_with_solution(A, B)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 5])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 3])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test !fl
    @test !can_solve(A, B, side = :left)
 
-   A = zero_matrix(F17, 2, 3)'
-   B = identity_matrix(F17, 3)'
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
    @test_throws ErrorException can_solve_with_solution(A, B, side = :left)
 
    @test_throws ErrorException can_solve_with_solution(A, B, side = :garbage)

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -603,28 +603,28 @@ end
    B = identity_matrix(F17, 3)
    @test_throws ErrorException can_solve_with_solution(A, B)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 5])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 3])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test !fl
    @test !can_solve(A, B, side = :left)
 
-   A = zero_matrix(F17, 2, 3)'
-   B = identity_matrix(F17, 3)'
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
    @test_throws ErrorException can_solve_with_solution(A, B, side = :left)
 
    @test_throws ErrorException can_solve_with_solution(A, B, side = :garbage)

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -603,28 +603,28 @@ end
    B = identity_matrix(F17, 3)
    @test_throws ErrorException can_solve_with_solution(A, B)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 5])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 2])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(F17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(F17, 2, 1, [1, 3])'
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test !fl
    @test !can_solve(A, B, side = :left)
 
-   A = zero_matrix(F17, 2, 3)'
-   B = identity_matrix(F17, 3)'
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
    @test_throws ErrorException can_solve_with_solution(A, B, side = :left)
 
    @test_throws ErrorException can_solve_with_solution(A, B, side = :garbage)

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -657,28 +657,28 @@ end
    B = identity_matrix(Z17, 3)
    @test_throws ErrorException can_solve_with_solution(A, B)
 
-   A = matrix(Z17, 2, 2, [1, 2, 2, 5])'
-   B = matrix(Z17, 2, 1, [1, 2])'
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(Z17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(Z17, 2, 1, [1, 2])'
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test fl
    @test X * A == B
    @test can_solve(A, B, side = :left)
 
-   A = matrix(Z17, 2, 2, [1, 2, 2, 4])'
-   B = matrix(Z17, 2, 1, [1, 3])'
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 3]))
    fl, X = can_solve_with_solution(A, B, side = :left)
    @test !fl
    @test !can_solve(A, B, side = :left)
 
-   A = zero_matrix(Z17, 2, 3)'
-   B = identity_matrix(Z17, 3)'
+   A = transpose(zero_matrix(Z17, 2, 3))
+   B = transpose(identity_matrix(Z17, 3))
    @test_throws ErrorException can_solve_with_solution(A, B, side = :left)
 
    @test_throws ErrorException can_solve_with_solution(A, B, side = :garbage)


### PR DESCRIPTION
Only leave in a few which are applied to `Matrix{Int}`, so we know they are fine.

This is a companion to https://github.com/Nemocas/AbstractAlgebra.jl/pull/838