### PR TITLE
Allow polynomial rings with 0 variables

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1267,8 +1267,6 @@ const flint_orderings = [:lex, :deglex, :degrevlex]
             error("$S is not a valid ordering")
          end
 
-         isempty(s) && error("need at least one indeterminate")
-
          z = new()
          ccall((:fmpz_mpoly_ctx_init, libflint), Nothing,
                (Ref{ZZMPolyRing}, Int, Int),
@@ -1462,8 +1460,6 @@ end
          else
             error("$S is not a valid ordering")
          end
-
-         isempty(s) && error("need at least one indeterminate")
 
          z = new()
          ccall((:fmpq_mpoly_ctx_init, libflint), Nothing,
@@ -1677,8 +1673,6 @@ end
             error("$S is not a valid ordering")
          end
 
-         isempty(s) && error("need at least one indeterminate")
-
          z = new()
          ccall((:nmod_mpoly_ctx_init, libflint), Nothing,
                (Ref{zzModMPolyRing}, Int, Cint, UInt),
@@ -1867,8 +1861,6 @@ end
          else
             error("$S is not a valid ordering")
          end
-
-         isempty(s) && error("need at least one indeterminate")
 
          z = new()
          ccall((:nmod_mpoly_ctx_init, libflint), Nothing,
@@ -2909,8 +2901,6 @@ end
          else
             error("$S is not a valid ordering")
          end
-
-         isempty(s) && error("need at least one indeterminate")
 
          z = new()
          ccall((:fq_nmod_mpoly_ctx_init, libflint), Nothing,

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "QQMPolyRingElem.constructors" begin
    R = FlintQQ
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -64,7 +64,9 @@
 
       bctx = MPolyBuildCtx(S)
       @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars + 1))
-      @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      if num_vars > 0
+         @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      end
       @test (@which push_term!(bctx, UInt(1), zeros(Int, num_vars))).module === Nemo
       @test (@which finish(bctx)).module === Nemo
       push_term!(bctx, UInt(1), zeros(Int, num_vars))

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "ZZMPolyRingElem.constructors" begin
    R = FlintZZ
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -64,7 +64,9 @@
 
       bctx = MPolyBuildCtx(S)
       @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars + 1))
-      @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      if num_vars > 0
+         @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      end
       @test (@which push_term!(bctx, UInt(1), zeros(Int, num_vars))).module === Nemo
       @test (@which finish(bctx)).module === Nemo
       push_term!(bctx, UInt(1), zeros(Int, num_vars))

--- a/test/flint/fq_default_mpoly-test.jl
+++ b/test/flint/fq_default_mpoly-test.jl
@@ -6,7 +6,7 @@ local test_fields = (finite_field(23, 1, "a"),
 
 @testset "FqMPolyRingElem.constructors" begin
    for (R, a) in test_fields
-      for num_vars = 1:10
+      for num_vars = 0:10
          var_names = ["x$j" for j in 1:num_vars]
          ord = rand_ordering()
 

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "fqPolyRepMPolyRingElem.constructors" begin
    R, a = Native.finite_field(23, 5, "a")
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -66,7 +66,9 @@
 
       bctx = MPolyBuildCtx(S)
       @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars + 1))
-      @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      if num_vars > 0
+         @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      end
       @test (@which finish(bctx)).module === Nemo
 
       for i in 1:num_vars

--- a/test/flint/gfp_fmpz_mpoly-test.jl
+++ b/test/flint/gfp_fmpz_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "FpMPolyRingElem.constructors" begin
    R = Native.GF(ZZRingElem(23))
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -16,10 +16,14 @@
 
       @test !(SSS === SSSS)
 
-      @test string(varlist[1]) == var_names[1]
+      if num_vars > 0
+         @test string(varlist[1]) == var_names[1]
+      end
       @test nvars(S) == num_vars
       @test modulus(S) == modulus(R)
-      @test modulus(varlist[1]) == modulus(R)
+      if num_vars > 0
+         @test modulus(varlist[1]) == modulus(R)
+      end
 
       @test elem_type(S) == FpMPolyRingElem
       @test elem_type(FpMPolyRing) == FpMPolyRingElem

--- a/test/flint/gfp_mpoly-test.jl
+++ b/test/flint/gfp_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "fpMPolyRingElem.constructors" begin
    R = Native.GF(23)
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -16,10 +16,14 @@
 
       @test !(SSS === SSSS)
 
-      @test string(varlist[1]) == var_names[1]
+      if num_vars > 0
+         @test string(varlist[1]) == var_names[1]
+      end
       @test nvars(S) == num_vars
       @test modulus(S) == modulus(R)
-      @test modulus(varlist[1]) == modulus(R)
+      if num_vars > 0
+         @test modulus(varlist[1]) == modulus(R)
+      end
 
       @test elem_type(S) == fpMPolyRingElem
       @test elem_type(fpMPolyRing) == fpMPolyRingElem
@@ -67,7 +71,9 @@
 
       bctx = MPolyBuildCtx(S)
       @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars + 1))
-      @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      if num_vars > 0
+         @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      end
       @test (@which finish(bctx)).module === Nemo
 
       for i in 1:num_vars

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -1,7 +1,7 @@
 @testset "zzModMPolyRingElem.constructors" begin
    R = residue_ring(FlintZZ, 23)
 
-   for num_vars = 1:10
+   for num_vars = 0:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = rand_ordering()
 
@@ -16,10 +16,14 @@
 
       @test !(SSS === SSSS)
 
-      @test string(varlist[1]) == var_names[1]
+      if num_vars > 0
+         @test string(varlist[1]) == var_names[1]
+      end
       @test nvars(S) == num_vars
       @test modulus(S) == modulus(R)
-      @test modulus(varlist[1]) == modulus(R)
+      if num_vars > 0
+         @test modulus(varlist[1]) == modulus(R)
+      end
 
       @test elem_type(S) == zzModMPolyRingElem
       @test elem_type(zzModMPolyRing) == zzModMPolyRingElem
@@ -69,7 +73,9 @@
 
       bctx = MPolyBuildCtx(S)
       @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars + 1))
-      @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      if num_vars > 0
+         @test_throws ErrorException push_term!(bctx, one(R), zeros(Int, num_vars - 1))
+      end
       @test (@which finish(bctx)).module === Nemo
 
       for i in 1:num_vars


### PR DESCRIPTION
One can't construct e.g. `polynomial_ring(ZZ, 0)` which would be quite convenient in https://github.com/oscar-system/Oscar.jl/pull/3159 and works for the generic multivariate polynomial rings in AbstractAlgebra.
Apparently, this was an artificial restriction on the julia side, so I simply removed the checks and it seems to work.