### PR TITLE
fix return in addmul!

### DIFF
--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2014,7 +2014,7 @@ end
 function addmul!(z::arb, x::arb, y::ZZRingElem)
   q = max(bits(z), bits(x))
   ccall((:arb_addmul_fmpz, libarb), Nothing, (Ref{arb}, Ref{arb}, Ref{ZZRingElem}, Int), z, x, y, q)
-  return nothing
+  return z
 end
 
 ################################################################################

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1427,13 +1427,13 @@ end
 function addmul!(z::ZZMatrix, y::ZZMatrix, x::ZZRingElem)
    ccall((:fmpz_mat_scalar_addmul_fmpz, libflint), Nothing,
                 (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZRingElem}), z, y, x)
-   return y
+   return z
 end
 
 function addmul!(z::ZZMatrix, y::ZZMatrix, x::Int)
    ccall((:fmpz_mat_scalar_addmul_si, libflint), Nothing,
                 (Ref{ZZMatrix}, Ref{ZZMatrix}, Int), z, y, x)
-   return y
+   return z
 end
 
 function addeq!(z::ZZMatrix, x::ZZMatrix)


### PR DESCRIPTION
Dispatches of `addmul!` returned different values depending on type. The returned value is now uniform for all dispatches.