### PR TITLE
moved two functions from Oscar to Nemo

### DIFF
--- a/src/embedding/embedding.jl
+++ b/src/embedding/embedding.jl
@@ -429,6 +429,10 @@ function embed(k::T, K::T) where T <: FinField
     end
 end
 
+function embed(k::Nemo.fpField, K::fqPolyRepField)
+  @assert characteristic(K) == characteristic(k)
+end
+
 ################################################################################
 #
 #   Preimage map

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -169,6 +169,8 @@ returned as a rational with denominator $1$.
 """
 Base.ceil(a::QQFieldElem) = QQFieldElem(cdiv(numerator(a), denominator(a)), 1)
 
+nbits(a::QQFieldElem) = nbits(numerator(a)) + nbits(denominator(a))
+
 ###############################################################################
 #
 #   Canonicalisation

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -155,6 +155,9 @@ end
    @test ceil(QQFieldElem(2, 3)) == 1
    @test ceil(QQFieldElem(-1, 3)) == 0
    @test ceil(QQFieldElem(2, 1)) == 2
+
+   @test nbits(QQFieldElem(12, 1)) == 5
+   @test nbits(QQFieldElem(1, 3)) == 3
 end
 
 @testset "QQFieldElem.unary_ops" begin


### PR DESCRIPTION
This is not yet satisfactory:

- Should `embed` return something? The `embed(k::T, K::T) where T <: FinField` method returns a mapping, but the documentation does not state what is returned, and the code that calls `embed` seems to ignore the return value.
- Tests and documentation are missing.