### PR TITLE
randseed: replace Random.make_seed with Random.hash_seed for nightly

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -426,10 +426,18 @@ function Random.seed!(a::rand_ctx, s::Integer)
    # two given seeds which could be "not very different"
    # (cf. the documentation of `gmp_randseed`).
    # Hashing has a negligible cost compared to the call to `gmp_randseed`.
-   ctx = SHA.SHA2_512_CTX()
-   seed = Random.make_seed(s)::Vector{UInt32}
-   SHA.update!(ctx, reinterpret(UInt8, seed))
-   digest = reinterpret(UInt, SHA.digest!(ctx))
+   if VERSION >= v"1.11.0-DEV.575"
+      # make seed was removed and hash_seed takes its place
+      # but hash_seed already does the hashing
+      # (although with SHA2_256 instead)
+      digest = Random.hash_seed(s)
+   else
+      ctx = SHA.SHA2_512_CTX()
+      seed = Random.make_seed(s)::Vector{UInt32}
+      SHA.update!(ctx, reinterpret(UInt8, seed))
+      digest = SHA.digest!(ctx)
+   end
+   digest = reinterpret(UInt, digest)
    @assert Base.GMP.Limb == UInt
 
    # two last words go for flint_randseed!


### PR DESCRIPTION
The function `Random.make_seed` was removed in favor of `Random.hash_seed` which already does a hashing similar to the code in `Nemo.randseed!`. See https://github.com/JuliaLang/julia/pull/51436.

I adjusted the code to use the new function for new julia versions (i.e. latest nightly).

But this does change the output since it uses a different hash and it makes the output inconsistent between older and newer julia versions. Not really sure if there are any guarantees about that?

_Edit:_ It does indeed change the results for nightly and cause the CI for nightly to fail.

An alternative to adjusting the output (depending on the julia version) would be to copy the old make_seed function to Nemo.


Note that both the old `make_seed` and the new `hash_seed` are described with:
> This is an internal function subject to change.



PS: This change caused an error in the Oscar.jl doctests for nightly: https://github.com/oscar-system/Oscar.jl/actions/runs/6362233902/job/17277140274#step:8:919