### PR TITLE
Unify rounding code

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -65,22 +65,6 @@ function evaluate!(z::fqPolyRepFieldElem, f::ZZPolyRingElem, r::fqPolyRepFieldEl
     return z
 end
 
-export trunc, round, ceil, floor
-
-for (s, f) in ((:trunc, Base.trunc), (:round, Base.round), (:ceil, Base.ceil), (:floor, Base.floor))
-    @eval begin
-        function ($s)(a::Matrix{BigFloat})
-            s = Base.size(a)
-            m = zero_matrix(FlintZZ, s[1], s[2])
-            for i = 1:s[1]
-                for j = 1:s[2]
-                    m[i, j] = FlintZZ(BigInt(($f)(a[i, j])))
-                end
-            end
-            return m
-        end
-    end
-end
 
 function norm(v::arb_mat)
     return sqrt(sum([a^2 for a in v]))
@@ -157,11 +141,6 @@ ZZMatrix(M::Matrix{Int}) = matrix(FlintZZ, M)
 order(::ZZRingElem) = FlintZZ
 
 export rem!
-
-function is_negative(x::QQFieldElem)
-    c = ccall((:fmpq_sgn, libflint), Cint, (Ref{QQFieldElem},), x)
-    return c < 0
-end
 
 function sub!(z::Vector{QQFieldElem}, x::Vector{QQFieldElem}, y::Vector{ZZRingElem})
     for i in 1:length(z)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -181,6 +181,9 @@ sign(::Type{Int}, a::ZZRingElem) = Int(ccall((:fmpz_sgn, libflint), Cint, (Ref{Z
 
 Base.signbit(a::ZZRingElem) = signbit(sign(Int, a))
 
+is_negative(n::ZZRingElem) = sign(Int, n) < 0
+is_positive(n::ZZRingElem) = sign(Int, n) > 0
+
 @doc raw"""
     fits(::Type{Int}, a::ZZRingElem)
 
@@ -312,12 +315,14 @@ function abs(x::ZZRingElem)
 end
 
 floor(x::ZZRingElem) = x
-
 ceil(x::ZZRingElem) = x
+trunc(x::ZZRingElem) = x
+round(x::ZZRingElem) = x
 
 floor(::Type{ZZRingElem}, x::ZZRingElem) = x
-
 ceil(::Type{ZZRingElem}, x::ZZRingElem) = x
+trunc(::Type{ZZRingElem}, x::ZZRingElem) = x
+round(::Type{ZZRingElem}, x::ZZRingElem) = x
 
 ###############################################################################
 #

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -168,6 +168,11 @@ end
 
    @test characteristic(R) == 0
 
+   @test nbits(QQFieldElem(12, 1)) == 5
+   @test nbits(QQFieldElem(1, 3)) == 3
+end
+
+@testset "QQFieldElem.rounding" begin
    @test floor(QQFieldElem(2, 3)) == 0
    @test floor(QQFieldElem(-1, 3)) == -1
    @test floor(QQFieldElem(2, 1)) == 2
@@ -176,8 +181,51 @@ end
    @test ceil(QQFieldElem(-1, 3)) == 0
    @test ceil(QQFieldElem(2, 1)) == 2
 
-   @test nbits(QQFieldElem(12, 1)) == 5
-   @test nbits(QQFieldElem(1, 3)) == 3
+   @test trunc(QQFieldElem(2, 3)) == 0
+   @test trunc(QQFieldElem(-1, 3)) == 0
+   @test trunc(QQFieldElem(2, 1)) == 2
+
+   @testset "$func" for func in (trunc, round, ceil, floor)
+      for d in -15:15
+         val = d//3
+         valQ = QQFieldElem(val)
+         @test func(valQ) isa QQFieldElem
+         @test func(valQ) == func(val)
+
+         @test func(QQFieldElem, valQ) isa QQFieldElem
+         @test func(QQFieldElem, valQ) == func(QQFieldElem, val)
+
+         @test func(ZZRingElem, valQ) isa ZZRingElem
+         @test func(ZZRingElem, valQ) == func(ZZRingElem, val)
+
+         @test func(BigInt, valQ) isa BigInt
+         @test func(BigInt, valQ) == func(BigInt, val)
+
+         @test func(Int, valQ) isa Int
+         @test func(Int, valQ) == func(Int, val)
+      end
+   end
+
+   @testset "$mode" for mode in (RoundUp, RoundDown, RoundNearest, RoundNearestTiesAway)
+      for d in -5:5
+         val = d//3
+         valQ = QQFieldElem(val)
+         @test round(valQ, mode) isa QQFieldElem
+         @test round(valQ, mode) == round(val, mode)
+
+         @test round(QQFieldElem, valQ, mode) isa QQFieldElem
+         @test round(QQFieldElem, valQ, mode) == round(val, mode)
+
+         @test round(ZZRingElem, valQ, mode) isa ZZRingElem
+         @test round(ZZRingElem, valQ, mode) == round(val, mode)
+
+         @test round(BigInt, valQ, mode) isa BigInt
+         @test round(BigInt, valQ, mode) == round(val, mode)
+
+         @test round(Int, valQ, mode) isa Int
+         @test round(Int, valQ, mode) == round(val, mode)
+      end
+   end
 end
 
 @testset "QQFieldElem.unary_ops" begin

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -183,10 +183,6 @@ end
 
    @test denominator(ZZRingElem(12)) == ZZRingElem(1)
 
-   @test floor(ZZRingElem(12)) == ZZRingElem(12)
-
-   @test ceil(ZZRingElem(12)) == ZZRingElem(12)
-
    @test iseven(ZZRingElem(12))
    @test isodd(ZZRingElem(13))
    b = big(2)
@@ -211,6 +207,28 @@ end
    @test !isinf(y)
 
    @test characteristic(ZZ) == 0
+end
+
+@testset "QQFieldElem.rounding" begin
+   @test floor(ZZRingElem(12)) == ZZRingElem(12)
+   @test ceil(ZZRingElem(12)) == ZZRingElem(12)
+   @test trunc(ZZRingElem(12)) == ZZRingElem(12)
+
+   @test floor(ZZRingElem, ZZRingElem(12)) == ZZRingElem(12)
+   @test ceil(ZZRingElem, ZZRingElem(12)) == ZZRingElem(12)
+   @test trunc(ZZRingElem, ZZRingElem(12)) == ZZRingElem(12)
+
+
+   @testset "$func" for func in (trunc, round, ceil, floor)
+      for val in -5:5
+         valZ = ZZRingElem(val)
+         @test func(valZ) isa ZZRingElem
+         @test func(valZ) == func(val)
+         @test func(ZZRingElem, valZ) isa ZZRingElem
+         @test func(ZZRingElem, valZ) == func(ZZRingElem, val)
+      end
+   end
+
 end
 
 @testset "ZZRingElem.binary_ops" begin

--- a/test/generic/Matrix-test.jl
+++ b/test/generic/Matrix-test.jl
@@ -215,6 +215,24 @@ end
    end
 end
 
+@testset "Matrix.rounding" begin
+    m = [ -1.2 -1.0 -0.7 -0.5 -0.3 0.0  ; 0.0 0.3 0.5 0.7 1.0 1.2 ]
+    @test m isa Matrix{Float64}
+
+    @test trunc(ZZMatrix, m) == ZZMatrix(map(x->trunc(Int,x), m))
+    @test round(ZZMatrix, m) == ZZMatrix(map(x->round(Int,x), m))
+    @test ceil(ZZMatrix, m) == ZZMatrix(map(x->ceil(Int,x), m))
+    @test floor(ZZMatrix, m) == ZZMatrix(map(x->floor(Int,x), m))
+
+    M = map(big, m)
+    @test M isa Matrix{BigFloat}
+
+    @test trunc(ZZMatrix, M) == ZZMatrix(map(x->trunc(Int,x), M))
+    @test round(ZZMatrix, M) == ZZMatrix(map(x->round(Int,x), M))
+    @test ceil(ZZMatrix, M) == ZZMatrix(map(x->ceil(Int,x), M))
+    @test floor(ZZMatrix, M) == ZZMatrix(map(x->floor(Int,x), M))
+end
+
 #=
    TODO: Add tests for the following when there are rings that are not fields
          that have delayed reduction


### PR DESCRIPTION
Systematically provide methods for ceil, floor, round, trunc with various source and/or target types we provide. Remove some (accidental?) type piracy.

For `m` a `Matrix{BigFloat}` instead of `trunc(m)` one now needs to write `trunc(ZZMatrix, m)` which avoids type piracy. On the upside, this is now supported for any `Matrix{<:Real}`.

Also add methods `is_positive(::QQFieldElem)` and `is_negative(::QQFieldElem)`, move some functions to more appropriate places, and "optimize" (?) `sign(::Type{Int}, a::QQFieldElem)`.

See also #1495