### PR TITLE
Add `parent(::QQPolyRingElem)`

### DIFF
--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -18,6 +18,8 @@ dense_poly_type(::Type{QQFieldElem}) = QQPolyRingElem
 
 base_ring(a::QQPolyRing) = FlintQQ
 
+parent(a::QQPolyRingElem) = a.parent
+
 var(a::QQPolyRing) = a.S
 
 ###############################################################################


### PR DESCRIPTION
All other Flint-backed PolyRings define it. Currently, a hacky fallback using attributes of the struct from AA provides this, so this would be cleaner.