### PR TITLE
Remove redundant methods

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -41,8 +41,6 @@ parent_type(::Type{ComplexFieldElem}) = ComplexField
 
 base_ring(R::ComplexField) = Union{}
 
-base_ring(a::ComplexFieldElem) = Union{}
-
 parent(x::ComplexFieldElem) = ComplexField()
 
 is_domain_type(::Type{ComplexFieldElem}) = true

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -71,8 +71,6 @@ function deepcopy_internal(a::ComplexPoly, dict::IdDict)
    return z
 end
 
-characteristic(::ComplexPolyRing) = 0
-
 ###############################################################################
 #
 #   AbstractString I/O

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -37,8 +37,6 @@ parent_type(::Type{RealFieldElem}) = RealField
 
 base_ring(R::RealField) = Union{}
 
-base_ring(x::RealFieldElem) = Union{}
-
 parent(x::RealFieldElem) = RealField()
 
 is_domain_type(::Type{RealFieldElem}) = true

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -71,8 +71,6 @@ function deepcopy_internal(a::RealPoly, dict::IdDict)
    return z
 end
 
-characteristic(::RealPolyRing) = 0
-
 ###############################################################################
 #
 #   Similar

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -71,8 +71,6 @@ function deepcopy_internal(a::acb_poly, dict::IdDict)
    return z
 end
 
-characteristic(::AcbPolyRing) = 0
-
 ###############################################################################
 #
 #   AbstractString I/O

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -71,8 +71,6 @@ function deepcopy_internal(a::arb_poly, dict::IdDict)
    return z
 end
 
-characteristic(::ArbPolyRing) = 0
-
 ###############################################################################
 #
 #   AbstractString I/O

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -48,8 +48,6 @@ base_ring(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = base_ring(laurent_
 
 base_ring(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = base_ring(laurent_ring(R))
 
-base_ring(a::FlintPuiseuxSeriesElem) = base_ring(parent(a))
-
 max_precision(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem = max_precision(laurent_ring(R))
 
 max_precision(R::FlintPuiseuxSeriesField{T}) where T <: FieldElem = max_precision(laurent_ring(R))

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -42,8 +42,6 @@ elem_type(::Type{QQField}) = QQFieldElem
 
 base_ring(a::QQField) = FlintZZ
 
-base_ring(a::QQFieldElem) = FlintZZ
-
 is_domain_type(::Type{QQFieldElem}) = true
 
 ###############################################################################

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -37,8 +37,6 @@ nvars(a::QQMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, libflint), Int,
 
 base_ring(a::QQMPolyRing) = FlintQQ
 
-base_ring(f::QQMPolyRingElem) = FlintQQ
-
 function ordering(a::QQMPolyRing)
    b = ccall((:fmpq_mpoly_ctx_ord, libflint), Cint, (Ref{QQMPolyRing}, ), a)
    return flint_orderings[b + 1]
@@ -151,8 +149,6 @@ function denominator(a::QQMPolyRingElem)
         (Ref{ZZRingElem}, Ref{QQMPolyRingElem}, Ref{QQMPolyRing}), c, a, parent(a))
   return c
 end
-
-characteristic(::QQMPolyRing) = 0
 
 ################################################################################
 #

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -72,13 +72,6 @@ Returns `Union{}` as this ring is not dependent on another ring.
 """
 base_ring(a::ZZRing) = Union{}
 
-@doc raw"""
-    base_ring(a::ZZRingElem)
-
-Returns `Union{}` as the parent ring is not dependent on another ring.
-"""
-base_ring(a::ZZRingElem) = Union{}
-
 is_domain_type(::Type{ZZRingElem}) = true
 
 ###############################################################################

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -32,8 +32,6 @@ elem_type(::Type{ZZLaurentSeriesRing}) = ZZLaurentSeriesRingElem
 
 base_ring(R::ZZLaurentSeriesRing) = FlintZZ
 
-base_ring(a::ZZLaurentSeriesRingElem) = base_ring(parent(a))
-
 is_domain_type(::Type{ZZLaurentSeriesRingElem}) = true
 
 is_exact_type(a::Type{ZZLaurentSeriesRingElem}) = false

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -18,8 +18,6 @@ elem_type(::Type{ZZModRing}) = ZZModRingElem
 
 base_ring(a::ZZModRing) = FlintZZ
 
-base_ring(a::ZZModRingElem) = FlintZZ
-
 parent(a::ZZModRingElem) = a.parent
 
 function check_parent(a::ZZModRingElem, b::ZZModRingElem)

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -16,10 +16,6 @@ parent(a::ZZModPolyRingElem) = a.parent
 
 base_ring(R::ZZModPolyRing) = R.base_ring
 
-base_ring(a::ZZModPolyRingElem) = base_ring(parent(a))
-
-elem_type(::Type{ZZModPolyRingElem}) = ZZModPolyRingElem
-
 elem_type(::Type{ZZModPolyRing}) = ZZModPolyRingElem
 
 parent_type(::Type{ZZModPolyRingElem}) = ZZModPolyRing
@@ -90,8 +86,6 @@ function deepcopy_internal(a::T, dict::IdDict) where {T <: Zmodn_fmpz_poly}
   z.parent = a.parent
   return z
 end
-
-characteristic(R::ZmodNFmpzPolyRing) = modulus(R)
 
 ###############################################################################
 #

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -32,8 +32,6 @@ nvars(a::ZZMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, libflint), Int,
 
 base_ring(a::ZZMPolyRing) = FlintZZ
 
-base_ring(f::ZZMPolyRingElem) = FlintZZ
-
 function ordering(a::ZZMPolyRing)
    b = ccall((:fmpz_mpoly_ctx_ord, libflint), Cint, (Ref{ZZMPolyRing}, ), a)
    return flint_orderings[b + 1]
@@ -255,8 +253,6 @@ function total_degree_fmpz(a::ZZMPolyRingElem)
             d, a, a.parent)
    return d
 end
-
-characteristic(::ZZMPolyRing) = 0
 
 ###############################################################################
 #

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -57,8 +57,6 @@ function deepcopy_internal(a::ZZPolyRingElem, dict::IdDict)
    return z
 end
 
-characteristic(::ZZPolyRing) = 0
-
 @doc raw"""
     height(a::ZZPolyRingElem)
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -19,8 +19,6 @@ elem_type(::Type{FqPolyRepField}) = FqPolyRepFieldElem
 
 base_ring(a::FqPolyRepField) = Union{}
 
-base_ring(a::FqPolyRepFieldElem) = Union{}
-
 parent(a::FqPolyRepFieldElem) = a.parent
 
 is_domain_type(::Type{FqPolyRepFieldElem}) = true

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -18,8 +18,6 @@ elem_type(::Type{FqField}) = FqFieldElem
 
 base_ring(a::FqField) = Union{}
 
-base_ring(a::FqFieldElem) = Union{}
-
 parent(a::FqFieldElem) = a.parent
 
 is_domain_type(::Type{FqFieldElem}) = true

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -22,10 +22,6 @@ nvars(a::FqMPolyRing) = nvars(a.data)
 
 base_ring(a::FqMPolyRing) = a.base_ring
 
-base_ring(f::FqMPolyRingElem) = base_ring(parent(f))
-
-characteristic(R::FqMPolyRing) = characteristic(base_ring(R))
-
 modulus(R::FqMPolyRing) = modulus(base_ring(R))
 
 modulus(f::FqMPolyRingElem) = modulus(base_ring(parent(f)))

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -85,8 +85,6 @@ function deepcopy_internal(a::FqPolyRingElem, dict::IdDict)
    return z
 end
 
-characteristic(R::FqPolyRing) = characteristic(base_ring(R))
-
 ###############################################################################
 #
 #   Similar

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -18,8 +18,6 @@ elem_type(::Type{fqPolyRepField}) = fqPolyRepFieldElem
 
 base_ring(a::fqPolyRepField) = Union{}
 
-base_ring(a::fqPolyRepFieldElem) = Union{}
-
 parent(a::fqPolyRepFieldElem) = a.parent
 
 is_domain_type(::Type{fqPolyRepFieldElem}) = true

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -31,8 +31,6 @@ nvars(a::fqPolyRepMPolyRing) = a.nvars
 
 base_ring(a::fqPolyRepMPolyRing) = a.base_ring
 
-base_ring(f::fqPolyRepMPolyRingElem) = f.parent.base_ring
-
 function ordering(a::fqPolyRepMPolyRing)
    b = a.ord
 #   b = ccall((:fq_nmod_mpoly_ctx_ord, libflint), Cint, (Ref{fqPolyRepMPolyRing}, ), a)
@@ -138,8 +136,6 @@ function is_constant(a::fqPolyRepMPolyRingElem)
              a, parent(a))
    return Bool(b)
 end
-
-characteristic(R::fqPolyRepMPolyRing) = characteristic(base_ring(R))
 
 ################################################################################
 #

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -80,8 +80,6 @@ function deepcopy_internal(a::fqPolyRepPolyRingElem, dict::IdDict)
    return z
 end
 
-characteristic(R::fqPolyRepPolyRing) = characteristic(base_ring(R))
-
 ###############################################################################
 #
 #   Similar

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -80,8 +80,6 @@ function deepcopy_internal(a::FqPolyRepPolyRingElem, dict::IdDict)
    return z
 end
 
-characteristic(R::FqPolyRepPolyRing) = characteristic(base_ring(R))
-
 ###############################################################################
 #
 #   Similar

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -18,8 +18,6 @@ elem_type(::Type{fpField}) = fpFieldElem
 
 base_ring(a::fpField) = Union{}
 
-base_ring(a::fpFieldElem) = Union{}
-
 parent(a::fpFieldElem) = a.parent
 
 function check_parent(a::fpFieldElem, b::fpFieldElem)

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -18,8 +18,6 @@ elem_type(::Type{FpField}) = FpFieldElem
 
 base_ring(a::FpField) = Union{}
 
-base_ring(a::FpFieldElem) = Union{}
-
 parent(a::FpFieldElem) = a.parent
 
 function check_parent(a::FpFieldElem, b::FpFieldElem)

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -16,17 +16,11 @@ parent(a::FpPolyRingElem) = a.parent
 
 base_ring(R::FpPolyRing) = R.base_ring
 
-base_ring(a::FpPolyRingElem) = base_ring(parent(a))
-
-elem_type(::Type{FpPolyRingElem}) = FpPolyRingElem
-
 elem_type(::Type{FpPolyRing}) = FpPolyRingElem
 
 parent_type(::Type{FpPolyRingElem}) = FpPolyRing
 
 dense_poly_type(::Type{FpFieldElem}) = FpPolyRingElem
-
-characteristic(R::FpPolyRing) = characteristic(base_ring(R))
 
 ###############################################################################
 #

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -16,11 +16,7 @@ parent(a::fpPolyRingElem) = a.parent
 
 base_ring(R::fpPolyRing) = R.base_ring
 
-base_ring(a::fpPolyRingElem) = base_ring(parent(a))
-
 parent_type(::Type{fpPolyRingElem}) = fpPolyRing
-
-elem_type(::Type{fpPolyRingElem}) = fpPolyRingElem
 
 elem_type(::Type{fpPolyRing}) = fpPolyRingElem
 
@@ -65,8 +61,6 @@ function deepcopy_internal(a::fpPolyRingElem, dict::IdDict)
   z.parent = a.parent
   return z
 end
-
-characteristic(R::fpPolyRing) = characteristic(base_ring(R))
 
 ###############################################################################
 #

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -18,8 +18,6 @@ elem_type(::Type{zzModRing}) = zzModRingElem
 
 base_ring(a::zzModRing) = FlintZZ
 
-base_ring(a::zzModRingElem) = FlintZZ
-
 parent(a::zzModRingElem) = a.parent
 
 function check_parent(a::zzModRingElem, b::zzModRingElem)

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -23,11 +23,7 @@ parent(a::zzModPolyRingElem) = a.parent
 
 base_ring(R::zzModPolyRing) = R.base_ring
 
-base_ring(a::zzModPolyRingElem) = base_ring(parent(a))
-
 parent_type(::Type{zzModPolyRingElem}) = zzModPolyRing
-
-elem_type(::Type{zzModPolyRingElem}) = zzModPolyRingElem
 
 elem_type(::Type{zzModPolyRing}) = zzModPolyRingElem
 
@@ -110,8 +106,6 @@ function deepcopy_internal(a::zzModPolyRingElem, dict::IdDict)
   z.parent = a.parent
   return z
 end
-
-characteristic(R::zzModPolyRing) = modulus(R)
 
 ###############################################################################
 #


### PR DESCRIPTION
- AA has `characteristic(a::PolyRing) = characteristic(base_ring(a))`
- AA has `base_ring(x::NCRingElement) = base_ring(parent(x))`
- `elem_type` for arguments which are element types is not part of the spec