### PR TITLE
try to improve the handling of doctests in Nemo

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, Nemo, AbstractAlgebra
 
-DocMeta.setdocmeta!(Nemo.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive = true)
+DocMeta.setdocmeta!(Nemo, :DocTestSetup, :(using Nemo); recursive = true)
 
 makedocs(
          format = Documenter.HTML(),


### PR DESCRIPTION
- call `DocMeta.setdocmeta!(Nemo, :DocTestSetup, :(using Nemo); recursive = true)`, in order to make it easier to add jldoctests to Nemo
- do *not* call `DocMeta.setdocmeta!(Nemo.AbstractAlgebra, :DocTestSetup, :(using AbstractAlgebra); recursive = true)`, in order to not mix up jldoctests in Nemo

(This is connected to Nemocas/AbstractAlgebra.jl/pull/1261.)