### PR TITLE
GHA: use julia-actions/cache some more

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -3,6 +3,11 @@ name: Invalidations
 on:
   pull_request:
 
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: always.
@@ -19,6 +24,7 @@ jobs:
     - uses: julia-actions/setup-julia@v1
       with:
         version: '1'
+    - uses: julia-actions/cache@v1
     - uses: actions/checkout@v3
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -9,6 +9,11 @@ on:
       - master
   workflow_dispatch:
 
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull
   # requests, we limit to 1 concurrent job, but for the master branch we don't
@@ -30,6 +35,7 @@ jobs:
       uses: julia-actions/setup-julia@v1
       with:
         version: '1.10'
+    - uses: julia-actions/cache@v1
     - name: OscarDevTools - CI
       if: github.repository == 'oscar-system/OscarDevTools.jl'
       run: |
@@ -70,6 +76,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v1
       - name: re-using OscarDevTools checkout
         if: github.repository == 'oscar-system/OscarDevTools.jl'
         run: |


### PR DESCRIPTION
On https://github.com/Nemocas/Nemo.jl/actions/runs/7609008679?pr=1620 it complains:

> [[julia-buildpkg] Caching of the julia depot was not detected](https://github.com/Nemocas/Nemo.jl/actions/runs/7609008679/job/20719334193#step:22:46)
Consider using `julia-actions/cache` to speed up runs https://github.com/julia-actions/cache. To ignore, set input `ignore-no-cache: true`

So this PR might resolve that -- and if it does, I assume something similar should be applied to our other repos?