### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/flint/mpoly.jl
+++ b/src/flint/mpoly.jl
@@ -106,7 +106,7 @@ function _hash_mpoly_coeffs(a::fq_nmod_mpoly, h::UInt)
 end
 
 # fallback
-function _hash_mpoly_coeffs(a::FlintMPolyUnion, h::UInt) where S
+function _hash_mpoly_coeffs(a::FlintMPolyUnion, h::UInt)
    for i in 1:length(a)
       h = hash(coeff(a, i), h)
    end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this isn't merely cosmetic.

FTR, there's a relevant function in Test in stdlib for checking this stuff:
https://docs.julialang.org/en/v1/stdlib/Test/#Test.detect_unbound_args