### PR TITLE
Make `digits` for negative `ZZRingElem` consistent

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2305,7 +2305,7 @@ function Base.digits!(a::AbstractVector{T}, n::ZZRingElem; base::Integer = 10) w
    end
 
    for i in eachindex(a)
-      n, r = divrem(n, base)
+      n, r = Base.divrem(n, base)
       a[i] = r
    end
    return a

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -802,6 +802,12 @@ end
    @test digits(a) == digits(BigInt(a))
    @test digits(a, base = 17) == digits(BigInt(a), base = 17)
    @test digits(a, base = 5, pad = 50) == digits(BigInt(a), base = 5, pad = 50)
+
+   a = -ZZRingElem(4611686837384281896)
+
+   @test digits(a) == digits(BigInt(a))
+   @test digits(a, base = 17) == digits(BigInt(a), base = 17)
+   @test digits(a, base = 5, pad = 50) == digits(BigInt(a), base = 5, pad = 50)
 end
 
 @testset "ZZRingElem.string_io" begin


### PR DESCRIPTION
The `digits` function behaves inconsistent with julia integer types for negative numbers:
```
julia> digits(ZZ(-3))
1-element Vector{Int64}:
 7

julia> digits(-3)
1-element Vector{Int64}:
 -3

julia> digits(BigInt(-3))
1-element Vector{Int64}:
 -3
```
From the tests, I would assume that the result for `ZZRingElem` and `BigInt` should coincide; the tests are of course only for positive numbers though.
The issue is that `Nemo.divrem` is not the same as `Base.divrem` as I learnt from this comment here: https://github.com/Nemocas/Nemo.jl/blob/659462da872f489545988b889cfe8879170ae3f4/src/flint/fmpz.jl#L629