### PR TITLE
Add `(::QQBarField)(::Rational)` conversion

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -73,6 +73,8 @@ function QQBarFieldElem(a::QQFieldElem)
    return z
 end
 
+QQBarFieldElem(a::Rational) = QQBarFieldElem(QQFieldElem(a))
+
 function deepcopy_internal(a::QQBarFieldElem, dict::IdDict)
    z = QQBarFieldElem()
    ccall((:qqbar_set, libcalcium), Nothing, (Ref{QQBarFieldElem}, Ref{QQBarFieldElem}), z, a)
@@ -1465,6 +1467,8 @@ end
 (a::QQBarField)(b::ZZRingElem) = QQBarFieldElem(b)
 
 (a::QQBarField)(b::Integer) = QQBarFieldElem(ZZRingElem(b))
+
+(a::QQBarField)(b::Rational) = QQBarFieldElem(b)
 
 (a::QQBarField)(b::QQFieldElem) = QQBarFieldElem(b)
 

--- a/test/calcium/qqbar-test.jl
+++ b/test/calcium/qqbar-test.jl
@@ -18,12 +18,16 @@
    @test isa(R(ZZRingElem(2)), QQBarFieldElem)
    @test isa(R(QQFieldElem(2)), QQBarFieldElem)
    @test isa(R(QQBarFieldElem(2)), QQBarFieldElem)
+   @test isa(R(1//2), QQBarFieldElem)
+   @test R(1//2) == R(QQ(1//2))
 
    @test isa(QQBarFieldElem(), QQBarFieldElem)
    @test isa(QQBarFieldElem(2), QQBarFieldElem)
    @test isa(QQBarFieldElem(2+3im), QQBarFieldElem)
    @test isa(QQBarFieldElem(ZZRingElem(2)), QQBarFieldElem)
    @test isa(QQBarFieldElem(QQFieldElem(2)), QQBarFieldElem)
+   @test isa(QQBarFieldElem(1//2), QQBarFieldElem)
+   @test QQBarFieldElem(1//2) == QQBarFieldElem(QQ(1//2))
 
    x = R(1)
    @test deepcopy(x) !== x


### PR DESCRIPTION
To make the following code work:
```julia
julia> QQBar = algebraic_closure(QQ)
Field of algebraic numbers

julia> sq3 = sqrt(QQBar(3))
Root 1.73205 of x^2 - 3

julia> A = QQBar[-1//2 -sq3//2 0 0; sq3//2 -1//2 0 0; 0 0 -1//2 -sq3//2; 0 0 sq3//2 -1//2]
[ Root -0.500000 of 2x + 1   Root -0.866025 of 4x^2 - 3                 Root 0 of x                  Root 0 of x]
[Root 0.866025 of 4x^2 - 3     Root -0.500000 of 2x + 1                 Root 0 of x                  Root 0 of x]
[              Root 0 of x                  Root 0 of x    Root -0.500000 of 2x + 1   Root -0.866025 of 4x^2 - 3]
[              Root 0 of x                  Root 0 of x   Root 0.866025 of 4x^2 - 3     Root -0.500000 of 2x + 1]
```