### PR TITLE
`nullspace(::QQMatrix)` via flint

### DIFF
--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1007,3 +1007,22 @@ end
 @inline mat_entry_ptr(A::QQMatrix, i::Int, j::Int) = 
    ccall((:fmpq_mat_entry, libflint), 
       Ptr{QQFieldElem}, (Ref{QQMatrix}, Int, Int), A, i-1, j-1)
+
+################################################################################
+#
+#  Nullspace
+#
+################################################################################
+
+function nullspace(A::QQMatrix)
+   AZZ = zero_matrix(FlintZZ, nrows(A), ncols(A))
+   ccall((:fmpq_mat_get_fmpz_mat_rowwise, libflint), Nothing,
+         (Ref{ZZMatrix}, Ptr{Nothing}, Ref{QQMatrix}), AZZ, C_NULL, A)
+   N = similar(AZZ, ncols(A), ncols(A))
+   nullity = ccall((:fmpz_mat_nullspace, libflint), Cint,
+                   (Ref{ZZMatrix}, Ref{ZZMatrix}), N, AZZ)
+   NQQ = similar(A, ncols(A), ncols(A))
+   ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing,
+         (Ref{QQMatrix}, Ref{ZZMatrix}), NQQ, N)
+   return nullity, NQQ
+end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1024,5 +1024,27 @@ function nullspace(A::QQMatrix)
    NQQ = similar(A, ncols(A), ncols(A))
    ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing,
          (Ref{QQMatrix}, Ref{ZZMatrix}), NQQ, N)
-   return nullity, view(NQQ, 1:nrows(NQQ), 1:nullity)
+
+   NQQ = view(NQQ, 1:nrows(NQQ), 1:nullity)
+
+   # Produce a 1 in the lowest non-zero entry of any column
+   s = FlintQQ()
+   t = FlintQQ()
+   for j in 1:nullity
+      # Find lowest non-zero entry
+      for i in nrows(NQQ):-1:1
+         getindex!(s, NQQ, i, j)
+         !is_zero(s) && break
+      end
+      # Scale the column by the inverse
+      s = inv(s)
+      for i in nrows(NQQ):-1:1
+         is_zero_entry(NQQ, i, j) && continue
+         getindex!(t, NQQ, i, j)
+         mul!(t, t, s)
+         NQQ[i, j] = t # creates a copy of t
+      end
+   end
+
+   return nullity, NQQ
 end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1019,7 +1019,7 @@ function nullspace(A::QQMatrix)
    ccall((:fmpq_mat_get_fmpz_mat_rowwise, libflint), Nothing,
          (Ref{ZZMatrix}, Ptr{Nothing}, Ref{QQMatrix}), AZZ, C_NULL, A)
    N = similar(AZZ, ncols(A), ncols(A))
-   nullity = ccall((:fmpz_mat_nullspace, libflint), Cint,
+   nullity = ccall((:fmpz_mat_nullspace, libflint), Int,
                    (Ref{ZZMatrix}, Ref{ZZMatrix}), N, AZZ)
    NQQ = similar(A, ncols(A), ncols(A))
    ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing,

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1024,5 +1024,5 @@ function nullspace(A::QQMatrix)
    NQQ = similar(A, ncols(A), ncols(A))
    ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing,
          (Ref{QQMatrix}, Ref{ZZMatrix}), NQQ, N)
-   return nullity, NQQ
+   return nullity, view(NQQ, 1:nrows(NQQ), 1:nullity)
 end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1025,6 +1025,12 @@ function nullspace(A::QQMatrix)
    ccall((:fmpq_mat_set_fmpz_mat, libflint), Nothing,
          (Ref{QQMatrix}, Ref{ZZMatrix}), NQQ, N)
 
+   # Now massage the result until it looks like what the generic AbstractAlgebra
+   # nullspace would return: remove zero columns and rescale the columns so that
+   # the lowest non-zero entry is 1.
+   # This is necessary because code in Hecke expects this structure, see e.g.
+   # https://github.com/thofma/Hecke.jl/issues/1385 .
+
    NQQ = view(NQQ, 1:nrows(NQQ), 1:nullity)
 
    # Produce a 1 in the lowest non-zero entry of any column

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1121,7 +1121,7 @@ $\mathbb{Q}$.
 function nullspace_right_rational(x::ZZMatrix)
    z = similar(x)
    u = similar(x, ncols(x), ncols(x))
-   rank = ccall((:fmpz_mat_nullspace, libflint), Cint,
+   rank = ccall((:fmpz_mat_nullspace, libflint), Int,
                 (Ref{ZZMatrix}, Ref{ZZMatrix}), u, x)
    return rank, u
 end

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -490,11 +490,15 @@ end
 
    A = S([QQFieldElem(2) 3 5; 1 4 7; 4 1 1])
 
-   @test nullspace(A) == (1, T([QQFieldElem(1, 5); QQFieldElem(-9, 5); QQFieldElem(1)]))
-
    r, N = nullspace(A)
-
    @test iszero(A*N)
+   @test r == 1
+
+   # A "properly" rational example (since the implementation works over ZZ)
+   A = QQ[ 1//2 1//3 1//5 ]
+   r, N = nullspace(A)
+   @test is_zero(A*N)
+   @test r == 2
 end
 
 @testset "QQMatrix.rank" begin

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -490,6 +490,8 @@ end
 
    A = S([QQFieldElem(2) 3 5; 1 4 7; 4 1 1])
 
+   @test nullspace(A) == (1, T([QQFieldElem(1, 5); QQFieldElem(-9, 5); QQFieldElem(1)]))
+
    r, N = nullspace(A)
    @test iszero(A*N)
    @test r == 1


### PR DESCRIPTION
Reintroduce `nullspace(::QQMatrix)` via flint from #1633 which was reverted in #1655 since it created problems in OSCAR.

This contains additional commits that massage the result until it looks like what the generic AbstractAlgebra `nullspace` would return. Let's see if it works.
