### PR TITLE
Add `zero` and `one` for `qqbar`, `QQFieldElem`, and `ZZRingElem`

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -180,8 +180,9 @@ zero(a::CalciumQQBarField) = a(0)
 
 one(a::CalciumQQBarField) = a(1)
 
-# Exists only to support Julia functionality (no guarantees)
 zero(::Type{qqbar}) = CalciumQQBar(0)
+
+one(::Type{qqbar}) = CalciumQQBar(1)
 
 @doc raw"""
     degree(x::qqbar)

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -180,6 +180,9 @@ zero(a::CalciumQQBarField) = a(0)
 
 one(a::CalciumQQBarField) = a(1)
 
+# Exists only to support Julia functionality (no guarantees)
+zero(::Type{qqbar}) = CalciumQQBar(0)
+
 @doc raw"""
     degree(x::qqbar)
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -104,12 +104,14 @@ function abs(a::QQFieldElem)
    return z
 end
 
-zero(a::QQField) = QQFieldElem(0)
+zero(_::QQField) = QQFieldElem(0)
 
-# Exists only to support Julia functionality (no guarantees)
+one(_::QQField) = QQFieldElem(1)
+
 zero(::Type{QQFieldElem}) = QQFieldElem(0)
 
-one(a::QQField) = QQFieldElem(1)
+one(::Type{QQFieldElem}) = QQFieldElem(1)
+
 
 function isone(a::QQFieldElem)
    return Bool(ccall((:fmpq_is_one, libflint), Cint, (Ref{QQFieldElem}, ), a))

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -158,12 +158,13 @@ end
 
 characteristic(R::ZZRing) = 0
 
-one(R::ZZRing) = ZZRingElem(1)
+one(_::ZZRing) = ZZRingElem(1)
 
-zero(R::ZZRing) = ZZRingElem(0)
+zero(_::ZZRing) = ZZRingElem(0)
 
-# Exists only to support Julia functionality (no guarantees)
 zero(::Type{ZZRingElem}) = ZZRingElem(0)
+
+one(::Type{ZZRingElem}) = ZZRingElem(1)
 
 @doc raw"""
     sign(a::ZZRingElem)

--- a/test/calcium/qqbar-test.jl
+++ b/test/calcium/qqbar-test.jl
@@ -49,6 +49,8 @@ end
    @test one(R) == 1
    @test isa(zero(R), qqbar)
    @test isa(one(R), qqbar)
+   @test zero(R) == zero(qqbar)
+   @test one(R) == one(qqbar)
 
    @test iszero(R(0))
    @test isone(R(1))

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -65,6 +65,10 @@ end
    @test QQFieldElem(typemax(Int)) == typemax(Int)
 
    @test QQFieldElem(typemin(Int)) == typemin(Int)
+
+   @test zero(R) == zero(QQFieldElem)
+
+   @test one(R) == one(QQFieldElem)
 end
 
 @testset "QQFieldElem.rand" begin

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -165,7 +165,11 @@ end
 
    @test iszero(b)
 
+   @test zero(ZZRing()) == zero(ZZRingElem)
+
    @test isone(a)
+
+   @test one(ZZRing()) == one(ZZRingElem)
 
    @test numerator(ZZRingElem(12)) == ZZRingElem(12)
 


### PR DESCRIPTION
Resolves #1348.