### PR TITLE
Remove redundant `polynomial_ring` implementations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractAlgebra = "^0.28.1, 0.29"
+AbstractAlgebra = "^0.28.4, 0.29"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -852,22 +852,3 @@ function (a::ComplexPolyRing)(b::ComplexPoly)
    z.parent = a
    return z
 end
-
-################################################################################
-#
-#  polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::ComplexField, s::Symbol; cached = true)
-  parent_obj = ComplexPolyRing(R, s, cached)
-  return parent_obj, parent_obj(ZZPolyRingElem([ZZRingElem(0), ZZRingElem(1)]))
-end
-
-function polynomial_ring(R::ComplexField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::ComplexField)
-   return ComplexPolyRing(R, :x, false)
-end

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -766,22 +766,3 @@ end
 function (R::RealPolyRing)(p::AbstractAlgebra.Generic.Poly{RealFieldElem})
    return R(p.coeffs)
 end
-
-################################################################################
-#
-#  polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::RealField, s::Symbol; cached = true)
-  parent_obj = RealPolyRing(R, s, cached)
-  return parent_obj, parent_obj(ZZPolyRingElem([ZZRingElem(0), ZZRingElem(1)]))
-end
-
-function polynomial_ring(R::RealField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::RealField)
-   return RealPolyRing(R, :x, false)
-end

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -842,22 +842,3 @@ function (a::AcbPolyRing)(b::acb_poly)
    z.parent = a
    return z
 end
-
-################################################################################
-#
-#  polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::AcbField, s::Symbol; cached = true)
-  parent_obj = AcbPolyRing(R, s, cached)
-  return parent_obj, parent_obj(ZZPolyRingElem([ZZRingElem(0), ZZRingElem(1)]))
-end
-
-function polynomial_ring(R::AcbField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::AcbField)
-   return AcbPolyRing(R, :x, false)
-end

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -756,22 +756,3 @@ end
 function (R::ArbPolyRing)(p::AbstractAlgebra.Generic.Poly{arb})
    return R(p.coeffs)
 end
-
-################################################################################
-#
-#  polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::ArbField, s::Symbol; cached = true)
-  parent_obj = ArbPolyRing(R, s, cached)
-  return parent_obj, parent_obj(ZZPolyRingElem([ZZRingElem(0), ZZRingElem(1)]))
-end
-
-function polynomial_ring(R::ArbField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::ArbField)
-   return ArbPolyRing(R, :x, false)
-end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -1246,19 +1246,3 @@ function (R::QQMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where T
 
    return R(newaa, newbb)
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::QQField, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = QQMPolyRing(s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::QQField, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end
-

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -902,23 +902,3 @@ function (a::QQPolyRing)(b::ZZPolyRingElem)
    z.parent = a
    return z
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::QQField, s::Symbol; cached = true)
-   parent_obj = QQPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([QQFieldElem(0), QQFieldElem(1)])
-end
-
-function polynomial_ring(R::QQField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::QQField)
-   return QQPolyRing(R, :x, false)
-end

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -1064,18 +1064,3 @@ end
 function divexact(f::FpMPolyRingElem, a::IntegerUnion; check::Bool=true)
   return divexact(f, base_ring(f)(a))
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::FpField, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = FpMPolyRing(R, s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::FpField, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -1043,23 +1043,3 @@ function (R::ZZModPolyRing)(f::ZZModPolyRingElem)
    parent(f) != R && error("Unable to coerce polynomial")
    return f
 end
-
-################################################################################
-#
-#  Polynomial ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::ZZModRing, s::Symbol; cached=true)
-   parent_obj = ZZModPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::ZZModRing, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::ZZModRing)
-   return ZZModPolyRing(R, :x, false)
-end

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -1156,19 +1156,3 @@ function (R::ZZMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where T
 
    return R(newaa, newbb)
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::ZZRing, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = ZZMPolyRing(s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::ZZRing, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end
-

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -958,23 +958,3 @@ end
 (a::ZZPolyRing)(b::Vector{T}) where {T <: Integer} = a(map(ZZRingElem, b))
 
 (a::ZZPolyRing)(b::ZZPolyRingElem) = b
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::ZZRing, s::Symbol; cached = true)
-   parent_obj = ZZPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([ZZRingElem(0), ZZRingElem(1)])
-end
-
-function polynomial_ring(R::ZZRing, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::ZZRing)
-   return ZZPolyRing(R, :x, false)
-end

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -593,37 +593,3 @@ end
 function divexact(a::FqMPolyRingElem, b::IntegerUnion; check::Bool=true)
   return a*inv(base_ring(a)(b))
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::FqField, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-    # try just FqPolyRepFieldElem for now
-    m = modulus(R)
-    p = characteristic(R)
-    if fits(UInt, p)
-        Fq = GF(UInt(p))
-        if isone(degree(m))
-            Fqx = polynomial_ring(Fq, s, cached = cached, ordering = ordering)[1]
-            parent_obj = FqMPolyRing(Fqx, R, 3, s, ordering, cached)
-        else
-            mm = polynomial_ring(Fq, "x")[1](lift(polynomial_ring(ZZ, "x")[1], m))
-            Fq = FlintFiniteField(mm, R.var, cached = cached, check = false)[1]
-            Fqx = polynomial_ring(Fq, s, cached = cached, ordering = ordering)[1]
-            parent_obj = FqMPolyRing(Fqx, R, 2, s, ordering, cached)
-        end
-    else
-        Fq = FqPolyRepField(m, Symbol(R.var), cached, check = false)
-        Fqx = AbstractAlgebra.Generic.polynomial_ring(Fq, s, cached = cached, ordering = ordering)[1]
-        parent_obj = FqMPolyRing(Fqx, R, 1, s, ordering, cached)
-    end
-    return parent_obj, gens(parent_obj)
-end
-
-function polynomial_ring(R::FqField, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end
-

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -903,15 +903,3 @@ function (R::FqPolyRing)(x::FqPolyRingElem)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end
-
-################################################################################
-#
-#   polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::FqField, s::AbstractString; cached = true)
-   S = Symbol(s)
-   parent_obj = FqPolyRing(R, S, cached)
-   return parent_obj, parent_obj([R(0), R(1)])
-end

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -1118,19 +1118,3 @@ function (R::fqPolyRepMPolyRing)(a::Vector{<:Any}, b::Vector{Vector{T}}) where T
 
    return R(newaa, newbb)
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::fqPolyRepField, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = fqPolyRepMPolyRing(R, s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::fqPolyRepField, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end
-

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -879,22 +879,3 @@ function (R::fqPolyRepPolyRing)(x::fqPolyRepPolyRingElem)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end
-
-################################################################################
-#
-#   polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::fqPolyRepField, s::Symbol; cached = true)
-   parent_obj = fqPolyRepPolyRing(R, s, cached)
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::fqPolyRepField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::fqPolyRepField)
-   return fqPolyRepPolyRing(R, :x, false)
-end

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -877,22 +877,3 @@ function (R::FqPolyRepPolyRing)(x::FqPolyRepPolyRingElem)
   parent(x) != R && error("Unable to coerce to polynomial")
   return x
 end
-
-################################################################################
-#
-#   polynomial_ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::FqPolyRepField, s::Symbol; cached = true)
-   parent_obj = FqPolyRepPolyRing(R, s, cached)
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::FqPolyRepField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::FqPolyRepField)
-   return FqPolyRepPolyRing(R, :x, false)
-end

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -532,23 +532,3 @@ function (R::FpPolyRing)(f::FpPolyRingElem)
    parent(f) != R && error("Unable to coerce polynomial")
    return f
 end
-
-################################################################################
-#
-#  Polynomial ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::FpField, s::Symbol; cached=true)
-   parent_obj = FpPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::FpField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::FpField)
-   return FpPolyRing(R, :x, false)
-end

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -609,23 +609,3 @@ function (R::fpPolyRing)(x::ZZPolyRingElem)
   z.parent = R
   return z
 end
-
-################################################################################
-#
-#  Polynomial ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::fpField, s::Symbol; cached=true)
-   parent_obj = fpPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::fpField, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::fpField)
-   return fpPolyRing(R, :x, false)
-end

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -1204,27 +1204,3 @@ end
 function divexact(f::zzModMPolyRingElem, a::IntegerUnion; check::Bool=true)
   return divexact(f, base_ring(f)(a))
 end
-
-###############################################################################
-#
-#   polynomial_ring constructor
-#
-###############################################################################
-
-function polynomial_ring(R::zzModRing, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = zzModMPolyRing(R, s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))
-end
-
-function polynomial_ring(R::zzModRing, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end
-
-function polynomial_ring(R::fpField, s::Vector{Symbol}; cached::Bool = true, ordering::Symbol = :lex)
-   parent_obj = fpMPolyRing(R, s, ordering, cached)
-   return tuple(parent_obj, gens(parent_obj))   
-end
-
-function polynomial_ring(R::fpField, s::Vector{String}; cached::Bool = true, ordering::Symbol = :lex)
-   return polynomial_ring(R, [Symbol(x) for x in s]; cached=cached, ordering=ordering)
-end

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -1081,23 +1081,3 @@ function (R::zzModPolyRing)(x::ZZPolyRingElem)
   z.parent = R
   return z
 end
-
-################################################################################
-#
-#  Polynomial ring constructor
-#
-################################################################################
-
-function polynomial_ring(R::zzModRing, s::Symbol; cached=true)
-   parent_obj = zzModPolyRing(R, s, cached)
-
-   return parent_obj, parent_obj([R(0), R(1)])
-end
-
-function polynomial_ring(R::zzModRing, s::AbstractString; cached = true)
-   return polynomial_ring(R, Symbol(s); cached=cached)
-end
-
-function PolyRing(R::zzModRing)
-   return zzModPolyRing(R, :x, false)
-end


### PR DESCRIPTION
Use Nemocas/AbstractAlgebra.jl#1282 to reduce all `polynomial_ring` implementations to single lines and thus fix #1405.

While cleaning up, I moved the `FqMPolyRing` construction logic out of the `polynomial_ring` method into its constructor.