### PR TITLE
README.md: corrected developers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 Nemo is a computer algebra package for the Julia programming language. It aims
 to cover commutative algebra, number theory and group theory.
 
-It is currently developed by Dan Schultz, William Hart, Tommy Hofmann, Fredrik Johansson and
-Claus Fieker with contributions from others.
+It was originally developed by Dan Schultz, William Hart, Tommy Hofmann, Fredrik Johansson and
+Claus Fieker with contributions from others. Current maintainers are Claus Fieker, Tommy Hofmann
+and Max Horn.
 
 - <https://nemocas.github.io/Nemo.jl/dev/> (Online documentation for development version)
 - <https://nemocas.github.io/Nemo.jl/stable/> (Online documentation for latest stable release)


### PR DESCRIPTION
The list of people who supposedly develop Nemo "currently" was not quite accurate. I tried to adjust this a bit.

Feedback welcome! In particular I really don't want to misrepresent anything or diminish someones contributions or whatever.