### PR TITLE
AnticNumberField: use standard attribute storage

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -242,11 +242,6 @@ function __init__()
       println("")
    end
 
-  t = create_accessors(AnticNumberField, Dict, get_handle())
-
-  global _get_Special_of_nf = t[1]
-  global _set_Special_of_nf = t[2]
-
   # Initialize the thread local random state
   resize!(_flint_rand_states, Threads.nthreads())
   for i in 1:Threads.nthreads()

--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -12,7 +12,7 @@
 
 const AnticNumberFieldID = Dict{Tuple{FmpqPolyRing, fmpq_poly, Symbol}, Field}()
 
-mutable struct AnticNumberField <: SimpleNumField{fmpq}
+@attributes mutable struct AnticNumberField <: SimpleNumField{fmpq}
    pol_coeffs::Ptr{Nothing}
    pol_den::Int
    pol_alloc::Int

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -258,23 +258,6 @@ function deepcopy_internal(d::nf_elem, dict::IdDict)
    return z
 end
 
-###############################################################################
-#
-#   Deal with "Special"
-#
-###############################################################################
-
-AbstractAlgebra._is_attribute_storing_type(::Type{AnticNumberField}) = true
-AbstractAlgebra._get_attributes(K::AnticNumberField) = _get_Special_of_nf(K, false)
-function AbstractAlgebra._get_attributes!(K::AnticNumberField)
-  d = _get_Special_of_nf(K, false)
-  if d === nothing
-    d = Dict{Symbol, Any}()
-    _set_Special_of_nf(K, d)
-  end
-  return d
-end
-
 function iscyclo_type(K::AnticNumberField)
   return !(get_attribute(K, :cyclo) === nothing) ::Bool
 end


### PR DESCRIPTION
There is no obvious advantage to routing it through an accessor.

See also discussion on https://github.com/Nemocas/AbstractAlgebra.jl/pull/1082 (CC @thofma). 

There is one remaining call to `create_accessors`, in `test/antic/nf_elem-test.jl`, which could also be eliminated. But I'd rather leave it as long as there is `auxilliary_data` in `AnticNumberField`, which we still need for Hecke. Once Hecke doesn't need it anymore, I guess we could just completely remove it?