### PR TITLE
Wrap more inplace operations for fmpz and fmpq

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -445,7 +445,7 @@ function inv(a::fmpq)
     return z
  end
 
- ###############################################################################
+###############################################################################
 #
 #   Exact division
 #
@@ -802,17 +802,53 @@ function mul!(c::fmpq, a::fmpq, b::fmpq)
    return c
 end
 
-function addeq!(c::fmpq, a::fmpq)
-   ccall((:fmpq_add, libflint), Nothing,
-         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, c, a)
+function mul!(c::fmpq, a::fmpq, b::fmpz)
+   ccall((:fmpq_mul_fmpz, libflint), Nothing,
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), c, a, b)
    return c
 end
+
+mul!(c::fmpq, a::fmpz, b::fmpq) = mul!(c, b, a)
+
+function mul!(c::fmpq, a::fmpq, b::Int)
+   ccall((:fmpq_mul_si, libflint), Nothing,
+         (Ref{fmpq}, Ref{fmpq}, Int), c, a, b)
+   return c
+end
+
+mul!(c::fmpq, a::Int, b::fmpq) = mul!(c, b, a)
+
+
+function addmul!(c::fmpq, a::fmpq, b::fmpq)
+   ccall((:fmpq_addmul, libflint), Nothing,
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
+   return c
+end
+
+
+addeq!(c::fmpq, a::fmpq) = add!(c, c, a)
 
 function add!(c::fmpq, a::fmpq, b::fmpq)
    ccall((:fmpq_add, libflint), Nothing,
          (Ref{fmpq}, Ref{fmpq}, Ref{fmpq}), c, a, b)
    return c
 end
+
+function add!(c::fmpq, a::fmpq, b::fmpz)
+   ccall((:fmpq_add_fmpz, libflint), Nothing,
+         (Ref{fmpq}, Ref{fmpq}, Ref{fmpz}), c, a, b)
+   return c
+end
+
+add!(c::fmpq, a::fmpz, b::fmpq) = add!(c, b, a)
+
+function add!(c::fmpq, a::fmpq, b::Int)
+   ccall((:fmpq_add_si, libflint), Nothing,
+         (Ref{fmpq}, Ref{fmpq}, Int), c, a, b)
+   return c
+end
+
+add!(c::fmpq, a::Int, b::fmpq) = add!(c, b, a)
 
 ###############################################################################
 #

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2000,6 +2000,14 @@ function mul!(z::fmpz, x::fmpz, y::fmpz)
    return z
 end
 
+function mul!(z::fmpz, x::fmpz, y::Int)
+   ccall((:fmpz_mul_si, libflint), Nothing,
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
+   return z
+end
+
+mul!(z::fmpz, x::Int, y::fmpz) = mul!(z, y, x)
+
 function addmul!(z::fmpz, x::fmpz, y::fmpz)
    ccall((:fmpz_addmul, libflint), Nothing,
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
@@ -2007,6 +2015,14 @@ function addmul!(z::fmpz, x::fmpz, y::fmpz)
 end
 
 addmul!(z::fmpz, x::fmpz, y::fmpz, ::fmpz) = addmul!(z, x, y)
+
+function addmul!(z::fmpz, x::fmpz, y::Int)
+   ccall((:fmpz_addmul_si, libflint), Nothing,
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
+   return z
+end
+
+addmul!(z::fmpz, x::fmpz, y::Int, ::fmpz) = addmul!(z, x, y)
 
 function addeq!(z::fmpz, x::fmpz)
    ccall((:fmpz_add, libflint), Nothing,
@@ -2019,6 +2035,14 @@ function add!(z::fmpz, x::fmpz, y::fmpz)
          (Ref{fmpz}, Ref{fmpz}, Ref{fmpz}), z, x, y)
    return z
 end
+
+function add!(z::fmpz, x::fmpz, y::Int)
+   ccall((:fmpz_add_si, libflint), Nothing,
+         (Ref{fmpz}, Ref{fmpz}, Int), z, x, y)
+   return z
+end
+
+add!(z::fmpz, x::Int, y::fmpz) = add!(z, y, x)
 
 function zero!(z::fmpz)
    ccall((:fmpz_zero, libflint), Nothing,

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -414,3 +414,40 @@ end
    @test simplest_between(fmpq(1//10), fmpq(3//10)) == 1//4
    @test simplest_between(fmpq(11//10), fmpq(21//10)) == 2
 end
+
+
+@testset "fmpq.unsafe" begin
+  a = fmpq(32//17)
+  b = fmpq(23//11)
+  c = one(FlintQQ)
+  b_copy = deepcopy(b)
+  c_copy = deepcopy(c)
+
+  zero!(a)
+  @test iszero(a)
+  mul!(a, a, b)
+  @test iszero(a)
+
+  add!(a, a, b)
+  @test a == b
+  add!(a, a, 1)
+  @test a == b + 1
+  add!(a, a, fmpz(0))
+  @test a == b + 1
+
+  addeq!(a, b^2)
+  @test a == 1 + b + b^2
+
+  mul!(a, a, b)
+  @test a == (1 + b + b^2) * b
+  mul!(a, a, 3)
+  @test a == (1 + b + b^2) * b * 3
+  mul!(a, a, fmpz(3))
+  @test a == (1 + b + b^2) * b * 9
+
+  addmul!(a, a, c)
+  @test a == 2 * (1 + b + b^2) * b * 9
+
+  @test b_copy == b
+  @test c_copy == c
+end

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -638,14 +638,22 @@ end
   @test iszero(a)
   mul!(a, a, b)
   @test iszero(a)
+
   add!(a, a, b)
   @test a == b
+  add!(a, a, 1)
+  @test a == b + 1
+
   addeq!(a, b^2)
-  @test a == b + b^2
+  @test a == 1 + b + b^2
+
   mul!(a, a, b)
-  @test a == (b + b^2) * b
+  @test a == (1 + b + b^2) * b
+  mul!(a, a, 3)
+  @test a == (1 + b + b^2) * b * 3
+
   addmul!(a, a, c)
-  @test a == 2 * (b + b^2) * b
+  @test a == 2 * (1 + b + b^2) * b * 3
 
   @test b_copy == b
   @test c_copy == c


### PR DESCRIPTION
I just saw issue #1166 and that reminded me of this patch which I wrote some time ago but then never submitted...

Tests are failing, though, but I am not sure if that's me doing something wrong, or a bug in flint... specifically, I get this nonsense:
```
julia> c = fmpq(1); b=fmpq(23//11); add!(c,b,fmpq(1)) # this work
34//11

julia> c = fmpq(1); b=fmpq(23//11); add!(c,b,1) # this doesn't
1548059296613127//11
```
So am I using `fmpq_add_si` wrong?