### PR TITLE
[MERGE ONLY WHEN FLINT_JLL GETS UPDATED] Change order of attributes for AnticNumberField

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -12,9 +12,9 @@
 
 @attributes mutable struct AnticNumberField <: SimpleNumField{fmpq}
    pol_coeffs::Ptr{Nothing}
-   pol_den::Int
    pol_alloc::Int
    pol_length::Int
+   pol_den::Int
    pinv_dinv::Ptr{Nothing}
    pinv_n::Int
    pinv_norm::Int


### PR DESCRIPTION
The order of the member in fmpq_poly_struct changed in FLINT late last year. Hence, the current state of Nemo with the current state of FLINT will make a permutation of the 'alloc'-, 'length'- and 'den'-member in fmpq_poly_struct, which obviously breaks things. This commit fixes this.

Stems from https://github.com/wbhart/flint2/pull/1053