### PR TITLE
Update finite field printing

### DIFF
--- a/docs/src/ff_embedding.md
+++ b/docs/src/ff_embedding.md
@@ -35,15 +35,15 @@ embed(::fqPolyRepField, ::fqPolyRepField)
 
 ```jldoctest; filter = r"[gG]F"
 julia> k2, x2 = finite_field(19, 2, "x2")
-(Finite field of degree 2 over GF(19), x2)
+(Finite field of characteristic 19 of degree 2, x2)
 
 julia> k4, x4 = finite_field(19, 4, "x4")
-(Finite field of degree 4 over GF(19), x4)
+(Finite field of characteristic 19 of degree 4, x4)
 
 julia> f = embed(k2, k4)
 Morphism of finite fields
-  from finite field of degree 2 over GF(19)
-  to finite field of degree 4 over GF(19)
+  from finite field of characteristic 19 of degree 2
+  to finite field of characteristic 19 of degree 4
 
 julia> y = f(x2)
 6*x4^3 + 5*x4^2 + 9*x4 + 17
@@ -63,15 +63,15 @@ preimage_map(::FinFieldMorphism)
 
 ```jldoctest
 julia> k7, x7 = finite_field(13, 7, "x7")
-(Finite field of degree 7 over GF(13), x7)
+(Finite field of characteristic 13 of degree 7, x7)
 
 julia> k21, x21 = finite_field(13, 21, "x21")
-(Finite field of degree 21 over GF(13), x21)
+(Finite field of characteristic 13 of degree 21, x21)
 
 julia> s = preimage_map(k7, k21)
 Preimage of a morphism
-  from finite field of degree 7 over GF(13)
-  to finite field of degree 21 over GF(13)
+  from finite field of characteristic 13 of degree 7
+  to finite field of characteristic 13 of degree 21
 
 julia> y = k21(x7);
 

--- a/docs/src/ff_embedding.md
+++ b/docs/src/ff_embedding.md
@@ -35,15 +35,15 @@ embed(::fqPolyRepField, ::fqPolyRepField)
 
 ```jldoctest; filter = r"[gG]F"
 julia> k2, x2 = finite_field(19, 2, "x2")
-(Finite field of characteristic 19 of degree 2, x2)
+(Finite field of degree 2 and characteristic 19, x2)
 
 julia> k4, x4 = finite_field(19, 4, "x4")
-(Finite field of characteristic 19 of degree 4, x4)
+(Finite field of degree 4 and characteristic 19, x4)
 
 julia> f = embed(k2, k4)
 Morphism of finite fields
-  from finite field of characteristic 19 of degree 2
-  to finite field of characteristic 19 of degree 4
+  from finite field of degree 2 and characteristic 19
+  to finite field of degree 4 and characteristic 19
 
 julia> y = f(x2)
 6*x4^3 + 5*x4^2 + 9*x4 + 17
@@ -63,15 +63,15 @@ preimage_map(::FinFieldMorphism)
 
 ```jldoctest
 julia> k7, x7 = finite_field(13, 7, "x7")
-(Finite field of characteristic 13 of degree 7, x7)
+(Finite field of degree 7 and characteristic 13, x7)
 
 julia> k21, x21 = finite_field(13, 21, "x21")
-(Finite field of characteristic 13 of degree 21, x21)
+(Finite field of degree 21 and characteristic 13, x21)
 
 julia> s = preimage_map(k7, k21)
 Preimage of a morphism
-  from finite field of characteristic 13 of degree 7
-  to finite field of characteristic 13 of degree 21
+  from finite field of degree 7 and characteristic 13
+  to finite field of degree 21 and characteristic 13
 
 julia> y = k21(x7);
 

--- a/docs/src/gfp.md
+++ b/docs/src/gfp.md
@@ -60,7 +60,7 @@ Below we describe the functionality that is provided in addition to these.
 
 ```jldoctest
 julia> F = GF(3)
-Finite field of degree 1 over GF(3)
+Prime field of characteristic 3
 
 julia> a = characteristic(F)
 3

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -83,10 +83,10 @@ Here is an example using generic recursive ring constructions.
 julia> using Nemo
 
 julia> R, x = finite_field(7, 11, "x")
-(Finite field of degree 11 over GF(7), x)
+(Finite field of characteristic 7 of degree 11, x)
 
 julia> S, y = polynomial_ring(R, "y")
-(Univariate polynomial ring in y over GF(7^11), y)
+(Univariate polynomial ring in y over GF(7, 11), y)
 
 julia> T = residue_ring(S, y^3 + 3x*y + 1)
 Residue ring of univariate polynomial ring modulo y^3 + 3*x*y + 1

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -83,7 +83,7 @@ Here is an example using generic recursive ring constructions.
 julia> using Nemo
 
 julia> R, x = finite_field(7, 11, "x")
-(Finite field of characteristic 7 of degree 11, x)
+(Finite field of degree 11 and characteristic 7, x)
 
 julia> S, y = polynomial_ring(R, "y")
 (Univariate polynomial ring in y over GF(7, 11), y)

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -857,15 +857,15 @@ $K = k[X]/(f)$ will be constructed as a finite field with base field $k$.
 
 ```jldoctest
 julia> K, a = finite_field(3, 2, "a")
-(Finite field of degree 2 over GF(3), a)
+(Finite field of characteristic 3 of degree 2, a)
 
 julia> K, a = finite_field(9, "a")
-(Finite field of degree 2 over GF(3), a)
+(Finite field of characteristic 3 of degree 2, a)
 
 julia> Kx, x = K["x"];
 
 julia> L, b = finite_field(x^3 + x^2 + x + 2, "b")
-(Relative finite field of degree 3 over GF(3^2), b)
+(Finite field of degree 3 over GF(3, 2), b)
 ```
 """
 finite_field
@@ -908,15 +908,15 @@ field with base field $k$.
 
 ```jldoctest
 julia> K = GF(3, 2, "a")
-Finite field of degree 2 over GF(3)
+Finite field of characteristic 3 of degree 2
 
 julia> K = GF(9, "a")
-Finite field of degree 2 over GF(3)
+Finite field of characteristic 3 of degree 2
 
 julia> Kx, x = K["x"];
 
 julia> L = GF(x^3 + x^2 + x + 2, "b")
-Relative finite field of degree 3 over GF(3^2)
+Finite field of degree 3 over GF(3, 2)
 ```
 """
 GF

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -375,7 +375,7 @@ function show(io::IO, a::FqField)
       if deg == 1
         print(io, "Prime field of characteristic $(characteristic(a))")
       else
-        print(io, "Finite field of characteristic $(characteristic(a)) of degree $(deg)")
+        print(io, "Finite field of degree $(deg) and characteristic $(characteristic(a))")
       end
     end
   else
@@ -857,10 +857,10 @@ $K = k[X]/(f)$ will be constructed as a finite field with base field $k$.
 
 ```jldoctest
 julia> K, a = finite_field(3, 2, "a")
-(Finite field of characteristic 3 of degree 2, a)
+(Finite field of degree 2 and characteristic 3, a)
 
 julia> K, a = finite_field(9, "a")
-(Finite field of characteristic 3 of degree 2, a)
+(Finite field of degree 2 and characteristic 3, a)
 
 julia> Kx, x = K["x"];
 
@@ -908,10 +908,10 @@ field with base field $k$.
 
 ```jldoctest
 julia> K = GF(3, 2, "a")
-Finite field of characteristic 3 of degree 2
+Finite field of degree 2 and characteristic 3
 
 julia> K = GF(9, "a")
-Finite field of characteristic 3 of degree 2
+Finite field of degree 2 and characteristic 3
 
 julia> Kx, x = K["x"];
 

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -363,16 +363,32 @@ show(io::IO, a::FqFieldElem) = print(io, AbstractAlgebra.obj_to_string(a, contex
 
 function show(io::IO, a::FqField)
   io = pretty(io)
-  if get(io, :supercompact, false)
-    print(io, LowercaseOff(), "GF($(order(base_field(a)))", degree(a) > 1 ? "^$(degree(a))" : "", ")")
-  else
-    if is_absolute(a)
-      # nested printing allowed, preferably supercompact
-      print(io, "Finite field of degree ", degree(a), " over ")
-      print(IOContext(io, :supercompact => true), base_field(a))
+  if is_absolute(a)
+    deg = degree(a)
+    if get(io, :supercompact, false)
+      if deg == 1
+        print(io, LowercaseOff(), "GF($(characteristic(a)))")
+      else
+        print(io, LowercaseOff(), "GF($(characteristic(a)), $(deg))")
+      end
     else
-      # nested printing allowed, preferably supercompact
-      print(io, "Relative finite field of degree ", degree(a), " over ")
+      if deg == 1
+        print(io, "Prime field of characteristic $(characteristic(a))")
+      else
+        print(io, "Finite field of characteristic $(characteristic(a)) of degree $(deg)")
+      end
+    end
+  else
+    if get(io, :supercompact, false)
+      degrees = Int[]
+      b = a
+      while !is_absolute(b)
+        push!(degrees, degree(b))
+        b = base_field(b)
+      end
+      print(io, LowercaseOff(), "GF($(characteristic(a)), $(join(reverse(degrees), '*')))")
+    else
+      print(io, "Finite field of degree $(degree(a)) over ")
       print(IOContext(io, :supercompact => true), base_field(a))
     end
   end

--- a/test/flint/fq_default_extended-test.jl
+++ b/test/flint/fq_default_extended-test.jl
@@ -34,6 +34,7 @@
    @test sprint(show, "text/plain", R) isa String
    @test sprint(show, "text/plain", F) isa String
    @test sprint(show, "text/plain", FF) isa String
+   @test sprint(show, "text/plain", FF, context=:supercompact => true) == "GF(7, 2*3)"
 
    a = F()
 


### PR DESCRIPTION
I think this should now do everything as written down in https://github.com/oscar-system/Oscar.jl/issues/3165#issuecomment-1896140078.
Unfortunately, I wasn't able to construct a relative field over a relative field to test the `GF(p, d1*d2)` printing. @thofma can you try to come up with something and put it into a doctest?

I'll mark this as breaking as it will break a lot of doctests downstream.

Resolves https://github.com/oscar-system/Oscar.jl/issues/3165.