### PR TITLE
add missing promote rules for fmpz

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -394,6 +394,8 @@ rand(R::FmpzModRing, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 promote_rule(::Type{fmpz_mod}, ::Type{T}) where T <: Integer = fmpz_mod
 
+promote_rule(::Type{fmpz_mod}, ::Type{fmpz}) = fmpz_mod
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -532,6 +532,8 @@ end
 
 promote_rule(::Type{(fq_default_mpoly)}, ::Type{V}) where {V <: Integer} = (fq_default_mpoly)
 
+promote_rule(::Type{(fq_default_mpoly)}, ::Type{fmpz}) = (fq_default_mpoly)
+
 promote_rule(::Type{(fq_default_mpoly)}, ::Type{fq_default}) = (fq_default_mpoly)
 
 ###############################################################################

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -960,6 +960,8 @@ end
 
 promote_rule(::Type{fq_nmod_mpoly}, ::Type{V}) where {V <: Integer} = fq_nmod_mpoly
 
+promote_rule(::Type{fq_nmod_mpoly}, ::Type{fmpz}) = fq_nmod_mpoly
+
 promote_rule(::Type{fq_nmod_mpoly}, ::Type{fq_nmod}) = fq_nmod_mpoly
 
 ###############################################################################

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -387,6 +387,8 @@ rand(R::GaloisField, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 promote_rule(::Type{gfp_elem}, ::Type{T}) where T <: Integer = gfp_elem
 
+promote_rule(::Type{gfp_elem}, ::Type{fmpz}) = gfp_elem
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -411,6 +411,8 @@ function promote_rule(::Type{gfp_fmpz_elem}, ::Type{T}) where T <: Integer
    return gfp_fmpz_elem
 end
 
+promote_rule(::Type{gfp_fmpz_elem}, ::Type{fmpz}) = gfp_fmpz_elem
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -368,6 +368,8 @@ setcoeff!(x::gfp_fmpz_poly, n::Int, y::gfp_fmpz_elem) = setcoeff!(x, n, y.data)
 
 promote_rule(::Type{gfp_fmpz_poly}, ::Type{gfp_fmpz_elem}) = gfp_fmpz_poly
 
+promote_rule(::Type{gfp_fmpz_poly}, ::Type{fmpz}) = gfp_fmpz_poly
+
 ###############################################################################
 #
 #   Polynomial substitution

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -397,6 +397,8 @@ rand(R::NmodRing, b::AbstractArray) = rand(Random.GLOBAL_RNG, R, b)
 
 promote_rule(::Type{nmod}, ::Type{T}) where T <: Integer = nmod
 
+promote_rule(::Type{nmod}, ::Type{fmpz}) = nmod
+
 ###############################################################################
 #
 #   Parent object call overload

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -1014,6 +1014,8 @@ end
 
 promote_rule(::Type{($etype)}, ::Type{V}) where {V <: Integer} = ($etype)
 
+promote_rule(::Type{($etype)}, ::Type{fmpz}) = ($etype)
+
 promote_rule(::Type{($etype)}, ::Type{$ctype}) = ($etype)
 
 ###############################################################################

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -8,6 +8,8 @@
    @test elem_type(Nemo.FmpzModRing) == Nemo.fmpz_mod
    @test parent_type(Nemo.fmpz_mod) == Nemo.FmpzModRing
 
+   @test Nemo.promote_rule(elem_type(R), fmpz) == elem_type(R)
+
    @test base_ring(R) == FlintZZ
 
    @test isa(R, Nemo.FmpzModRing)

--- a/test/flint/fq_default_mpoly-test.jl
+++ b/test/flint/fq_default_mpoly-test.jl
@@ -29,10 +29,11 @@ local test_fields = (NGFiniteField(23, 1, "a"),
          @test elem_type(FqDefaultMPolyRing) == fq_default_mpoly
          @test parent_type(fq_default_mpoly) == FqDefaultMPolyRing
 
-         @test typeof(S) <: FqDefaultMPolyRing
-
          @test Nemo.promote_rule(elem_type(S), elem_type(R)) == elem_type(S)
          @test Nemo.promote_rule(elem_type(S), Int) == elem_type(S)
+         @test Nemo.promote_rule(elem_type(S), fmpz) == elem_type(S)
+
+         @test typeof(S) <: FqDefaultMPolyRing
 
          isa(symbols(S), Vector{Symbol})
 

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -22,6 +22,8 @@
       @test elem_type(FqNmodMPolyRing) == fq_nmod_mpoly
       @test parent_type(fq_nmod_mpoly) == FqNmodMPolyRing
 
+      @test Nemo.promote_rule(elem_type(S), fmpz) == elem_type(S)
+
       @test typeof(S) <: FqNmodMPolyRing
 
       isa(symbols(S), Vector{Symbol})

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -18,6 +18,8 @@ end
    @test elem_type(Nemo.GaloisField) == Nemo.gfp_elem
    @test parent_type(Nemo.gfp_elem) == Nemo.GaloisField
 
+   @test Nemo.promote_rule(elem_type(R), fmpz) == elem_type(R)
+
    @test isa(R, Nemo.GaloisField)
 
    @test isa(R(), Nemo.gfp_elem)

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -7,6 +7,8 @@
    @test elem_type(Nemo.GaloisFmpzField) == Nemo.gfp_fmpz_elem
    @test parent_type(Nemo.gfp_fmpz_elem) == Nemo.GaloisFmpzField
 
+   @test Nemo.promote_rule(elem_type(R), fmpz) == elem_type(R)
+
    @test isa(R, Nemo.GaloisFmpzField)
 
    @test isa(R(), Nemo.gfp_fmpz_elem)

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -14,6 +14,8 @@
    @test parent_type(gfp_fmpz_poly) == GFPFmpzPolyRing
    @test dense_poly_type(Generic.ResF{fmpz}) == gfp_fmpz_poly
 
+   @test Nemo.promote_rule(elem_type(S), fmpz) == elem_type(S)
+
    @test typeof(S) <: GFPFmpzPolyRing
 
    @test isa(x, PolyElem{Nemo.gfp_fmpz_elem})

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -20,6 +20,8 @@ end
    @test elem_type(Nemo.NmodRing) == Nemo.nmod
    @test parent_type(Nemo.nmod) == Nemo.NmodRing
 
+   @test Nemo.promote_rule(elem_type(R), fmpz) == elem_type(R)
+
    @test base_ring(R) == FlintZZ
 
    @test isa(R, Nemo.NmodRing)

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -25,6 +25,8 @@
       @test elem_type(NmodMPolyRing) == nmod_mpoly
       @test parent_type(nmod_mpoly) == NmodMPolyRing
 
+      @test Nemo.promote_rule(elem_type(S), fmpz) == elem_type(S)
+
       @test typeof(S) <: NmodMPolyRing
 
       isa(symbols(S), Vector{Symbol})


### PR DESCRIPTION
fixes https://github.com/oscar-system/Oscar.jl/issues/960
Let me know if these would be better if combined as `::Type{T}) where T <: IntegerUnion` and I will change all of them.