### PR TITLE
More conversions between QQFieldElem and  Rational

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1163,6 +1163,8 @@ end
 
 convert(::Type{QQFieldElem}, a::Integer) = QQFieldElem(a)
 
+convert(::Type{QQFieldElem}, a::Rational) = QQFieldElem(a)
+
 convert(::Type{QQFieldElem}, a::ZZRingElem) = QQFieldElem(a)
 
 Base.promote_rule(::Type{QQFieldElem}, ::Type{T}) where {T <: Integer} = QQFieldElem
@@ -1178,14 +1180,12 @@ promote_rule(::Type{QQFieldElem}, ::Type{Rational{T}} where {T <: Integer}) = QQ
 Base.promote_rule(::Type{QQFieldElem}, ::Type{Rational{T}}) where {T <: Integer} = QQFieldElem
 
 function Base.convert(::Type{Rational{T}}, a::QQFieldElem) where T <: Integer
-   return Rational{T}(convert(T, numerator(a)), convert(T, denominator(a)))
+   return Rational{T}(a)
 end
 
-function Base.convert(::Type{QQFieldElem}, a::Rational{T}) where T <: Integer
-   return convert(ZZRingElem, numerator(a))//convert(ZZRingElem, denominator(a))
+function Base.Rational{T}(z::QQFieldElem) where T <: Integer
+   return Rational{T}(T(numerator(z)), T(denominator(z)))
 end
-
-convert(::Type{Rational{BigInt}}, a::QQFieldElem) = Rational(a)
 
 function Base.Rational{BigInt}(z::QQFieldElem)
    r = Rational{BigInt}(0)
@@ -1196,8 +1196,8 @@ end
 
 Rational(z::QQFieldElem) = Rational{BigInt}(z)
 
-function Base.Rational{BigInt}(z::ZZRingElem)
-   return Rational{BigInt}(BigInt(z))
+function Base.Rational{T}(z::ZZRingElem) where T <: Integer
+   return Rational{T}(T(z))
 end
 
 Rational(z::ZZRingElem) = Rational{BigInt}(z)

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -99,9 +99,19 @@ end
 end
 
 @testset "QQFieldElem.conversions" begin
+   @test convert(Rational{Int}, QQFieldElem(3, 7)) == 3//7
+   @test convert(Rational{BigInt}, QQFieldElem(3, 7)) == 3//7
+
+   @test convert(QQFieldElem, 3) == QQFieldElem(3)
+   @test convert(QQFieldElem, 3//7) == QQFieldElem(3, 7)
+
    @test Rational(ZZRingElem(12)) == 12
+   @test Rational{Int}(ZZRingElem(12)) == 12
+   @test Rational{BigInt}(ZZRingElem(12)) == 12
 
    @test Rational(QQFieldElem(3, 7)) == 3//7
+   @test Rational{Int}(QQFieldElem(3, 7)) == 3//7
+   @test Rational{BigInt}(QQFieldElem(3, 7)) == 3//7
 
    @test ZZ(QQFieldElem(3)) isa ZZRingElem
    @test_throws Exception ZZ(QQFieldElem(3, 2))


### PR DESCRIPTION
Before we only allowed conversion of `QQFieldElem` to `Base.Rational{BigInt}`. Now any `Base.Rational{T} where T<:Integer` works.