### PR TITLE
import `Base.trunc`

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -32,7 +32,7 @@ import Base: Array, abs, abs2, acos, acosh, asin, asinh, atan, atanh, bin, binom
              parent, parse, powermod,
              precision, rand, Rational, rem, reverse, round, setindex!,
              show, similar, sign, sin, sincos, sincospi, sinh, sinpi, size, sqrt, string,
-             tan, tanh, trailing_zeros, transpose, truncate, typed_hvcat,
+             tan, tanh, trailing_zeros, transpose, trunc, truncate, typed_hvcat,
              typed_hcat, vcat, xor, zero, zeros, +, -, *, ==, ^, &, |, <<, >>,
              ~, <=, >=, <, >, //, /, \, !=
 


### PR DESCRIPTION
Without this change, `Base.trunc` is different from `Nemo.trunc`, and the following happens.
```
julia> using Oscar
[...]

julia> trunc
WARNING: both Oscar and Base export "trunc"; uses of it in module Main must be qualified
ERROR: UndefVarError: trunc not defined
```

(I noticed this problem when a function for tab completion ran over the variables in `Main`, which triggered the warning.)
