### PR TITLE
Remove stub matrix coercion methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "^0.28"
+AbstractAlgebra = "^0.28.1"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -782,8 +782,6 @@ end
 
 (x::ComplexMatSpace)(y::Rational{T}) where {T <: Integer} = x(QQFieldElem(y))
 
-(x::ComplexMatSpace)(y::ComplexMat) = y
-
 ###############################################################################
 #
 #   Matrix constructor

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -672,8 +672,6 @@ function (x::RealMatSpace)(y::Union{Int, UInt, ZZRingElem, QQFieldElem, Float64,
    return z
 end
 
-(x::RealMatSpace)(y::RealMat) = y
-
 ###############################################################################
 #
 #   Matrix constructor

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -792,8 +792,6 @@ end
 
 (x::AcbMatSpace)(y::Rational{T}) where {T <: Integer} = x(QQFieldElem(y))
 
-(x::AcbMatSpace)(y::acb_mat) = y
-
 ###############################################################################
 #
 #   Matrix constructor

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -680,8 +680,6 @@ function (x::ArbMatSpace)(y::Union{Int, UInt, ZZRingElem, QQFieldElem, Float64,
    return z
 end
 
-(x::ArbMatSpace)(y::arb_mat) = y
-
 ###############################################################################
 #
 #   Matrix constructor

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -894,8 +894,6 @@ function (a::QQMatrixSpace)(M::ZZMatrix)
    return z
 end
 
-(a::QQMatrixSpace)(d::QQMatrix) = d
-
 ###############################################################################
 #
 #   Promotions

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1427,8 +1427,6 @@ function (a::ZZMatrixSpace)(d::Integer)
    return z
 end
 
-(a::ZZMatrixSpace)(d::ZZMatrix) = d
-
 ###############################################################################
 #
 #   Conversions and promotions


### PR DESCRIPTION
These methods are now properly covered by the abstract method from Nemocas/AbstractAlgebra.jl#1268.