### PR TITLE
Add factor_squarefree for fmpz/fmpq_poly

### DIFF
--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -691,30 +691,38 @@ end
 #
 ################################################################################
 
-function factor(x::fmpq_poly)
-   res, z = _factor(x)
-   return Fac(parent(x)(z), res)
-end
+for (factor_fn, factor_fn_inner, flint_fn) in
+             [(:factor, :_factor, "fmpz_poly_factor"),
+              (:factor_squarefree, :_factor_squarefree, "fmpz_poly_factor_squarefree")]
+   eval(quote
 
-function _factor(x::fmpq_poly)
-   res = Dict{fmpq_poly, Int}()
-   y = fmpz_poly()
-   ccall((:fmpq_poly_get_numerator, libflint), Nothing,
-         (Ref{fmpz_poly}, Ref{fmpq_poly}), y, x)
-   fac = fmpz_poly_factor()
-   ccall((:fmpz_poly_factor, libflint), Nothing,
-              (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, y)
-   z = fmpz()
-   ccall((:fmpz_poly_factor_get_fmpz, libflint), Nothing,
-            (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
-   f = fmpz_poly()
-   for i in 1:fac.num
-      ccall((:fmpz_poly_factor_get_fmpz_poly, libflint), Nothing,
-            (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
-      e = unsafe_load(fac.exp, i)
-      res[parent(x)(f)] = e
-   end
-   return res, fmpq(z, denominator(x))
+      function $factor_fn(x::fmpq_poly)
+         res, z = $factor_fn_inner(x)
+         return Fac(parent(x)(z), res)
+      end
+
+      function $factor_fn_inner(x::fmpq_poly)
+         res = Dict{fmpq_poly, Int}()
+         y = fmpz_poly()
+         ccall((:fmpq_poly_get_numerator, libflint), Nothing,
+               (Ref{fmpz_poly}, Ref{fmpq_poly}), y, x)
+         fac = fmpz_poly_factor()
+         ccall(($flint_fn, libflint), Nothing,
+               (Ref{fmpz_poly_factor}, Ref{fmpz_poly}), fac, y)
+         z = fmpz()
+         ccall((:fmpz_poly_factor_get_fmpz, libflint), Nothing,
+               (Ref{fmpz}, Ref{fmpz_poly_factor}), z, fac)
+         f = fmpz_poly()
+         for i in 1:fac.num
+            ccall((:fmpz_poly_factor_get_fmpz_poly, libflint), Nothing,
+                  (Ref{fmpz_poly}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
+            e = unsafe_load(fac.exp, i)
+            res[parent(x)(f)] = e
+         end
+         return res, fmpq(z, denominator(x))
+      end
+
+   end)
 end
 
 function is_irreducible(x::fmpq_poly)

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -490,6 +490,10 @@ end
 
    @test f == unit(fac) * prod([ p^e for (p, e) in fac])
    @test occursin("y", sprint(show, "text/plain", fac))
+
+   fac = factor_squarefree(f)
+
+   @test f == unit(fac) * prod([ p^e for (p, e) in fac])
 end
 
 @testset "fmpq_poly.signature" begin

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -390,6 +390,11 @@ end
   @test f in fac
   @test !(x in fac)
 
+  fac = factor_squarefree(-10*f^10 * g^20)
+
+  @test -10*f^10 * g^20 == unit(fac) * prod([ p^e for (p, e) in fac])
+  @test length(fac.fac) == 4
+
   @test is_irreducible(Rx(2))
   @test is_irreducible(x^4 + 1)
   @test is_irreducible(x + 1)


### PR DESCRIPTION
These are documented in AbstractAlgebra but were missing in Nemo.

Fixes https://github.com/Nemocas/Nemo.jl/issues/1294