### PR TITLE
Don't link to 'latest' versions of docs

### DIFF
--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -35,7 +35,7 @@ elements in this field, i.e. complex boxes in this case, belong to the
 
 The complex balls in Nemo provide all the field functionality defined by AbstractAlgebra:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below, we document the additional functionality provided for complex balls.
 

--- a/docs/src/arb.md
+++ b/docs/src/arb.md
@@ -35,7 +35,7 @@ abstract type.
 
 Real balls in Nemo provide all the field functionality described in AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below, we document the additional functionality provided for real balls.
 

--- a/docs/src/finitefield.md
+++ b/docs/src/finitefield.md
@@ -46,7 +46,7 @@ provided for the `fq_nmod` finite field type, we simply document the former.
 
 Finite fields in Nemo provide all the field functionality described in AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below we describe the functionality that is provided in addition to this.
 

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -54,12 +54,12 @@ one to write generic functions that can accept any Nemo fraction type.
 All fraction types in Nemo provide funtionality for fields described in
 AbstractAlgebra.jl:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 In addition all the fraction field functionality of AbstractAlgebra.jl is provided,
 along with generic fractions fields as described here:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/fraction>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/fraction>
 
 ### Basic manipulation
 

--- a/docs/src/gfp.md
+++ b/docs/src/gfp.md
@@ -43,11 +43,11 @@ belong to the abstract type `FinField`.
 
 Galois fields in Nemo provide all the residue ring functionality of AbstractAlgebra.jl:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/residue>
 
 In addition, all the functionality for rings is available:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/ring>
 
 Below we describe the functionality that is provided in addition to these.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ Tommy Hofmann, Claus Fieker, Fredrik Johansson with additional code by Oleksandr
 
 - <https://nemocas.org> (Website)
 - <https://github.com/Nemocas/Nemo.jl> (Source code)
-- <https://nemocas.github.io/Nemo.jl/latest/> (Online documentation)
+- <https://nemocas.github.io/Nemo.jl/stable/> (Online documentation)
 
 The features of Nemo so far include:
 

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -39,9 +39,9 @@ IntegerUnion = Union{Integer,fmpz}
 Nemo integers provide all of the ring and Euclidean ring functionality of
 AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/ring>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Nemo/Flint integer ring.
 

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -36,14 +36,14 @@ one to write generic functions that can accept any Nemo matrix type.
 
 Note that the preferred way to create matrices is not to use the type
 constructors but to use the `matrix` function, see also the
-[Matrix element constructors](https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix/#Matrix-element-constructors)
+[Matrix element constructors](https://nemocas.github.io/AbstractAlgebra.jl/stable/matrix/#Matrix-element-constructors)
 section of the AbstractAlgebra manual.
 
 ## Matrix functionality
 
 All matrix spaces in Nemo provide the matrix functionality of AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/matrix>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/matrix>
 
 Some of this functionality is provided in Nemo by C libraries, such as Flint,
 for various specific rings.

--- a/docs/src/mpolynomial.md
+++ b/docs/src/mpolynomial.md
@@ -42,7 +42,7 @@ one to write generic functions that can accept any Nemo multivariate polynomial 
 All multivariate polynomial types in Nemo provide the multivariate polynomial
 functionality described by AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/mpolynomial>
 
 Generic multivariate polynomials are also available.
 

--- a/docs/src/numberfield.md
+++ b/docs/src/numberfield.md
@@ -34,13 +34,13 @@ ideals, orders, class groups, relative extensions, class field theory, etc.
 The basic number field element type used in Hecke is the Nemo/antic number field
 element type, making the two libraries tightly integrated.
 
-<https://thofma.github.io/Hecke.jl/latest/>
+<https://thofma.github.io/Hecke.jl/stable/>
 
 ## Number field functionality
 
 The number fields in Nemo provide all of the AbstractAlgebra field functionality:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below, we document the additional functionality provided for number field elements.
 

--- a/docs/src/padic.md
+++ b/docs/src/padic.md
@@ -33,7 +33,7 @@ $p$-adic field element types belong to the `FieldElem` abstract type.
 
 P-adic fields in Nemo implement all the AbstractAlgebra field functionality:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below, we document all the additional function that is provide by Nemo for p-adic
 fields.

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -42,7 +42,7 @@ one to write generic functions that can accept any Nemo univariate polynomial ty
 All univariate polynomial types in Nemo provide the AbstractAlgebra univariate
 polynomial functionality:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/polynomial>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/polynomial>
 
 Generic polynomials are also available.
 

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -52,7 +52,7 @@ Puiseux series rings in Nemo implement all the same functionality that is availa
 AbstractAlgebra series rings, with the exception of the `pol_length` and `polcoeff`
 functions:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/series>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/series>
 
 In addition, generic Puiseux series are provided by AbstractAlgebra.jl
 

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -35,7 +35,7 @@ $q$-adic field element types belong to the `FieldElem` abstract type.
 Q-adic fields in Nemo provide all the functionality described in AbstractAlgebra
 for fields:.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/field>
 
 Below, we document all the additional function that is provide by Nemo for q-adic
 fields.

--- a/docs/src/residue.md
+++ b/docs/src/residue.md
@@ -36,7 +36,7 @@ This enables one to write generic functions that accept any Nemo residue type.
 All the residue rings in Nemo provide the functionality described in AbstractAlgebra
 for residue rings:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/residue>
 
 In addition, generic residue rings are available.
 

--- a/docs/src/series.md
+++ b/docs/src/series.md
@@ -148,7 +148,7 @@ very much like the quotient $R[x]/(x^p)$ of the polynomial ring over $R$.
 Power series rings in Nemo provide all the functionality described for power
 series in AbstractAlgebra:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/latest/series>
+<https://nemocas.github.io/AbstractAlgebra.jl/stable/series>
 
 In addition, generic power series and Laurent series are provided by AbstractAlgebra.
 


### PR DESCRIPTION
These link forms have been deprecated in Documented for a long time now
