### PR TITLE
Remove modulus from MatSpace implementations

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5073,7 +5073,6 @@ end
 
 mutable struct zzModMatrixSpace <: MatSpace{zzModRingElem}
   base_ring::zzModRing
-  n::UInt
   nrows::Int
   ncols::Int
 
@@ -5081,7 +5080,7 @@ mutable struct zzModMatrixSpace <: MatSpace{zzModRingElem}
                         cached::Bool = true)
     (r < 0 || c < 0) && throw(error_dim_negative)
     return get_cached!(NmodMatID, (R, r, c), cached) do
-       return new(R, R.n, r, c)
+       return new(R, r, c)
     end
   end
 end
@@ -5251,7 +5250,6 @@ end
 
 mutable struct ZZModMatrixSpace <: MatSpace{ZZModRingElem}
   base_ring::ZZModRing
-  n::ZZRingElem
   nrows::Int
   ncols::Int
 
@@ -5259,7 +5257,7 @@ mutable struct ZZModMatrixSpace <: MatSpace{ZZModRingElem}
                         cached::Bool = true)
     (r < 0 || c < 0) && throw(error_dim_negative)
     return get_cached!(FmpzModMatID, (R, r, c), cached) do
-       return new(R, R.n, r, c)
+       return new(R, r, c)
     end
   end
 end
@@ -5391,14 +5389,13 @@ end
 
 mutable struct FpMatrixSpace <: MatSpace{FpFieldElem}
   base_ring::FpField
-  n::ZZRingElem
   nrows::Int
   ncols::Int
 
   function FpMatrixSpace(R::FpField, r::Int, c::Int, cached::Bool = true)
     (r < 0 || c < 0) && throw(error_dim_negative)
     return get_cached!(GaloisFmpzMatID, (R, r, c), cached) do
-       return new(R, R.n, r, c)
+       return new(R, r, c)
     end
   end
 end
@@ -5530,7 +5527,6 @@ end
 
 mutable struct fpMatrixSpace <: MatSpace{fpFieldElem}
   base_ring::fpField
-  n::UInt
   nrows::Int
   ncols::Int
 
@@ -5538,7 +5534,7 @@ mutable struct fpMatrixSpace <: MatSpace{fpFieldElem}
                         cached::Bool = true)
     (r < 0 || c < 0) && throw(error_dim_negative)
     return get_cached!(GFPMatID, (R, r, c), cached) do
-       return new(R, R.n, r, c)
+       return new(R, r, c)
     end
   end
 end

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -84,7 +84,7 @@ end
 end
 
 function deepcopy_internal(a::ZZModMatrix, dict::IdDict)
-  z = ZZModMatrix(nrows(a), ncols(a), a.base_ring.n)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   if isdefined(a, :base_ring)
     z.base_ring = a.base_ring
   end
@@ -732,7 +732,7 @@ promote_rule(::Type{ZZModMatrix}, ::Type{ZZRingElem}) = ZZModMatrix
 ################################################################################
 
 function (a::ZZModMatrixSpace)()
-  z = ZZModMatrix(nrows(a), ncols(a), a.n)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   z.base_ring = a.base_ring
   return z
 end
@@ -782,42 +782,42 @@ end
 
 function (a::ZZModMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::ZZModMatrixSpace)(arr::AbstractVector{BigInt})
   _check_dim(nrows(a), ncols(a), arr)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::ZZModMatrixSpace)(arr::AbstractVector{ZZRingElem})
   _check_dim(nrows(a), ncols(a), arr)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::ZZModMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::ZZModMatrixSpace)(arr::AbstractVector{Int})
   _check_dim(nrows(a), ncols(a), arr)
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -825,7 +825,7 @@ end
 function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZModRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
@@ -833,7 +833,7 @@ end
 function (a::ZZModMatrixSpace)(arr::AbstractVector{ZZModRingElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = ZZModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = ZZModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -72,7 +72,7 @@ end
 end
 
 function deepcopy_internal(a::FpMatrix, dict::IdDict)
-  z = FpMatrix(nrows(a), ncols(a), a.base_ring.n)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   if isdefined(a, :base_ring)
     z.base_ring = a.base_ring
   end
@@ -213,7 +213,7 @@ promote_rule(::Type{FpMatrix}, ::Type{ZZRingElem}) = FpMatrix
 ################################################################################
 
 function (a::FpMatrixSpace)()
-  z = FpMatrix(nrows(a), ncols(a), a.n)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   z.base_ring = a.base_ring
   return z
 end
@@ -237,42 +237,42 @@ end
 
 function (a::FpMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::FpMatrixSpace)(arr::AbstractVector{BigInt})
   _check_dim(nrows(a), ncols(a), arr)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::FpMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::FpMatrixSpace)(arr::AbstractVector{ZZRingElem})
   _check_dim(nrows(a), ncols(a), arr)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::FpMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::FpMatrixSpace)(arr::AbstractVector{Int})
   _check_dim(nrows(a), ncols(a), arr)
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -280,7 +280,7 @@ end
 function (a::FpMatrixSpace)(arr::AbstractMatrix{FpFieldElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
@@ -288,7 +288,7 @@ end
 function (a::FpMatrixSpace)(arr::AbstractVector{FpFieldElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = FpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = FpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -52,7 +52,7 @@ end
 end
 
 function deepcopy_internal(a::fpMatrix, dict::IdDict)
-  z = fpMatrix(nrows(a), ncols(a), a.n)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   if isdefined(a, :base_ring)
     z.base_ring = a.base_ring
   end
@@ -322,7 +322,7 @@ end
 ################################################################################
 
 function (a::fpMatrixSpace)()
-  z = fpMatrix(nrows(a), ncols(a), a.n)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   z.base_ring = a.base_ring
   return z
 end
@@ -372,42 +372,42 @@ end
 
 function (a::fpMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(arr::AbstractVector{BigInt})
   _check_dim(nrows(a), ncols(a), arr)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(arr::AbstractVector{ZZRingElem})
   _check_dim(nrows(a), ncols(a), arr)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(arr::AbstractVector{Int})
   _check_dim(nrows(a), ncols(a), arr)
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -415,7 +415,7 @@ end
 function (a::fpMatrixSpace)(arr::AbstractMatrix{fpFieldElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
@@ -423,14 +423,14 @@ end
 function (a::fpMatrixSpace)(arr::AbstractVector{fpFieldElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = fpMatrix(nrows(a), ncols(a), a.n, arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::fpMatrixSpace)(b::ZZMatrix)
   (ncols(a) != b.c || nrows(a) != b.r) && error("Dimensions do not fit")
-  z = fpMatrix(a.n, b)
+  z = fpMatrix(modulus(base_ring(a)), b)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -703,7 +703,7 @@ promote_rule(::Type{zzModMatrix}, ::Type{ZZRingElem}) = zzModMatrix
 ################################################################################
 
 function (a::zzModMatrixSpace)()
-  z = zzModMatrix(nrows(a), ncols(a), a.n)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
   z.base_ring = a.base_ring
   return z
 end
@@ -753,42 +753,42 @@ end
 
 function (a::zzModMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(arr::AbstractVector{BigInt})
   _check_dim(nrows(a), ncols(a), arr)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(arr::AbstractVector{ZZRingElem})
   _check_dim(nrows(a), ncols(a), arr)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(arr::AbstractVector{Int})
   _check_dim(nrows(a), ncols(a), arr)
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -796,7 +796,7 @@ end
 function (a::zzModMatrixSpace)(arr::AbstractMatrix{zzModRingElem}, transpose::Bool = false)
   _check_dim(nrows(a), ncols(a), arr, transpose)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr, transpose)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
   z.base_ring = a.base_ring
   return z
 end
@@ -804,14 +804,14 @@ end
 function (a::zzModMatrixSpace)(arr::AbstractVector{zzModRingElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = zzModMatrix(nrows(a), ncols(a), a.n, arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
 
 function (a::zzModMatrixSpace)(b::ZZMatrix)
   (ncols(a) != b.c || nrows(a) != b.r) && error("Dimensions do not fit")
-  z = zzModMatrix(a.n, b)
+  z = zzModMatrix(modulus(base_ring(a)), b)
   z.base_ring = a.base_ring
   return z
 end


### PR DESCRIPTION
Instead access it via `modulus(base_ring(a))`.
