### PR TITLE
Fix `ZZ` printing

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -272,7 +272,7 @@ function show(io::IO, a::ZZRing)
       print(io, LowercaseOff(), "ZZ")
    else
       # nested printing allowed, preferably supercompact
-      print(io, "Integer Ring")
+      print(io, "Integer ring")
    end
 end
 


### PR DESCRIPTION
Other types print with only the first word capitalized, e.g. `QQ` as `Rational field`, `ZZi` as `Gaussian integer ring`. `ZZ` currently is the black sheep with an uppercase `Integer Ring`.