### PR TITLE
Add arb -> BigFloat and support rounding modes

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -35,6 +35,21 @@ mutable struct arf_struct
   size::UInt # mp_size_t
   d1::UInt # mantissa_struct
   d2::UInt
+
+  function arf_struct()
+    z = new()
+    ccall((:arf_init, libarb), Nothing, (Ref{arf_struct}, ), z)
+    finalizer(_arf_clear_fn, z)
+    return z
+  end
+
+  function arf_struct(exp::Int, size::UInt, d1::UInt, d2::UInt)
+    new(exp, size, d1, d2)
+  end
+end
+
+function _arf_clear_fn(x::arf_struct)
+  ccall((:arf_clear, libarb), Nothing, (Ref{arf_struct}, ), x)
 end
 
 mutable struct mag_struct

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -85,17 +85,82 @@ characteristic(::ArbField) = 0
 #
 ################################################################################
 
-function Float64(x::arb)
-   GC.@preserve x begin
-      t = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), x)
-      # 4 == round to nearest
-      d = ccall((:arf_get_d, libarb), Float64, (Ptr{arf_struct}, Int), t, 4)
-   end
-   return d
+@doc Markdown.doc"""
+    Float64(x::arb, round::RoundingMode=RoundNearest)
+
+Converts $x$ to a `Float64`, rounded in the direction specified by $round$.
+For `RoundNearest` the return value approximates the midpoint of $x$. For
+`RoundDown` or `RoundUp` the return value is a lower bound or upper bound for
+all values in $x$.
+"""
+function Float64(x::arb, round::RoundingMode=RoundNearest)
+  t = _arb_get_arf(x, round)
+  return _arf_get_d(t, round)
+end
+
+@doc Markdown.doc"""
+    BigFloat(x::arb, round::RoundingMode=RoundNearest)
+
+Converts $x$ to a `BigFloat` of the currently used precision, rounded in the
+direction specified by $round$. For `RoundNearest` the return value
+approximates the midpoint of $x$. For `RoundDown` or `RoundUp` the return
+value is a lower bound or upper bound for all values in $x$.
+"""
+function BigFloat(x::arb, round::RoundingMode=RoundNearest)
+  t = _arb_get_arf(x, round)
+  return _arf_get_mpfr(t, round)
+end
+
+function _arb_get_arf(x::arb, ::RoundingMode{:Nearest})
+  GC.@preserve x begin
+    t = ccall((:arb_mid_ptr, libarb), Ptr{arf_struct}, (Ref{arb}, ), x)
+  end
+  return t
+end
+
+for (b, f) in ((RoundingMode{:Down}, :arb_get_lbound_arf),
+               (RoundingMode{:Up}, :arb_get_ubound_arf))
+  @eval begin
+    function _arb_get_arf(x::arb, ::$b)
+      GC.@preserve x begin
+        t = arf_struct()
+        ccall(($(string(f)), libarb), Nothing,
+              (Ref{arf_struct}, Ref{arb}, Int), t, x, parent(x).prec)
+      end
+      return Ref(t)
+    end
+  end
+end
+
+for (b, i) in ((RoundingMode{:Down}, 2),
+               (RoundingMode{:Up}, 3),
+               (RoundingMode{:Nearest}, 4))
+  @eval begin
+    function _arf_get_d(t::Ref{arf_struct}, ::$b)
+      GC.@preserve t begin
+        d = ccall((:arf_get_d, libarb), Float64,
+                  (Ref{arf_struct}, Int), t, $i)
+      end
+      return d
+    end
+    function _arf_get_mpfr(t::Ref{arf_struct}, ::$b)
+      GC.@preserve t begin
+        d = BigFloat()
+        ccall((:arf_get_mpfr, libarb), Int32,
+              (Ref{BigFloat}, Ref{arf_struct}, Base.MPFR.MPFRRoundingMode),
+              d, t, $b())
+      end
+      return d
+    end
+  end
 end
 
 function convert(::Type{Float64}, x::arb)
     return Float64(x)
+end
+
+function convert(::Type{BigFloat}, x::arb)
+    return BigFloat(x)
 end
 
 @doc Markdown.doc"""

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -41,6 +41,8 @@ end
 
    @test Float64(RR(0.5)) == 0.5
    @test convert(Float64, RR(0.5)) == 0.5
+   @test BigFloat(RR(0.5)) == 0.5
+   @test convert(BigFloat, RR(0.5)) == 0.5
 
    a = 123
    b = -8162
@@ -55,6 +57,19 @@ end
    @test_throws ErrorException Int(RR(c))
 
    @test abs(Float64(RR("2.3")) - 2.3) < 1e-10
+   @test setprecision(BigFloat, 1000) do
+      abs(BigFloat(ArbField(1000)("2.3")) - BigFloat("2.3")) < 1e-299
+   end
+
+   for T in [Float64, BigFloat]
+      x = RR(-1)/3
+      y = T(-1)/3
+      @test abs(T(x, RoundDown) - T(x, RoundUp)) < 1e-10
+      for z in [T(x, RoundNearest), y]
+         @test T(x, RoundDown) <= z <= T(x, RoundUp)
+      end
+   end
+
    @test characteristic(RR) == 0
 end
 


### PR DESCRIPTION
Provides functions `Float64(x::arb, round::RoundingMode=RoundNearest)` and `BigFloat(x::arb, round::RoundingMode=RoundNearest)`

This extends the existing `Float64(x::arb)` which converts the midpoint of `x`. A lower bound for `x` is returned if `round=RoundDown` and an upper bound is returned if `round=RoundUp`.