### PR TITLE
Add /(::arb_poly, ::arb) as well as for acb

### DIFF
--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -334,12 +334,16 @@ for T in [Integer, fmpz, fmpq, Float64, BigFloat, arb, acb]
       divexact(x::acb_poly, y::$T; check::Bool=true) = x * inv(base_ring(parent(x))(y))
 
       //(x::acb_poly, y::$T) = divexact(x, y)
+
+      /(x::acb_poly, y::$T) = divexact(x, y)
    end
 end
 
 divexact(x::acb_poly, y::Rational{T}; check::Bool=true) where {T <: Integer} = x * inv(base_ring(parent(x))(y))
 
 //(x::acb_poly, y::Rational{T}) where {T <: Integer} = divexact(x, y)
+
+/(x::acb_poly, y::Rational{T}) where {T <: Integer} = divexact(x, y)
 
 ###############################################################################
 #

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -320,12 +320,16 @@ for T in [Integer, fmpz, fmpq, Float64, BigFloat, arb]
       divexact(x::arb_poly, y::$T; check::Bool=true) = x * inv(base_ring(parent(x))(y))
 
       //(x::arb_poly, y::$T) = divexact(x, y)
+
+      /(x::arb_poly, y::$T) = divexact(x, y)
    end
 end
 
 divexact(x::arb_poly, y::Rational{T}; check::Bool=true) where {T <: Integer} = x * inv(base_ring(parent(x))(y))
 
 //(x::arb_poly, y::Rational{T}) where {T <: Integer} = divexact(x, y)
+
+/(x::arb_poly, y::Rational{T}) where {T <: Integer} = divexact(x, y)
 
 ###############################################################################
 #


### PR DESCRIPTION
Btw, should `divexact` exist for `arb`?