### PR TITLE
Add more special `Solve.*` methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.37.0"
+AbstractAlgebra = "0.37.6"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -770,7 +770,7 @@ function eigenvalues_with_multiplicities(L::Field, M::MatElem{T}) where T <: Rin
 end
 
 @doc raw"""
-    eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :right)
+    eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :left)
       where T <: FieldElem -> Vector{MatElem{T}}
 
 Return a basis of the eigenspace of $M$ with respect to the eigenvalue $\lambda$.
@@ -778,7 +778,7 @@ If side is `:right`, the right eigenspace is computed, i.e. vectors $v$ such tha
 $Mv = \lambda v$. If side is `:left`, the left eigenspace is computed, i.e. vectors
 $v$ such that $vM = \lambda v$.
 """
-function eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :right) where T <: FieldElem
+function eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :left) where T <: FieldElem
   @assert is_square(M)
   N = deepcopy(M)
   for i = 1:ncols(N)
@@ -788,7 +788,7 @@ function eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :right) where T <: 
 end
 
 @doc raw"""
-    eigenspaces(M::MatElem{T}; side::Symbol = :right)
+    eigenspaces(M::MatElem{T}; side::Symbol = :left)
       where T <: FieldElem -> Dict{T, MatElem{T}}
 
 Return a dictionary containing the eigenvalues of $M$ as keys and bases for the
@@ -798,7 +798,7 @@ left eigenspaces are computed.
 
 See also `eigenspace`.
 """
-function eigenspaces(M::MatElem{T}; side::Symbol = :right) where T<:FieldElem
+function eigenspaces(M::MatElem{T}; side::Symbol = :left) where T<:FieldElem
 
   S = eigenvalues(M)
   L = Dict{elem_type(base_ring(M)), typeof(M)}()

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -597,7 +597,7 @@ function solve_lu_precomp(P::Generic.Perm, LU::ComplexMat, y::ComplexMat)
   return z
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ComplexMat, b::ComplexMat, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ComplexMat, b::ComplexMat, task::Symbol; side::Symbol = :left)
    nrows(A) != ncols(A) && error("Only implemented for square matrices")
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -672,7 +672,7 @@ function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.S
    return nothing
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{ComplexFieldElem}, b::ComplexMat, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{ComplexFieldElem}, b::ComplexMat, task::Symbol; side::Symbol = :left)
    if side === :right
       LU = AbstractAlgebra.Solve.reduced_matrix(C)
       p = AbstractAlgebra.Solve.lu_permutation(C)

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -539,7 +539,7 @@ function solve_lu_precomp(P::Generic.Perm, LU::RealMat, y::RealMat)
   return z
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::RealMat, b::RealMat, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::RealMat, b::RealMat, task::Symbol; side::Symbol = :left)
    nrows(A) != ncols(A) && error("Only implemented for square matrices")
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -614,7 +614,7 @@ function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.S
    return nothing
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{RealFieldElem}, b::RealMat, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{RealFieldElem}, b::RealMat, task::Symbol; side::Symbol = :left)
    if side === :right
       LU = AbstractAlgebra.Solve.reduced_matrix(C)
       p = AbstractAlgebra.Solve.lu_permutation(C)

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -600,7 +600,7 @@ function solve_lu_precomp(P::Generic.Perm, LU::AcbMatrix, y::AcbMatrix)
   return z
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::AcbMatrix, b::AcbMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::AcbMatrix, b::AcbMatrix, task::Symbol; side::Symbol = :left)
    nrows(A) != ncols(A) && error("Only implemented for square matrices")
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -675,7 +675,7 @@ function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.S
    return nothing
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{AcbFieldElem}, b::AcbMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{AcbFieldElem}, b::AcbMatrix, task::Symbol; side::Symbol = :left)
    if side === :right
       LU = AbstractAlgebra.Solve.reduced_matrix(C)
       p = AbstractAlgebra.Solve.lu_permutation(C)

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -566,7 +566,7 @@ function solve_cholesky_precomp(cho::ArbMatrix, y::ArbMatrix)
   return z
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ArbMatrix, b::ArbMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ArbMatrix, b::ArbMatrix, task::Symbol; side::Symbol = :left)
    nrows(A) != ncols(A) && error("Only implemented for square matrices")
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -641,7 +641,7 @@ function AbstractAlgebra.Solve._init_reduce_transpose(C::AbstractAlgebra.Solve.S
    return nothing
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{ArbFieldElem}, b::ArbMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(C::AbstractAlgebra.Solve.SolveCtx{ArbFieldElem}, b::ArbMatrix, task::Symbol; side::Symbol = :left)
    if side === :right
       LU = AbstractAlgebra.Solve.reduced_matrix(C)
       p = AbstractAlgebra.Solve.lu_permutation(C)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -704,7 +704,7 @@ function can_solve(a::QQMatrix, b::QQMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::QQMatrix, b::QQMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::QQMatrix, b::QQMatrix, task::Symbol; side::Symbol = :left)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -1070,3 +1070,14 @@ function nullspace(A::QQMatrix)
 
    return nullity, NQQ
 end
+
+# For compatibility with the generic `kernel` method in AbstractAlgebra:
+# Otherwise the generic nullspace would be used for a "lazy transposed QQMatrix"
+# instead of flint.
+function nullspace(A::AbstractAlgebra.Solve.LazyTransposeMatElem{QQFieldElem, QQMatrix})
+   B = transpose(AbstractAlgebra.Solve.data(A))
+   n, N = nullspace(B)
+   # Looks worse than it is: we have to transpose here, the lazy_transpose is
+   # just for type stability
+   return n, AbstractAlgebra.Solve.lazy_transpose(transpose(N))
+end

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1110,6 +1110,27 @@ function nullspace(x::ZZMatrix)
   return ncols(x), identity_matrix(x, ncols(x))
 end
 
+function AbstractAlgebra.Solve.kernel(A::ZZMatrix; side::Symbol = :right)
+   AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
+
+   if side === :left
+      K = AbstractAlgebra.Solve.kernel(transpose(A), side = :right)
+      return transpose(K)
+   end
+
+   A = transpose(hnf(A))
+   H, U = hnf_with_transform(A)
+   r = nrows(H)
+   while r > 0 && is_zero_row(H, r)
+      r -= 1
+   end
+   if is_zero(r)
+      return transpose(U)
+   else
+      return transpose(view(U, r + 1:nrows(U), 1:ncols(U)))
+   end
+end
+
 @doc raw"""
     nullspace_right_rational(x::ZZMatrix)
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1110,7 +1110,7 @@ function nullspace(x::ZZMatrix)
   return ncols(x), identity_matrix(x, ncols(x))
 end
 
-function AbstractAlgebra.Solve.kernel(A::ZZMatrix; side::Symbol = :right)
+function AbstractAlgebra.Solve.kernel(A::ZZMatrix; side::Symbol = :left)
    AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
 
    if side === :left
@@ -1314,7 +1314,7 @@ function cansolve(a::ZZMatrix, b::ZZMatrix)
    return true, transpose(z*T)
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZMatrix, b::ZZMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZMatrix, b::ZZMatrix, task::Symbol; side::Symbol = :left)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
       return fl, transpose(sol), transpose(K)
@@ -1324,7 +1324,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZMatrix, b::ZZMa
    if task === :only_check || task === :with_solution
      return fl, sol, zero(A, 0, 0)
    end
-   return fl, sol, AbstractAlgebra.Solve.kernel(A)
+   return fl, sol, AbstractAlgebra.Solve.kernel(A, side = :right)
  end
 
 Base.reduce(::typeof(hcat), A::AbstractVector{ZZMatrix}) = AbstractAlgebra._hcat(A)

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -500,7 +500,7 @@ end
 
 =#
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :left)
    check_parent(A, b)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -513,7 +513,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::ZZModMatrix, b::Z
    if task === :only_check || task === :with_solution
      return Bool(fl), x, zero(A, 0, 0)
    end
-   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A, side = :right)
 end
 
 ################################################################################
@@ -922,7 +922,7 @@ end
 #
 ################################################################################
 
-function AbstractAlgebra.Solve.kernel(M::ZZModMatrix; side::Symbol = :right)
+function AbstractAlgebra.Solve.kernel(M::ZZModMatrix; side::Symbol = :left)
    AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
 
    if side === :left

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -450,7 +450,7 @@ function can_solve(a::FqMatrix, b::FqMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :left)
    check_parent(A, b)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -464,7 +464,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMa
    if task === :only_check || task === :with_solution
       return Bool(fl), x, zero(A, 0, 0)
    end
-   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A, side = :right)
 end
 
 ################################################################################

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -457,7 +457,7 @@ function can_solve(a::FqPolyRepMatrix, b::FqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :left)
    check_parent(A, b)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -471,7 +471,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, 
    if task === :only_check || task === :with_solution
       return Bool(fl), x, zero(A, 0, 0)
    end
-   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A, side = :right)
 end
 
 ################################################################################

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -445,7 +445,7 @@ function can_solve(a::fqPolyRepMatrix, b::fqPolyRepMatrix; side::Symbol = :right
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :left)
    check_parent(A, b)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -459,7 +459,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, 
    if task === :only_check || task === :with_solution
       return Bool(fl), x, zero(A, 0, 0)
    end
-   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A, side = :right)
 end
 
 ################################################################################

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -312,7 +312,7 @@ function can_solve(a::fpMatrix, b::fpMatrix; side::Symbol = :right)
    return fl
 end
 
-function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMatrix, task::Symbol; side::Symbol = :right)
+function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMatrix, task::Symbol; side::Symbol = :left)
    check_parent(A, b)
    if side === :left
       fl, sol, K = AbstractAlgebra.Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
@@ -326,7 +326,7 @@ function AbstractAlgebra.Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMa
    if task === :only_check || task === :with_solution
       return Bool(fl), x, zero(A, 0, 0)
    end
-   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A)
+   return Bool(fl), x, AbstractAlgebra.Solve.kernel(A, side = :right)
 end
 
 ################################################################################
@@ -515,7 +515,7 @@ end
 #
 ################################################################################
 
-function AbstractAlgebra.Solve.kernel(A::fpMatrix; side::Symbol = :right)
+function AbstractAlgebra.Solve.kernel(A::fpMatrix; side::Symbol = :left)
    AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
 
    if side === :left

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -508,3 +508,22 @@ function matrix_space(R::fpField, r::Int, c::Int; cached::Bool = true)
    # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
   fpMatrixSpace(R, r, c)
 end
+
+################################################################################
+#
+#  Kernel
+#
+################################################################################
+
+function AbstractAlgebra.Solve.kernel(A::fpMatrix; side::Symbol = :right)
+   AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
+
+   if side === :left
+      K = AbstractAlgebra.Solve.kernel(transpose(A), side = :right)
+      return transpose(K)
+   end
+
+   K = zero_matrix(base_ring(A), ncols(A), max(nrows(A), ncols(A)))
+   n = ccall((:nmod_mat_nullspace, libflint), Int, (Ref{fpMatrix}, Ref{fpMatrix}), K, A)
+   return view(K, 1:nrows(K), 1:n)
+end

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -925,7 +925,7 @@ end
 #
 ################################################################################
 
-function AbstractAlgebra.Solve.kernel(M::zzModMatrix; side::Symbol = :right)
+function AbstractAlgebra.Solve.kernel(M::zzModMatrix; side::Symbol = :left)
    AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
 
    if side === :left

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -919,3 +919,43 @@ function matrix_space(R::zzModRing, r::Int, c::Int; cached::Bool = true)
   zzModMatrixSpace(R, r, c)
 end
 
+################################################################################
+#
+#  Kernel
+#
+################################################################################
+
+function AbstractAlgebra.Solve.kernel(M::zzModMatrix; side::Symbol = :right)
+   AbstractAlgebra.Solve.check_option(side, [:right, :left], "side")
+
+   if side === :left
+      K = AbstractAlgebra.Solve.kernel(transpose(M), side = :right)
+      return transpose(K)
+   end
+
+   R = base_ring(M)
+   if is_prime(modulus(R))
+      k = zero_matrix(R, ncols(M), ncols(M))
+      n = ccall((:nmod_mat_nullspace, libflint), Int, (Ref{zzModMatrix}, Ref{zzModMatrix}), k, M)
+      return view(k, 1:nrows(k), 1:n)
+   end
+
+   H = hcat(transpose(M), identity_matrix(R, ncols(M)))
+   if nrows(H) < ncols(H)
+      H = vcat(H, zero_matrix(R, ncols(H) - nrows(H), ncols(H)))
+   end
+   howell_form!(H)
+   nr = 1
+   while nr <= nrows(H) && !is_zero_row(H, nr)
+      nr += 1
+   end
+   nr -= 1
+   h = view(H, 1:nr, 1:nrows(M))
+   for i = 1:nrows(h)
+      if is_zero_row(h, i)
+         k = view(H, i:nrows(h), nrows(M) + 1:ncols(H))
+         return transpose(k)
+      end
+   end
+   return zero_matrix(R, ncols(M), 0)
+end

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -457,51 +457,51 @@ end
    b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
    b2 = 2*b
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(A, b)
+   y = AbstractAlgebra.Solve.solve(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
    C = AbstractAlgebra.Solve.solve_init(A)
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b)
+   y = AbstractAlgebra.Solve.solve(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2))
    @test fl
    @test overlaps(y*A, transpose(b2))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b2)
+   y = AbstractAlgebra.Solve.solve(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -423,51 +423,51 @@ end
    b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
    b2 = 2*b
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(A, b)
+   y = AbstractAlgebra.Solve.solve(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
    C = AbstractAlgebra.Solve.solve_init(A)
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b)
+   y = AbstractAlgebra.Solve.solve(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2))
    @test fl
    @test overlaps(y*A, transpose(b2))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b2)
+   y = AbstractAlgebra.Solve.solve(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -457,51 +457,51 @@ end
    b = transpose(CC["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
    b2 = 2*b
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(A, b)
+   y = AbstractAlgebra.Solve.solve(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
    C = AbstractAlgebra.Solve.solve_init(A)
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b)
+   y = AbstractAlgebra.Solve.solve(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2))
    @test fl
    @test overlaps(y*A, transpose(b2))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b2)
+   y = AbstractAlgebra.Solve.solve(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -443,51 +443,51 @@ end
    b = transpose(RR["6.0 +/- 0.1" "15.0 +/- 0.1" "25.0 +/- 0.1"])
    b2 = 2*b
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(A, b)
+   y = AbstractAlgebra.Solve.solve(A, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
    C = AbstractAlgebra.Solve.solve_init(A)
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b))
    @test fl
    @test overlaps(y*A, transpose(b))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b)
+   y = AbstractAlgebra.Solve.solve(C, b, side = :right)
    @test fl
    @test overlaps(A*y, b)
    @test contains(transpose(y), ZZ[1 1 1])
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])
    @test ncols(K) == 0
 
-   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2), side = :left)
+   fl, y, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(C, transpose(b2))
    @test fl
    @test overlaps(y*A, transpose(b2))
    @test nrows(K) == 0
 
-   y = AbstractAlgebra.Solve.solve(C, b2)
+   y = AbstractAlgebra.Solve.solve(C, b2, side = :right)
    @test fl
    @test overlaps(A*y, b2)
    @test contains(transpose(y), ZZ[2 2 2])

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -751,6 +751,20 @@ end
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+
+   A = matrix(QQ, [ 1 2 3 ; 4 5 6 ])
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :right)
+   @test is_zero(A*K)
+   @test ncols(K) == 1
+
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 0
+
+   A = transpose(A)
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 1
 end
 
 @testset "QQMatrix.concat" begin

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -640,7 +640,7 @@ end
 
    B = T([QQFieldElem(4), 5, 7])
 
-   X = AbstractAlgebra.Solve.solve(A, B)
+   X = AbstractAlgebra.Solve.solve(A, B, side = :right)
 
    @test X == T([3, -24, 14])
 
@@ -651,7 +651,7 @@ end
    m1Q = matrix(QQ, m1)
    m2Q = matrix(QQ, m2);
 
-   N = AbstractAlgebra.Solve.solve(m1Q, m2Q)
+   N = AbstractAlgebra.Solve.solve(m1Q, m2Q, side = :right)
 
    @test N == matrix(QQ, 2, 2, [0 1; 1 -1])
 
@@ -666,13 +666,13 @@ end
       A = rand(M, -10:10)
       B = rand(N, -10:10)
 
-      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+      fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
 
       if fl
          @test A * X == B
       end
 
-      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
 
       if fl
         @test A*X == B
@@ -683,11 +683,11 @@ end
 
    A = matrix(QQ, 2, 2, [1, 2, 2, 5])
    B = matrix(QQ, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test fl
    @test A*X == B
    @test is_zero(A*K)
@@ -695,11 +695,11 @@ end
 
    A = matrix(QQ, 2, 2, [1, 2, 2, 4])
    B = matrix(QQ, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test fl
    @test A*X == B
    @test is_zero(A*K)
@@ -707,31 +707,31 @@ end
 
    A = matrix(QQ, 2, 2, [1, 2, 2, 4])
    B = matrix(QQ, 2, 1, [1, 3])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B)
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test !fl
 
    A = zero_matrix(QQ, 2, 3)
    B = identity_matrix(QQ, 3)
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
 
    # Transpose
    A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 5]))
    B = transpose(matrix(QQ, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test fl
    @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   @test AbstractAlgebra.Solve.can_solve(A, B)
 
    A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
    B = transpose(matrix(QQ, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test fl
    @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
    @test fl
    @test X*A == B
    @test is_zero(K*A)
@@ -739,15 +739,15 @@ end
 
    A = transpose(matrix(QQ, 2, 2, [1, 2, 2, 4]))
    B = transpose(matrix(QQ, 2, 1, [1, 3]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
    @test !fl
 
    A = transpose(zero_matrix(QQ, 2, 3))
    B = transpose(identity_matrix(QQ, 3))
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
@@ -757,12 +757,12 @@ end
    @test is_zero(A*K)
    @test ncols(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 0
 
    A = transpose(A)
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 1
 end

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -692,39 +692,39 @@ end
 
    B = T([ZZRingElem(4), 5, 7])
 
-   X = AbstractAlgebra.Solve.solve(A, B)
+   X = AbstractAlgebra.Solve.solve(A, B, side = :right)
 
    @test X == T([3, -24, 14])
    @test A*X == B
 
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl && A * X == B
 
    A = matrix(ZZ, 2, 2, [1, 0, 0, 0])
    B = matrix(ZZ, 2, 2, [0, 0, 0, 1])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+   @test !fl
    fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test !fl
-   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test !fl
 
    A = matrix(ZZ, 2, 2, [1, 0, 0, 0])
    B = matrix(ZZ, 2, 2, [0, 1, 0, 0])
-   fl, X, Z = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   fl, X, Z = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test fl && A*X == B && iszero(A * Z)
 
    # Non-square example
    A = matrix(ZZ, [1 2 3; 4 5 6])
    B = matrix(ZZ, 2, 1, [1, 1])
-   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test fl
    @test A*x == B
    @test is_zero(A*K)
    @test ncols(K) + rank(A) == ncols(A)
 
    B = matrix(ZZ, 1, 3, [1, 2, 3])
-   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
    @test fl
    @test x*A == B
    @test is_zero(K*A)
@@ -735,20 +735,20 @@ end
    @test is_zero(A*K)
    @test ncols(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 0
 
    A = transpose(A)
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2))
+   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2), side = :right)
    @test ncols(K) == 2
    @test hnf(K) == identity_matrix(ZZ, 2)
 
-   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2), side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2))
    @test nrows(K) == 2
    @test hnf(K) == identity_matrix(ZZ, 2)
 end

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -743,6 +743,14 @@ end
    K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
    @test is_zero(K*A)
    @test nrows(K) == 1
+
+   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2))
+   @test ncols(K) == 2
+   @test hnf(K) == identity_matrix(ZZ, 2)
+
+   K = @inferred AbstractAlgebra.Solve.kernel(zero_matrix(ZZ, 2, 2), side = :left)
+   @test nrows(K) == 2
+   @test hnf(K) == identity_matrix(ZZ, 2)
 end
 
 @testset "ZZMatrix.concat" begin

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -729,6 +729,20 @@ end
    @test x*A == B
    @test is_zero(K*A)
    @test nrows(K) + rank(A) == nrows(A)
+
+   A = matrix(ZZ, [ 1 2 3 ; 4 5 6 ])
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :right)
+   @test is_zero(A*K)
+   @test ncols(K) == 1
+
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 0
+
+   A = transpose(A)
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 1
 end
 
 @testset "ZZMatrix.concat" begin

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -592,22 +592,22 @@ end
    a = matrix(Z17, [1 2 3; 3 2 1; 0 0 2])
    b = matrix(Z17, [2 1 0 1; 0 0 0 0; 0 1 2 0])
    c = a*b
-   d = AbstractAlgebra.Solve.solve(a, c)
+   d = AbstractAlgebra.Solve.solve(a, c, side = :right)
    @test d == b
- 
+
    a = zero(a, 3, 3)
-   @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
- 
+   @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c, side = :right)
+
    A = matrix(Z17, [1 2 3; 4 5 6])
    B = matrix(Z17, 2, 1, [1, 1])
-   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
    @test fl
    @test A*x == B
    @test is_zero(A*K)
    @test ncols(K) + rank(A) == ncols(A)
- 
+
    B = matrix(Z17, 1, 3, [1, 2, 3])
-   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
    @test fl
    @test x*A == B
    @test is_zero(K*A)
@@ -618,12 +618,12 @@ end
    @test is_zero(A*K)
    @test ncols(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 0
 
    A = transpose(A)
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 1
 end

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -588,30 +588,44 @@ end
 =#
 
 @testset "ZZModMatrix.Solve.solve" begin
-  Z17, = residue_ring(ZZ, ZZ(17))
-  a = matrix(Z17, [1 2 3; 3 2 1; 0 0 2])
-  b = matrix(Z17, [2 1 0 1; 0 0 0 0; 0 1 2 0])
-  c = a*b
-  d = AbstractAlgebra.Solve.solve(a, c)
-  @test d == b
+   Z17, = residue_ring(ZZ, ZZ(17))
+   a = matrix(Z17, [1 2 3; 3 2 1; 0 0 2])
+   b = matrix(Z17, [2 1 0 1; 0 0 0 0; 0 1 2 0])
+   c = a*b
+   d = AbstractAlgebra.Solve.solve(a, c)
+   @test d == b
+ 
+   a = zero(a, 3, 3)
+   @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+ 
+   A = matrix(Z17, [1 2 3; 4 5 6])
+   B = matrix(Z17, 2, 1, [1, 1])
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+   @test fl
+   @test A*x == B
+   @test is_zero(A*K)
+   @test ncols(K) + rank(A) == ncols(A)
+ 
+   B = matrix(Z17, 1, 3, [1, 2, 3])
+   fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
+   @test fl
+   @test x*A == B
+   @test is_zero(K*A)
+   @test nrows(K) + rank(A) == nrows(A)
 
-  a = zero(a, 3, 3)
-  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+   A = matrix(Z17, [ 1 2 3 ; 4 5 6 ])
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :right)
+   @test is_zero(A*K)
+   @test ncols(K) == 1
 
-  A = matrix(Z17, [1 2 3; 4 5 6])
-  B = matrix(Z17, 2, 1, [1, 1])
-  fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
-  @test fl
-  @test A*x == B
-  @test is_zero(A*K)
-  @test ncols(K) + rank(A) == ncols(A)
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 0
 
-  B = matrix(Z17, 1, 3, [1, 2, 3])
-  fl, x, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :left)
-  @test fl
-  @test x*A == B
-  @test is_zero(K*A)
-  @test nrows(K) + rank(A) == nrows(A)
+   A = transpose(A)
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 1
 end
 
 #= Not implemented in Flint yet

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -653,13 +653,13 @@ end
 
   c = a*b
 
-  d = AbstractAlgebra.Solve.solve(a, c)
+  d = AbstractAlgebra.Solve.solve(a, c, side = :right)
 
   @test d == b
 
   a = zero(R)
 
-  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c, side = :right)
 
    for i in 1:10
       m = rand(0:10)
@@ -672,7 +672,7 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
 
       if fl
          @test A * X == B
@@ -683,51 +683,51 @@ end
 
    A = matrix(F17, 2, 2, [1, 2, 2, 5])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 3])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test !fl
    @test !can_solve(A, B)
 
    A = zero_matrix(F17, 2, 3)
    B = identity_matrix(F17, 3)
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
 
    A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
    B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test fl
    @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   @test AbstractAlgebra.Solve.can_solve(A, B)
 
    A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
    B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test fl
    @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   @test AbstractAlgebra.Solve.can_solve(A, B)
 
    A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
    B = transpose(matrix(F17, 2, 1, [1, 3]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
+   @test !AbstractAlgebra.Solve.can_solve(A, B)
 
    A = transpose(zero_matrix(F17, 2, 3))
    B = transpose(identity_matrix(F17, 3))
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -641,13 +641,13 @@ end
 
   c = a*b
 
-  d = AbstractAlgebra.Solve.solve(a, c)
+  d = AbstractAlgebra.Solve.solve(a, c, side = :right)
 
   @test d == b
 
   a = zero(R)
 
-  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c, side = :right)
 
    for i in 1:10
       m = rand(0:10)
@@ -660,7 +660,7 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
 
       if fl
          @test A * X == B
@@ -671,51 +671,51 @@ end
 
    A = matrix(F17, 2, 2, [1, 2, 2, 5])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+
+   A = zero_matrix(F17, 2, 3)
+   B = identity_matrix(F17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
    fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
    @test !AbstractAlgebra.Solve.can_solve(A, B)
 
-   A = zero_matrix(F17, 2, 3)
-   B = identity_matrix(F17, 3)
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
-   B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(F17, 2, 1, [1, 3]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
    A = transpose(zero_matrix(F17, 2, 3))
    B = transpose(identity_matrix(F17, 3))
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -641,13 +641,13 @@ end
 
   c = a*b
 
-  d = AbstractAlgebra.Solve.solve(a, c)
+  d = AbstractAlgebra.Solve.solve(a, c, side = :right)
 
   @test d == b
 
   a = zero(R)
 
-  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c, side = :right)
 
    for i in 1:10
       m = rand(0:10)
@@ -660,7 +660,7 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
 
       if fl
          @test A * X == B
@@ -671,51 +671,51 @@ end
 
    A = matrix(F17, 2, 2, [1, 2, 2, 5])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(F17, 2, 2, [1, 2, 2, 4])
    B = matrix(F17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+
+   A = zero_matrix(F17, 2, 3)
+   B = identity_matrix(F17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(F17, 2, 1, [1, 3]))
    fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
    @test !AbstractAlgebra.Solve.can_solve(A, B)
 
-   A = zero_matrix(F17, 2, 3)
-   B = identity_matrix(F17, 3)
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 5]))
-   B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(F17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(F17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(F17, 2, 1, [1, 3]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
    A = transpose(zero_matrix(F17, 2, 3))
    B = transpose(identity_matrix(F17, 3))
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -692,13 +692,13 @@ end
 
   c = a*b
 
-  d = AbstractAlgebra.Solve.solve(a, c)
+  d = AbstractAlgebra.Solve.solve(a, c, side = :right)
 
   @test d == b
 
   a = zero(R)
 
-  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c)
+  @test_throws ArgumentError AbstractAlgebra.Solve.solve(a, c, side = :right)
 
   for i in 1:10
       m = rand(0:10)
@@ -711,7 +711,7 @@ end
       A = rand(M)
       B = rand(N)
 
-      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B)
+      fl, X, K = AbstractAlgebra.Solve.can_solve_with_solution_and_kernel(A, B, side = :right)
 
       if fl
          @test A * X == B
@@ -722,51 +722,51 @@ end
 
    A = matrix(Z17, 2, 2, [1, 2, 2, 5])
    B = matrix(Z17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(Z17, 2, 2, [1, 2, 2, 4])
    B = matrix(Z17, 2, 1, [1, 2])
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
    @test fl
    @test A * X == B
-   @test AbstractAlgebra.Solve.can_solve(A, B)
+   @test AbstractAlgebra.Solve.can_solve(A, B, side = :right)
 
    A = matrix(Z17, 2, 2, [1, 2, 2, 4])
    B = matrix(Z17, 2, 1, [1, 3])
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+   @test !fl
+   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :right)
+
+   A = zero_matrix(Z17, 2, 3)
+   B = identity_matrix(Z17, 3)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :right)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 5]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 2]))
+   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
+   @test fl
+   @test X * A == B
+   @test AbstractAlgebra.Solve.can_solve(A, B)
+
+   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
+   B = transpose(matrix(Z17, 2, 1, [1, 3]))
    fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B)
    @test !fl
    @test !AbstractAlgebra.Solve.can_solve(A, B)
 
-   A = zero_matrix(Z17, 2, 3)
-   B = identity_matrix(Z17, 3)
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
-
-   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 5]))
-   B = transpose(matrix(Z17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(Z17, 2, 1, [1, 2]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test fl
-   @test X * A == B
-   @test AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
-   A = transpose(matrix(Z17, 2, 2, [1, 2, 2, 4]))
-   B = transpose(matrix(Z17, 2, 1, [1, 3]))
-   fl, X = AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
-   @test !fl
-   @test !AbstractAlgebra.Solve.can_solve(A, B, side = :left)
-
    A = transpose(zero_matrix(Z17, 2, 3))
    B = transpose(identity_matrix(Z17, 3))
-   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :left)
+   @test_throws ErrorException AbstractAlgebra.Solve.can_solve_with_solution(A, B)
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
@@ -776,12 +776,12 @@ end
    @test is_zero(A*K)
    @test ncols(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 0
 
    A = transpose(A)
-   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 1
 end

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -770,6 +770,20 @@ end
 
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError AbstractAlgebra.Solve.can_solve(A, B, side = :garbage)
+
+   A = matrix(Z17, [ 1 2 3 ; 4 5 6 ])
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :right)
+   @test is_zero(A*K)
+   @test ncols(K) == 1
+
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 0
+
+   A = transpose(A)
+   K = @inferred AbstractAlgebra.Solve.kernel(A, side = :left)
+   @test is_zero(K*A)
+   @test nrows(K) == 1
 end
 
 @testset "fpMatrix.lu" begin

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -830,3 +830,40 @@ end
    M = rand(S)
    @test parent(M) == S
 end
+
+
+@testset "zzModMatrix.Solve.kernel" begin
+   # Prime modulus
+   R, _ = residue_ring(ZZ, 17)
+   M = matrix(R, [ 1 2 3 ; 4 5 6 ])
+
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :right)
+   @test is_zero(M*K)
+   @test ncols(K) == 1
+
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   @test is_zero(K*M)
+   @test nrows(K) == 0
+
+   M = transpose(M)
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   @test is_zero(K*M)
+   @test nrows(K) == 1
+
+   # Composite modulus
+   R, _ = residue_ring(ZZ, 18)
+   M = matrix(R, [ 1 2 3 ; 4 5 6 ])
+
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :right)
+   @test is_zero(M*K)
+   @test ncols(K) == 2
+
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   @test is_zero(K*M)
+   @test nrows(K) == 1
+
+   M = transpose(M)
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   @test is_zero(K*M)
+   @test nrows(K) == 2
+end

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -866,4 +866,13 @@ end
    K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
    @test is_zero(K*M)
    @test nrows(K) == 2
+
+   M = identity_matrix(R, 2)
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :right)
+   @test is_zero(M*K)
+   @test ncols(K) == 0
+
+   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   @test is_zero(K*M)
+   @test nrows(K) == 0
 end

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -841,12 +841,12 @@ end
    @test is_zero(M*K)
    @test ncols(K) == 1
 
-   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(M)
    @test is_zero(K*M)
    @test nrows(K) == 0
 
    M = transpose(M)
-   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(M)
    @test is_zero(K*M)
    @test nrows(K) == 1
 
@@ -858,12 +858,12 @@ end
    @test is_zero(M*K)
    @test ncols(K) == 2
 
-   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(M)
    @test is_zero(K*M)
    @test nrows(K) == 1
 
    M = transpose(M)
-   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(M)
    @test is_zero(K*M)
    @test nrows(K) == 2
 
@@ -872,7 +872,7 @@ end
    @test is_zero(M*K)
    @test ncols(K) == 0
 
-   K = @inferred AbstractAlgebra.Solve.kernel(M, side = :left)
+   K = @inferred AbstractAlgebra.Solve.kernel(M)
    @test is_zero(K*M)
    @test nrows(K) == 0
 end


### PR DESCRIPTION
Add some special `Solve.kernel` methods for types coming from flint or non-domain rings. All of this is more or less taken from `HeckeMiscMatrix.jl`.
I add tests in the next days; I just wanted to push this to ask about some things before I forget them.
