### PR TITLE
Remove `rising_factorial(::Int, ::Int)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.32.0"
+AbstractAlgebra = "0.32.3"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1851,27 +1851,6 @@ If $n < 0$ we throw a `DomainError()`.
 rising_factorial(x::ZZRingElem, n::ZZRingElem) = rising_factorial(x, Int(n))
 
 @doc raw"""
-    rising_factorial(x::Int, n::Int)
-
-Return the rising factorial of $x$, i.e. $x(x + 1)(x + 2)\ldots (x + n - 1)$.
-If $n < 0$ we throw a `DomainError()`.
-"""
-function rising_factorial(x::Int, n::Int)
-    n < 0 && throw(DomainError(n, "Argument must be non-negative"))
-    z = ZZRingElem()
-    if x < 0
-       if n <= -x # we don't pass zero
-          z = isodd(n) ? -rising_factorial(-x - n + 1, n) :
-                          rising_factorial(-x - n + 1, n)
-       end
-    else
-       ccall((:fmpz_rfac_uiui, libflint), Nothing,
-             (Ref{ZZRingElem}, UInt, UInt), z, x, n)
-    end
-    return Int(z)
-end
-
-@doc raw"""
     primorial(x::Int)
 
 Return the primorial of $x$, i.e. the product of all primes less than or


### PR DESCRIPTION
The version from AbstractAlgebra is actually faster and avoids allocations.

And this gets rid of one instances of type piracy, see #1495

Before:
```
julia> @benchmark sum(i->rising_factorial(10,i), 1:12)
BenchmarkTools.Trial: 10000 samples with 210 evaluations.
 Range (min … max):  352.976 ns … 519.090 μs  ┊ GC (min … max):  0.00% … 53.77%
 Time  (median):     359.324 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   768.972 ns ±  14.411 μs  ┊ GC (mean ± σ):  28.19% ±  1.50%

     ▁     ▂█▃
  ▁▂▇█▅▂▁▂▄███▅▂▂▂▂▂▃▃▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  353 ns           Histogram: frequency by time          389 ns <

 Memory estimate: 192 bytes, allocs estimate: 12.
```

After:
```
julia> @benchmark sum(i->rising_factorial(10,i), 1:12)
BenchmarkTools.Trial: 10000 samples with 992 evaluations.
 Range (min … max):  38.348 ns … 144.111 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     38.516 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.126 ns ±   2.919 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▄▁▁▂▃▁  ▁▁▂▁                                                ▁
  █████████████▅▅▄▅▁▅▆▆▅▄▅▅▅▅▅▄▄▄▄▅▄▅▃▄▃▄▅▅▄▄▅▅▅▅▄▅▄▄▅▅▅▅▅▄▅▅▅ █
  38.3 ns       Histogram: log(frequency) by time      54.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
