### PR TITLE
Add parent check for `(::fqPolyRepPolyRing)(::fqPolyRepFieldElem)`

### DIFF
--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -823,9 +823,10 @@ function (R::fqPolyRepPolyRing)()
 end
 
 function (R::fqPolyRepPolyRing)(x::fqPolyRepFieldElem)
-  z = fqPolyRepPolyRingElem(x)
-  z.parent = R
-  return z
+   parent(x) !== base_ring(R) && error("Element not contained in coefficient ring")
+   z = fqPolyRepPolyRingElem(x)
+   z.parent = R
+   return z
 end
 
 function (R::fqPolyRepPolyRing)(x::ZZRingElem)

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -572,3 +572,11 @@ end
 
    @test !v
 end
+
+@testset "issue #1353" begin
+   F, _ = FiniteField(2, 1, "1")
+   E, a = FiniteField(2, 15, "a")
+   S, x = PolynomialRing(F, "x")
+   
+   @test_throws ErrorException x+a
+end


### PR DESCRIPTION
Resolves #1353.