### PR TITLE
Turn FlintIntegerRing/FlintRationalField into fake singleton type

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -11,6 +11,10 @@
 ###############################################################################
 
 mutable struct FlintIntegerRing <: Ring
+    function FlintIntegerRing()
+        isdefined(Nemo, :FlintZZ) && return FlintZZ
+        return new()
+    end
 end
 
 const FlintZZ = FlintIntegerRing()
@@ -117,6 +121,10 @@ end
 ###############################################################################
 
 mutable struct FlintRationalField <: FracField{fmpz}
+    function FlintRationalField()
+        isdefined(Nemo, :FlintQQ) && return FlintQQ
+        return new()
+    end
 end
 
 const FlintQQ = FlintRationalField()

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -7,6 +7,11 @@ end
    test_Field_interface_recursive(FlintQQ)
 end
 
+@testset "fmpq.singleton" begin
+   @test QQ === FlintRationalField()
+   @test QQ === FractionField(ZZ)
+end
+
 @testset "fmpq.constructors" begin
    R = FractionField(ZZ)
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -16,6 +16,10 @@ end
    @test parent_type(fmpz) == FlintIntegerRing
 end
 
+@testset "fmpz.singleton" begin
+   @test ZZ === FlintIntegerRing()
+end
+
 @testset "fmpz.constructors" begin
    a = fmpz(-123)
    @test isa(a, RingElem)


### PR DESCRIPTION
PR #1221 is stalled or may even be a no-go; but I still think that it's potentially confusing that one can have multiple instances of type `FlintIntegerRing`/`FlintRationalField`; I certainly see code not expecting this.

So, let's fake it, by restricting the constructors. Also add tests to verify this works.