### PR TITLE
Stop degree(::MPoly,...) from overflowing

### DIFF
--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -224,6 +224,12 @@ end
    @test trailing_coefficient(x) == 1
    @test trailing_coefficient(S(2)) == 2
    @test trailing_coefficient(S()) == 0
+
+   f = x^(ZZ(2)^100) * y^100
+   @test_throws InexactError degree(f, 1)
+   @test degree(f, 2) == 100
+   @test_throws OverflowError degrees(f)
+   @test_throws OverflowError total_degree(f)
 end
 
 @testset "QQMPolyRingElem.multivariate_coeff" begin

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -213,6 +213,12 @@ end
    @test trailing_coefficient(x) == 1
    @test trailing_coefficient(S(2)) == 2
    @test trailing_coefficient(S()) == 0
+
+   f = x^(ZZ(2)^100) * y^100
+   @test_throws InexactError degree(f, 1)
+   @test degree(f, 2) == 100
+   @test_throws OverflowError degrees(f)
+   @test_throws OverflowError total_degree(f)
 end
 
 @testset "ZZMPolyRingElem.multivariate_coeff" begin

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -241,6 +241,12 @@ end
    @test trailing_coefficient(x) == 1
    @test trailing_coefficient(S(2)) == 2
    @test trailing_coefficient(S()) == 0
+
+   f = x^(ZZ(2)^100) * y^100
+   @test_throws InexactError degree(f, 1)
+   @test degree(f, 2) == 100
+   @test_throws OverflowError degrees(f)
+   @test_throws OverflowError total_degree(f)
 end
 
 @testset "fqPolyRepMPolyRingElem.multivariate_coeff" begin

--- a/test/flint/gfp_fmpz_mpoly-test.jl
+++ b/test/flint/gfp_fmpz_mpoly-test.jl
@@ -201,6 +201,12 @@ end
    @test trailing_coefficient(x) == 1
    @test trailing_coefficient(S(2)) == 2
    @test trailing_coefficient(S()) == 0
+
+   f = x^(ZZ(2)^100) * y^100
+   @test_throws InexactError degree(f, 1)
+   @test degree(f, 2) == 100
+   @test_throws OverflowError degrees(f)
+   @test_throws OverflowError total_degree(f)
 end
 
 @testset "FpMPolyRingElem.multivariate_coeff" begin

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -241,6 +241,12 @@ end
    @test trailing_coefficient(x) == 1
    @test trailing_coefficient(S(2)) == 2
    @test trailing_coefficient(S()) == 0
+
+   f = x^(ZZ(2)^100) * y^100
+   @test_throws InexactError degree(f, 1)
+   @test degree(f, 2) == 100
+   @test_throws OverflowError degrees(f)
+   @test_throws OverflowError total_degree(f)
 end
 
 @testset "zzModMPolyRingElem.multivariate_coeff" begin


### PR DESCRIPTION
Fixes the following feature:
```
julia> Qx, x = QQ["x1", "x2"]
(Multivariate polynomial ring in 2 variables over QQ, QQMPolyRingElem[x1, x2])

julia> degree(x[1]^(ZZ(2)^70), 1)
0
```
CC: @fieker 