### PR TITLE
Update argument order in `compose`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.35.3"
+version = "0.36.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -449,7 +449,7 @@ function compose(x::ComplexPoly, y::ComplexPoly, prec::Int = precision(Balls))
    z = parent(x)()
    ccall((:acb_poly_compose, libarb), Nothing,
                 (Ref{ComplexPoly}, Ref{ComplexPoly}, Ref{ComplexPoly}, Int),
-                z, x, y, prec)
+                z, y, x, prec)
    return z
 end
 

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -452,7 +452,7 @@ function compose(x::RealPoly, y::RealPoly, prec::Int = precision(Balls))
    z = parent(x)()
    ccall((:arb_poly_compose, libarb), Nothing,
                 (Ref{RealPoly}, Ref{RealPoly}, Ref{RealPoly}, Int),
-                z, x, y, prec)
+                z, y, x, prec)
    return z
 end
 

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -454,7 +454,7 @@ function compose(x::acb_poly, y::acb_poly)
    z = parent(x)()
    ccall((:acb_poly_compose, libarb), Nothing,
                 (Ref{acb_poly}, Ref{acb_poly}, Ref{acb_poly}, Int),
-                z, x, y, precision(parent(x)))
+                z, y, x, precision(parent(x)))
    return z
 end
 

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -463,7 +463,7 @@ function compose(x::arb_poly, y::arb_poly)
    z = parent(x)()
    ccall((:arb_poly_compose, libarb), Nothing,
                 (Ref{arb_poly}, Ref{arb_poly}, Ref{arb_poly}, Int),
-                z, x, y, precision(parent(x)))
+                z, y, x, precision(parent(x)))
    return z
 end
 

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -561,7 +561,7 @@ function compose(x::QQPolyRingElem, y::QQPolyRingElem)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpq_poly_compose, libflint), Nothing,
-                (Ref{QQPolyRingElem}, Ref{QQPolyRingElem}, Ref{QQPolyRingElem}), z, x, y)
+                (Ref{QQPolyRingElem}, Ref{QQPolyRingElem}, Ref{QQPolyRingElem}), z, y, x)
    return z
 end
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -708,7 +708,7 @@ function compose(x::T, y::T) where {T <: Zmodn_fmpz_poly}
   z = parent(x)()
   ccall((:fmpz_mod_poly_compose, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
-        z, x, y, x.parent.base_ring.ninv)
+        z, y, x, x.parent.base_ring.ninv)
   return z
 end
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -548,7 +548,7 @@ function compose(x::ZZPolyRingElem, y::ZZPolyRingElem)
    check_parent(x, y)
    z = parent(x)()
    ccall((:fmpz_poly_compose, libflint), Nothing,
-                (Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}), z, x, y)
+                (Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}), z, y, x)
    return z
 end
 
@@ -752,14 +752,14 @@ function chebyshev_t(n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_chebyshev_t, libflint), Nothing,
                                                   (Ref{ZZPolyRingElem}, Int), z, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 function chebyshev_u(n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_chebyshev_u, libflint), Nothing,
                                                   (Ref{ZZPolyRingElem}, Int), z, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 @doc raw"""
@@ -773,7 +773,7 @@ function cyclotomic(n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_cyclotomic, libflint), Nothing,
                                                   (Ref{ZZPolyRingElem}, Int), z, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 @doc raw"""
@@ -790,7 +790,7 @@ function swinnerton_dyer(n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_swinnerton_dyer, libflint), Nothing,
                                                   (Ref{ZZPolyRingElem}, Int), z, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 @doc raw"""
@@ -804,7 +804,7 @@ function cos_minpoly(n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_cos_minpoly, libflint), Nothing,
                                                   (Ref{ZZPolyRingElem}, Int), z, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 @doc raw"""
@@ -818,7 +818,7 @@ function theta_qexp(e::Int, n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_theta_qexp, libflint), Nothing,
                                           (Ref{ZZPolyRingElem}, Int, Int), z, e, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 @doc raw"""
@@ -836,7 +836,7 @@ function eta_qexp(e::Int, n::Int, x::ZZPolyRingElem)
    z = parent(x)()
    ccall((:fmpz_poly_eta_qexp, libflint), Nothing,
                                           (Ref{ZZPolyRingElem}, Int, Int), z, e, n)
-   return is_gen(x) ? z : compose(z, x)
+   return is_gen(x) ? z : compose(x, z)
 end
 
 ###############################################################################

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -566,7 +566,7 @@ function compose(x::FqPolyRingElem, y::FqPolyRingElem)
    z = parent(x)()
    ccall((:fq_default_poly_compose, libflint), Nothing,
          (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqPolyRingElem},
-         Ref{FqField}), z, x, y, base_ring(parent(x)))
+         Ref{FqField}), z, y, x, base_ring(parent(x)))
    return z
 end
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -569,7 +569,7 @@ function compose(x::fqPolyRepPolyRingElem, y::fqPolyRepPolyRingElem)
    z = parent(x)()
    ccall((:fq_nmod_poly_compose, libflint), Nothing,
          (Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepPolyRingElem},
-         Ref{fqPolyRepField}), z, x, y, base_ring(parent(x)))
+         Ref{fqPolyRepField}), z, y, x, base_ring(parent(x)))
    return z
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -567,7 +567,7 @@ function compose(x::FqPolyRepPolyRingElem, y::FqPolyRepPolyRingElem)
    z = parent(x)()
    ccall((:fq_poly_compose, libflint), Nothing,
          (Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepPolyRingElem},
-         Ref{FqPolyRepField}), z, x, y, base_ring(parent(x)))
+         Ref{FqPolyRepField}), z, y, x, base_ring(parent(x)))
    return z
 end
 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -624,7 +624,7 @@ function compose(x::T, y::T) where T <: Zmodn_poly
   check_parent(x,y)
   z = parent(x)()
   ccall((:nmod_poly_compose, libflint), Nothing,
-          (Ref{T}, Ref{T}, Ref{T}), z, x, y)
+          (Ref{T}, Ref{T}, Ref{T}), z, y, x)
   return z
 end
 

--- a/src/polysubst.jl
+++ b/src/polysubst.jl
@@ -5,7 +5,7 @@ for T in [zzModPolyRingElem, fpPolyRingElem, ZZModPolyRingElem, FpPolyRingElem, 
      if parent(f) != parent(a)
         return subst(f, a)
      end
-     return compose(f, a)
+     return compose(a, f)
   end
 
   (f::T)(a::Integer) = evaluate(f, a)

--- a/test/arb/ComplexPoly-test.jl
+++ b/test/arb/ComplexPoly-test.jl
@@ -318,7 +318,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "ComplexPoly.derivative_integral" begin

--- a/test/arb/ComplexPoly-test.jl
+++ b/test/arb/ComplexPoly-test.jl
@@ -318,7 +318,6 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(g, f) == f(g(x))
    @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 

--- a/test/arb/RealPoly-test.jl
+++ b/test/arb/RealPoly-test.jl
@@ -333,7 +333,6 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(g, f) == f(g(x))
    @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 

--- a/test/arb/RealPoly-test.jl
+++ b/test/arb/RealPoly-test.jl
@@ -333,7 +333,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "RealPoly.derivative_integral" begin

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -318,7 +318,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "acb_poly.derivative_integral" begin

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -318,7 +318,6 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(g, f) == f(g(x))
    @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -333,7 +333,6 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(g, f) == f(g(x))
    @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -333,7 +333,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "arb_poly.derivative_integral" begin

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -436,7 +436,8 @@ end
    f = 7y^2 + 12y + 3
    g = 11y + 9
 
-   @test compose(f, g) == 847*y^2 + 1518*y + 678
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == 847*y^2 + 1518*y + 678
 end
 
 @testset "QQPolyRingElem.derivative" begin

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -436,7 +436,7 @@ end
    f = 7y^2 + 12y + 3
    g = 11y + 9
 
-   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == f(g(y))
    @test compose(g, f) == 847*y^2 + 1518*y + 678
 end
 

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -440,7 +440,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "ZZModPolyRingElem.derivative" begin

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -328,7 +328,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "ZZPolyRingElem.derivative" begin

--- a/test/flint/fq_default_poly-test.jl
+++ b/test/flint/fq_default_poly-test.jl
@@ -411,7 +411,7 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == f(g(y))
    @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 

--- a/test/flint/fq_default_poly-test.jl
+++ b/test/flint/fq_default_poly-test.jl
@@ -411,7 +411,8 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(f, g) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 
 @testset "FqPolyRingElem.derivative" begin

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -422,7 +422,7 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == f(g(y))
    @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -422,7 +422,8 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(f, g) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 
 @testset "fqPolyRepPolyRingElem.derivative" begin

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -423,7 +423,7 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == f(g(y))
    @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -423,7 +423,8 @@ end
    f = x*y^2 + (x + 1)*y + 3
    g = (x + 1)*y + (x^3 + 2x + 2)
 
-   @test compose(f, g) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == (x^3+2*x^2+x)*y^2+(2*x^5+2*x^4+4*x^3+9*x^2+6*x+1)*y+(x^7+4*x^5+5*x^4+5*x^3+10*x^2+8*x+5)
 end
 
 @testset "FqPolyRepPolyRingElem.derivative" begin

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -439,7 +439,8 @@ end
    f = x^2 + 2x + 1
    g = x^3 + 3x + 1
 
-   @test compose(f, g) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
+   @test compose(g, f) == f(g(x))
+   @test compose(g, f) == x^6+6*x^4+4*x^3+9*x^2+12*x+4
 end
 
 @testset "FpPolyRingElem.derivative" begin

--- a/test/flint/gfp_poly-test.jl
+++ b/test/flint/gfp_poly-test.jl
@@ -491,10 +491,10 @@ end
   f = x^5 + x^4 + 2 *x^2 + x
   g = x+1
 
-  ff = compose(f,g)
+  ff = compose(g, f)
 
   @test parent(ff) == parent(f)
-
+  @test ff == f(g(x))
   @test ff == x^5 + 6*x^4 + 14*x^3 + 18*x^2 + 14*x + 5
 end
 

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -514,10 +514,10 @@ end
   f = x^5 + x^4 + 2 *x^2 + x
   g = x+1
 
-  ff = compose(f,g)
+  ff = compose(g, f)
 
   @test parent(ff) == parent(f)
-
+  @test ff == f(g(x))
   @test ff == x^5 + 6*x^4 + 14*x^3 + 18*x^2 + 14*x + 5
 end
 


### PR DESCRIPTION
This updates all definitions and uses of `compose` in Nemo according to https://github.com/oscar-system/Oscar.jl/issues/690 to follow `compose(f,g) = g(f(x))`.

This change is obviously breaking.