### PR TITLE
Wrap cholesky factorization for arb_mat's

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -41,7 +41,7 @@ if isdefined(Base, :tanpi) # added in julia >= 1.10-DEV
 end
 
 import LinearAlgebra: det, norm, nullspace, rank, transpose!, hessenberg, tr,
-                      lu, lu!, eigvals
+                      lu, lu!, eigvals, cholesky
 
 import AbstractAlgebra: nullspace, @show_name, @show_special, find_name,
                         get_attribute, set_attribute!, @attributes,

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -7,7 +7,8 @@
 export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
        overlaps, contains, inv, divexact, charpoly, det, lu, lu!, solve,
        solve!, solve_lu_precomp, solve_lu_precomp!, swap_rows, swap_rows!,
-       bound_inf_norm
+       bound_inf_norm, cholesky, ldlt, solve_cholesky_precomp, 
+       solve_cholesky_precomp!
 
 ###############################################################################
 #
@@ -505,6 +506,15 @@ end
 #
 ###############################################################################
 
+function cholesky(x::arb_mat)
+  ncols(x) != nrows(x) && error("Matrix must be square")
+  z = similar(x, nrows(x), ncols(x))
+  p = precision(base_ring(x))
+  fl = ccall((:arb_mat_cho, libarb), Cint, (Ref{arb_mat}, Ref{arb_mat}, Int), z, x, p)
+  fl == 0 && error("Matrix is not positive definite")
+  return z
+end
+
 function lu!(P::Generic.Perm, x::arb_mat)
   parent(P).n != nrows(x) && error("Permutation does not match matrix")
   P.d .-= 1
@@ -545,6 +555,20 @@ function solve_lu_precomp(P::Generic.Perm, LU::arb_mat, y::arb_mat)
   ncols(LU) != nrows(y) && error("Matrix dimensions are wrong")
   z = similar(y)
   solve_lu_precomp!(z, P, LU, y)
+  return z
+end
+
+function solve_cholesky_precomp!(z::arb_mat, cho::arb_mat, y::arb_mat)
+  ccall((:arb_mat_solve_cho_precomp, libarb), Nothing,
+              (Ref{arb_mat}, Ref{arb_mat}, Ref{arb_mat}, Int),
+              z, cho, y, precision(base_ring(cho)))
+  nothing
+end
+
+function solve_cholesky_precomp(cho::arb_mat, y::arb_mat)
+  ncols(cho) != nrows(y) && error("Matrix dimensions are wrong")
+  z = similar(y)
+  solve_cholesky_precomp!(z, cho, y)
   return z
 end
 

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -7,8 +7,8 @@
 export zero, one, deepcopy, -, transpose, +, *, &, ==, !=,
        overlaps, contains, inv, divexact, charpoly, det, lu, lu!, solve,
        solve!, solve_lu_precomp, solve_lu_precomp!, swap_rows, swap_rows!,
-       bound_inf_norm, cholesky, ldlt, solve_cholesky_precomp, 
-       solve_cholesky_precomp!
+       bound_inf_norm, cholesky, solve_cholesky_precomp, solve_cholesky_precomp!
+       
 
 ###############################################################################
 #

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -381,6 +381,26 @@ end
     @test r == 2
 end
 
+@testset "arb_mat.cholesky_solving" begin
+   S = matrix_space(RR, 3, 3)
+
+   A = S(["4.0 +/- 0.01" "1.0 +/- 0.01" "1.0 +/- 0.01";
+          "1.0 +/- 0.01" "4.0 +/- 0.01" "-1.0 +/- 0.01";
+          "1.0 +/- 0.01" "-1.0 +/- 0.01" "4.0 +/- 0.01"])
+
+   cho = cholesky(A)
+
+   @test overlaps(cho * transpose(cho), A)
+
+   b = RR["6.0 +/- 0.1" "4.0 +/- 0.1" "4.0 +/- 0.1"]
+
+   y = solve_cholesky_precomp(cho, transpose(b))
+
+   @test overlaps(A*y, transpose(b))
+
+   @test contains(transpose(y), ZZ[1 1 1])
+end
+
 @testset "arb_mat.linear_solving" begin
    S = matrix_space(RR, 3, 3)
    T = matrix_space(ZZ, 3, 3)


### PR DESCRIPTION
The cholesky factorization for arb_mat's and solving using the precomputed cholesky were not yet wrapped. I don't know what the policy is about using the Julia structs for matrix factorizations, but since AbstractAlgebra.lu does not use that, I did not do that either.