### PR TITLE
OscarCI: fix running without PR_NUMBER, e.g. on master

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      PR_NUMBER: ${{github.event.number}}
+      PR_NUMBER: ${{github.event.number || '0' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Unfortunately I cannot fix this directly with a new release of OscarDevTools, but this should also work even with the current release. In the next OscarDevTools version the corresponding code will be slightly more robust.