### PR TITLE
Make all (?) fields & rings attribute storing

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -132,7 +132,7 @@ end
 
 # fixed precision
 
-mutable struct ArbField <: Field
+@attributes mutable struct ArbField <: Field
   prec::Int
 
   function ArbField(p::Int = 256; cached::Bool = true)
@@ -354,7 +354,7 @@ end
 
 # fixed precision
 
-mutable struct AcbField <: Field
+@attributes mutable struct AcbField <: Field
   prec::Int
 
   function AcbField(p::Int = 256; cached::Bool = true)
@@ -461,7 +461,7 @@ end
 #
 ################################################################################
 
-mutable struct RealPolyRing <: PolyRing{RealFieldElem}
+@attributes mutable struct RealPolyRing <: PolyRing{RealFieldElem}
   S::Symbol
 
   function RealPolyRing(R::RealField, S::Symbol, cached::Bool = true)
@@ -554,7 +554,7 @@ base_ring(a::RealPolyRing) = RealField()
 
 # fixed precision
 
-mutable struct ArbPolyRing <: PolyRing{ArbFieldElem}
+@attributes mutable struct ArbPolyRing <: PolyRing{ArbFieldElem}
   base_ring::ArbField
   S::Symbol
 
@@ -654,7 +654,7 @@ base_ring(a::ArbPolyRing) = a.base_ring
 #
 ################################################################################
 
-mutable struct ComplexPolyRing <: PolyRing{ComplexFieldElem}
+@attributes mutable struct ComplexPolyRing <: PolyRing{ComplexFieldElem}
   S::Symbol
 
   function ComplexPolyRing(R::ComplexField, S::Symbol, cached::Bool = true)
@@ -758,7 +758,7 @@ base_ring(a::ComplexPolyRing) = ComplexField()
 
 # fixed precision
 
-mutable struct AcbPolyRing <: PolyRing{AcbFieldElem}
+@attributes mutable struct AcbPolyRing <: PolyRing{AcbFieldElem}
   base_ring::AcbField
   S::Symbol
 

--- a/src/calcium/CalciumTypes.jl
+++ b/src/calcium/CalciumTypes.jl
@@ -117,7 +117,7 @@ ca_ctx_options = [
     :vieta_limit,
     :trig_form]
 
-mutable struct CalciumField <: Field
+@attributes mutable struct CalciumField <: Field
    ext_cache_items::Ptr{Nothing}
    ext_cache_length::Int
    ext_cache_alloc::Int


### PR DESCRIPTION
While I don't have an immediate application, all other field and ring
types in Nemo (and most in Oscar) are attribute storing (be it via an
explicit @attributes, or because they are singleton types). So it seems
sensible to also enable it for these types proactively. Otherwise
we end up writing "generic" code using attributes that doesn't work on
all kinds of rings.


(Old branch I had still sitting on my disk)