### PR TITLE
do not accept `PolynomialRing(QQ, String[])`

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1240,6 +1240,8 @@ mutable struct FmpzMPolyRing <: MPolyRing{fmpz}
             error("$S is not a valid ordering")
          end
 
+         isempty(s) && error("need at least one indeterminate")
+
          z = new()
          ccall((:fmpz_mpoly_ctx_init, libflint), Nothing,
                (Ref{FmpzMPolyRing}, Int, Int),
@@ -1659,6 +1661,8 @@ mutable struct NmodMPolyRing <: MPolyRing{nmod}
             error("$S is not a valid ordering")
          end
 
+         isempty(s) && error("need at least one indeterminate")
+
          z = new()
          ccall((:nmod_mpoly_ctx_init, libflint), Nothing,
                (Ref{NmodMPolyRing}, Int, Cint, UInt),
@@ -1852,6 +1856,8 @@ mutable struct GFPMPolyRing <: MPolyRing{gfp_elem}
          else
             error("$S is not a valid ordering")
          end
+
+         isempty(s) && error("need at least one indeterminate")
 
          z = new()
          ccall((:nmod_mpoly_ctx_init, libflint), Nothing,


### PR DESCRIPTION
Up to now, entering `R, vars = PolynomialRing(QQ, String[]); one(R)` causes a segmentation fault.

(I am not sure where the right place to catch this error would be.
There are other instances of this problem, for example `R, vars = PolynomialRing(GF(2), String[]); one(R)`,
but I have been told that it is a good strategy to propose a fix for the current problem,
and to let the experts deal with the optimal solution.)