### PR TITLE
Remove `divisible`, copy documentation to `is_divisible_by` instead

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -322,8 +322,8 @@ iroot(::ZZRingElem, ::Int)
 ### Number theoretic functionality
 
 ```@docs
-divisible(::ZZRingElem, ::Int)
-divisible(::ZZRingElem, ::ZZRingElem)
+is_divisible_by(::ZZRingElem, ::Int)
+is_divisible_by(::ZZRingElem, ::ZZRingElem)
 ```
 
 ```@docs

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -118,4 +118,5 @@
 
 # Deprecated in 0.39.*
 
-Base.@deprecate_binding divisible is_divisible_by
+@deprecate divisible(x::ZZRingElem, y::Int) is_divisible_by(x, y)
+@deprecate divisible(x::ZZRingElem, y::ZZRingElem) is_divisible_by(x, y)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -115,3 +115,7 @@
 @deprecate roots(f::QQPolyRingElem, R::T) where {T<:Union{fqPolyRepField,fpField}} roots(R, f)
 
 @deprecate factor(f::QQPolyRingElem, R::T) where {T<:Union{fqPolyRepField,fpField}} factor(R, f)
+
+# Deprecated in 0.39.*
+
+Base.@deprecate_binding divisible is_divisible_by

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -118,5 +118,6 @@
 
 # Deprecated in 0.39.*
 
+@deprecate divisible(x::Int, y::Int) is_divisible_by(x, y)
 @deprecate divisible(x::ZZRingElem, y::Int) is_divisible_by(x, y)
 @deprecate divisible(x::ZZRingElem, y::ZZRingElem) is_divisible_by(x, y)

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -149,7 +149,6 @@ export digamma
 export div!
 export divexact
 export divexact!
-export divisible
 export divisor_lenstra
 export divisor_sigma
 export divisors

--- a/src/HeckeMiscInteger.jl
+++ b/src/HeckeMiscInteger.jl
@@ -96,10 +96,6 @@ function log(a::ZZRingElem, b::ZZRingElem)
     log(b) / log(a)
 end
 
-function divisible(x::Integer, y::Integer)
-    return iszero(rem(x, y))
-end
-
 Base.in(x::IntegerUnion, r::AbstractRange{ZZRingElem}) =
     !isempty(r) && first(r) <= x <= last(r) &&
     mod(convert(ZZRingElem, x), step(r)) == mod(first(r), step(r))

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -372,6 +372,11 @@ end
 
 divides(x::ZZRingElem, y::Integer) = divides(x, ZZRingElem(y))
 
+@doc raw"""
+    is_divisible_by(x::ZZRingElem, y::ZZRingElem)
+
+Return `true` if $x$ is divisible by $y$, otherwise return `false`.
+"""
 function is_divisible_by(x::ZZRingElem, y::ZZRingElem)
    if iszero(x)
       return true
@@ -387,6 +392,11 @@ function is_divisible_by(x::ZZRingElem, y::ZZRingElem)
    end
 end
 
+@doc raw"""
+    is_divisible_by(x::ZZRingElem, y::ZZRingElem)
+
+Return `true` if $x$ is divisible by $y$, otherwise return `false`.
+"""
 function is_divisible_by(x::ZZRingElem, y::Integer)
    if iszero(x)
       return true
@@ -1577,30 +1587,6 @@ end
 #   Number theoretic/combinatorial
 #
 ###############################################################################
-
-@doc raw"""
-    divisible(x::ZZRingElem, y::ZZRingElem)
-
-Return `true` if $x$ is divisible by $y$, otherwise return `false`. We
-require $x \neq 0$.
-"""
-function divisible(x::ZZRingElem, y::ZZRingElem)
-   iszero(y) && throw(DivideError())
-   Bool(ccall((:fmpz_divisible, libflint), Cint,
-              (Ref{ZZRingElem}, Ref{ZZRingElem}), x, y))
-end
-
-@doc raw"""
-    divisible(x::ZZRingElem, y::Int)
-
-Return `true` if $x$ is divisible by $y$, otherwise return `false`. We
-require $x \neq 0$.
-"""
-function divisible(x::ZZRingElem, y::Int)
-   y == 0 && throw(DivideError())
-   Bool(ccall((:fmpz_divisible_si, libflint), Cint,
-              (Ref{ZZRingElem}, Int), x, y))
-end
 
 @doc raw"""
     divisors(a::Union{Int, ZZRingElem})

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -1014,7 +1014,7 @@ end
 
    @test is_probable_prime(ZZRingElem(13))
 
-   @test divisible(ZZRingElem(12), ZZRingElem(6))
+   @test is_divisible_by(ZZRingElem(12), ZZRingElem(6))
 
    n = ZZRingElem(2^2 * 3 * 13^2)
    d = ZZRingElem.([1, 2, 3, 4, 6, 12, 13, 26, 39, 52, 78, 156, 169, 338, 507, 676, 1014, 2028])


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3178 by removing `divisible` and promoting `is_divisible_by` with a fixed docstring instead. (as suggested by @fieker in https://github.com/oscar-system/Oscar.jl/issues/3178#issuecomment-1887310107)

This function is already used throughout AbstractAlgebra. Thus I removed the duplicate implementation for `(::Integer, ::Integer)` here in Nemo.

cc @JohnAAbbott 