### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-local/*
-deps/*
-doc/nemo.aux
-doc/nemo.log
-doc/nemo.out
-doc/nemo.pdf
-doc/nemo.toc
-doc/build/assets
-doc/site
+/local/
+/deps/
+/docs/build/
+Manifest.toml
+.DS_Store


### PR DESCRIPTION
Similar changes to Nemocas/AbstractAlgebra.jl#1355.

The .gitignore file seems not up to date. At least I propose to add the three lines analogously to [Oscar.jl .gitignore](https://github.com/oscar-system/Oscar.jl/blob/c6aafa8c25796368d4c99f1f738720ba1c28b36a/.gitignore).

For the lines to be removed, I could not find any references in this repo of places where those files get created. If there is some reason to keep them, that would be fine with me as well.

`/deps/` is used e.g. in https://github.com/Nemocas/Nemo.jl/blob/a5ba24beca110d33cec131166f65a60b9972d9a1/src/Nemo.jl#L326
and thus kept.