### PR TITLE
fq_abs_series sqrt functions

### DIFF
--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -499,6 +499,84 @@ end
 
 ###############################################################################
 #
+#   Square root
+#
+###############################################################################
+
+function sqrt_classical_char2(a::($etype); check::Bool=true)
+   S = parent(a)
+   asqrt = S()
+   prec = div(precision(a) + 1, 2)
+   asqrt = set_precision!(asqrt, prec)
+   if check
+     for i = 1:2:precision(a) - 1 # series must have even exponents
+       if !iszero(coeff(a, i))
+         return false, S()
+       end
+     end
+   end
+   for i = 0:prec - 1
+     asqrt = setcoeff!(asqrt, i, coeff(a, 2*i))
+   end
+   return true, asqrt
+end
+ 
+function sqrt_classical(a::($etype); check::Bool=true)
+   R = base_ring(a)
+   S = parent(a)
+   if characteristic(R) == 2
+      return sqrt_classical_char2(a; check=check)
+   end
+   v = valuation(a)
+   z = S()
+   z.prec = a.prec - div(v, 2)
+   if iszero(a)
+      return true, z
+   end
+   if check && !iseven(v)
+      return false, S()
+   end
+   a = shift_right(a, v)
+   c = coeff(a, 0)
+   if check
+      flag, s = issquare_with_sqrt(c)
+      if !flag
+         return false, S()
+      end
+   else
+      s = sqrt(c; check=check)
+   end
+   a = divexact(a, c)
+   z.prec = a.prec - div(v, 2)
+   ccall(($(flint_fn*"_sqrt_series"), libflint), Nothing,
+         (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+                z, a, a.prec, base_ring(a))
+   if !isone(s)
+      z *= s
+   end
+   if !iszero(v)
+      z = shift_left(z, div(v, 2))
+   end
+   return true, z
+end
+ 
+function Base.sqrt(a::Ref{($etype)}; check::Bool=true)
+   flag, s = sqrt_classical(a; check=check)
+   check && !flag && error("Not a square")
+   return s
+end
+  
+function issquare(a::Ref{($etype)})
+   flag, s = sqrt_classical(a; check=true)
+   return flag
+end
+ 
+function issquare_with_sqrt(a::Ref{($etype)})
+   return sqrt_classical(a; check=true)
+end
+
+###############################################################################
+#
 #   Unsafe functions
 #
 ###############################################################################

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -560,18 +560,18 @@ function sqrt_classical(a::($etype); check::Bool=true)
    return true, z
 end
  
-function Base.sqrt(a::Ref{($etype)}; check::Bool=true)
+function Base.sqrt(a::($etype); check::Bool=true)
    flag, s = sqrt_classical(a; check=check)
    check && !flag && error("Not a square")
    return s
 end
   
-function issquare(a::Ref{($etype)})
+function issquare(a::($etype))
    flag, s = sqrt_classical(a; check=true)
    return flag
 end
  
-function issquare_with_sqrt(a::Ref{($etype)})
+function issquare_with_sqrt(a::($etype))
    return sqrt_classical(a; check=true)
 end
 

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -509,14 +509,21 @@ function sqrt_classical_char2(a::($etype); check::Bool=true)
    prec = div(precision(a) + 1, 2)
    asqrt = set_precision!(asqrt, prec)
    if check
-     for i = 1:2:precision(a) - 1 # series must have even exponents
-       if !iszero(coeff(a, i))
-         return false, S()
-       end
-     end
+      for i = 1:2:precision(a) - 1 # series must have even exponents
+         if !iszero(coeff(a, i))
+            return false, S()
+         end
+      end
    end
    for i = 0:prec - 1
-     asqrt = setcoeff!(asqrt, i, coeff(a, 2*i))
+      if check
+         flag, c = issquare_with_sqrt(coeff(a, 2*i))
+         !flag && error("Not a square")
+      else
+         # degree of finite field could be > 1 so sqrt necessary here
+         c = sqrt(coeff(a, 2*i); check=check)
+      end
+      asqrt = setcoeff!(asqrt, i, c)
    end
    return true, asqrt
 end

--- a/src/flint/fq_default_abs_series.jl
+++ b/src/flint/fq_default_abs_series.jl
@@ -483,6 +483,85 @@ end
 
 ###############################################################################
 #
+#   Square root
+#
+###############################################################################
+
+function sqrt_classical_char2(a::fq_default_abs_series; check::Bool=true)
+   S = parent(a)
+   asqrt = S()
+   prec = div(precision(a) + 1, 2)
+   asqrt = set_precision!(asqrt, prec)
+   if check
+     for i = 1:2:precision(a) - 1 # series must have even exponents
+       if !iszero(coeff(a, i))
+         return false, S()
+       end
+     end
+   end
+   for i = 0:prec - 1
+     asqrt = setcoeff!(asqrt, i, coeff(a, 2*i))
+   end
+   return true, asqrt
+end
+ 
+function sqrt_classical(a::fq_default_abs_series; check::Bool=true)
+   R = base_ring(a)
+   S = parent(a)
+   if characteristic(R) == 2
+      return sqrt_classical_char2(a; check=check)
+   end
+   v = valuation(a)
+   z = S()
+   z.prec = a.prec - div(v, 2)
+   if iszero(a)
+      return true, z
+   end
+   if check && !iseven(v)
+      return false, S()
+   end
+   a = shift_right(a, v)
+   c = coeff(a, 0)
+   if check
+      flag, s = issquare_with_sqrt(c)
+      if !flag
+         return false, S()
+      end
+   else
+      s = sqrt(c; check=check)
+   end
+   a = divexact(a, c)
+   z.prec = a.prec - div(v, 2)
+   ccall((:fq_default_poly_sqrt_series, libflint), Nothing,
+         (Ref{fq_default_abs_series}, Ref{fq_default_abs_series},
+             Int, Ref{FqDefaultFiniteField}),
+                z, a, a.prec, base_ring(a))
+   if !isone(s)
+      z *= s
+   end
+   if !iszero(v)
+      z = shift_left(z, div(v, 2))
+   end
+   return true, z
+end
+ 
+function Base.sqrt(a::fq_default_abs_series; check::Bool=true)
+   flag, s = sqrt_classical(a; check=check)
+   check && !flag && error("Not a square")
+   return s
+end
+  
+function issquare(a::fq_default_abs_series)
+   flag, s = sqrt_classical(a; check=true)
+   return flag
+end
+ 
+function issquare_with_sqrt(a::fq_default_abs_series)
+   return sqrt_classical(a; check=true)
+end
+
+###############################################################################
+#
 #   Unsafe functions
 #
 ###############################################################################

--- a/src/flint/fq_default_abs_series.jl
+++ b/src/flint/fq_default_abs_series.jl
@@ -493,14 +493,21 @@ function sqrt_classical_char2(a::fq_default_abs_series; check::Bool=true)
    prec = div(precision(a) + 1, 2)
    asqrt = set_precision!(asqrt, prec)
    if check
-     for i = 1:2:precision(a) - 1 # series must have even exponents
-       if !iszero(coeff(a, i))
-         return false, S()
-       end
-     end
+      for i = 1:2:precision(a) - 1 # series must have even exponents
+         if !iszero(coeff(a, i))
+            return false, S()
+         end
+      end
    end
    for i = 0:prec - 1
-     asqrt = setcoeff!(asqrt, i, coeff(a, 2*i))
+      if check
+         flag, c = issquare_with_sqrt(coeff(a, 2*i))
+         !flag && error("Not a square")
+      else
+         # degree of finite field could be > 1 so sqrt necessary here
+         c = sqrt(coeff(a, 2*i); check=check)
+      end
+      asqrt = setcoeff!(asqrt, i, c)
    end
    return true, asqrt
 end

--- a/test/flint/fq_abs_series-test.jl
+++ b/test/flint/fq_abs_series-test.jl
@@ -343,18 +343,6 @@ end
    @test isequal(divexact(94872394861923874346987123694871329847a, 94872394861923874346987123694871329847), a)
 end
 
-@testset "fq_abs_series.inversion" begin
-   S, t = FiniteField(fmpz(23), 5, "t")
-   R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
-
-   a = 1 + x + 2x^2 + O(x^5)
-   b = R(-1)
-
-   @test inv(a) == -x^4+3*x^3-x^2-x+1+O(x^5)
-
-   @test inv(b) == -1
-end
-
 @testset "fq_abs_series.adhoc_exact_division" begin
    S, t = FiniteField(fmpz(23), 5, "t")
    R, x = PowerSeriesRing(ZZ, 30, "x", model=:capped_absolute)
@@ -385,6 +373,46 @@ end
    @test inv(a) == -x^4+3*x^3-x^2-x+1+O(x^5)
 
    @test inv(b) == -1
+end
+
+@testset "fq_abs_series.square_root" begin
+   S, t = FiniteField(fmpz(31), 5, "t")
+   R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
+
+   for iter = 1:300
+      f = rand(R, 0:9)
+
+      @test sqrt(f^2) == f || sqrt(f^2) == -f
+   end
+
+   for p in [2, 7, 19, 65537]
+      R, t = FiniteField(fmpz(p), 2, "t")
+      S, x = PowerSeriesRing(R, 10, "x", model=:capped_absolute)
+
+      for iter = 1:10
+         f = rand(S, 0:10)
+
+         s = f^2
+
+         @test issquare(s)
+
+         q = sqrt(s)
+
+         @test q^2 == s
+
+         q = sqrt(s; check=false)
+
+         @test q^2 == s
+
+         f1, s1 = issquare_with_sqrt(s)
+
+         @test f1 && s1^2 == s
+
+         if s*x != 0
+            @test_throws ErrorException sqrt(s*x)
+         end
+      end
+   end
 end
 
 @testset "fq_abs_series.unsafe_operators" begin

--- a/test/flint/fq_default_abs_series-test.jl
+++ b/test/flint/fq_default_abs_series-test.jl
@@ -348,6 +348,46 @@ end
    @test inv(b) == -1
 end
 
+@testset "fq_default_abs_series.square_root" begin
+   S, t = NGFiniteField(fmpz(31), 5, "t")
+   R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
+
+   for iter = 1:300
+      f = rand(R, 0:9)
+
+      @test sqrt(f^2) == f || sqrt(f^2) == -f
+   end
+
+   for p in [2, 7, 19, 65537]
+      R, t = NGFiniteField(fmpz(p), 2, "t")
+      S, x = PowerSeriesRing(R, 10, "x", model=:capped_absolute)
+
+      for iter = 1:10
+         f = rand(S, 0:10)
+
+         s = f^2
+
+         @test issquare(s)
+
+         q = sqrt(s)
+
+         @test q^2 == s
+
+         q = sqrt(s; check=false)
+
+         @test q^2 == s
+
+         f1, s1 = issquare_with_sqrt(s)
+
+         @test f1 && s1^2 == s
+
+         if s*x != 0
+            @test_throws ErrorException sqrt(s*x)
+         end
+      end
+   end
+end
+
 @testset "fq_default_abs_series.unsafe_operators" begin
    S, t = NGFiniteField(fmpz(23), 5, "t")
    R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)

--- a/test/flint/fq_nmod_abs_series-test.jl
+++ b/test/flint/fq_nmod_abs_series-test.jl
@@ -360,6 +360,46 @@ end
    @test inv(b) == -1
 end
 
+@testset "fq_nmod_abs_series.square_root" begin
+   S, t = FiniteField(31, 5, "t")
+   R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)
+
+   for iter = 1:300
+      f = rand(R, 0:9)
+
+      @test sqrt(f^2) == f || sqrt(f^2) == -f
+   end
+
+   for p in [2, 7, 19, 65537]
+      R, t = FiniteField(p, 2, "t")
+      S, x = PowerSeriesRing(R, 10, "x", model=:capped_absolute)
+
+      for iter = 1:10
+         f = rand(S, 0:10)
+
+         s = f^2
+
+         @test issquare(s)
+
+         q = sqrt(s)
+
+         @test q^2 == s
+
+         q = sqrt(s; check=false)
+
+         @test q^2 == s
+
+         f1, s1 = issquare_with_sqrt(s)
+
+         @test f1 && s1^2 == s
+
+         if s*x != 0
+            @test_throws ErrorException sqrt(s*x)
+         end
+      end
+   end
+end
+
 @testset "fq_nmod_abs_series.unsafe_operators" begin
    S, t = FiniteField(23, 5, "t")
    R, x = PowerSeriesRing(S, 30, "x", model=:capped_absolute)


### PR DESCRIPTION
Adds sqrt functions for:

* fq_abs_series
* fq_nmod_abs_series
* fq_default_abs_series

Deals with characteristic 2.

Requires flint-2.9.