### PR TITLE
Add method for inv(a::FpMatrix)

### DIFF
--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -206,6 +206,21 @@ promote_rule(::Type{FpMatrix}, ::Type{ZZRingElem}) = FpMatrix
 
 ################################################################################
 #
+#  Inverse
+#
+################################################################################
+
+function inv(a::FpMatrix)
+  !is_square(a) && error("Matrix must be a square matrix")
+  z = similar(a)
+  r = ccall((:fmpz_mod_mat_inv, libflint), Int,
+          (Ref{FpMatrix}, Ref{FpMatrix}), z, a)
+  !Bool(r) && error("Matrix not invertible")
+  return z
+end
+
+################################################################################
+#
 #  Parent object overloading
 #
 ################################################################################
@@ -350,4 +365,3 @@ function matrix_space(R::FpField, r::Int, c::Int; cached::Bool = true)
   # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
   FpMatrixSpace(R, r, c)
 end
-

--- a/test/flint/gfp_fmpz_mat-test.jl
+++ b/test/flint/gfp_fmpz_mat-test.jl
@@ -516,6 +516,29 @@ end
   @test c == 2
 end
 
+@testset "FpMatrix.inv" begin
+  Z17 = GF(ZZ(17))
+  R = matrix_space(Z17, 3, 4)
+  RR = matrix_space(Z17, 4, 3)
+  Z2 = GF(ZZ(2))
+  S = matrix_space(Z2, 3, 4)
+
+  a = R([ 1 2 3 1; 3 2 1 2; 1 3 2 0])
+
+  aa = matrix_space(Z17,3,3)([ 1 2 3; 3 2 1; 1 1 2])
+
+  b = R([ 2 1 0 1; 0 0 0 0; 0 1 2 0 ])
+
+  c = inv(aa)
+
+  @test c == parent(aa)([12 13 1; 14 13 15; 4 4 1])
+
+  @test_throws ErrorException inv(a)
+
+  @test_throws ErrorException inv(transpose(a)*a)
+end
+
+
 @testset "FpMatrix.swap_rows" begin
   Z17 = GF(ZZ(17))
 


### PR DESCRIPTION
There was previously no specialized method for computing the inverse of an FpMatrix. This addition significantly improves performance in code that relies on inverting matrices of this type.