### PR TITLE
Remove instance dispatches for `elem_type`

### DIFF
--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -34,9 +34,9 @@ function O(a::FlintPuiseuxSeriesElem{T}) where T <: RingElem
    return parent(a)(laur, denominator(val))
 end
 
-parent_type(::Type{T}) where {S <: RingElem, T <: FlintPuiseuxSeriesRingElem{S}} = FlintPuiseuxSeriesRing{S}
+parent_type(::Type{FlintPuiseuxSeriesRingElem{T}}) where T <: RingElem = FlintPuiseuxSeriesRing{T}
 
-parent_type(::Type{T}) where {S <: FieldElem, T <: FlintPuiseuxSeriesFieldElem{S}} = FlintPuiseuxSeriesField{S}
+parent_type(::Type{FlintPuiseuxSeriesFieldElem{T}}) where T <: FieldElem = FlintPuiseuxSeriesField{T}
 
 parent(a::FlintPuiseuxSeriesElem) = a.parent
 

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -40,9 +40,9 @@ parent_type(::Type{T}) where {S <: FieldElem, T <: FlintPuiseuxSeriesFieldElem{S
 
 parent(a::FlintPuiseuxSeriesElem) = a.parent
 
-elem_type(::Type{T}) where {S <: RingElem, T <: FlintPuiseuxSeriesRing{S}} = FlintPuiseuxSeriesRingElem{S}
+elem_type(::Type{FlintPuiseuxSeriesRing{T}}) where T <: RingElem = FlintPuiseuxSeriesRingElem{T}
 
-elem_type(::Type{T}) where {S <: FieldElem, T <: FlintPuiseuxSeriesField{S}} = FlintPuiseuxSeriesFieldElem{S}
+elem_type(::Type{FlintPuiseuxSeriesField{T}}) where T <: FieldElem = FlintPuiseuxSeriesFieldElem{T}
 
 base_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = base_ring(laurent_ring(R))
 

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -21,8 +21,6 @@ parent_type(::Type{QQMPolyRingElem}) = QQMPolyRing
 
 elem_type(::Type{QQMPolyRing}) = QQMPolyRingElem
 
-elem_type(::QQMPolyRing) = QQMPolyRingElem
-
 mpoly_type(::Type{QQFieldElem}) = QQMPolyRingElem
 
 symbols(a::QQMPolyRing) = a.S

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -21,8 +21,6 @@ parent_type(::Type{($etype)}) = ($rtype)
 
 elem_type(::Type{($rtype)}) = ($etype)
 
-elem_type(::($rtype)) = ($etype)
-
 mpoly_type(::Type{FpFieldElem}) = FpMPolyRingElem
 
 symbols(a::($rtype)) = a.S

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -16,8 +16,6 @@ parent_type(::Type{ZZMPolyRingElem}) = ZZMPolyRing
 
 elem_type(::Type{ZZMPolyRing}) = ZZMPolyRingElem
 
-elem_type(::ZZMPolyRing) = ZZMPolyRingElem
-
 mpoly_type(::Type{ZZRingElem}) = ZZMPolyRingElem
 
 symbols(a::ZZMPolyRing) = a.S

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -12,8 +12,6 @@ parent_type(::Type{FqMPolyRingElem}) = FqMPolyRing
 
 elem_type(::Type{FqMPolyRing}) = FqMPolyRingElem
 
-elem_type(::FqMPolyRing) = FqMPolyRingElem
-
 mpoly_type(::Type{FqFieldElem}) = FqMPolyRingElem
 
 symbols(a::FqMPolyRing) = symbols(a.data)

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -16,8 +16,6 @@ parent_type(::Type{fqPolyRepMPolyRingElem}) = fqPolyRepMPolyRing
 
 elem_type(::Type{fqPolyRepMPolyRing}) = fqPolyRepMPolyRingElem
 
-elem_type(::fqPolyRepMPolyRing) = fqPolyRepMPolyRingElem
-
 mpoly_type(::Type{fqPolyRepFieldElem}) = fqPolyRepMPolyRingElem
 
 symbols(a::fqPolyRepMPolyRing) = a.S

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -22,8 +22,6 @@ parent_type(::Type{($etype)}) = ($rtype)
 
 elem_type(::Type{($rtype)}) = ($etype)
 
-elem_type(::($rtype)) = ($etype)
-
 mpoly_type(::Type{$ctype}) = $etype
 
 symbols(a::($rtype)) = a.S


### PR DESCRIPTION
As they already exist via https://github.com/Nemocas/AbstractAlgebra.jl/blob/9dd22199b5262f23ad071b877f5d4fb5ce9ad436/src/fundamental_interface.jl#L53 and are only inconsistently used throughout Nemo.jl.