### PR TITLE
Add sqrt/issquare/issquare_with_sqrt for finite field poly types

### DIFF
--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -372,6 +372,52 @@ end
 
 ################################################################################
 #
+#  Square root
+#
+################################################################################
+
+function sqrt(x::fq_default_poly; check::Bool=true)
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_default_poly_sqrt, libflint), Cint,
+                     (Ref{fq_default_poly}, Ref{fq_default_poly}, Ref{FqDefaultFiniteField}),
+                      s, x, base_ring(parent(x))))
+   check && !flag && error("Not a square in sqrt")
+   return s
+end
+
+function issquare(x::fq_default_poly)
+   if iszero(x)
+      return true
+   end
+   if !iseven(degree(x))
+      return false
+   end
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_default_poly_sqrt, libflint), Cint,
+                     (Ref{fq_default_poly}, Ref{fq_default_poly}, Ref{FqDefaultFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag
+end
+
+function issquare_with_sqrt(x::fq_default_poly)
+   R = parent(x)
+   if iszero(x)
+      return true, zero(R)
+   end
+   if !iseven(degree(x))
+      return false, zero(R)
+   end
+   s = R()
+   flag = Bool(ccall((:fq_default_poly_sqrt, libflint), Cint,
+                     (Ref{fq_default_poly}, Ref{fq_default_poly}, Ref{FqDefaultFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag, s
+end
+
+################################################################################
+#
 #   Remove and valuation
 #
 ################################################################################

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -399,6 +399,52 @@ end
 
 ################################################################################
 #
+#  Square root
+#
+################################################################################
+
+function sqrt(x::fq_nmod_poly; check::Bool=true)
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_nmod_poly_sqrt, libflint), Cint,
+                     (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                      s, x, base_ring(parent(x))))
+   check && !flag && error("Not a square in sqrt")
+   return s
+end
+
+function issquare(x::fq_nmod_poly)
+   if iszero(x)
+      return true
+   end
+   if !iseven(degree(x))
+      return false
+   end
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_nmod_poly_sqrt, libflint), Cint,
+                     (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag
+end
+
+function issquare_with_sqrt(x::fq_nmod_poly)
+   R = parent(x)
+   if iszero(x)
+      return true, zero(R)
+   end
+   if !iseven(degree(x))
+      return false, zero(R)
+   end
+   s = R()
+   flag = Bool(ccall((:fq_nmod_poly_sqrt, libflint), Cint,
+                     (Ref{fq_nmod_poly}, Ref{fq_nmod_poly}, Ref{FqNmodFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag, s
+end
+
+################################################################################
+#
 #   Remove and valuation
 #
 ################################################################################

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -399,6 +399,52 @@ end
 
 ################################################################################
 #
+#  Square root
+#
+################################################################################
+
+function sqrt(x::fq_poly; check::Bool=true)
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_poly_sqrt, libflint), Cint,
+                     (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+                      s, x, base_ring(parent(x))))
+   check && !flag && error("Not a square in sqrt")
+   return s
+end
+
+function issquare(x::fq_poly)
+   if iszero(x)
+      return true
+   end
+   if !iseven(degree(x))
+      return false
+   end
+   R = parent(x)
+   s = R()
+   flag = Bool(ccall((:fq_poly_sqrt, libflint), Cint,
+                     (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag
+end
+
+function issquare_with_sqrt(x::fq_poly)
+   R = parent(x)
+   if iszero(x)
+      return true, zero(R)
+   end
+   if !iseven(degree(x))
+      return false, zero(R)
+   end
+   s = R()
+   flag = Bool(ccall((:fq_poly_sqrt, libflint), Cint,
+                     (Ref{fq_poly}, Ref{fq_poly}, Ref{FqFiniteField}),
+                      s, x, base_ring(parent(x))))
+   return flag, s
+end
+
+################################################################################
+#
 #   Remove and valuation
 #
 ################################################################################

--- a/test/flint/fq_default_poly-test.jl
+++ b/test/flint/fq_default_poly-test.jl
@@ -325,6 +325,39 @@ end
    @test gcdinv(r, s) == (1, 3*y^4+8*y^3+18*y^2+4*y+2)
 end
 
+@testset "fq_default_poly.square_root" begin
+   R, x = NGFiniteField(fmpz(23), 5, "x")
+   S, y = PolynomialRing(R, "y")
+
+   for iter in 1:1000
+      f = rand(S, -1:10)
+      while issquare(f)
+         f = rand(S, -1:10)
+      end
+
+      g0 = rand(S, -1:10)
+      g = g0^2
+
+      @test issquare(g)
+      @test sqrt(g)^2 == g
+
+      if !iszero(g)
+         @test !issquare(f*g)
+         @test_throws ErrorException sqrt(f*g)
+      end
+
+      f1, s1 = issquare_with_sqrt(g)
+
+      @test f1 && s1^2 == g
+
+      if !iszero(g)
+         f2, s2 = issquare_with_sqrt(f*g)
+
+         @test !f2
+      end
+   end
+end
+
 @testset "fq_default_poly.evaluation" begin
    R, x = NGFiniteField(fmpz(23), 5, "x")
    S, y = PolynomialRing(R, "y")

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -359,6 +359,41 @@ end
    @test gcdinv(r, s) == (1, 3*y^4+8*y^3+18*y^2+4*y+2)
 end
 
+@testset "fq_nmod_poly.square_root" begin
+   for p in [2, 23]
+      R, x = FiniteField(p, 3, "x")
+      S, y = PolynomialRing(R, "y")
+
+      for iter in 1:1000
+         f = rand(S, -1:10)
+         while issquare(f)
+            f = rand(S, -1:10)
+         end
+
+         g0 = rand(S, -1:10)
+         g = g0^2
+
+         @test issquare(g)
+         @test sqrt(g)^2 == g
+
+         if !iszero(g)
+            @test !issquare(f*g)
+            @test_throws ErrorException sqrt(f*g)
+         end
+
+         f1, s1 = issquare_with_sqrt(g)
+
+         @test f1 && s1^2 == g
+
+         if !iszero(g)
+            f2, s2 = issquare_with_sqrt(f*g)
+
+            @test !f2
+         end
+      end
+   end
+end
+
 @testset "fq_nmod_poly.evaluation" begin
    R, x = FiniteField(23, 5, "x")
    S, y = PolynomialRing(R, "y")

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -360,6 +360,41 @@ end
    @test gcdinv(r, s) == (1, 3*y^4+8*y^3+18*y^2+4*y+2)
 end
 
+@testset "fq_poly.square_root" begin
+   for p in [2, 23]
+      R, x = FiniteField(fmpz(p), 3, "x")
+      S, y = PolynomialRing(R, "y")
+
+      for iter in 1:1000
+         f = rand(S, -1:10)
+         while issquare(f)
+            f = rand(S, -1:10)
+         end
+
+         g0 = rand(S, -1:10)
+         g = g0^2
+
+         @test issquare(g)
+         @test sqrt(g)^2 == g
+
+         if !iszero(g)
+            @test !issquare(f*g)
+            @test_throws ErrorException sqrt(f*g)
+         end
+
+         f1, s1 = issquare_with_sqrt(g)
+
+         @test f1 && s1^2 == g
+
+         if !iszero(g)
+            f2, s2 = issquare_with_sqrt(f*g)
+
+            @test !f2
+         end
+      end
+   end
+end
+
 @testset "fq_poly.evaluation" begin
    R, x = FiniteField(fmpz(23), 5, "x")
    S, y = PolynomialRing(R, "y")


### PR DESCRIPTION
Requires flint-2.9.

Also adds the functions for the new fq_default_poly type.