### PR TITLE
Fix to nullspace(::fmpz_mat).

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1020,7 +1020,7 @@ function nullspace(x::fmpz_mat)
       end
     end
   end
-  return 0, identity_matrix(x, ncols(x))
+  return ncols(x), identity_matrix(x, ncols(x))
 end
 
 @doc Markdown.doc"""

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1020,7 +1020,7 @@ function nullspace(x::fmpz_mat)
       end
     end
   end
-  return 0, similar(x, ncols(x), 0)
+  return 0, identity_matrix(x, ncols(x))
 end
 
 @doc Markdown.doc"""

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -554,13 +554,13 @@ end
 
    r, N = nullspace(A)
 
-    @test iszero(A*N)
+   @test iszero(A*N)
 
-    B = S([0 0 0; 0 0 0; 0 0 0])
-    I = S([1 0 0; 0 1 0; 0 0 1])
-    
-    r, N = nullspace(B)
-    @test r == 3 && N == I
+   B = S([0 0 0; 0 0 0; 0 0 0])
+   I = S([1 0 0; 0 1 0; 0 0 1])
+
+   r, N = nullspace(B)
+   @test r == 3 && N == I
 end
 
 @testset "fmpz_mat.rank" begin

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -554,7 +554,13 @@ end
 
    r, N = nullspace(A)
 
-   @test iszero(A*N)
+    @test iszero(A*N)
+
+    B = S([0 0 0; 0 0 0; 0 0 0])
+    I = S([1 0 0; 0 1 0; 0 0 1])
+    
+    r, N = nullspace(B)
+    @test r == 3 && N == I
 end
 
 @testset "fmpz_mat.rank" begin


### PR DESCRIPTION
Before this would happen:
```
A = zero_matrix(ZZ, 5, 5)
nullspace(A)
(0, 5 by 0 empty matrix)
```
Which is very inconsistent with pretty much everything else (like nullspace_right_rational).

Proposed change:
```
A = zero_matrix(ZZ, 5, 5)
nullspace(A)
(5, [1 0 0 0 0; 0 1 0 0 0; 0 0 1 0 0; 0 0 0 1 0; 0 0 0 0 1])
```


