### PR TITLE
chg: diagonal, prod_diagonal for matrices with more rows than cols

### DIFF
--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -600,7 +600,7 @@ end
 
 Returns the diagonal of `A` as an array.
 """
-diagonal(A::MatrixElem{T}) where {T} = T[A[i, i] for i in 1:nrows(A)]
+diagonal(A::MatrixElem{T}) where {T} = T[A[i, i] for i in 1:min(nrows(A),ncols(A))]
 
 ################################################################################
 #
@@ -612,7 +612,7 @@ diagonal(A::MatrixElem{T}) where {T} = T[A[i, i] for i in 1:nrows(A)]
 function prod_diagonal(A::ZZMatrix)
     a = one(ZZRingElem)
     GC.@preserve a A begin
-        for i = 1:nrows(A)
+        for i = 1:min(nrows(A),ncols(A))
             b = ccall((:fmpz_mat_entry, libflint), Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), A, i - 1, i - 1)
             ccall((:fmpz_mul, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}, Ptr{ZZRingElem}), a, a, b)
         end


### PR DESCRIPTION
`diagonal` and `prod_diagonal` raise errors when the matrix has more rows than columns. Stopping the diagonal element enumeration at the minimum of the number of rows and cols fixes it.