### PR TITLE
Format and spellcheck README.maintainer.md

### DIFF
--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -1,7 +1,9 @@
-# Directions for overriding the C libraries (flint)
+# Directions for overriding the C libraries
 
-In `.julia/artifacts` you should have or make a file `Overrides.toml` with the following
-entry (replace `/usr/local` with the location of your installation)
+## FLINT
+
+In `.julia/artifacts` you should have or make a file `Overrides.toml` with the
+following entry (replace `/usr/local` with the location of your installation)
 
 ```
 [e134572f-a0d5-539d-bddf-3cad8db41a82]
@@ -9,8 +11,9 @@ FLINT = "/usr/local"
 ```
 
 The UUID is that of `FLINT_jll`, which is available in Nemo's `Project.toml`.
-Note the case sensitivity of the artifact name: if the jll is called `XxX_jll`, the entry should be `XxX = `.
-This is all that is needed to override the flint location. If it has worked:
+Note the case sensitivity of the artifact name: if the jll is called `XxX_jll`,
+the entry should be `XxX = `. This is all that is needed to override the FLINT
+location. If it has worked:
 
 ```
 julia> using Nemo
@@ -20,18 +23,35 @@ julia> Nemo.libflint
 
 Troubleshooting guide:
 
-- If setting up the override for the first time, Nemo should be re-precompiled. This can be triggered by touching a source file.
-- Several of the other libraries depending on flint might want a specific so version. This can be tweaked by hacking the flint makefile.
+- If setting up the override for the first time, Nemo should be re-precompiled.
+  This can be triggered by touching a source file.
 
-## arb
+- Several of the other libraries depending on FLINT might want a specific
+  so-version of FLINT. This can be tweaked by hacking the FLINT makefile.
 
-This should set `Nemo.libarb`.
+## Arb
+
+For Arb, adapt the following entry for `Overrides.toml`:
 
 ```
 [d9960996-1013-53c9-9ba4-74a4155039c3]
 Arb = "/usr/local"
 ```
 
-## antic
+## Antic
 
-## calcium
+For Antic, adapt the following entry for `Overrides.toml`:
+
+```
+[e21ec000-9f72-519e-ba6d-10061e575a27]
+Antic = "/usr/local"
+```
+
+## Calcium
+
+For Calcium, adapt the following entry for `Overrides.toml`:
+
+```
+[fcfa6d1b-d8ce-59d5-8c0a-c0d7f69e4f40]
+Calcium = "/usr/local"
+```


### PR DESCRIPTION
Edit: The part about copying libflint like `cp libflint.so.17 libflint.so.16` was wrong. Thanks to Benjamin Lorenz explaining this. I removed this part, and hence some small spell checks and formatting of the file is left.