### PR TITLE
Unify evaluate/evaluate2 methods for arb_poly, acb_poly

### DIFF
--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -421,8 +421,14 @@ function evaluate(x::ComplexPoly, y::ComplexFieldElem, prec::Int = precision(Bal
    return z
 end
 
+evaluate(x::ComplexPoly, y::RingElem, prec::Int = precision(Balls)) = evaluate(x, base_ring(parent(x))(y), prec)
+evaluate(x::ComplexPoly, y::Integer, prec::Int = precision(Balls)) = evaluate(x, base_ring(parent(x))(y), prec)
+evaluate(x::ComplexPoly, y::Rational, prec::Int = precision(Balls)) = evaluate(x, base_ring(parent(x))(y), prec)
+evaluate(x::ComplexPoly, y::Float64, prec::Int = precision(Balls)) = evaluate(x, base_ring(parent(x))(y), prec)
+evaluate(x::ComplexPoly, y::Any, prec::Int = precision(Balls)) = evaluate(x, base_ring(parent(x))(y), prec)
+
 @doc Markdown.doc"""
-    evaluate2(x::ComplexPoly, y::ComplexFieldElem)
+    evaluate2(x::ComplexPoly, y::RingElement; prec::Int = precision(Balls))
 
 Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
 its derivative evaluated at $y$.
@@ -436,11 +442,7 @@ function evaluate2(x::ComplexPoly, y::ComplexFieldElem, prec::Int = precision(Ba
    return z, w
 end
 
-function evaluate(x::ComplexPoly, y::Union{Int, Float64, ZZRingElem, QQFieldElem, RealFieldElem}, prec::Int = precision(Balls))
-    return evaluate(x, base_ring(parent(x))(y), prec)
-end
-
-function evaluate2(x::ComplexPoly, y::Union{Integer, Float64, ZZRingElem, QQFieldElem, RealFieldElem}, prec::Int = precision(Balls))
+function evaluate2(x::ComplexPoly, y::RingElement, prec::Int = precision(Balls))
     return evaluate2(x, base_ring(parent(x))(y), prec)
 end
 

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -413,8 +413,22 @@ function evaluate(x::RealPoly, y::RealFieldElem, prec::Int = precision(Balls))
    return z
 end
 
+function evaluate(x::RealPoly, y::acb, prec::Int = precision(Balls))
+   z = parent(y)()
+   ccall((:arb_poly_evaluate_acb, libarb), Nothing,
+                (Ref{acb}, Ref{RealPoly}, Ref{acb}, Int),
+                z, x, y, prec)
+   return z
+end
+
+evaluate(x::RealPoly, y::RingElem) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::RealPoly, y::Integer) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::RealPoly, y::Rational) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::RealPoly, y::Float64) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::RealPoly, y::Any) = evaluate(x, base_ring(parent(x))(y))
+
 @doc Markdown.doc"""
-    evaluate2(x::RealPoly, y::RealFieldElem)
+    evaluate2(x::RealPoly, y::RingElement)
 
 Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
 its derivative evaluated at $y$.
@@ -428,20 +442,6 @@ function evaluate2(x::RealPoly, y::RealFieldElem, prec::Int = precision(Balls))
    return z, w
 end
 
-function evaluate(x::RealPoly, y::acb, prec::Int = precision(Balls))
-   z = parent(y)()
-   ccall((:arb_poly_evaluate_acb, libarb), Nothing,
-                (Ref{acb}, Ref{RealPoly}, Ref{acb}, Int),
-                z, x, y, prec)
-   return z
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::RealPoly, y::acb)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
 function evaluate2(x::RealPoly, y::ComplexFieldElem, prec::Int = precision(Balls))
    z = parent(y)()
    w = parent(y)()
@@ -451,21 +451,7 @@ function evaluate2(x::RealPoly, y::ComplexFieldElem, prec::Int = precision(Balls
    return z, w
 end
 
-for T in [Integer, Float64, ZZRingElem, QQFieldElem, Rational]
-  @eval begin
-    function evaluate(x::RealPoly, y::$T)
-        return evaluate(x, base_ring(parent(x))(y))
-    end
-  end
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::RealPoly, y::Integer)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::RealPoly, y::Union{Integer, Float64, ZZRingElem, QQFieldElem, Rational})
+function evaluate2(x::RealPoly, y::RingElement)
     return evaluate2(x, base_ring(parent(x))(y))
 end
 

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -421,8 +421,14 @@ function evaluate(x::acb_poly, y::acb)
    return z
 end
 
+evaluate(x::acb_poly, y::RingElem) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::acb_poly, y::Integer) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::acb_poly, y::Rational) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::acb_poly, y::Float64) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::acb_poly, y::Any) = evaluate(x, base_ring(parent(x))(y))
+
 @doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::acb)
+    evaluate2(x::acb_poly, y::RingElement)
 
 Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
 its derivative evaluated at $y$.
@@ -436,63 +442,7 @@ function evaluate2(x::acb_poly, y::acb)
    return z, w
 end
 
-function evaluate(x::acb_poly, y::Union{Int,Float64,QQFieldElem,arb})
-    return evaluate(x, base_ring(parent(x))(y))
-end
-
-function evaluate(x::acb_poly, y::ZZRingElem)
-    return evaluate(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::Integer)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::acb_poly, y::Integer)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::Float64)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::acb_poly, y::Float64)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::ZZRingElem)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::acb_poly, y::ZZRingElem)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::QQFieldElem)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::acb_poly, y::QQFieldElem)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::acb_poly, y::arb)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::acb_poly, y::arb)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
+evaluate2(x::acb_poly, y::RingElement) = evaluate2(x, base_ring(parent(x))(y))
 
 ###############################################################################
 #

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -413,8 +413,22 @@ function evaluate(x::arb_poly, y::arb)
    return z
 end
 
+function evaluate(x::arb_poly, y::acb)
+   z = parent(y)()
+   ccall((:arb_poly_evaluate_acb, libarb), Nothing,
+                (Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
+                z, x, y, precision(parent(y)))
+   return z
+end
+
+evaluate(x::arb_poly, y::RingElem) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::arb_poly, y::Integer) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::arb_poly, y::Rational) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::arb_poly, y::Float64) = evaluate(x, base_ring(parent(x))(y))
+evaluate(x::arb_poly, y::Any) = evaluate(x, base_ring(parent(x))(y))
+
 @doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::arb)
+    evaluate2(x::arb_poly, y::Any)
 
 Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
 its derivative evaluated at $y$.
@@ -428,20 +442,6 @@ function evaluate2(x::arb_poly, y::arb)
    return z, w
 end
 
-function evaluate(x::arb_poly, y::acb)
-   z = parent(y)()
-   ccall((:arb_poly_evaluate_acb, libarb), Nothing,
-                (Ref{acb}, Ref{arb_poly}, Ref{acb}, Int),
-                z, x, y, precision(parent(y)))
-   return z
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::acb)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
 function evaluate2(x::arb_poly, y::acb)
    z = parent(y)()
    w = parent(y)()
@@ -451,53 +451,7 @@ function evaluate2(x::arb_poly, y::acb)
    return z, w
 end
 
-function evaluate(x::arb_poly, y::Union{Int,Float64,QQFieldElem})
-    return evaluate(x, base_ring(parent(x))(y))
-end
-
-function evaluate(x::arb_poly, y::ZZRingElem)
-    return evaluate(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::Integer)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::arb_poly, y::Integer)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::Float64)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::arb_poly, y::Float64)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::ZZRingElem)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::arb_poly, y::ZZRingElem)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
-
-@doc Markdown.doc"""
-    evaluate2(x::arb_poly, y::QQFieldElem)
-
-Return a tuple $p, q$ consisting of the polynomial $x$ evaluated at $y$ and
-its derivative evaluated at $y$.
-"""
-function evaluate2(x::arb_poly, y::QQFieldElem)
-    return evaluate2(x, base_ring(parent(x))(y))
-end
+evaluate2(x::arb_poly, y::Any) = evaluate2(x, base_ring(parent(x))(y))
 
 ###############################################################################
 #


### PR DESCRIPTION
There seems to be no point in artificially restricting the second argument.
This way, if there are other rings that can be coerced into RealFieldElem or
ComplexFieldElem, then they'll just work.
