### PR TITLE
Change deprecated functions

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -274,7 +274,7 @@ canonical_unit(x::ZZRingElem) = x < 0 ? ZZRingElem(-1) : ZZRingElem(1)
 
 function -(x::ZZRingElem)
     z = ZZRingElem()
-    ccall((:__fmpz_neg, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}), z, x)
+    ccall((:fmpz_neg, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}), z, x)
     return z
 end
 
@@ -449,7 +449,7 @@ function -(c::Int, x::ZZRingElem)
        ccall((:fmpz_add_ui, libflint), Nothing,
              (Ref{ZZRingElem}, Ref{ZZRingElem}, Int), z, x, -c)
     end
-    ccall((:__fmpz_neg, libflint), Nothing,
+    ccall((:fmpz_neg, libflint), Nothing,
           (Ref{ZZRingElem}, Ref{ZZRingElem}), z, z)
     return z
 end

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -421,7 +421,7 @@ function _factor(x::fpPolyRingElem)
   res = Dict{fpPolyRingElem, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{fpPolyRingElem}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -440,7 +440,7 @@ function _factor_squarefree(x::fpPolyRingElem)
   res = Dict{fpPolyRingElem, Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{fpPolyRingElem}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -464,7 +464,7 @@ function factor_distinct_deg(x::fpPolyRingElem)
   res = Dict{Int, fpPolyRingElem}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{fpPolyRingElem}, Ref{gfp_poly_factor}, Int), f, fac, i-1)
     res[degs[i]] = f
   end
@@ -481,7 +481,7 @@ function roots(a::fpPolyRingElem)
   f = R()
   res = fpFieldElem[]
   for i in 1:fac.num
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
           (Ref{fpPolyRingElem}, Ref{nmod_poly_factor}, Int),
           f, fac, i - 1)
     @assert isone(coeff(f, 1))

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -751,7 +751,7 @@ function _factor(x::zzModPolyRingElem)
   res = Dict{zzModPolyRingElem,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{zzModPolyRingElem}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -771,7 +771,7 @@ function _factor_squarefree(x::zzModPolyRingElem)
   res = Dict{zzModPolyRingElem,Int}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{zzModPolyRingElem}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     e = unsafe_load(fac.exp,i)
     res[f] = e
@@ -796,7 +796,7 @@ function factor_distinct_deg(x::zzModPolyRingElem)
   res = Dict{Int,zzModPolyRingElem}()
   for i in 1:fac.num
     f = parent(x)()
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
             (Ref{zzModPolyRingElem}, Ref{nmod_poly_factor}, Int), f, fac, i-1)
     res[degs[i]] = f
   end
@@ -840,7 +840,7 @@ function roots(a::zzModPolyRingElem)
   f = R()
   res = zzModRingElem[]
   for i in 1:fac.num
-    ccall((:nmod_poly_factor_get_nmod_poly, libflint), Nothing,
+    ccall((:nmod_poly_factor_get_poly, libflint), Nothing,
           (Ref{zzModPolyRingElem}, Ref{nmod_poly_factor}, Int),
           f, fac, i - 1)
     @assert isone(coeff(f, 1))


### PR DESCRIPTION
Currently Nemo is calling on deprecated functions in FLINT. This PR changes them to their non-deprecated version, as they will probably become dead soon.