### PR TITLE
Change default return type of `order(::Group)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.40.0"
+version = "0.40.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -16,7 +16,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.36.1"
+AbstractAlgebra = "0.36.5"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -619,6 +619,16 @@ const QQBar = CalciumQQBar
 
 ###############################################################################
 #
+#   Some explicit type piracy against AbstractAlgebra
+#
+###############################################################################
+
+AbstractAlgebra._order(G::AbstractAlgebra.Group) = order(ZZRingElem, G)
+AbstractAlgebra._order(g::AbstractAlgebra.GroupElem) = order(ZZRingElem, g)
+
+
+###############################################################################
+#
 #   Test code
 #
 ###############################################################################


### PR DESCRIPTION
As pointed out by @fingolfin in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1528#discussion_r1425147632.

This requires https://github.com/Nemocas/AbstractAlgebra.jl/pull/1572 to be available.