### PR TITLE
Get the generic linear solving back in

### DIFF
--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -597,6 +597,25 @@ function solve_lu_precomp(P::Generic.Perm, LU::ComplexMat, y::ComplexMat)
   return z
 end
 
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ComplexMat, b::ComplexMat, task::Symbol; side::Symbol = :right)
+   nrows(A) != ncols(A) && error("Only implemented for square matrices")
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:acb_mat_solve, libarb), Cint,
+              (Ref{ComplexMat}, Ref{ComplexMat}, Ref{ComplexMat}, Int),
+              x, A, b, precision(Balls))
+   fl == 0 && error("Matrix cannot be inverted numerically")
+   if task === :only_check || task === :with_solution
+      return true, x, zero(A, 0, 0)
+   end
+   # If we ended up here, then A is invertible, so the kernel is trivial
+   return true, x, zero(A, ncols(A), 0)
+end
+
 ################################################################################
 #
 #   Row swapping

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -539,6 +539,25 @@ function solve_lu_precomp(P::Generic.Perm, LU::RealMat, y::RealMat)
   return z
 end
 
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::RealMat, b::RealMat, task::Symbol; side::Symbol = :right)
+   nrows(A) != ncols(A) && error("Only implemented for square matrices")
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:arb_mat_solve, libarb), Cint,
+              (Ref{RealMat}, Ref{RealMat}, Ref{RealMat}, Int),
+              x, A, b, precision(Balls))
+   fl == 0 && error("Matrix cannot be inverted numerically")
+   if task === :only_check || task === :with_solution
+      return true, x, zero(A, 0, 0)
+   end
+   # If we ended up here, then A is invertible, so the kernel is trivial
+   return true, x, zero(A, ncols(A), 0)
+end
+
 ################################################################################
 #
 #   Row swapping

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -560,6 +560,92 @@ end
 
 ################################################################################
 #
+#   Linear solving via context object
+#
+################################################################################
+
+function AbstractAlgebra.Solve.solve_init(A::RealMat)
+   return AbstractAlgebra.Solve.SolveCtx{RealFieldElem, RealMat, RealMat}(A)
+end
+
+function AbstractAlgebra.Solve._init_reduce(C::AbstractAlgebra.Solve.SolveCtx{RealFieldElem})
+   if isdefined(C, :red) && isdefined(C, :lu_perm)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = matrix(C)
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:arb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{RealMat}, Ref{RealMat}, Int),
+               P.d, x, A, precision(Balls))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red = x
+   C.lu_perm = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.SolveCtx{RealFieldElem})
+   if isdefined(C, :red_transp) && isdefined(C, :lu_perm_transp)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = transpose(matrix(C))
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:arb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{RealMat}, Ref{RealMat}, Int),
+               P.d, x, A, precision(Balls))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red_transp = x
+   C.lu_perm_transp = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{RealFieldElem}, b::RealMat, task::Symbol; side::Symbol = :right)
+   if side === :right
+      LU = AbstractAlgebra.Solve.reduced_matrix(C)
+      p = AbstractAlgebra.Solve.lu_permutation(C)
+   else
+      LU = AbstractAlgebra.Solve.reduced_matrix_of_transpose(C)
+      p = AbstractAlgebra.Solve.lu_permutation_of_transpose(C)
+      b = transpose(b)
+   end
+
+   x = similar(b, ncols(C), ncols(b))
+   ccall((:arb_mat_solve_lu_precomp, libarb), Nothing,
+         (Ref{RealMat}, Ptr{Int}, Ref{RealMat}, Ref{RealMat}, Int),
+         x, inv(p).d .- 1, LU, b, precision(Balls))
+
+   if side === :left
+     x = transpose(x)
+   end
+
+   if task === :only_check || task === :with_solution
+      return true, x, zero(b, 0, 0)
+   end
+   # If we ended up here, then the matrix is invertible, so the kernel is trivial
+   if side === :right
+      return true, x, zero(b, ncols(C), 0)
+   else
+      return true, x, zero(b, 0, nrows(C))
+   end
+end
+
+################################################################################
+#
 #   Row swapping
 #
 ################################################################################

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -621,6 +621,92 @@ end
 
 ################################################################################
 #
+#   Linear solving via context object
+#
+################################################################################
+
+function AbstractAlgebra.Solve.solve_init(A::acb_mat)
+   return AbstractAlgebra.Solve.SolveCtx{acb, acb_mat, acb_mat}(A)
+end
+
+function AbstractAlgebra.Solve._init_reduce(C::AbstractAlgebra.Solve.SolveCtx{acb})
+   if isdefined(C, :red) && isdefined(C, :lu_perm)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = matrix(C)
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:acb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{acb_mat}, Ref{acb_mat}, Int),
+               P.d, x, A, precision(base_ring(A)))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red = x
+   C.lu_perm = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.SolveCtx{acb})
+   if isdefined(C, :red_transp) && isdefined(C, :lu_perm_transp)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = transpose(matrix(C))
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:acb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{acb_mat}, Ref{acb_mat}, Int),
+               P.d, x, A, precision(base_ring(A)))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red_transp = x
+   C.lu_perm_transp = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{acb}, b::acb_mat, task::Symbol; side::Symbol = :right)
+   if side === :right
+      LU = AbstractAlgebra.Solve.reduced_matrix(C)
+      p = AbstractAlgebra.Solve.lu_permutation(C)
+   else
+      LU = AbstractAlgebra.Solve.reduced_matrix_of_transpose(C)
+      p = AbstractAlgebra.Solve.lu_permutation_of_transpose(C)
+      b = transpose(b)
+   end
+
+   x = similar(b, ncols(C), ncols(b))
+   ccall((:acb_mat_solve_lu_precomp, libarb), Nothing,
+         (Ref{acb_mat}, Ptr{Int}, Ref{acb_mat}, Ref{acb_mat}, Int),
+         x, inv(p).d .- 1, LU, b, precision(base_ring(LU)))
+
+   if side === :left
+     x = transpose(x)
+   end
+
+   if task === :only_check || task === :with_solution
+      return true, x, zero(b, 0, 0)
+   end
+   # If we ended up here, then the matrix is invertible, so the kernel is trivial
+   if side === :right
+      return true, x, zero(b, ncols(C), 0)
+   else
+      return true, x, zero(b, 0, nrows(C))
+   end
+end
+
+################################################################################
+#
 #   Row swapping
 #
 ################################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -587,6 +587,92 @@ end
 
 ################################################################################
 #
+#   Linear solving via context object
+#
+################################################################################
+
+function AbstractAlgebra.Solve.solve_init(A::arb_mat)
+   return AbstractAlgebra.Solve.SolveCtx{arb, arb_mat, arb_mat}(A)
+end
+
+function AbstractAlgebra.Solve._init_reduce(C::AbstractAlgebra.Solve.SolveCtx{arb})
+   if isdefined(C, :red) && isdefined(C, :lu_perm)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = matrix(C)
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:arb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{arb_mat}, Ref{arb_mat}, Int),
+               P.d, x, A, precision(base_ring(A)))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red = x
+   C.lu_perm = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.SolveCtx{arb})
+   if isdefined(C, :red_transp) && isdefined(C, :lu_perm_transp)
+      return nothing
+   end
+
+   nrows(C) != ncols(C) && error("Only implemented for square matrices")
+
+   A = transpose(matrix(C))
+   P = Generic.Perm(nrows(C))
+   x = similar(A, nrows(A), ncols(A))
+   P.d .-= 1
+   fl = ccall((:arb_mat_lu, libarb), Cint,
+               (Ptr{Int}, Ref{arb_mat}, Ref{arb_mat}, Int),
+               P.d, x, A, precision(base_ring(A)))
+   fl == 0 && error("Could not find $(nrows(x)) invertible pivot elements")
+   P.d .+= 1
+   inv!(P)
+
+   C.red_transp = x
+   C.lu_perm_transp = P
+   return nothing
+end
+
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{arb}, b::arb_mat, task::Symbol; side::Symbol = :right)
+   if side === :right
+      LU = AbstractAlgebra.Solve.reduced_matrix(C)
+      p = AbstractAlgebra.Solve.lu_permutation(C)
+   else
+      LU = AbstractAlgebra.Solve.reduced_matrix_of_transpose(C)
+      p = AbstractAlgebra.Solve.lu_permutation_of_transpose(C)
+      b = transpose(b)
+   end
+
+   x = similar(b, ncols(C), ncols(b))
+   ccall((:arb_mat_solve_lu_precomp, libarb), Nothing,
+         (Ref{arb_mat}, Ptr{Int}, Ref{arb_mat}, Ref{arb_mat}, Int),
+         x, inv(p).d .- 1, LU, b, precision(base_ring(LU)))
+
+   if side === :left
+     x = transpose(x)
+   end
+
+   if task === :only_check || task === :with_solution
+      return true, x, zero(b, 0, 0)
+   end
+   # If we ended up here, then the matrix is invertible, so the kernel is trivial
+   if side === :right
+      return true, x, zero(b, ncols(C), 0)
+   else
+      return true, x, zero(b, 0, nrows(C))
+   end
+end
+
+################################################################################
+#
 #   Row swapping
 #
 ################################################################################

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -704,6 +704,32 @@ function can_solve(a::QQMatrix, b::QQMatrix; side::Symbol = :right)
    return fl
 end
 
+function AbstractAlgebra.Solve._can_solve_internal(A::QQMatrix, b::QQMatrix, task::Symbol; side = Symbol = :right)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:fmpq_mat_can_solve_multi_mod, libflint), Cint,
+              (Ref{QQMatrix}, Ref{QQMatrix}, Ref{QQMatrix}), x, A, b)
+
+   if task === :only_check || task === :with_solution
+      return Bool(fl), x, zero(A, 0, 0)
+   end
+   return Bool(fl), x, kernel(A)[2]
+end
+
 ###############################################################################
 #
 #   Trace

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -704,21 +704,11 @@ function can_solve(a::QQMatrix, b::QQMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::QQMatrix, b::QQMatrix, task::Symbol; side = Symbol = :right)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::QQMatrix, b::QQMatrix, task::Symbol; side::Symbol = :right)
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:fmpq_mat_can_solve_multi_mod, libflint), Cint,

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1293,6 +1293,28 @@ function cansolve(a::ZZMatrix, b::ZZMatrix)
    return true, transpose(z*T)
 end
 
+function AbstractAlgebra.Solve._can_solve_internal(A::ZZMatrix, b::ZZMatrix, task::Symbol; side::Symbol = :right)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+   fl, sol = Nemo.cansolve(A, b)
+   if task === :only_check || task === :with_solution
+     return fl, sol, zero(A, 0, 0)
+   end
+   return fl, sol, AbstractAlgebra.Solve.kernel(A)
+ end
+
 Base.reduce(::typeof(hcat), A::AbstractVector{ZZMatrix}) = AbstractAlgebra._hcat(A)
 
 Base.reduce(::typeof(vcat), A::AbstractVector{ZZMatrix}) = AbstractAlgebra._vcat(A)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1293,21 +1293,12 @@ function cansolve(a::ZZMatrix, b::ZZMatrix)
    return true, transpose(z*T)
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::ZZMatrix, b::ZZMatrix, task::Symbol; side::Symbol = :right)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZMatrix, b::ZZMatrix, task::Symbol; side::Symbol = :right)
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
 
-   nrows(A) != nrows(b) && error("Incompatible matrices")
    fl, sol = Nemo.cansolve(A, b)
    if task === :only_check || task === :with_solution
      return fl, sol, zero(A, 0, 0)

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -500,6 +500,32 @@ end
 
 =#
 
+function AbstractAlgebra.Solve._can_solve_internal(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :right)
+   check_parent(A, b)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:fmpz_mod_mat_can_solve, libflint), Cint,
+              (Ref{ZZModMatrix}, Ref{ZZModMatrix}, Ref{ZZModMatrix}), x, A, b)
+   if task === :only_check || task === :with_solution
+     return Bool(fl), x, zero(A, 0, 0)
+   end
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+end
+
 ################################################################################
 #
 #  LU decomposition

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -500,22 +500,12 @@ end
 
 =#
 
-function AbstractAlgebra.Solve._can_solve_internal(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :right)
    check_parent(A, b)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:fmpz_mod_mat_can_solve, libflint), Cint,

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -450,22 +450,12 @@ function can_solve(a::FqMatrix, b::FqMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :right)
    check_parent(A, b)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:fq_default_mat_can_solve, libflint), Cint,

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -450,6 +450,33 @@ function can_solve(a::FqMatrix, b::FqMatrix; side::Symbol = :right)
    return fl
 end
 
+function AbstractAlgebra.Solve._can_solve_internal(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :right)
+   check_parent(A, b)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:fq_default_mat_can_solve, libflint), Cint,
+             (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix},
+              Ref{FqField}), x, A, b, base_ring(A))
+   if task === :only_check || task === :with_solution
+      return Bool(fl), x, zero(A, 0, 0)
+   end
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+end
+
 ################################################################################
 #
 #  LU decomposition

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -457,6 +457,33 @@ function can_solve(a::FqPolyRepMatrix, b::FqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
+function AbstractAlgebra.Solve._can_solve_internal(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+   check_parent(A, b)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:fq_mat_can_solve, libflint), Cint,
+             (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix},
+              Ref{FqPolyRepField}), x, A, b, base_ring(A))
+   if task === :only_check || task === :with_solution
+      return Bool(fl), x, zero(A, 0, 0)
+   end
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+end
+
 ################################################################################
 #
 #  LU decomposition

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -457,22 +457,12 @@ function can_solve(a::FqPolyRepMatrix, b::FqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :right)
    check_parent(A, b)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:fq_mat_can_solve, libflint), Cint,

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -445,6 +445,33 @@ function can_solve(a::fqPolyRepMatrix, b::fqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
+function AbstractAlgebra.Solve._can_solve_internal(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+   check_parent(A, b)
+   if task !== :only_check && task !== :with_solution && task !== :with_kernel
+      error("task $(task) not recognized")
+   end
+
+   if side !== :right && side !== :left
+      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
+   end
+
+   if side === :left
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      return fl, transpose(sol), transpose(K)
+   end
+
+   nrows(A) != nrows(b) && error("Incompatible matrices")
+
+   x = similar(A, ncols(A), ncols(b))
+   fl = ccall((:fq_nmod_mat_can_solve, libflint), Cint,
+             (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix},
+              Ref{fqPolyRepField}), x, A, b, base_ring(A))
+   if task === :only_check || task === :with_solution
+      return Bool(fl), x, zero(A, 0, 0)
+   end
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+end
+
 ################################################################################
 #
 #  LU decomposition

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -445,22 +445,12 @@ function can_solve(a::fqPolyRepMatrix, b::fqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :right)
    check_parent(A, b)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:fq_nmod_mat_can_solve, libflint), Cint,

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -312,22 +312,12 @@ function can_solve(a::fpMatrix, b::fpMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal(A::fpMatrix, b::fpMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMatrix, task::Symbol; side::Symbol = :right)
    check_parent(A, b)
-   if task !== :only_check && task !== :with_solution && task !== :with_kernel
-      error("task $(task) not recognized")
-   end
-
-   if side !== :right && side !== :left
-      throw(ArgumentError("Unsupported argument :$side for side: Must be :left or :right."))
-   end
-
    if side === :left
-      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal(transpose(A), transpose(b), task, side = :right)
+      fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
    end
-
-   nrows(A) != nrows(b) && error("Incompatible matrices")
 
    x = similar(A, ncols(A), ncols(b))
    fl = ccall((:nmod_mat_can_solve, libflint), Cint,

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -455,6 +455,7 @@ end
           "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
 
    b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+   b2 = 2*b
 
    fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
    @test fl
@@ -471,6 +472,39 @@ end
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
+
+   C = AbstractAlgebra.Solve.solve_init(A)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b2))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
 end
 
 @testset "ComplexMat.bound_inf_norm" begin

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -447,6 +447,32 @@ end
    @test contains(transpose(y), ZZ[1 1 1])
 end
 
+@testset "ComplexMat.Solve.solve" begin
+   S = matrix_space(CC, 3, 3)
+
+   A = S(["1.0 +/- 0.01" "2.0 +/- 0.01" "3.0 +/- 0.01";
+          "4.0 +/- 0.01" "5.0 +/- 0.01" "6.0 +/- 0.01";
+          "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
+
+   b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+end
+
 @testset "ComplexMat.bound_inf_norm" begin
    S = matrix_space(CC, 3, 3)
 

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -413,6 +413,32 @@ end
    @test contains(transpose(y), ZZ[1 1 1])
 end
 
+@testset "RealMat.Solve.solve" begin
+   S = matrix_space(RR, 3, 3)
+
+   A = S(["1.0 +/- 0.01" "2.0 +/- 0.01" "3.0 +/- 0.01";
+          "4.0 +/- 0.01" "5.0 +/- 0.01" "6.0 +/- 0.01";
+          "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
+
+   b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+end
+
 @testset "RealMat.bound_inf_norm" begin
    S = matrix_space(RR, 3, 3)
 

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -421,6 +421,7 @@ end
           "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
 
    b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+   b2 = 2*b
 
    fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
    @test fl
@@ -437,6 +438,39 @@ end
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
+
+   C = AbstractAlgebra.Solve.solve_init(A)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b2))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
 end
 
 @testset "RealMat.bound_inf_norm" begin

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -455,6 +455,7 @@ end
           "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
 
    b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+   b2 = 2*b
 
    fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
    @test fl
@@ -471,6 +472,39 @@ end
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
+
+   C = AbstractAlgebra.Solve.solve_init(A)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b2))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
 end
 
 @testset "AcbMatrix.bound_inf_norm" begin

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -447,6 +447,32 @@ end
    @test contains(transpose(y), ZZ[1 1 1])
 end
 
+@testset "AcbMatrix.Solve.solve" begin
+   S = matrix_space(CC, 3, 3)
+
+   A = S(["1.0 +/- 0.01" "2.0 +/- 0.01" "3.0 +/- 0.01";
+          "4.0 +/- 0.01" "5.0 +/- 0.01" "6.0 +/- 0.01";
+          "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
+
+   b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+end
+
 @testset "AcbMatrix.bound_inf_norm" begin
    S = matrix_space(CC, 3, 3)
 

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -441,6 +441,7 @@ end
           "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
 
    b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+   b2 = 2*b
 
    fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
    @test fl
@@ -457,6 +458,39 @@ end
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
+
+   C = AbstractAlgebra.Solve.solve_init(A)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b2))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(C, b2)
+   @test fl
+   @test overlaps(A*y, b2)
+   @test contains(transpose(y), ZZ[2 2 2])
 end
 
 @testset "ArbMatrix.bound_inf_norm" begin

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -433,6 +433,32 @@ end
    @test contains(transpose(y), ZZ[1 1 1])
 end
 
+@testset "ArbMatrix.Solve.solve" begin
+   S = matrix_space(RR, 3, 3)
+
+   A = S(["1.0 +/- 0.01" "2.0 +/- 0.01" "3.0 +/- 0.01";
+          "4.0 +/- 0.01" "5.0 +/- 0.01" "6.0 +/- 0.01";
+          "8.0 +/- 0.01" "8.0 +/- 0.01" "9.0 +/- 0.01"])
+
+   b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+   @test ncols(K) == 0
+
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   @test fl
+   @test overlaps(y*A, transpose(b))
+   @test nrows(K) == 0
+
+   y = AbstractAlgebra.Solve.solve(A, b)
+   @test fl
+   @test overlaps(A*y, b)
+   @test contains(transpose(y), ZZ[1 1 1])
+end
+
 @testset "ArbMatrix.bound_inf_norm" begin
    S = matrix_space(RR, 3, 3)
 

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -625,6 +625,128 @@ end
    @test_throws ErrorException can_solve(A, B, side = :garbage)
 end
 
+@testset "QQMatrix.Solve.solve" begin
+   S = matrix_space(QQ, 3, 3)
+
+   A = S([QQFieldElem(2) 3 5; 1 4 7; 9 2 2])
+
+   T = matrix_space(QQ, 3, 1)
+
+   B = T([QQFieldElem(4), 5, 7])
+
+   X = AbstractAlgebra.Solve.solve(A, B)
+
+   @test X == T([3, -24, 14])
+
+   @test A*X == B
+
+   m1 = [1 1; 1 0; 1 0]
+   m2 = [ 1 0 ; 0 1; 0 1 ]
+   m1Q = matrix(QQ, m1)
+   m2Q = matrix(QQ, m2);
+
+   N = AbstractAlgebra.Solve.solve(m1Q, m2Q)
+
+   @test N == matrix(QQ, 2, 2, [0 1; 1 -1])
+
+   for i in 1:10
+      m = rand(0:10)
+      n = rand(0:10)
+      k = rand(0:10)
+
+      M = matrix_space(QQ, n, k)
+      N = matrix_space(QQ, n, m)
+
+      A = rand(M, -10:10)
+      B = rand(N, -10:10)
+
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+      if fl
+         @test A * X == B
+      end
+
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+
+      if fl
+        @test A*X == B
+        @test is_zero(A*K)
+        @test ncols(K) + rank(A) == ncols(A)
+      end
+   end
+
+   A = matrix(QQ, 2, 2, [1, 2, 2, 5])
+   B = matrix(QQ, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test fl
+   @test A*X == B
+   @test is_zero(A*K)
+   @test ncols(K) + rank(A) == ncols(A)
+
+   A = matrix(QQ, 2, 2, [1, 2, 2, 4])
+   B = matrix(QQ, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test fl
+   @test A*X == B
+   @test is_zero(A*K)
+   @test ncols(K) + rank(A) == ncols(A)
+
+   A = matrix(QQ, 2, 2, [1, 2, 2, 4])
+   B = matrix(QQ, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test !fl
+
+   A = zero_matrix(QQ, 2, 3)
+   B = identity_matrix(QQ, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+   # Transpose
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(QQ, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(QQ, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test fl
+   @test X*A == B
+   @test is_zero(K*A)
+   @test nrows(K) + rank(A) == nrows(A)
+
+   A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(QQ, 2, 1, [1, 3]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test !fl
+
+   A = transpose(zero_matrix(QQ, 2, 3))
+   B = transpose(identity_matrix(QQ, 3))
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+end
+
 @testset "QQMatrix.concat" begin
    S = matrix_space(QQ, 3, 3)
    T = matrix_space(QQ, 3, 6)

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -683,6 +683,53 @@ end
    @test c == matrix(ZZ, 2, 1, [1, 1])
 end
 
+@testset "ZZMatrix.Solve.solve" begin
+   S = matrix_space(FlintZZ, 3, 3)
+
+   A = S([ZZRingElem(2) 3 5; 1 4 7; 9 2 2])
+
+   T = matrix_space(FlintZZ, 3, 1)
+
+   B = T([ZZRingElem(4), 5, 7])
+
+   X = AbstractAlgebra.Solve.solve(A, B)
+
+   @test X == T([3, -24, 14])
+   @test A*X == B
+
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl && A * X == B
+
+   A = matrix(ZZ, 2, 2, [1, 0, 0, 0])
+   B = matrix(ZZ, 2, 2, [0, 0, 0, 1])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test !fl
+
+   A = matrix(ZZ, 2, 2, [1, 0, 0, 0])
+   B = matrix(ZZ, 2, 2, [0, 1, 0, 0])
+   fl, X, Z = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test fl && A*X == B && iszero(A * Z)
+
+   # Non-square example
+   A = matrix(ZZ, [1 2 3; 4 5 6])
+   B = matrix(ZZ, 2, 1, [1, 1])
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test fl
+   @test A*x == B
+   @test is_zero(A*K)
+   @test ncols(K) + rank(A) == ncols(A)
+
+   B = matrix(ZZ, 1, 3, [1, 2, 3])
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test fl
+   @test x*A == B
+   @test is_zero(K*A)
+   @test nrows(K) + rank(A) == nrows(A)
+end
 
 @testset "ZZMatrix.concat" begin
    S = matrix_space(FlintZZ, 3, 3)

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -588,15 +588,15 @@ end
 =#
 
 @testset "ZZModMatrix.Solve.solve" begin
-  Z17 = residue_ring(ZZ, ZZ(17))
+  Z17, = residue_ring(ZZ, ZZ(17))
   a = matrix(Z17, [1 2 3; 3 2 1; 0 0 2])
   b = matrix(Z17, [2 1 0 1; 0 0 0 0; 0 1 2 0])
   c = a*b
   d = AbstractAlgebra.Solve.solve(a, c)
   @test d == b
 
-  a = zero(R)
-  @test_throws ArgumentError solve(a, c)
+  a = zero(a, 3, 3)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
 
   A = matrix(Z17, [1 2 3; 4 5 6])
   B = matrix(Z17, 2, 1, [1, 1])

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -587,6 +587,33 @@ end
 
 =#
 
+@testset "ZZModMatrix.Solve.solve" begin
+  Z17 = residue_ring(ZZ, ZZ(17))
+  a = matrix(Z17, [1 2 3; 3 2 1; 0 0 2])
+  b = matrix(Z17, [2 1 0 1; 0 0 0 0; 0 1 2 0])
+  c = a*b
+  d = AbstractAlgebra.Solve.solve(a, c)
+  @test d == b
+
+  a = zero(R)
+  @test_throws ArgumentError solve(a, c)
+
+  A = matrix(Z17, [1 2 3; 4 5 6])
+  B = matrix(Z17, 2, 1, [1, 1])
+  fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+  @test fl
+  @test A*x == B
+  @test is_zero(A*K)
+  @test ncols(K) + rank(A) == ncols(A)
+
+  B = matrix(Z17, 1, 3, [1, 2, 3])
+  fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+  @test fl
+  @test x*A == B
+  @test is_zero(K*A)
+  @test nrows(K) + rank(A) == nrows(A)
+end
+
 #= Not implemented in Flint yet
 
 @testset "ZZModMatrix.lu" begin

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -642,6 +642,95 @@ end
    @test_throws ErrorException can_solve(A, B, side = :garbage)
 end
 
+@testset "FqMatrix.Solve.solve" begin
+  F17, _ = finite_field(ZZRingElem(17), 1, "a")
+  R = matrix_space(F17, 3, 3)
+  S = matrix_space(F17, 3, 4)
+
+  a = R([ 1 2 3 ; 3 2 1 ; 0 0 2 ])
+
+  b = S([ 2 1 0 1; 0 0 0 0; 0 1 2 0 ])
+
+  c = a*b
+
+  d = AbstractAlgebra.Solve.solve(a, c)
+
+  @test d == b
+
+  a = zero(R)
+
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+
+   for i in 1:10
+      m = rand(0:10)
+      n = rand(0:10)
+      k = rand(0:10)
+
+      M = matrix_space(F17, n, k)
+      N = matrix_space(F17, n, m)
+
+      A = rand(M)
+      B = rand(N)
+
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+      if fl
+         @test A * X == B
+      end
+   end
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 5])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   @test !can_solve(A, B)
+
+   A = zero_matrix(F17, 2, 3)
+   B = identity_matrix(F17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+end
+
 @testset "FqMatrix.lu" begin
 
   F17, _ = finite_field(ZZRingElem(17), 1, "a")

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -672,10 +672,12 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
 
       if fl
          @test A * X == B
+         @test is_zero(A*K)
+         @test rank(A) + ncols(K) == ncols(A)
       end
    end
 

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -630,6 +630,95 @@ end
    @test_throws ErrorException can_solve(A, B, side = :garbage)
 end
 
+@testset "FqPolyRepMatrix.Solve.solve" begin
+  F17, _ = Native.finite_field(ZZRingElem(17), 1, "a")
+  R = matrix_space(F17, 3, 3)
+  S = matrix_space(F17, 3, 4)
+
+  a = R([ 1 2 3 ; 3 2 1 ; 0 0 2 ])
+
+  b = S([ 2 1 0 1; 0 0 0 0; 0 1 2 0 ])
+
+  c = a*b
+
+  d = AbstractAlgebra.Solve.solve(a, c)
+
+  @test d == b
+
+  a = zero(R)
+
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+
+   for i in 1:10
+      m = rand(0:10)
+      n = rand(0:10)
+      k = rand(0:10)
+
+      M = matrix_space(F17, n, k)
+      N = matrix_space(F17, n, m)
+
+      A = rand(M)
+      B = rand(N)
+
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+      if fl
+         @test A * X == B
+      end
+   end
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 5])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = zero_matrix(F17, 2, 3)
+   B = identity_matrix(F17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+end
+
 @testset "FqPolyRepMatrix.lu" begin
 
   F17, _ = Native.finite_field(ZZRingElem(17), 1, "a")

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -660,10 +660,12 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
 
       if fl
          @test A * X == B
+         @test is_zero(A*K)
+         @test rank(A) + ncols(K) == ncols(A)
       end
    end
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -660,10 +660,12 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
 
       if fl
          @test A * X == B
+         @test is_zero(A*K)
+         @test rank(A) + ncols(K) == ncols(A)
       end
    end
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -630,6 +630,95 @@ end
    @test_throws ErrorException can_solve(A, B, side = :garbage)
 end
 
+@testset "fqPolyRepMatrix.Solve.solve" begin
+  F17, _ = Native.finite_field(17, 1, "a")
+  R = matrix_space(F17, 3, 3)
+  S = matrix_space(F17, 3, 4)
+
+  a = R([ 1 2 3 ; 3 2 1 ; 0 0 2 ])
+
+  b = S([ 2 1 0 1; 0 0 0 0; 0 1 2 0 ])
+
+  c = a*b
+
+  d = AbstractAlgebra.Solve.solve(a, c)
+
+  @test d == b
+
+  a = zero(R)
+
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+
+   for i in 1:10
+      m = rand(0:10)
+      n = rand(0:10)
+      k = rand(0:10)
+
+      M = matrix_space(F17, n, k)
+      N = matrix_space(F17, n, m)
+
+      A = rand(M)
+      B = rand(N)
+
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+      if fl
+         @test A * X == B
+      end
+   end
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 5])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(F17, 2, 2, [1, 2, 2, 4])
+   B = matrix(F17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = zero_matrix(F17, 2, 3)
+   B = identity_matrix(F17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(zero_matrix(F17, 2, 3))
+   B = transpose(identity_matrix(F17, 3))
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+end
+
 @testset "fqPolyRepMatrix.lu" begin
 
   F17, _ = Native.finite_field(17, 1, "a")

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -711,10 +711,12 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
 
       if fl
          @test A * X == B
+         @test is_zero(A*K)
+         @test rank(A) + ncols(K) == ncols(A)
       end
    end
 

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -681,6 +681,95 @@ end
    @test_throws ErrorException can_solve(A, B, side = :garbage)
 end
 
+@testset "fpMatrix.Solve.solve" begin
+  Z17 = Native.GF(17)
+  R = matrix_space(Z17, 3, 3)
+  S = matrix_space(Z17, 3, 4)
+
+  a = R([ 1 2 3 ; 3 2 1 ; 0 0 2 ])
+
+  b = S([ 2 1 0 1; 0 0 0 0; 0 1 2 0 ])
+
+  c = a*b
+
+  d = AbstractAlgebra.Solve.solve(a, c)
+
+  @test d == b
+
+  a = zero(R)
+
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+
+  for i in 1:10
+      m = rand(0:10)
+      n = rand(0:10)
+      k = rand(0:10)
+
+      M = matrix_space(Z17, n, k)
+      N = matrix_space(Z17, n, m)
+
+      A = rand(M)
+      B = rand(N)
+
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+      if fl
+         @test A * X == B
+      end
+   end
+
+   A = matrix(Z17, 2, 2, [1, 2, 2, 5])
+   B = matrix(Z17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(Z17, 2, 2, [1, 2, 2, 4])
+   B = matrix(Z17, 2, 1, [1, 2])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test A * X == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = matrix(Z17, 2, 2, [1, 2, 2, 4])
+   B = matrix(Z17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = zero_matrix(Z17, 2, 3)
+   B = identity_matrix(Z17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 3]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+
+   A = transpose(zero_matrix(Z17, 2, 3))
+   B = transpose(identity_matrix(Z17, 3))
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
+   @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+end
+
 @testset "fpMatrix.lu" begin
 
   Z17 = Native.GF(17)


### PR DESCRIPTION
Implement the new linear solving interface for all the C matrix types.

Partially reverts #1655 which reverted #1633, so this is #1633 without the new `nullspace(::QQMatrix)`.
