### PR TITLE
Remove line breaks in error messages

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -734,20 +734,17 @@ function evaluate(a::QQMPolyRingElem, b::Vector{<:Integer})
 end
 
 function (a::QQMPolyRingElem)(vals::QQFieldElem...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    return evaluate(a, [vals...])
 end
 
 function (a::QQMPolyRingElem)(vals::Integer...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    return evaluate(a, [vals...])
 end
 
 function (a::QQMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    R = base_ring(a)
    # The best we can do here is to cache previously used powers of the values
    # being substituted, as we cannot assume anything about the relative

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -704,20 +704,17 @@ function evaluate(a::($etype), b::Vector{UInt})
 end
 
 function (a::($etype))(vals::zzModRingElem...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    return evaluate(a, [vals...])
 end
 
 function (a::($etype))(vals::Integer...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    return evaluate(a, [vals...])
 end
 
 function (a::($etype))(vals::Union{NCRingElem, RingElement}...)
-   length(vals) != nvars(parent(a)) && error("Number of variables does not match number o
-f values")
+   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
    R = base_ring(a)
    # The best we can do here is to cache previously used powers of the values
    # being substituted, as we cannot assume anything about the relative


### PR DESCRIPTION
... since these are printed on the command line:
```
julia> R, (x, y) = QQ["x", "y"]
(Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x, y])

julia> x(x)
ERROR: Number of variables does not match number o
f values
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] (::QQMPolyRingElem)(vals::QQMPolyRingElem)
   @ Nemo ~/.julia/dev/Nemo/src/flint/fmpq_mpoly.jl:749
 [3] top-level scope
   @ REPL[2]:1
```