### PR TITLE
Add `unsafe_reconstruct` for rational reconstruction

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -759,6 +759,18 @@ reconstruct(a::Integer, b::ZZRingElem) =  reconstruct(ZZRingElem(a), b)
 
 reconstruct(a::Integer, b::Integer) =  reconstruct(ZZRingElem(a), ZZRingElem(b))
 
+@doc raw"""
+   unsafe_reconstruct(a::ZZRingElem, b::ZZRingElem)
+Same as [`reconstruct`](@ref), but does not throw if the reconstruction fails.
+Returns a tuple (`success`, `n/d`), where `success` signals the success of reconstruction.
+"""
+function unsafe_reconstruct(a::ZZRingElem, b::ZZRingElem)
+   c = QQFieldElem()
+   success = Bool(ccall((:fmpq_reconstruct_fmpz, libflint), Cint,
+                     (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), c, a, b))
+   return success, c
+end
+
 ###############################################################################
 #
 #   Rational enumeration

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -530,6 +530,14 @@ end
    @test reconstruct(ZZRingElem(123), ZZRingElem(237)) == ZZRingElem(9)//2
 
    @test reconstruct(123, ZZRingElem(237)) == ZZRingElem(9)//2
+
+   flag, nd = Nemo.unsafe_reconstruct(ZZRingElem(123), ZZRingElem(237))
+   @test flag && nd == ZZRingElem(9)//2
+
+   a, m = ZZRingElem(643465418), ZZRingElem(2^31-1)
+   @test_throws ErrorException reconstruct(a, m)
+   flag, nd = Nemo.unsafe_reconstruct(a, m)
+   @test !flag
 end
 
 @testset "QQFieldElem.rational_enumeration" begin


### PR DESCRIPTION
I plan to use `reconstruct` in my project. 
Unfortunately, at the moment, the function throws when the reconstruction fails. 
In my opinion, it is not very convenient, and also has a tiny bit of overhead.

This PR adds a no-throwing friend `unsafe_reconstruct`.