### PR TITLE
number_of_partitions works on Windows after all

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2102,8 +2102,7 @@ euler_phi(x::Int) = Int(euler_phi(ZZRingElem(x)))
     number_of_partitions(x::Int)
     number_of_partitions(x::ZZRingElem)
 
-Return the number of partitions of $x$. This function is not available on
-Windows 64.
+Return the number of partitions of $x$.
 
 # Examples
 
@@ -2116,22 +2115,16 @@ julia> number_of_partitions(ZZ(1000))
 ```
 """
 function number_of_partitions(x::Int)
-   if (Sys.iswindows() ? true : false) && Int == Int64
-#      error("not yet supported on win64")
-   end
-   z = ZZRingElem()
    if x < 0
       return 0
    end
+   z = ZZRingElem()
    ccall((:partitions_fmpz_ui, libarb), Nothing,
          (Ref{ZZRingElem}, UInt), z, x)
    return Int(z)
 end
 
 function number_of_partitions(x::ZZRingElem)
-   if (Sys.iswindows() ? true : false) && Int == Int64
-#      error("not yet supported on win64")
-   end
    z = ZZRingElem()
    if x < 0
       return z


### PR DESCRIPTION
Resolves #1387

For testing purposes I disabled the Windows check, just to see what happens (wrong output? crash? something else). And it worked (and then I accidentally merged the result 😬 ).

Anyway, since it seems to work fine in Windows CI, I figure the issue was already resolved in Flint and we can just proceed to strip out the remains of the warning. Thoughts?

