### PR TITLE
Tests and fixes for factoring related methods

### DIFF
--- a/src/HeckeMiscInteger.jl
+++ b/src/HeckeMiscInteger.jl
@@ -231,12 +231,8 @@ end
 Returns true if $n$ is squarefree, false otherwise.
 """
 function is_squarefree(n::Union{Int,ZZRingElem})
-    if iszero(n)
-        error("Argument must be non-zero")
-    end
-    if isone(abs(n))
-        return true
-    end
+    iszero(n) && return false
+    is_unit(n) && return true
     e, b = is_power(n)
     if e > 1
         return false

--- a/src/HeckeMiscPoly.jl
+++ b/src/HeckeMiscPoly.jl
@@ -501,9 +501,8 @@ end
 function is_squarefree(f::PolyRingElem{<:FieldElement})
   R = coefficient_ring(f)
 
-  if iszero(f) || degree(f) == 0
-    return true
-  end
+  iszero(f) && return false
+  degree(f) == 0 && return true
 
   if !is_monic(f)
     g = divexact(f, leading_coefficient(f))
@@ -520,9 +519,8 @@ function is_squarefree(f::PolyRingElem{<:FieldElement})
 end
 
 function is_squarefree(f::PolyRingElem{<:RingElement})
-  if iszero(f)
-    return true
-  end
+  iszero(f) && return false
+  degree(f) == 0 && return is_squarefree(leading_coefficient(f))
   fac = factor_squarefree(f)
   return all(e <= 1 for (_, e) in fac)
 end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -520,6 +520,7 @@ function (::Type{Fac{QQMPolyRingElem}})(fac::fmpq_mpoly_factor, preserve_input::
 end
 
 function factor(a::QQMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fmpq_mpoly_factor(R)
    ok = ccall((:fmpq_mpoly_factor, libflint), Cint,
@@ -530,6 +531,7 @@ function factor(a::QQMPolyRingElem)
 end
 
 function factor_squarefree(a::QQMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fmpq_mpoly_factor(R)
    ok = ccall((:fmpq_mpoly_factor_squarefree, libflint), Cint,

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -692,6 +692,7 @@ for (factor_fn, factor_fn_inner, flint_fn) in
    eval(quote
 
       function $factor_fn(x::QQPolyRingElem)
+         iszero(x) && throw(ArgumentError("Argument must be non-zero"))
          res, z = $factor_fn_inner(x)
          return Fac(parent(x)(z), res)
       end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1491,9 +1491,7 @@ function _factor(a::ZZRingElem)
 end
 
 function factor(a::T) where T <: Union{Int, UInt}
-   if iszero(a)
-      throw(ArgumentError("Argument is not non-zero"))
-   end
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    u = sign(a)
    a = u < 0 ? -a : a
    F = n_factor()
@@ -1592,9 +1590,7 @@ julia> factor(12)
 ```
 """
 function factor(a::ZZRingElem)
-   if iszero(a)
-      throw(ArgumentError("Argument is not non-zero"))
-   end
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    fac, z = _factor(a)
    return Fac(z, fac)
 end

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -532,6 +532,7 @@ function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool = true)
 end
 
 function factor(a::($etype))
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = ($ftype)(R)
    ok = ccall((:fmpz_mod_mpoly_factor, libflint), Cint,
@@ -542,6 +543,7 @@ function factor(a::($etype))
 end
 
 function factor_squarefree(a::($etype))
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = ($ftype)(R)
    ok = ccall((:fmpz_mod_mpoly_factor_squarefree, libflint), Cint,

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -767,6 +767,7 @@ end
 ################################################################################
 
 function factor(x::ZZModPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   !is_probable_prime(modulus(x)) && error("Modulus not prime in factor")
   fac = _factor(x)
   return Fac(parent(x)(leading_coefficient(x)), fac)
@@ -792,6 +793,7 @@ function _factor(x::ZZModPolyRingElem)
 end
 
 function factor_squarefree(x::ZZModPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   !is_probable_prime(modulus(x)) && error("Modulus not prime in factor_squarefree")
   fac = _factor_squarefree(x)
   return Fac(parent(x)(leading_coefficient(x)), fac)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -491,6 +491,7 @@ function (::Type{Fac{ZZMPolyRingElem}})(fac::fmpz_mpoly_factor, preserve_input::
 end
 
 function factor(a::ZZMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fmpz_mpoly_factor(R)
    ok = ccall((:fmpz_mpoly_factor, libflint), Cint,
@@ -501,6 +502,7 @@ function factor(a::ZZMPolyRingElem)
 end
 
 function factor_squarefree(a::ZZMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fmpz_mpoly_factor(R)
    ok = ccall((:fmpz_mpoly_factor_squarefree, libflint), Cint,

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -699,6 +699,7 @@ for (factor_fn, factor_fn_inner, flint_fn) in
   eval(quote
     
     function $factor_fn(x::ZZPolyRingElem)
+      iszero(x) && throw(ArgumentError("Argument must be non-zero"))
       fac, z = $factor_fn_inner(x)
       ffac = factor(z)
 

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -271,10 +271,12 @@ function _convert_fac(a::FqMPolyRing, b::Fac)
 end
 
 function factor(a::FqMPolyRingElem)
+    iszero(a) && throw(ArgumentError("Argument must be non-zero"))
     return _convert_fac(parent(a), factor(a.data))
 end
 
 function factor_squarefree(a::FqMPolyRingElem)
+    iszero(a) && throw(ArgumentError("Argument must be non-zero"))
     return _convert_fac(parent(a), factor_squarefree(a.data))
 end
 

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -648,6 +648,7 @@ function length(x::fq_default_poly_factor)
 end   
 
 function factor(x::FqPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
    fac, z = _factor(x)
    return Fac(parent(x)(z), fac)
 end
@@ -673,6 +674,7 @@ function _factor(x::FqPolyRingElem)
 end
 
 function factor_squarefree(x::FqPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   # _factor_squareefree does weird things if the polynomial is not monic
   return Fac(parent(x)(leading_coefficient(x)),
 	      _factor_squarefree(divexact(x, leading_coefficient(x))))

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -449,6 +449,7 @@ function (::Type{Fac{fqPolyRepMPolyRingElem}})(fac::fq_nmod_mpoly_factor, preser
 end
 
 function factor(a::fqPolyRepMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fq_nmod_mpoly_factor(R)
    ok = ccall((:fq_nmod_mpoly_factor, libflint), Cint,
@@ -459,6 +460,7 @@ function factor(a::fqPolyRepMPolyRingElem)
 end
 
 function factor_squarefree(a::fqPolyRepMPolyRingElem)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = fq_nmod_mpoly_factor(R)
    ok = ccall((:fq_nmod_mpoly_factor_squarefree, libflint), Cint,

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -639,6 +639,7 @@ end
 ################################################################################
 
 function factor(x::fqPolyRepPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
    res, z = _factor(x)
    return Fac(parent(x)(z), res)
 end
@@ -664,6 +665,7 @@ function _factor(x::fqPolyRepPolyRingElem)
 end
 
 function factor_squarefree(x::fqPolyRepPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   # _factor_squareefree does weird things if the polynomial is not monic
   return Fac(parent(x)(leading_coefficient(x)),
 	     _factor_squarefree(divexact(x, leading_coefficient(x))))

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -637,6 +637,7 @@ end
 ################################################################################
 
 function factor(x::FqPolyRepPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
    fac, z = _factor(x)
    return Fac(parent(x)(z), fac)
 end
@@ -662,6 +663,7 @@ function _factor(x::FqPolyRepPolyRingElem)
 end
 
 function factor_squarefree(x::FqPolyRepPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   # _factor_squareefree does weird things if the polynomial is not monic
   return Fac(parent(x)(leading_coefficient(x)),
 	      _factor_squarefree(divexact(x, leading_coefficient(x))))

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -348,6 +348,7 @@ end
 ################################################################################
 
 function factor(x::FpPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   fac = _factor(x)
   return Fac(parent(x)(leading_coefficient(x)), fac)
 end
@@ -373,6 +374,7 @@ function _factor(x::FpPolyRingElem)
 end  
 
 function factor_squarefree(x::FpPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   fac = _factor_squarefree(x)
   return Fac(parent(x)(leading_coefficient(x)), fac)
 end

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -397,6 +397,7 @@ end
 ################################################################################
 
 function factor(x::fpPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   fac, z = _factor(x)
   return Fac(parent(x)(z), fac)
 end
@@ -417,6 +418,7 @@ function _factor(x::fpPolyRingElem)
 end
 
 function factor_squarefree(x::fpPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   return Fac(parent(x)(leading_coefficient(x)), _factor_squarefree(x))
 end
 

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -490,6 +490,7 @@ function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool = true)
 end
 
 function factor(a::($etype))
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = ($ftype)(R)
    ok = ccall((:nmod_mpoly_factor, libflint), Cint,
@@ -500,6 +501,7 @@ function factor(a::($etype))
 end
 
 function factor_squarefree(a::($etype))
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    R = parent(a)
    fac = ($ftype)(R)
    ok = ccall((:nmod_mpoly_factor_squarefree, libflint), Cint,

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -726,6 +726,7 @@ end
 ################################################################################
 
 function factor(x::zzModPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   fac, z = _factor(x)
   return Fac(parent(x)(z), fac)
 end
@@ -747,6 +748,7 @@ function _factor(x::zzModPolyRingElem)
 end
 
 function factor_squarefree(x::zzModPolyRingElem)
+  iszero(x) && throw(ArgumentError("Argument must be non-zero"))
   !is_prime(modulus(x)) && error("Modulus not prime in factor_squarefree")
   return Fac(parent(x)(leading_coefficient(x)), _factor_squarefree(x))
 end

--- a/src/gaussiannumbers/ZZi.jl
+++ b/src/gaussiannumbers/ZZi.jl
@@ -803,6 +803,7 @@ function _sum_of_squares(p::ZZRingElem)
 end
 
 function factor(a::fmpzi)
+   iszero(a) && throw(ArgumentError("Argument must be non-zero"))
    f = Fac{fmpzi}()
    g = gcd(a.x, a.y)
    f.unit = divexact(a, g)   # throw if a=0

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -525,6 +525,9 @@ end
 @testset "QQMPolyRingElem.factor" begin
    R, (x, y, z) = polynomial_ring(FlintQQ, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test a == unit(f) * prod([p^e for (p, e) in f])

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -488,6 +488,9 @@ end
 @testset "QQPolyRingElem.factor" begin
    S, y = polynomial_ring(QQ, "y")
 
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
+
    f = (2y + 1)^10*(5*y^3 + 1)^100*(-QQFieldElem(1,5))
 
    fac = factor(f)
@@ -499,6 +502,11 @@ end
 
    @test f == unit(fac) * prod([ p^e for (p, e) in fac])
 
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
+
+   @test !is_irreducible(S(0))
+   @test !is_irreducible(S(1))
    @test !is_irreducible(S(2))
    @test is_irreducible(y^4 + 1)
    @test is_irreducible(y + 1)
@@ -506,6 +514,10 @@ end
    @test is_irreducible(2y + 2)
    @test !is_irreducible(y^2)
 
+   @test !is_squarefree(S(0))
+   @test is_squarefree(S(1))
+   @test is_squarefree(S(2))
+   @test is_squarefree(S(4))
    @test is_squarefree(7*y^2 + 2)
    @test is_squarefree(2*y)
    @test is_squarefree(4*y)

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -502,16 +502,24 @@ end
 
 @testset "ZZModPolyRingElem.is_squarefree" begin
    R = residue_ring(ZZ, 123456789012345678949)
-   S, x = polynomial_ring(R, "x")
+   Rx, x = polynomial_ring(R, "x")
 
    f = x^2 + 2x + 1
 
    @test is_squarefree(f) == false
+
+   @test !is_squarefree(Rx(0))
+   @test is_squarefree(Rx(1))
+   @test is_squarefree(Rx(2))
+   @test is_squarefree(Rx(4))
 end
 
 @testset "ZZModPolyRingElem.factor" begin
    R = residue_ring(ZZ, 123456789012345678949)
    S, x = polynomial_ring(R, "x")
+
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
 
    f = 3*(x^2 + 2x + 1)
    g = x^3 + 3x + 1

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -505,6 +505,9 @@ end
 @testset "ZZMPolyRingElem.factor" begin
    R, (x, y, z) = polynomial_ring(FlintZZ, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test is_unit(unit(f))

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -389,6 +389,9 @@ end
 @testset "ZZPolyRingElem.factor" begin
   Rx, x = polynomial_ring(FlintZZ, "x")
 
+  @test_throws ArgumentError factor(Rx(0))
+  @test_throws ArgumentError factor_squarefree(Rx(0))
+
   f = x^24 - x^23 + x^19 - x^18 + x^17 - x^16 + x^14 - x^13 + x^12 - x^11 + x^10 - x^8 + x^7 - x^6 + x^5 - x + 1
   g = x - 1
 
@@ -406,10 +409,12 @@ end
   @test -10*f^10 * g^20 == unit(fac) * prod([ p^e for (p, e) in fac])
   @test length(fac.fac) == 4
 
+  @test !is_irreducible(Rx(0))
+  @test !is_irreducible(Rx(1))
   @test is_irreducible(Rx(2))
+  @test !is_irreducible(Rx(4))
   @test is_irreducible(x^4 + 1)
   @test is_irreducible(x + 1)
-  @test !is_irreducible(Rx(4))
   @test !is_irreducible(2x + 2)
   @test !is_irreducible(x^2)
 
@@ -417,6 +422,10 @@ end
   @test length(factor(g)) == 6
   @test length(factor(4 * g)) == 7
 
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test !is_squarefree(Rx(4))
   @test is_squarefree(7*x^2 + 2)
   @test is_squarefree(2*x)
   @test !is_squarefree(4*x)

--- a/test/flint/fq_default_mpoly-test.jl
+++ b/test/flint/fq_default_mpoly-test.jl
@@ -537,6 +537,10 @@ end
    for (R, a) in test_fields
       characteristic(R) == 23 || continue
       S, (x, y, z) = polynomial_ring(R, ["x", "y", "z"])
+
+      @test_throws ArgumentError factor(S(0))
+      @test_throws ArgumentError factor_squarefree(S(0))
+
       a = iszero(a) ? one(R) : a
       check_factor(3*a^3*x^23+2*a^2*y^23+a*z^23, 23)
       check_factor(x^99-a^33*y^99*z^33, 22)

--- a/test/flint/fq_default_poly-test.jl
+++ b/test/flint/fq_default_poly-test.jl
@@ -501,11 +501,19 @@ end
   @test !is_squarefree(f)
 
   @test is_squarefree((x+1)*(x+2)*(x+3))
+
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test is_squarefree(Rx(4))
 end
 
 @testset "FqPolyRingElem.factor" begin
    R, x = NGFiniteField(ZZRingElem(23), 5, "x")
    S, y = polynomial_ring(R, "y")
+
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
 
    f = 7y^2 + 3y + 2
    g = 11y^3 - 2y^2 + 5

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -536,6 +536,9 @@ end
    R, a = finite_field(23, 5, "a")
    R, (x, y, z) = polynomial_ring(R, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test a == unit(f) * prod([p^e for (p, e) in f])

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -505,18 +505,26 @@ end
 
 @testset "fqPolyRepPolyRingElem.is_squarefree" begin
   R, x = finite_field(23, 5, "x")
-  S, y = polynomial_ring(R, "y")
+  Rx, y = polynomial_ring(R, "y")
 
   f = y^6 + y^4 + 2 *y^2
 
   @test !is_squarefree(f)
 
   @test is_squarefree((y+1)*(y+2)*(y+3))
+
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test is_squarefree(Rx(4))
 end
 
 @testset "fqPolyRepPolyRingElem.factor" begin
    R, x = finite_field(23, 5, "x")
    S, y = polynomial_ring(R, "y")
+
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
 
    f = 7y^2 + 3y + 2
    g = 11y^3 - 2y^2 + 5

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -513,11 +513,19 @@ end
   @test !is_squarefree(f)
 
   @test is_squarefree((x+1)*(x+2)*(x+3))
+
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test is_squarefree(Rx(4))
 end
 
 @testset "FqPolyRepPolyRingElem.factor" begin
    R, x = finite_field(ZZRingElem(23), 5, "x")
    S, y = polynomial_ring(R, "y")
+
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
 
    f = 7y^2 + 3y + 2
    g = 11y^3 - 2y^2 + 5

--- a/test/flint/gfp_fmpz_mpoly-test.jl
+++ b/test/flint/gfp_fmpz_mpoly-test.jl
@@ -501,6 +501,9 @@ end
    R = GF(ZZRingElem(23))
    R, (x, y, z) = polynomial_ring(R, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test a == unit(f) * prod([p^e for (p, e) in f])

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -501,17 +501,25 @@ end
 
 @testset "FpPolyRingElem.is_squarefree" begin
    R = GF(ZZRingElem(123456789012345678949))
-   S, x = polynomial_ring(R, "x")
+   Rx, x = polynomial_ring(R, "x")
 
    f = x^2 + 2x + 1
 
    @test is_squarefree(f) == false
+
+   @test !is_squarefree(Rx(0))
+   @test is_squarefree(Rx(1))
+   @test is_squarefree(Rx(2))
+   @test is_squarefree(Rx(4))
 end
 
 @testset "FpPolyRingElem.factor" begin
    R = GF(ZZRingElem(123456789012345678949))
    S, x = polynomial_ring(R, "x")
    F = R
+
+   @test_throws ArgumentError factor(S(0))
+   @test_throws ArgumentError factor_squarefree(S(0))
 
    f = 3*(x^2 + 2x + 1)
    g = x^3 + 3x + 1

--- a/test/flint/gfp_mpoly-test.jl
+++ b/test/flint/gfp_mpoly-test.jl
@@ -520,6 +520,9 @@ end
    R = GF(23)
    R, (x, y, z) = polynomial_ring(R, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test a == unit(f) * prod([p^e for (p, e) in f])

--- a/test/flint/gfp_poly-test.jl
+++ b/test/flint/gfp_poly-test.jl
@@ -575,6 +575,11 @@ end
   @test !is_squarefree(f)
 
   @test is_squarefree((x+1)*(x+2)*(x+3))
+
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test is_squarefree(Rx(4))
 end
 
 @testset "fpPolyRingElem.square_root" begin
@@ -614,6 +619,9 @@ end
 @testset "fpPolyRingElem.factor" begin
   R = GF(23)
   Rx, x = polynomial_ring(R, "x")
+
+  @test_throws ArgumentError factor(Rx(0))
+  @test_throws ArgumentError factor_squarefree(Rx(0))
 
   f = 2*((x^6 + x^4 + 2 *x^2 )^10 + x - 1)
 

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -541,6 +541,9 @@ end
    R = residue_ring(FlintZZ, 23)
    R, (x, y, z) = polynomial_ring(R, ["x", "y", "z"])
 
+   @test_throws ArgumentError factor(R(0))
+   @test_throws ArgumentError factor_squarefree(R(0))
+
    function check_factor(a, esum)
       f = factor(a)
       @test a == unit(f) * prod([p^e for (p, e) in f])

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -598,11 +598,19 @@ end
   @test !is_squarefree(f)
 
   @test is_squarefree((x+1)*(x+2)*(x+3))
+
+  @test !is_squarefree(Rx(0))
+  @test is_squarefree(Rx(1))
+  @test is_squarefree(Rx(2))
+  @test is_squarefree(Rx(4))
 end
 
 @testset "zzModPolyRingElem.factor" begin
   R = residue_ring(ZZ, 23)
   Rx, x = polynomial_ring(R, "x")
+
+  @test_throws ArgumentError factor(Rx(0))
+  @test_throws ArgumentError factor_squarefree(Rx(0))
 
   f = 2*((x^6 + x^4 + 2 *x^2 )^10 + x - 1)
 


### PR DESCRIPTION
- `is_squarefree`: zero is never square free, units always are
- `factor` and `factor_squarefree` throw a uniform error if argument is zero
- add a bunch of tests to verify the fixes above

Fixes #1594