### PR TITLE
[WIP] fixing the mpoly hash and printing on big exponents

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -6643,3 +6643,46 @@ function _rand_ctx_clear_fn(a::rand_ctx)
    ccall((:flint_rand_free, libflint), Cvoid, (Ptr{Cvoid}, ), a.ptr)
    nothing
 end
+
+################################################################################
+#
+# Unsafe iterators
+#
+################################################################################
+
+struct MPolyCoeffs_Unsafe{T, S}
+   poly::T
+   coeff::S
+end
+
+struct MPolyExponentVectors_Unsafe{T, S}
+   poly::T
+   vec::Vector{S}
+end
+
+struct MPolyTerms_Unsafe{T}
+   poly::T
+   term::T
+end
+
+function Base.iterate(x::MPolyCoeffs_Unsafe{T, S}, state = 0) where {T, S}
+   state += 1
+   state > length(x.poly) && return nothing
+   coeff!(x.coeff, x.poly, state)
+   return x.coeff, state
+end
+
+function Base.iterate(x::MPolyExponentVectors_Unsafe{T, S}, state = 0) where {T, S}
+   state += 1
+   state > length(x.poly) && return nothing
+   exponent_vector!(x.vec, x.poly, state)
+   return x.vec, state
+end
+
+function Base.iterate(x::MPolyTerms_Unsafe{T}, state = 0) where T
+   state += 1
+   state > length(x.poly) && return nothing
+   term!(x.term, x.poly, state)
+   return x.term, state
+end
+


### PR DESCRIPTION
`myhash2` is using the same `exponent_vector!` as versions 0 and 1, it just has it wrapped in the fancy iterator. What I don't understand is why `myhash2` is allocating:
```julia
julia> _, (x, y, z, w) = ZZ["x", "y", "z", "w"]
(Multivariate Polynomial Ring in x, y, z, w over Integer Ring, fmpz_mpoly[x, y, z, w])

julia> p = (1+x+y+z+w+x^2+y^3+z^3+w^4)^20; length(p)
366335

julia> @btime Nemo.myhash0(p, UInt(0))
  10.476 ms (2 allocations: 128 bytes)
0x9bcb91cbe0cdd065

julia> @btime Nemo.myhash1(p, UInt(0))
  34.163 ms (2 allocations: 128 bytes)
0x582dd022c669792d

julia> @btime Nemo.myhash2(p, UInt(0))
  40.005 ms (732672 allocations: 22.36 MiB)
0x582dd022c669792d

julia> @btime hash(p, UInt(0))
  65.360 ms (732671 allocations: 44.72 MiB)
0x582dd022c669792d
```