### PR TITLE
chore: Bump version to 0.40.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.40.0-DEV"
+version = "0.40.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
ToDo-List before merging this:

- [x] https://github.com/Nemocas/Nemo.jl/pull/1611 (merge missing)
- [x] https://github.com/Nemocas/Nemo.jl/pull/1619
- [x] https://github.com/Nemocas/Nemo.jl/pull/1620
- [x] https://github.com/Nemocas/Nemo.jl/pull/1628
- [x] https://github.com/Nemocas/Nemo.jl/pull/1618
- [x] https://github.com/Nemocas/Nemo.jl/pull/1622 (review missing)
- [x] https://github.com/Nemocas/Nemo.jl/pull/1621 (review missing)
- [ ] https://github.com/Nemocas/Nemo.jl/pull/1624 (review missing)
- [x] https://github.com/Nemocas/Nemo.jl/issues/1623 / https://github.com/Nemocas/Nemo.jl/pull/1625
- [x] https://github.com/Nemocas/Nemo.jl/pull/1626
- [ ] https://github.com/Nemocas/Nemo.jl/pull/1635 (waiting for https://github.com/Nemocas/AbstractAlgebra.jl/pull/1562)
- [x] Adapt `residue_ring` and `residue_field` dispatches introduced in Nemo to return two things (@thofma) https://github.com/Nemocas/Nemo.jl/pull/1636