### PR TITLE
Remove old `@polynomial_ring` test

### DIFF
--- a/test/generic/Poly-test.jl
+++ b/test/generic/Poly-test.jl
@@ -27,11 +27,3 @@ end
       @test truncate(f*g, n) == mullow(f, g, n)
    end
 end
-
-@testset "@polynomial_ring" begin
-   # cf. AbstractAlgebra issue #274
-   R, x = @polynomial_ring(ZZ, x)
-   @test typeof(R) == ZZMPolyRing
-   R, x = @polynomial_ring(QQ, x)
-   @test typeof(R) == QQMPolyRing
-end


### PR DESCRIPTION
We chose a contradicting meaning for `@polynomial_ring` in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1360/.