### PR TITLE
BREAKING: Remove auxilliary_data from AnticNumberField

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -27,7 +27,6 @@
    flag::UInt
    pol::fmpq_poly
    S::Symbol
-   auxilliary_data::Vector{Any}
 
    function AnticNumberField(pol::fmpq_poly, s::Symbol, cached::Bool = false, check::Bool = true)
      check && !isirreducible(pol) && error("Polynomial must be irreducible")
@@ -38,7 +37,6 @@
            (Ref{AnticNumberField}, Ref{fmpq_poly}), nf, pol)
         finalizer(_AnticNumberField_clear_fn, nf)
         nf.S = s
-        nf.auxilliary_data = Vector{Any}(undef, 5)
         return nf
       end
    end

--- a/test/antic/nf_elem-test.jl
+++ b/test/antic/nf_elem-test.jl
@@ -1,15 +1,3 @@
-@testset "nf_elem.accessors" begin
-   t = create_accessors(AnticNumberField, fmpz, get_handle())
-   get_test = t[1]
-   set_test = t[2]
-
-   R, x = PolynomialRing(QQ, "x")
-   K, a = NumberField(x^3 + 3x + 1, "a")
-
-   set_test(K, fmpz(2))
-   @test 2 == get_test(K)
-end
-
 @testset "nf_elem.constructors" begin
    R, x = PolynomialRing(QQ, "x")
    K, a = NumberField(x^3 + 3x + 1, "a")


### PR DESCRIPTION
This must only be merged after Hecke stopped using `create_accessor`
on `AnticNumberField`.

No other package in the Julia general registry depending on Nemo uses
this feature.