### PR TITLE
Don't store singleton rings as `base_ring`

### DIFF
--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -697,7 +697,6 @@ The matrix is of type QQMatrix.
 function representation_matrix(a::nf_elem)
   K = parent(a)
   z = QQMatrix(degree(K), degree(K))
-  z.base_ring = FlintQQ
   ccall((:nf_elem_rep_mat, libantic), Nothing,
         (Ref{QQMatrix}, Ref{nf_elem}, Ref{AnticNumberField}), z, a, K)
   return z
@@ -714,7 +713,6 @@ a primitive integer matrix and a denominator.
 function representation_matrix_q(a::nf_elem)
   K = parent(a)
   z = ZZMatrix(degree(K), degree(K))
-  z.base_ring = FlintZZ
   d = ZZRingElem()
   ccall((:nf_elem_rep_mat_fmpz_mat_den, libantic), Nothing,
         (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{nf_elem}, Ref{AnticNumberField}),

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -29,7 +29,7 @@ elem_type(::Type{QQAbsPowerSeriesRing}) = QQAbsPowerSeriesRingElem
 
 parent_type(::Type{QQAbsPowerSeriesRingElem}) = QQAbsPowerSeriesRing
 
-base_ring(R::QQAbsPowerSeriesRing) = R.base_ring
+base_ring(R::QQAbsPowerSeriesRing) = FlintQQ
 
 abs_series_type(::Type{QQFieldElem}) = QQAbsPowerSeriesRingElem
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -16,9 +16,9 @@ elem_type(::Type{QQMatrixSpace}) = QQMatrix
 
 parent_type(::Type{QQMatrix}) = QQMatrixSpace
 
-base_ring(a::QQMatrixSpace) = a.base_ring
+base_ring(a::QQMatrixSpace) = FlintQQ
 
-base_ring(a::QQMatrix) = a.base_ring
+base_ring(a::QQMatrix) = FlintQQ
 
 dense_matrix_type(::Type{QQFieldElem}) = QQMatrix
 
@@ -39,7 +39,6 @@ end
 
 function similar(::QQMatrix, R::QQField, r::Int, c::Int)
    z = QQMatrix(r, c)
-   z.base_ring = R
    return z
 end
 
@@ -69,7 +68,6 @@ function Base.view(x::QQMatrix, r1::Int, c1::Int, r2::Int, c2::Int)
 
   b = QQMatrix()
   b.view_parent = x
-  b.base_ring = x.base_ring
   ccall((:fmpq_mat_window_init, libflint), Nothing,
         (Ref{QQMatrix}, Ref{QQMatrix}, Int, Int, Int, Int),
             b, x, r1 - 1, c1 - 1, r2, c2)
@@ -179,7 +177,6 @@ isone(a::QQMatrix) = ccall((:fmpq_mat_is_one, libflint), Bool,
 
 function deepcopy_internal(d::QQMatrix, dict::IdDict)
    z = QQMatrix(d)
-   z.base_ring = d.base_ring
    return z
 end
 
@@ -513,7 +510,6 @@ divexact(x::QQMatrix, y::Rational{T}; check::Bool=true) where T <: Union{Int, Bi
 ###############################################################################
 
 function kronecker_product(x::QQMatrix, y::QQMatrix)
-   base_ring(x) == base_ring(y) || error("Incompatible matrices")
    z = similar(x, nrows(x)*nrows(y), ncols(x)*ncols(y))
    ccall((:fmpq_mat_kronecker_product, libflint), Nothing,
                 (Ref{QQMatrix}, Ref{QQMatrix}, Ref{QQMatrix}), z, x, y)
@@ -806,21 +802,18 @@ end
 
 function (a::QQMatrixSpace)()
    z = QQMatrix(nrows(a), ncols(a))
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractMatrix{QQFieldElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
@@ -828,60 +821,51 @@ end
 function (a::QQMatrixSpace)(arr::AbstractMatrix{T}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractMatrix{Rational{T}}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), map(QQFieldElem, arr))
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractVector{QQFieldElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractVector{ZZRingElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractVector{T}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(arr::AbstractVector{Rational{T}}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = QQMatrix(nrows(a), ncols(a), map(QQFieldElem, arr))
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(d::QQFieldElem)
    z = QQMatrix(nrows(a), ncols(a), d)
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(d::ZZRingElem)
    z = QQMatrix(nrows(a), ncols(a), QQFieldElem(d))
-   z.base_ring = a.base_ring
    return z
 end
 
 function (a::QQMatrixSpace)(d::Integer)
    z = QQMatrix(nrows(a), ncols(a), QQFieldElem(d))
-   z.base_ring = a.base_ring
    return z
 end
 
@@ -916,40 +900,34 @@ promote_rule(::Type{QQMatrix}, ::Type{Rational{T}}) where T <: Union{Int, BigInt
 
 function matrix(R::QQField, arr::AbstractMatrix{QQFieldElem})
    z = QQMatrix(size(arr, 1), size(arr, 2), arr)
-   z.base_ring = FlintQQ
    return z
 end
 
 function matrix(R::QQField, arr::AbstractMatrix{<: Union{ZZRingElem, Int, BigInt}})
    z = QQMatrix(size(arr, 1), size(arr, 2), arr)
-   z.base_ring = FlintQQ
    return z
 end
 
 function matrix(R::QQField, arr::AbstractMatrix{Rational{T}}) where {T <: Integer}
    z = QQMatrix(size(arr, 1), size(arr, 2), map(QQFieldElem, arr))
-   z.base_ring = FlintQQ
    return z
 end
 
 function matrix(R::QQField, r::Int, c::Int, arr::AbstractVector{QQFieldElem})
    _check_dim(r, c, arr)
    z = QQMatrix(r, c, arr)
-   z.base_ring = FlintQQ
    return z
 end
 
 function matrix(R::QQField, r::Int, c::Int, arr::AbstractVector{<: Union{ZZRingElem, Int, BigInt}})
    _check_dim(r, c, arr)
    z = QQMatrix(r, c, arr)
-   z.base_ring = FlintQQ
    return z
 end
 
 function matrix(R::QQField, r::Int, c::Int, arr::AbstractVector{Rational{T}}) where {T <: Union{ZZRingElem, Int, BigInt}}
    _check_dim(r, c, arr)
    z = QQMatrix(r, c, map(QQFieldElem, arr))
-   z.base_ring = FlintQQ
    return z
 end
 
@@ -964,7 +942,6 @@ function zero_matrix(R::QQField, r::Int, c::Int)
      error("dimensions must not be negative")
    end
    z = QQMatrix(r, c)
-   z.base_ring = FlintQQ
    return z
 end
 
@@ -980,7 +957,6 @@ function identity_matrix(R::QQField, n::Int)
    end
    z = QQMatrix(n, n)
    ccall((:fmpq_mat_one, libflint), Nothing, (Ref{QQMatrix}, ), z)
-   z.base_ring = FlintQQ
    return z
 end
 

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -35,9 +35,9 @@ end
 nvars(a::QQMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, libflint), Int,
                                 (Ref{QQMPolyRing}, ), a)
 
-base_ring(a::QQMPolyRing) = a.base_ring
+base_ring(a::QQMPolyRing) = FlintQQ
 
-base_ring(f::QQMPolyRingElem) = f.parent.base_ring
+base_ring(f::QQMPolyRingElem) = FlintQQ
 
 function ordering(a::QQMPolyRing)
    b = ccall((:fmpq_mpoly_ctx_ord, libflint), Cint, (Ref{QQMPolyRing}, ), a)

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -18,7 +18,7 @@ elem_type(::Type{QQPolyRing}) = QQPolyRingElem
 
 dense_poly_type(::Type{QQFieldElem}) = QQPolyRingElem
 
-base_ring(a::QQPolyRing) = a.base_ring
+base_ring(a::QQPolyRing) = FlintQQ
 
 var(a::QQPolyRing) = a.S
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -24,7 +24,7 @@ elem_type(::Type{QQRelPowerSeriesRing}) = QQRelPowerSeriesRingElem
 
 parent_type(::Type{QQRelPowerSeriesRingElem}) = QQRelPowerSeriesRing
 
-base_ring(R::QQRelPowerSeriesRing) = R.base_ring
+base_ring(R::QQRelPowerSeriesRing) = FlintQQ
 
 rel_series_type(::Type{QQFieldElem}) = QQRelPowerSeriesRingElem
 

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -27,7 +27,7 @@ elem_type(::Type{ZZAbsPowerSeriesRing}) = ZZAbsPowerSeriesRingElem
 
 parent_type(::Type{ZZAbsPowerSeriesRingElem}) = ZZAbsPowerSeriesRing
 
-base_ring(R::ZZAbsPowerSeriesRing) = R.base_ring
+base_ring(R::ZZAbsPowerSeriesRing) = FlintZZ
 
 abs_series_type(::Type{ZZRingElem}) = ZZAbsPowerSeriesRingElem
 

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -30,7 +30,7 @@ parent(a::ZZLaurentSeriesRingElem) = a.parent
 
 elem_type(::Type{ZZLaurentSeriesRing}) = ZZLaurentSeriesRingElem
 
-base_ring(R::ZZLaurentSeriesRing) = R.base_ring
+base_ring(R::ZZLaurentSeriesRing) = FlintZZ
 
 base_ring(a::ZZLaurentSeriesRingElem) = base_ring(parent(a))
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -24,7 +24,9 @@ elem_type(::Type{ZZMatrixSpace}) = ZZMatrix
 
 parent_type(::Type{ZZMatrix}) = ZZMatrixSpace
 
-base_ring(a::ZZMatrixSpace) = a.base_ring
+base_ring(a::ZZMatrixSpace) = FlintZZ
+
+base_ring(a::ZZMatrix) = FlintZZ
 
 dense_matrix_type(::Type{ZZRingElem}) = ZZMatrix
 
@@ -45,7 +47,6 @@ end
 
 function similar(::ZZMatrix, R::ZZRing, r::Int, c::Int)
    z = ZZMatrix(r, c)
-   z.base_ring = R
    return z
 end
 
@@ -81,7 +82,6 @@ function Base.view(x::ZZMatrix, r1::Int, c1::Int, r2::Int, c2::Int)
    end
 
    b = ZZMatrix()
-   b.base_ring = FlintZZ
    b.view_parent = x
    ccall((:fmpz_mat_window_init, libflint), Nothing,
          (Ref{ZZMatrix}, Ref{ZZMatrix}, Int, Int, Int, Int),
@@ -173,7 +173,6 @@ isone(a::ZZMatrix) = ccall((:fmpz_mat_is_one, libflint), Bool,
 
 function deepcopy_internal(d::ZZMatrix, dict::IdDict)
    z = ZZMatrix(d)
-   z.base_ring = d.base_ring
    return z
 end
 
@@ -560,7 +559,6 @@ divexact(x::ZZMatrix, y::Integer; check::Bool=true) = divexact(x, ZZRingElem(y);
 ###############################################################################
 
 function kronecker_product(x::ZZMatrix, y::ZZMatrix)
-   base_ring(x) == base_ring(y) || error("Incompatible matrices")
    z = similar(x, nrows(x)*nrows(y), ncols(x)*ncols(y))
    ccall((:fmpz_mat_kronecker_product, libflint), Nothing,
                 (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZMatrix}), z, x, y)
@@ -1478,47 +1476,40 @@ end
 
 function (a::ZZMatrixSpace)()
    z = ZZMatrix(nrows(a), ncols(a))
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = ZZMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(arr::AbstractMatrix{T}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = ZZMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(arr::AbstractVector{ZZRingElem})
    _check_dim(nrows(a), ncols(a), arr)
    z = ZZMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(arr::AbstractVector{T}) where {T <: Integer}
    _check_dim(nrows(a), ncols(a), arr)
    z = ZZMatrix(nrows(a), ncols(a), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(d::ZZRingElem)
    z = ZZMatrix(nrows(a), ncols(a), d)
-   z.base_ring = FlintZZ
    return z
 end
 
 function (a::ZZMatrixSpace)(d::Integer)
    z = ZZMatrix(nrows(a), ncols(a), ZZRingElem(d))
-   z.base_ring = FlintZZ
    return z
 end
 
@@ -1559,27 +1550,23 @@ end
 
 function matrix(R::ZZRing, arr::AbstractMatrix{ZZRingElem})
    z = ZZMatrix(size(arr, 1), size(arr, 2), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function matrix(R::ZZRing, arr::AbstractMatrix{<: Integer})
    z = ZZMatrix(size(arr, 1), size(arr, 2), arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function matrix(R::ZZRing, r::Int, c::Int, arr::AbstractVector{ZZRingElem})
    _check_dim(r, c, arr)
    z = ZZMatrix(r, c, arr)
-   z.base_ring = FlintZZ
    return z
 end
 
 function matrix(R::ZZRing, r::Int, c::Int, arr::AbstractVector{<: Integer})
    _check_dim(r, c, arr)
    z = ZZMatrix(r, c, arr)
-   z.base_ring = FlintZZ
    return z
 end
 
@@ -1594,7 +1581,6 @@ function zero_matrix(R::ZZRing, r::Int, c::Int)
      error("dimensions must not be negative")
    end
    z = ZZMatrix(r, c)
-   z.base_ring = FlintZZ
    return z
 end
 
@@ -1610,7 +1596,6 @@ function identity_matrix(R::ZZRing, n::Int)
    end
    z = ZZMatrix(n, n)
    ccall((:fmpz_mat_one, libflint), Nothing, (Ref{ZZMatrix}, ), z)
-   z.base_ring = FlintZZ
    return z
 end
 

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -664,7 +664,6 @@ entries of the returned matrix are those of $a$ lifted to $\mathbb{Z}$.
 """
 function lift(a::T) where {T <: Zmod_fmpz_mat}
   z = ZZMatrix(nrows(a), ncols(a))
-  z.base_ring = FlintZZ
   ccall((:fmpz_mat_set_fmpz_mod_mat, libflint), Nothing,
           (Ref{ZZMatrix}, Ref{T}), z, a)
   return z

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -30,9 +30,9 @@ end
 nvars(a::ZZMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, libflint), Int,
                                 (Ref{ZZMPolyRing}, ), a)
 
-base_ring(a::ZZMPolyRing) = a.base_ring
+base_ring(a::ZZMPolyRing) = FlintZZ
 
-base_ring(f::ZZMPolyRingElem) = f.parent.base_ring
+base_ring(f::ZZMPolyRingElem) = FlintZZ
 
 function ordering(a::ZZMPolyRing)
    b = ccall((:fmpz_mpoly_ctx_ord, libflint), Cint, (Ref{ZZMPolyRing}, ), a)

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -19,7 +19,7 @@ elem_type(::Type{ZZPolyRing}) = ZZPolyRingElem
 
 dense_poly_type(::Type{ZZRingElem}) = ZZPolyRingElem
 
-base_ring(a::ZZPolyRing) = a.base_ring
+base_ring(a::ZZPolyRing) = FlintZZ
 
 parent(a::ZZPolyRingElem) = a.parent
 
@@ -120,7 +120,7 @@ function show(io::IO, p::ZZPolyRing)
    print(io, "Univariate Polynomial Ring in ")
    print(io, string(var(p)))
    print(io, " over ")
-   show(io, p.base_ring)
+   show(io, FlintZZ)
 end
 
 ###############################################################################

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -24,7 +24,7 @@ elem_type(::Type{ZZRelPowerSeriesRing}) = ZZRelPowerSeriesRingElem
 
 parent_type(::Type{ZZRelPowerSeriesRingElem}) = ZZRelPowerSeriesRing
 
-base_ring(R::ZZRelPowerSeriesRing) = R.base_ring
+base_ring(R::ZZRelPowerSeriesRing) = FlintZZ
 
 rel_series_type(::Type{ZZRingElem}) = ZZRelPowerSeriesRingElem
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -227,7 +227,6 @@ entries of the returned matrix are those of $a$ lifted to $\mathbb{Z}$.
 """
 function lift(a::fpMatrix)
   z = ZZMatrix(nrows(a), ncols(a))
-  z.base_ring = FlintZZ
   ccall((:fmpz_mat_set_nmod_mat, libflint), Nothing,
           (Ref{ZZMatrix}, Ref{fpMatrix}), z, a)
   return z

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -645,7 +645,6 @@ entries of the returned matrix are those of $a$ lifted to $\mathbb{Z}$.
 """
 function lift(a::T) where {T <: Zmodn_mat}
   z = ZZMatrix(nrows(a), ncols(a))
-  z.base_ring = FlintZZ
   ccall((:fmpz_mat_set_nmod_mat, libflint), Nothing,
           (Ref{ZZMatrix}, Ref{T}), z, a)
   return z


### PR DESCRIPTION
It turns out this is a breaking change, at least if one considers the exact layouts of our structs as a part of our API... Though code which wants to access the base ring, really should be using `base_ring(x)` instead of `x.base_ring` to begin with.