### PR TITLE
Fix `ComplexPolyRing` definition

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -668,7 +668,7 @@ base_ring(a::ArbPolyRing) = a.base_ring
 #
 ################################################################################
 
-mutable struct ComplexPolyRing <: PolyRing{acb}
+mutable struct ComplexPolyRing <: PolyRing{ComplexFieldElem}
   S::Symbol
 
   function ComplexPolyRing(R::ComplexField, S::Symbol, cached::Bool = true)


### PR DESCRIPTION
Fixes https://github.com/Nemocas/Nemo.jl/issues/1537.

This seems to be an error that was originally introduced in #1367, but only got relevant due to the more restrictive type signatures in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1434.