### PR TITLE
Improve various rand() methods

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2078,9 +2078,9 @@ RandomExtensions.maketype(R::FlintIntegerRing, _) = fmpz
 rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{fmpz,FlintIntegerRing}}) =
         sp[][1](rand(rng, sp[][2]))
 
-rand(rng::AbstractRNG, R::FlintIntegerRing, n::UnitRange{Int}) = R(rand(rng, n))
+rand(rng::AbstractRNG, R::FlintIntegerRing, n::AbstractArray) = R(rand(rng, n))
 
-rand(R::FlintIntegerRing, n::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, n)
+rand(R::FlintIntegerRing, n::AbstractArray) = rand(Random.GLOBAL_RNG, R, n)
 
 @doc Markdown.doc"""
     rand_bits(::FlintIntegerRing, b::Int)

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -375,18 +375,18 @@ end
 
 Random.gentype(::Type{FmpzModRing}) = elem_type(FmpzModRing)
 
-# define rand(make(::FmpzModRing, n:m))
+# define rand(make(::FmpzModRing, arr)), where arr is any abstract array with integer or fmpz entries
 
 RandomExtensions.maketype(R::FmpzModRing, _) = elem_type(R)
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{fmpz_mod,FmpzModRing,UnitRange{Int}}}) =
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{fmpz_mod,FmpzModRing,<:AbstractArray{<:Union{fmpz,Integer}}}}) =
    sp[][1](rand(rng, sp[][2]))
 
-# define rand(::FmpzModRing, n:m)
+# define rand(::FmpzModRing, arr), where arr is any abstract array with integer or fmpz entries
 
-rand(r::Random.AbstractRNG, R::FmpzModRing, b::UnitRange{Int}) = rand(r, make(R, b))
+rand(r::Random.AbstractRNG, R::FmpzModRing, b::AbstractArray) = rand(r, make(R, b))
 
-rand(R::FmpzModRing, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
+rand(R::FmpzModRing, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -481,18 +481,18 @@ end
 
 Random.gentype(::Type{FqNmodFiniteField}) = elem_type(FqNmodFiniteField)
 
-# define rand(make(::FqNmodFiniteField, n:m))
+# define rand(make(::FqNmodFiniteField, arr)), where arr is any abstract array with integer or fmpz entries
 
 RandomExtensions.maketype(R::FqNmodFiniteField, _) = elem_type(R)
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{fq_nmod,FqNmodFiniteField,UnitRange{Int}}}) =
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{fq_nmod,FqNmodFiniteField,<:AbstractArray{<:Union{fmpz,Integer}}}}) =
    sp[][1](rand(rng, sp[][2]))
 
-# define rand(::FqNmodFiniteField, n:m)
+# define rand(::FqNmodFiniteField, arr), where arr is any abstract array with integer or fmpz entries
 
-rand(r::Random.AbstractRNG, R::FqNmodFiniteField, b::UnitRange{Int}) = rand(r, make(R, b))
+rand(r::Random.AbstractRNG, R::FqNmodFiniteField, b::AbstractArray) = rand(r, make(R, b))
 
-rand(R::FqNmodFiniteField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
+rand(R::FqNmodFiniteField, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -331,18 +331,18 @@ Random.Sampler(::Type{RNG}, R::GaloisField, n::Random.Repetition) where {RNG<:Ab
 rand(rng::AbstractRNG, R::Random.SamplerSimple{GaloisField}) =
    gfp_elem(rand(rng, R.data), R[])
 
-# define rand(make(::GaloisField, n:m))
+# define rand(make(::GaloisField, arr)), where arr is any abstract array with integer or fmpz entries
 
 RandomExtensions.maketype(R::GaloisField, _) = elem_type(R)
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{gfp_elem,GaloisField,UnitRange{Int}}}) =
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{gfp_elem,GaloisField,<:AbstractArray{<:Union{fmpz,Integer}}}}) =
    sp[][1](rand(rng, sp[][2]))
 
-# define rand(::GaloisField, n:m)
+# define rand(::GaloisField, arr), where arr is any abstract array with integer or fmpz entries
 
-rand(rng::AbstractRNG, R::GaloisField, b::UnitRange{Int}) = rand(rng, make(R, b))
+rand(rng::AbstractRNG, R::GaloisField, b::AbstractArray) = rand(rng, make(R, b))
 
-rand(R::GaloisField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
+rand(R::GaloisField, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -326,19 +326,19 @@ function rand(rng::AbstractRNG, R::Random.SamplerSimple{GaloisFmpzField})
    gfp_fmpz_elem(fmpz(n), R[])
 end
 
-# define rand(make(::GaloisFmpzField, n:m))
+# define rand(make(::GaloisFmpzField, arr)), where arr is any abstract array with integer or fmpz entries
 
 RandomExtensions.maketype(R::GaloisFmpzField, _) = elem_type(R)
 
 rand(rng::AbstractRNG,
-     sp::SamplerTrivial{<:Make2{gfp_fmpz_elem,GaloisFmpzField,UnitRange{Int}}}) =
+     sp::SamplerTrivial{<:Make2{gfp_fmpz_elem,GaloisFmpzField,<:AbstractArray{<:Union{fmpz,Integer}}}}) =
         sp[][1](rand(rng, sp[][2]))
 
-# define rand(::GaloisFmpzField, n:m)
+# define rand(::GaloisFmpzField, arr), where arr is any abstract array with integer or fmpz entries
 
-rand(r::Random.AbstractRNG, R::GaloisFmpzField, b::UnitRange{Int}) = rand(r, make(R, b))
+rand(r::Random.AbstractRNG, R::GaloisFmpzField, b::AbstractArray) = rand(r, make(R, b))
 
-rand(R::GaloisFmpzField, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
+rand(R::GaloisFmpzField, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -378,18 +378,18 @@ rand(rng::AbstractRNG, R::Random.SamplerSimple{NmodRing}) = nmod(rand(rng, R.dat
 
 Random.gentype(::Type{NmodRing}) = elem_type(NmodRing)
 
-# define rand(make(R::NmodRing, n:m))
+# define rand(make(R::NmodRing, arr)), where arr is any abstract array with integer or fmpz entries
 
 RandomExtensions.maketype(R::NmodRing, _) = elem_type(R)
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{nmod,NmodRing,UnitRange{Int}}}) =
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Make2{nmod,NmodRing,<:AbstractArray{<:Union{fmpz,Integer}}}}) =
    sp[][1](rand(rng, sp[][2]))
 
-# define rand(R::NmodRing, n:m)
+# define rand(R::NmodRing, arr), where arr is any abstract array with integer or fmpz entries
 
-rand(r::Random.AbstractRNG, R::NmodRing, b::UnitRange{Int}) = rand(r, make(R, b))
+rand(r::Random.AbstractRNG, R::NmodRing, b::AbstractArray) = rand(r, make(R, b))
 
-rand(R::NmodRing, b::UnitRange{Int}) = rand(Random.GLOBAL_RNG, R, b)
+rand(R::NmodRing, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 ###############################################################################
 #

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -33,7 +33,13 @@ end
 
 @testset "fmpz.rand" begin
    test_rand(FlintZZ, 1:9)
-   test_rand(FlintZZ(1):FlintZZ(9))
+   test_rand(FlintZZ, Int16(1):Int16(9))
+   test_rand(FlintZZ, big(1):big(9))
+   test_rand(FlintZZ, fmpz(1):fmpz(9))
+   test_rand(FlintZZ, [3,9,2])
+   test_rand(FlintZZ, Int16[3,9,2])
+   test_rand(FlintZZ, BigInt[3,9,2])
+   test_rand(FlintZZ, fmpz[3,9,2])
 
    for bits in 0:100
       t = rand_bits(FlintZZ, bits)

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -44,6 +44,13 @@ end
 
    test_rand(R)
    test_rand(R, 1:9)
+   test_rand(R, Int16(1):Int16(9))
+   test_rand(R, big(1):big(9))
+   test_rand(R, fmpz(1):fmpz(9))
+   test_rand(R, [3,9,2])
+   test_rand(R, Int16[3,9,2])
+   test_rand(R, BigInt[3,9,2])
+   test_rand(R, fmpz[3,9,2])
 end
 
 @testset "fmpz_mod.printing" begin

--- a/test/flint/fq_nmod-test.jl
+++ b/test/flint/fq_nmod-test.jl
@@ -42,6 +42,20 @@
    @test_throws DomainError FiniteField(yyy^2+1, "z")
 end
 
+@testset "fq_nmod.rand" begin
+   R, x = FiniteField(7, 5, "x")
+
+   test_rand(R)
+   test_rand(R, 1:9)
+   test_rand(R, Int16(1):Int16(9))
+   test_rand(R, big(1):big(9))
+   test_rand(R, fmpz(1):fmpz(9))
+   test_rand(R, [3,9,2])
+   test_rand(R, Int16[3,9,2])
+   test_rand(R, BigInt[3,9,2])
+   test_rand(R, fmpz[3,9,2])
+end
+
 @testset "fq_nmod.printing" begin
    R, x = FiniteField(7, 5, "x")
 

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -67,6 +67,13 @@ end
 
    test_rand(R)
    test_rand(R, 1:9)
+   test_rand(R, Int16(1):Int16(9))
+   test_rand(R, big(1):big(9))
+   test_rand(R, fmpz(1):fmpz(9))
+   test_rand(R, [3,9,2])
+   test_rand(R, Int16[3,9,2])
+   test_rand(R, BigInt[3,9,2])
+   test_rand(R, fmpz[3,9,2])
 end
 
 @testset "gfp.printing" begin

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -63,6 +63,13 @@ end
 
    test_rand(R)
    test_rand(R, 1:9)
+   test_rand(R, Int16(1):Int16(9))
+   test_rand(R, big(1):big(9))
+   test_rand(R, fmpz(1):fmpz(9))
+   test_rand(R, [3,9,2])
+   test_rand(R, Int16[3,9,2])
+   test_rand(R, BigInt[3,9,2])
+   test_rand(R, fmpz[3,9,2])
 end
 
 @testset "gfp_fmpz.printing" begin

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -44,6 +44,13 @@ end
 
    test_rand(R)
    test_rand(R, 1:9)
+   test_rand(R, Int16(1):Int16(9))
+   test_rand(R, big(1):big(9))
+   test_rand(R, fmpz(1):fmpz(9))
+   test_rand(R, [3,9,2])
+   test_rand(R, Int16[3,9,2])
+   test_rand(R, BigInt[3,9,2])
+   test_rand(R, fmpz[3,9,2])
 end
 
 @testset "nmod.printing" begin


### PR DESCRIPTION
Instead of restricting the "sampling hints" to UnitRange{Int}, allow
any AbstractArray{<:Integer}.
