### PR TITLE
Remove redundant 'convert' invocations

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -96,7 +96,7 @@ canonical_unit(a::QQBarFieldElem) = a
 ###############################################################################
 
 # todo
-# function expressify(a::QQBarFieldElem; context = nothing)::Any
+# function expressify(a::QQBarFieldElem; context = nothing)
 # end
 
 #=

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -236,7 +236,7 @@ canonical_unit(a::QQFieldElem) = a
 #
 ###############################################################################
 
-function expressify(a::QQFieldElem; context = nothing)::Any
+function expressify(a::QQFieldElem; context = nothing)
     n = numerator(a)
     d = denominator(a)
     if isone(d)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2231,8 +2231,8 @@ julia> number_of_digits(ZZ(12), 3)
 3
 ```
 """
-function number_of_digits(x::ZZRingElem, b::Integer)::Int
-   number_of_digits(x, base=b)
+function number_of_digits(x::ZZRingElem, b::Integer)
+   number_of_digits(x, base=b)::Int
 end
 
 function number_of_digits(a::ZZRingElem; base::Integer = 10, pad::Integer = 1)


### PR DESCRIPTION
Declaring a type of 'Any' is pointless in this context.

For number_of_digits, what is really wanted is presumably a type assertion
inside the code, instead of a conversion inducing type declaration.