### PR TITLE
Fix `lu!` requiring real matrices to be square.

### DIFF
--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -566,21 +566,22 @@ function lu!(P::Generic.Perm, x::ComplexMat)
 end
 
 function lu(P::Generic.Perm, x::ComplexMat)
-  ncols(x) != nrows(x) && error("Matrix must be square")
-  parent(P).n != nrows(x) && error("Permutation does not match matrix")
-  R = base_ring(x)
-  L = similar(x)
-  U = deepcopy(x)
+  m = nrows(x)
   n = ncols(x)
+  P.n != m && error("Permutation does not match matrix")
+  p = one(P)
+  R = base_ring(x)
+  L = similar(x, R, m, m)
+  U = deepcopy(x)
   lu!(P, U)
-  for i = 1:n
+  for i = 1:m
     for j = 1:n
       if i > j
         L[i, j] = U[i, j]
         U[i, j] = R()
       elseif i == j
         L[i, j] = one(R)
-      else
+      elseif j <= m
         L[i, j] = R()
       end
     end

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -565,30 +565,6 @@ function lu!(P::Generic.Perm, x::ComplexMat)
   return nrows(x)
 end
 
-function lu(P::Generic.Perm, x::ComplexMat)
-  m = nrows(x)
-  n = ncols(x)
-  P.n != m && error("Permutation does not match matrix")
-  p = one(P)
-  R = base_ring(x)
-  L = similar(x, R, m, m)
-  U = deepcopy(x)
-  lu!(P, U)
-  for i = 1:m
-    for j = 1:n
-      if i > j
-        L[i, j] = U[i, j]
-        U[i, j] = R()
-      elseif i == j
-        L[i, j] = one(R)
-      elseif j <= m
-        L[i, j] = R()
-      end
-    end
-  end
-  return L, U
-end
-
 function solve!(z::ComplexMat, x::ComplexMat, y::ComplexMat)
   r = ccall((:acb_mat_solve, libarb), Cint,
               (Ref{ComplexMat}, Ref{ComplexMat}, Ref{ComplexMat}, Int),

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -562,7 +562,7 @@ function lu!(P::Generic.Perm, x::ComplexMat)
   r == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
   P.d .+= 1
   inv!(P)
-  return nrows(x)
+  return min(nrows(x), ncols(x))
 end
 
 function solve!(z::ComplexMat, x::ComplexMat, y::ComplexMat)

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -515,7 +515,6 @@ function lu(x::RealMat, P = SymmetricGroup(nrows(x)))
   R = base_ring(x)
   L = similar(x, R, m, m)
   U = deepcopy(x)
-
   r = lu!(p, U)
   for i = 1:m
     for j = 1:n

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -507,30 +507,6 @@ function lu!(P::Generic.Perm, x::RealMat)
   return nrows(x)
 end
 
-function lu(x::RealMat, P = SymmetricGroup(nrows(x)))
-  m = nrows(x)
-  n = ncols(x)
-  P.n != m && error("Permutation does not match matrix")
-  p = one(P)
-  R = base_ring(x)
-  L = similar(x, R, m, m)
-  U = deepcopy(x)
-  r = lu!(p, U)
-  for i = 1:m
-    for j = 1:n
-      if i > j
-        L[i, j] = U[i, j]
-        U[i, j] = R()
-      elseif i == j
-        L[i, j] = one(R)
-      elseif j <= m
-        L[i, j] = R()
-      end
-    end
-  end
-  return r, p, L, U
-end
-
 function solve!(z::RealMat, x::RealMat, y::RealMat)
   r = ccall((:arb_mat_solve, libarb), Cint,
               (Ref{RealMat}, Ref{RealMat}, Ref{RealMat}, Int),

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -508,20 +508,23 @@ function lu!(P::Generic.Perm, x::RealMat)
 end
 
 function lu(x::RealMat, P = SymmetricGroup(nrows(x)))
+  m = nrows(x)
+  n = ncols(x)
+  P.n != m && error("Permutation does not match matrix")
   p = one(P)
   R = base_ring(x)
-  L = similar(x)
+  L = similar(x, R, m, m)
   U = deepcopy(x)
-  n = ncols(x)
+
   r = lu!(p, U)
-  for i = 1:n
+  for i = 1:m
     for j = 1:n
       if i > j
         L[i, j] = U[i, j]
         U[i, j] = R()
       elseif i == j
         L[i, j] = one(R)
-      else
+      elseif j <= m
         L[i, j] = R()
       end
     end

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -504,7 +504,7 @@ function lu!(P::Generic.Perm, x::RealMat)
   r == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
   P.d .+= 1
   inv!(P)
-  return nrows(x)
+  return min(nrows(x), ncols(x))
 end
 
 function solve!(z::RealMat, x::RealMat, y::RealMat)

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -496,7 +496,6 @@ end
 ###############################################################################
 
 function lu!(P::Generic.Perm, x::RealMat)
-  ncols(x) != nrows(x) && error("Matrix must be square")
   parent(P).n != nrows(x) && error("Permutation does not match matrix")
   P.d .-= 1
   r = ccall((:arb_mat_lu, libarb), Cint,

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -569,21 +569,22 @@ function lu!(P::Generic.Perm, x::acb_mat)
 end
 
 function lu(P::Generic.Perm, x::acb_mat)
-  ncols(x) != nrows(x) && error("Matrix must be square")
-  parent(P).n != nrows(x) && error("Permutation does not match matrix")
-  R = base_ring(x)
-  L = similar(x)
-  U = deepcopy(x)
+  m = nrows(x)
   n = ncols(x)
+  P.n != m && error("Permutation does not match matrix")
+  p = one(P)
+  R = base_ring(x)
+  L = similar(x, R, m, m)
+  U = deepcopy(x)
   lu!(P, U)
-  for i = 1:n
+  for i = 1:m
     for j = 1:n
       if i > j
         L[i, j] = U[i, j]
         U[i, j] = R()
       elseif i == j
         L[i, j] = one(R)
-      else
+      elseif j <= m
         L[i, j] = R()
       end
     end

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -568,30 +568,6 @@ function lu!(P::Generic.Perm, x::acb_mat)
   return nrows(x)
 end
 
-function lu(P::Generic.Perm, x::acb_mat)
-  m = nrows(x)
-  n = ncols(x)
-  P.n != m && error("Permutation does not match matrix")
-  p = one(P)
-  R = base_ring(x)
-  L = similar(x, R, m, m)
-  U = deepcopy(x)
-  lu!(P, U)
-  for i = 1:m
-    for j = 1:n
-      if i > j
-        L[i, j] = U[i, j]
-        U[i, j] = R()
-      elseif i == j
-        L[i, j] = one(R)
-      elseif j <= m
-        L[i, j] = R()
-      end
-    end
-  end
-  return L, U
-end
-
 function solve!(z::acb_mat, x::acb_mat, y::acb_mat)
   r = ccall((:acb_mat_solve, libarb), Cint,
               (Ref{acb_mat}, Ref{acb_mat}, Ref{acb_mat}, Int),

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -511,30 +511,6 @@ function lu!(P::Generic.Perm, x::arb_mat)
   return nrows(x)
 end
 
-function lu(x::arb_mat, P = SymmetricGroup(nrows(x)))
-  m = nrows(x)
-  n = ncols(x)
-  P.n != m && error("Permutation does not match matrix")
-  p = one(P)
-  R = base_ring(x)
-  L = similar(x, R, m, m)
-  U = deepcopy(x)
-  r = lu!(p, U)
-  for i = 1:m
-    for j = 1:n
-      if i > j
-        L[i, j] = U[i, j]
-        U[i, j] = R()
-      elseif i == j
-        L[i, j] = one(R)
-      elseif j <= m
-        L[i, j] = R()
-      end
-    end
-  end
-  return r, p, L, U
-end
-
 function solve!(z::arb_mat, x::arb_mat, y::arb_mat)
   r = ccall((:arb_mat_solve, libarb), Cint,
               (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -500,7 +500,6 @@ end
 ###############################################################################
 
 function lu!(P::Generic.Perm, x::arb_mat)
-  ncols(x) != nrows(x) && error("Matrix must be square")
   parent(P).n != nrows(x) && error("Permutation does not match matrix")
   P.d .-= 1
   r = ccall((:arb_mat_lu, libarb), Cint,
@@ -513,20 +512,22 @@ function lu!(P::Generic.Perm, x::arb_mat)
 end
 
 function lu(x::arb_mat, P = SymmetricGroup(nrows(x)))
+  m = nrows(x)
+  n = ncols(x)
+  P.n != m && error("Permutation does not match matrix")
   p = one(P)
   R = base_ring(x)
-  L = similar(x)
+  L = similar(x, R, m, m)
   U = deepcopy(x)
-  n = ncols(x)
   r = lu!(p, U)
-  for i = 1:n
+  for i = 1:m
     for j = 1:n
       if i > j
         L[i, j] = U[i, j]
         U[i, j] = R()
       elseif i == j
         L[i, j] = one(R)
-      else
+      elseif j <= m
         L[i, j] = R()
       end
     end

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -395,6 +395,18 @@ end
    @test overlaps(B, C)
 end
 
+@testset "ComplexMat.lu_nonsquare" begin
+   S = matrix_space(CC, 2, 3)
+
+   A = S(["1.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";
+          "1.0 +/- 0.01" "0.0 +/- 0.01" "-1.0 +/- 0.01"])
+
+    r, p, L, U = lu(A)
+
+    @test overlaps(L*U, p*A)
+    @test r == 2
+end
+
 @testset "ComplexMat.linear_solving" begin
    S = matrix_space(CC, 3, 3)
    T = matrix_space(ZZ, 3, 3)

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -361,6 +361,18 @@ end
    @test overlaps(B, C)
 end
 
+@testset "RealMat.lu_nonsquare" begin
+   S = matrix_space(RR, 2, 3)
+
+   A = S(["1.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";
+          "1.0 +/- 0.01" "0.0 +/- 0.01" "-1.0 +/- 0.01"])
+
+    r, p, L, U = lu(A)
+
+    @test overlaps(L*U, p*A)
+    @test r == 2
+end
+
 @testset "RealMat.linear_solving" begin
    S = matrix_space(RR, 3, 3)
    T = matrix_space(ZZ, 3, 3)

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -395,6 +395,18 @@ end
    @test overlaps(B, C)
 end
 
+@testset "acb_mat.lu_nonsquare" begin
+   S = matrix_space(CC, 2, 3)
+
+   A = S(["1.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";
+          "1.0 +/- 0.01" "0.0 +/- 0.01" "-1.0 +/- 0.01"])
+
+    r, p, L, U = lu(A)
+
+    @test overlaps(L*U, p*A)
+    @test r == 2
+end
+
 @testset "acb_mat.linear_solving" begin
    S = matrix_space(CC, 3, 3)
    T = matrix_space(ZZ, 3, 3)

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -361,6 +361,18 @@ end
    @test overlaps(B, C)
 end
 
+@testset "RealMat.lu_nonsquare" begin
+   S = matrix_space(RR, 2, 3)
+
+   A = S(["1.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";
+          "1.0 +/- 0.01" "0.0 +/- 0.01" "-1.0 +/- 0.01"])
+
+    r, p, L, U = lu(A)
+
+    @test overlaps(L*U, p*A)
+    @test r == 2
+end
+
 @testset "arb_mat.linear_solving" begin
    S = matrix_space(RR, 3, 3)
    T = matrix_space(ZZ, 3, 3)

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -361,7 +361,7 @@ end
    @test overlaps(B, C)
 end
 
-@testset "RealMat.lu_nonsquare" begin
+@testset "arb_mat.lu_nonsquare" begin
    S = matrix_space(RR, 2, 3)
 
    A = S(["1.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";


### PR DESCRIPTION
The Nemo call to the method `lu!` for real matrices was previously requiring the matrices to be square. This method calls to the `arb` library, which does not actually require the matrices to be square.

This pull request fixes issue #1498 which arises because the call to `is_invertible_with_inverse` relies on `rref` which functions correctly within `AbstractAlgebra`, but when called from `Nemo` (or `Oscar`), uses `Nemo`'s `lu!` method instead of `AbstractAlgebra`'s and then fails on non-square matrices.

You can see this issue within Nemo or Oscar:
```
mm=MatrixSpace(RealField(),1,2)([1,2])
rref(mm)

ERROR: Matrix must be square
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] lu!(P::Perm{Int64}, x::RealMat)
   @ Nemo ~/.julia/packages/Nemo/EuCgH/src/arb/RealMat.jl:499
 [3] rref!(A::RealMat)
   @ AbstractAlgebra ~/.julia/packages/AbstractAlgebra/YkCOC/src/Matrix.jl:1880
 [4] rref(M::RealMat)
   @ AbstractAlgebra ~/.julia/packages/AbstractAlgebra/YkCOC/src/Matrix.jl:1943
 [5] top-level scope
   @ REPL[11]:1
```