### PR TITLE
Turn FlintZZiRing and FlintQQiField into singletons

### DIFF
--- a/src/gaussiannumbers/GaussianNumberTypes.jl
+++ b/src/gaussiannumbers/GaussianNumberTypes.jl
@@ -1,6 +1,6 @@
 #### QQ(i) and ZZ(i) ####
 
-mutable struct FlintZZiRing <: Nemo.Ring
+struct FlintZZiRing <: Nemo.Ring
 end
 
 const FlintZZi = FlintZZiRing()
@@ -10,7 +10,7 @@ struct fmpzi <: RingElem
   y::fmpz
 end
 
-mutable struct FlintQQiField <: Nemo.Field
+struct FlintQQiField <: Nemo.Field
 end
 
 const FlintQQi = FlintQQiField()

--- a/src/gaussiannumbers/QQi.jl
+++ b/src/gaussiannumbers/QQi.jl
@@ -141,10 +141,6 @@ function Base.hash(a::fmpqi, h::UInt)
    return hash(a.num, xor(hash(a.den, h), 0x6edeadc6d0447c19%UInt))
 end
 
-function Base.hash(a::FlintQQiField)
-   return 0x4c00da8e36fcc4a8%UInt
-end
-
 ###############################################################################
 #
 #   Random generation

--- a/src/gaussiannumbers/ZZi.jl
+++ b/src/gaussiannumbers/ZZi.jl
@@ -113,10 +113,6 @@ function Base.hash(a::fmpzi, h::UInt)
    return hash(a.x, xor(hash(a.y, h), 0x94405bdfac6c8acd%UInt))
 end
 
-function Base.hash(a::FlintZZiRing)
-   return 0xc76722b5285975da%UInt
-end
-
 ###############################################################################
 #
 #   Random generation


### PR DESCRIPTION
Also remove the now redundant hash methods.

Motivated by realizing that those `hash` methods need to be fixed (they are missing the second argument), *then* realizing the easier fix would be to remove them...

But perhaps there is an obstacle for this I am not aware, so let's see what @tthsqe12 has to say :-)

