### PR TITLE
Use LU decomposition in solve context

### DIFF
--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -170,6 +170,7 @@ iszero(a::QQMatrix) = ccall((:fmpq_mat_is_zero, libflint), Bool,
                             (Ref{QQMatrix},), a)
 
 @inline function is_zero_entry(A::QQMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = mat_entry_ptr(A, i, j)
       return ccall((:fmpz_is_zero, libflint), Bool, (Ptr{QQFieldElem},), x)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -656,35 +656,6 @@ end
 
 ###############################################################################
 #
-#   Permutation
-#
-###############################################################################
-
-# Unfortunately, there is no fmpq_mat_set_perm in flint
-function *(P::Perm, x::QQMatrix)
-   z = similar(x)
-   t = QQ()
-   @inbounds for i = 1:nrows(x)
-      for j = 1:ncols(x)
-         z[P[i], j] = getindex!(t, x, i, j)
-      end
-   end
-   return z
-end
-
-function *(x::QQMatrix, P::Perm)
-   z = similar(x)
-   t = QQ()
-   @inbounds for i = 1:nrows(x)
-      for j = 1:ncols(x)
-        z[i, P[j]] = getindex!(t, x, i, j)
-      end
-   end
-   return z
-end
-
-###############################################################################
-#
 #   Linear solving
 #
 ###############################################################################

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -707,8 +707,8 @@ function Solve._init_reduce_fflu(C::Solve.SolveCtx{QQFieldElem})
    dLU = ZZ()
    p.d .-= 1
    r = ccall((:fmpz_mat_fflu, libflint), Int,
-             (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Int),
-             Aint, dLU, p.d, Aint, 0)
+             (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Cint),
+             Aint, dLU, p.d, Aint, Cint(false))
    p.d .+= 1
    inv!(p)
    Solve.set_rank!(C, r)
@@ -764,8 +764,8 @@ function Solve._init_reduce_transpose_fflu(C::Solve.SolveCtx{QQFieldElem})
    dLU = ZZ()
    p.d .-= 1
    r = ccall((:fmpz_mat_fflu, libflint), Int,
-             (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Int),
-             Aint, dLU, p.d, Aint, 0)
+             (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Cint),
+             Aint, dLU, p.d, Aint, Cint(false))
    p.d .+= 1
    inv!(p)
    Solve.set_rank!(C, r)
@@ -823,7 +823,7 @@ function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{QQFieldElem}
          (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), bint, db, b)
    yint = zero_matrix(FlintZZ, ncols(C), ncols(b))
    p = inv(Solve.lu_permutation(C)).d .- 1
-   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Int,
+   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Cint,
                 (Ref{ZZMatrix}, Ptr{Int}, Ref{ZZMatrix}, Ref{ZZMatrix}),
                 yint, p, Solve.reduced_matrix_lu(C), bint)
    fl = Bool(flag)
@@ -861,7 +861,7 @@ function Solve._can_solve_internal_no_check_left(C::Solve.SolveCtx{QQFieldElem},
          (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), bint, db, transpose(b))
    yint = zero_matrix(FlintZZ, nrows(C), ncols(bint))
    p = inv(Solve.lu_permutation_of_transpose(C)).d .- 1
-   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Int,
+   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Cint,
                 (Ref{ZZMatrix}, Ptr{Int}, Ref{ZZMatrix}, Ref{ZZMatrix}),
                 yint, p, Solve.reduced_matrix_of_transpose_lu(C), bint)
    fl = Bool(flag)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -656,6 +656,35 @@ end
 
 ###############################################################################
 #
+#   Permutation
+#
+###############################################################################
+
+# Unfortunately, there is no fmpq_mat_set_perm in flint
+function *(P::Perm, x::QQMatrix)
+   z = similar(x)
+   t = QQ()
+   @inbounds for i = 1:nrows(x)
+      for j = 1:ncols(x)
+         z[P[i], j] = getindex!(t, x, i, j)
+      end
+   end
+   return z
+end
+
+function *(x::QQMatrix, P::Perm)
+   z = similar(x)
+   t = QQ()
+   @inbounds for i = 1:nrows(x)
+      for j = 1:ncols(x)
+        z[i, P[j]] = getindex!(t, x, i, j)
+      end
+   end
+   return z
+end
+
+###############################################################################
+#
 #   Linear solving
 #
 ###############################################################################
@@ -690,6 +719,205 @@ function Solve._can_solve_internal_no_check(A::QQMatrix, b::QQMatrix, task::Symb
       return Bool(fl), x, zero(A, 0, 0)
    end
    return Bool(fl), x, kernel(A, side = :right)
+end
+
+function Solve._init_reduce_fflu(C::Solve.SolveCtx{QQFieldElem})
+  if has_attribute(C, :reduced_matrix_lu)
+    return nothing
+  end
+
+  A = matrix(C)
+  Aint = zero_matrix(FlintZZ, nrows(A), ncols(A))
+  dA = FlintZZ()
+  ccall((:fmpq_mat_get_fmpz_mat_matwise, libflint), Nothing,
+        (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), Aint, dA, A)
+  p = Generic.Perm(nrows(A))
+  dLU = ZZ()
+  p.d .-= 1
+  r = ccall((:fmpz_mat_fflu, libflint), Int,
+            (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Int),
+            Aint, dLU, p.d, Aint, 0)
+  p.d .+= 1
+  inv!(p)
+  Solve.set_rank!(C, r)
+  C.lu_perm = p
+  d = divexact(dA, base_ring(C)(dLU))
+  set_attribute!(C, :reduced_matrix_lu => Aint, :scaling_factor_fflu => d)
+  if r < nrows(A)
+    A2 = p*A
+    A3 = view(A2, r + 1:nrows(A), 1:ncols(A))
+    set_attribute!(C, :permuted_matrix_fflu => A3)
+  else
+    set_attribute!(C, :permuted_matrix_fflu => zero(A, 0, ncols(A)))
+  end
+  return nothing
+end
+
+function Solve.lu_permutation(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_fflu(C)
+  return C.lu_perm
+end
+
+function Solve.reduced_matrix_lu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_fflu(C)
+  return get_attribute(C, :reduced_matrix_lu)::ZZMatrix
+end
+
+# Factor by which any solution needs to be multiplied.
+# This is the chosen denominator of matrix(C) divided by the denominator computed
+# by fmpz_mat_fflu.
+function Solve.scaling_factor_fflu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_fflu(C)
+  return get_attribute(C, :scaling_factor_fflu)::QQFieldElem
+end
+
+# Let A = matrix(C).
+# Return the matrix (p*A)[rank(A) + 1:nrows(A), :] where p is lu_permutation(C).
+function Solve.permuted_matrix_fflu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_fflu(C)
+  return get_attribute(C, :permuted_matrix_fflu)::QQMatrix
+end
+
+function Solve._init_reduce_transpose_fflu(C::Solve.SolveCtx{QQFieldElem})
+  if has_attribute(C, :reduced_matrix_of_transpose_lu)
+    return nothing
+  end
+
+  A = matrix(C)
+  Aint = zero_matrix(FlintZZ, ncols(A), nrows(A))
+  dA = FlintZZ()
+  ccall((:fmpq_mat_get_fmpz_mat_matwise, libflint), Nothing,
+        (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), Aint, dA, transpose(A))
+  p = Generic.Perm(ncols(A))
+  dLU = ZZ()
+  p.d .-= 1
+  r = ccall((:fmpz_mat_fflu, libflint), Int,
+            (Ref{ZZMatrix}, Ref{ZZRingElem}, Ptr{Int}, Ref{ZZMatrix}, Int),
+            Aint, dLU, p.d, Aint, 0)
+  p.d .+= 1
+  inv!(p)
+  Solve.set_rank!(C, r)
+  C.lu_perm_transp = p
+  d = divexact(dA, base_ring(C)(dLU))
+  set_attribute!(C, :reduced_matrix_of_transpose_lu => Aint, :scaling_factor_of_transpose_fflu => d)
+  if r < ncols(A)
+    A2 = A*p
+    A3 = view(A2, 1:nrows(A), r + 1:ncols(A))
+    set_attribute!(C, :permuted_matrix_of_transpose_fflu => A3)
+  else
+    set_attribute!(C, :permuted_matrix_of_transpose_fflu => zero(A, nrows(A), 0))
+  end
+  return nothing
+end
+
+function Solve.lu_permutation_of_transpose(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_transpose_fflu(C)
+  return C.lu_perm_transp
+end
+
+function Solve.reduced_matrix_of_transpose_lu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_transpose_fflu(C)
+  return get_attribute(C, :reduced_matrix_of_transpose_lu)::ZZMatrix
+end
+
+# Factor by which any solution needs to be multiplied.
+# This is the chosen denominator of matrix(C) divided by the denominator computed
+# by fmpz_mat_fflu.
+function Solve.scaling_factor_of_transpose_fflu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_transpose_fflu(C)
+  return get_attribute(C, :scaling_factor_of_transpose_fflu)::QQFieldElem
+end
+
+# Let A = matrix(C).
+# Return the matrix (p*A)[rank(A) + 1:nrows(A), :] where p is lu_permutation_of_transpose(C).
+function Solve.permuted_matrix_of_transpose_fflu(C::Solve.SolveCtx{QQFieldElem})
+  Solve._init_reduce_transpose_fflu(C)
+  return get_attribute(C, :permuted_matrix_of_transpose_fflu)::QQMatrix
+end
+
+function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{QQFieldElem}, b::QQMatrix, task::Symbol; side::Symbol = :left)
+  # Split up in separate functions to make the compiler happy
+  if side === :right
+    return Solve._can_solve_internal_no_check_right(C, b, task)
+  else
+    return Solve._can_solve_internal_no_check_left(C, b, task)
+  end
+end
+
+function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{QQFieldElem}, b::QQMatrix, task::Symbol)
+   bint = zero_matrix(FlintZZ, nrows(b), ncols(b))
+   db = FlintZZ()
+   ccall((:fmpq_mat_get_fmpz_mat_matwise, libflint), Nothing,
+        (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), bint, db, b)
+   yint = zero_matrix(FlintZZ, ncols(C), ncols(b))
+   p = inv(Solve.lu_permutation(C)).d .- 1
+   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Int,
+              (Ref{ZZMatrix}, Ptr{Int}, Ref{ZZMatrix}, Ref{ZZMatrix}),
+              yint, p, Solve.reduced_matrix_lu(C), bint)
+   fl = Bool(flag)
+   if !fl
+      return fl, zero(b, 0, 0), zero(b, 0, 0)
+   end
+   # We have fl == true, but we still have to check whether this really is a solution
+   y = zero_matrix(FlintQQ, nrows(yint), ncols(yint))
+   ccall((:fmpq_mat_set_fmpz_mat_div_fmpz, libflint), Nothing,
+         (Ref{QQMatrix}, Ref{ZZMatrix}, Ref{ZZRingElem}),
+         y, yint, db)
+   ccall((:fmpq_mat_scalar_mul_fmpq, libflint), Nothing,
+         (Ref{QQMatrix}, Ref{QQMatrix}, Ref{QQFieldElem}),
+         y, y, Solve.scaling_factor_fflu(C))
+   # Now y == (yint//db)*scaling_factor_fflu(C)
+   if rank(C) < nrows(C)
+      # We have to check whether y is also a solution for the "lower part"
+      # of the system
+      pb = Solve.lu_permutation(C)*b
+      pA = Solve.permuted_matrix_fflu(C)
+      fl = pA*y == view(pb, rank(C) + 1:nrows(C), 1:ncols(b))
+   end
+   if task === :with_kernel
+      # I don't know how to compute the kernel using an (ff)lu factoring
+      return fl, y, kernel(C, side = :right)
+   else
+      return fl, y, zero(b, 0, 0)
+   end
+end
+
+function Solve._can_solve_internal_no_check_left(C::Solve.SolveCtx{QQFieldElem}, b::QQMatrix, task::Symbol)
+   bint = zero_matrix(FlintZZ, ncols(b), nrows(b))
+   db = FlintZZ()
+   ccall((:fmpq_mat_get_fmpz_mat_matwise, libflint), Nothing,
+         (Ref{ZZMatrix}, Ref{ZZRingElem}, Ref{QQMatrix}), bint, db, transpose(b))
+   yint = zero_matrix(FlintZZ, nrows(C), ncols(bint))
+   p = inv(Solve.lu_permutation_of_transpose(C)).d .- 1
+   flag = ccall((:fmpz_mat_solve_fflu_precomp, libflint), Int,
+              (Ref{ZZMatrix}, Ptr{Int}, Ref{ZZMatrix}, Ref{ZZMatrix}),
+              yint, p, Solve.reduced_matrix_of_transpose_lu(C), bint)
+   fl = Bool(flag)
+   if !fl
+      return fl, zero(b, 0, 0), zero(b, 0, 0)
+   end
+   # We have fl == true, but we still have to check whether this really is a solution
+   y = zero_matrix(FlintQQ, ncols(yint), nrows(yint))
+   ccall((:fmpq_mat_set_fmpz_mat_div_fmpz, libflint), Nothing,
+         (Ref{QQMatrix}, Ref{ZZMatrix}, Ref{ZZRingElem}),
+         y, transpose(yint), db)
+   ccall((:fmpq_mat_scalar_mul_fmpq, libflint), Nothing,
+         (Ref{QQMatrix}, Ref{QQMatrix}, Ref{QQFieldElem}),
+         y, y, Solve.scaling_factor_of_transpose_fflu(C))
+   # Now y == (transpose(yint)//db)*scaling_factor_fflu(C)
+   if rank(C) < ncols(C)
+      # We have to check whether y is also a solution for the "right hand part"
+      # of the system
+      pb = b*Solve.lu_permutation_of_transpose(C)
+      pA = Solve.permuted_matrix_of_transpose_fflu(C)
+      fl = y*pA == view(pb, 1:nrows(b), rank(C) + 1:ncols(C))
+   end
+   if task === :with_kernel
+      # I don't know how to compute the kernel using an (ff)lu factoring
+      return fl, y, kernel(C, side = :left)
+   else
+      return fl, y, zero(b, 0, 0)
+   end
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -175,6 +175,7 @@ isone(a::ZZMatrix) = ccall((:fmpz_mat_is_one, libflint), Bool,
                            (Ref{ZZMatrix},), a)
 
 @inline function is_zero_entry(A::ZZMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = mat_entry_ptr(A, i, j)
       return ccall((:fmpz_is_zero, libflint), Bool, (Ptr{ZZRingElem},), x)

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -43,9 +43,8 @@ zero(m::FqMatrix, R::FqField, r::Int, c::Int) = FqMatrix(r, c, R)
 function getindex!(v::FqFieldElem, a::FqMatrix, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    ccall((:fq_default_mat_entry, libflint), Ptr{FqFieldElem},
-         (Ref{FqFieldElem}, Ref{FqMatrix}, Int, Int,
-          Ref{FqField}),
-          v, a, i - 1 , j - 1, base_ring(a))
+         (Ref{FqFieldElem}, Ref{FqMatrix}, Int, Int, Ref{FqField}),
+         v, a, i - 1 , j - 1, base_ring(a))
    return v
 end
 

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -40,6 +40,15 @@ zero(m::FqMatrix, R::FqField, r::Int, c::Int) = FqMatrix(r, c, R)
 #
 ################################################################################
 
+function getindex!(v::FqFieldElem, a::FqMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(a, i, j)
+   ccall((:fq_default_mat_entry, libflint), Ptr{FqFieldElem},
+         (Ref{FqFieldElem}, Ref{FqMatrix}, Int, Int,
+          Ref{FqField}),
+          v, a, i - 1 , j - 1, base_ring(a))
+   return v
+end
+
 @inline function getindex(a::FqMatrix, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    z = base_ring(a)()
@@ -110,6 +119,13 @@ function iszero(a::FqMatrix)
    r = ccall((:fq_default_mat_is_zero, libflint), Cint,
              (Ref{FqMatrix}, Ref{FqField}), a, base_ring(a))
   return Bool(r)
+end
+
+@inline function is_zero_entry(A::FqMatrix, i::Int, j::Int)
+   GC.@preserve A begin
+      x = fq_default_mat_entry_ptr(A, i, j)
+      return ccall((:fq_default_is_zero, libflint), Bool, (Ptr{FqFieldElem}, Ref{FqField}), x, base_ring(A))
+   end
 end
 
 ################################################################################
@@ -430,6 +446,181 @@ function Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMatrix, task::Symb
       return Bool(fl), x, zero(A, 0, 0)
    end
    return Bool(fl), x, kernel(A, side = :right)
+end
+
+function Solve._init_reduce(C::Solve.SolveCtx{FqFieldElem})
+   if isdefined(C, :red) && isdefined(C, :lu_perm)
+      return nothing
+   end
+
+   LU = deepcopy(matrix(C))
+   p = Generic.Perm(1:nrows(LU))
+   p.d .-= 1
+   r = ccall((:fq_default_mat_lu, libflint), Int,
+             (Ptr{Int}, Ref{FqMatrix}, Int, Ref{FqField}),
+             p.d, LU, 0, base_ring(C))
+
+   p.d .+= 1
+   inv!(p)
+   Solve.set_rank!(C, r)
+   C.red = LU
+   C.lu_perm = p
+   if r < nrows(C)
+      pA = p*matrix(C)
+      set_attribute!(C, :permuted_matrix_lu => view(pA, r + 1:nrows(C), :))
+   else
+      set_attribute!(C, :permuted_matrix_lu => zero(matrix(C), 0, ncols(C)))
+   end
+   return nothing
+end
+
+function permuted_matrix_lu(C::Solve.SolveCtx{FqFieldElem})
+   Solve._init_reduce(C)
+   return get_attribute(C, :permuted_matrix_lu)::FqMatrix
+end
+
+function Solve._init_reduce_transpose(C::Solve.SolveCtx{FqFieldElem})
+   if isdefined(C, :red_transp) && isdefined(C, :lu_perm_transp)
+      return nothing
+   end
+
+   LU = transpose(matrix(C))
+   p = Generic.Perm(1:nrows(LU))
+   p.d .-= 1
+   r = ccall((:fq_default_mat_lu, libflint), Int,
+             (Ptr{Int}, Ref{FqMatrix}, Int, Ref{FqField}),
+             p.d, LU, 0, base_ring(C))
+
+   p.d .+= 1
+   inv!(p)
+   Solve.set_rank!(C, r)
+   C.red_transp = LU
+   C.lu_perm_transp = p
+   if r < ncols(C)
+      Ap = matrix(C)*p
+      set_attribute!(C, :permuted_matrix_of_transpose_lu => view(Ap, :, r + 1:ncols(C)))
+   else
+      set_attribute!(C, :permuted_matrix_of_transpose_lu => zero(matrix(C), nrows(C), 0))
+   end
+   return nothing
+end
+
+function permuted_matrix_of_transpose_lu(C::Solve.SolveCtx{FqFieldElem})
+   Solve._init_reduce_transpose(C)
+   return get_attribute(C, :permuted_matrix_of_transpose_lu)::FqMatrix
+end
+
+function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{FqFieldElem}, b::FqMatrix, task::Symbol; side::Symbol = :left)
+  # Split up in separate functions to make the compiler happy
+  if side === :right
+    return Solve._can_solve_internal_no_check_right(C, b, task)
+  else
+    return Solve._can_solve_internal_no_check_left(C, b, task)
+  end
+end
+
+function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{FqFieldElem}, b::FqMatrix, task::Symbol)
+   LU = Solve.reduced_matrix(C)
+   p = Solve.lu_permutation(C)
+   pb = p*b
+   r = rank(C)
+
+   x = similar(b, r, ncols(b))
+   # Solve L x = b for the first r rows. We tell flint to pretend that there
+   # are ones on the diagonal of LU (fourth argument)
+   ccall((:fq_default_mat_solve_tril, libflint), Nothing,
+         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Int, Ref{FqField}),
+         x, view(LU, 1:r, 1:r), view(pb, 1:r, :), 1, base_ring(C))
+
+   # Check whether x solves Lx = b also for the lower part of L
+   if r < nrows(C) && view(LU, r + 1:nrows(LU), 1:r)*x != view(pb, r + 1:nrows(b), :)
+     return false, zero(b, 0, 0), zero(b, 0, 0)
+   end
+
+   # Solve U y = x. We need to take extra care as U might have non-pivot columns.
+   y = _solve_triu_right(view(LU, 1:r, :), x)
+
+   fl = true
+   if r < nrows(C)
+     fl = permuted_matrix_lu(C)*y == view(pb, r + 1:nrows(C), :)
+   end
+
+   if task !== :with_kernel
+     return fl, y, zero(b, 0, 0)
+   else
+     return fl, y, kernel(C, side = :right)
+   end
+end
+
+function Solve._can_solve_internal_no_check_left(C::Solve.SolveCtx{FqFieldElem}, b::FqMatrix, task::Symbol)
+   LU = Solve.reduced_matrix_of_transpose(C)
+   p = Solve.lu_permutation_of_transpose(C)
+   pbt = p*transpose(b)
+   r = rank(C)
+
+   x = similar(b, r, nrows(b))
+   ccall((:fq_default_mat_solve_tril, libflint), Nothing,
+         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Int, Ref{FqField}),
+         x, view(LU, 1:r, 1:r), view(pbt, 1:r, :), 1, base_ring(C))
+
+   # Check whether x solves Lx = b also for the lower part of L
+   if r < ncols(C) && view(LU, r + 1:nrows(LU), 1:r)*x != view(pbt, r + 1:nrows(pbt), :)
+     return false, zero(b, 0, 0), zero(b, 0, 0)
+   end
+
+   # Solve U y = x. We need to take extra care as U might have non-pivot columns.
+   yy = _solve_triu_right(view(LU, 1:r, :), x)
+   y = transpose(yy)
+
+   fl = true
+   if r < ncols(C)
+     bp = b*p
+     fl = y*permuted_matrix_of_transpose_lu(C) == view(bp, :, r + 1:ncols(C))
+   end
+
+   if task !== :with_kernel
+     return fl, y, zero(b, 0, 0)
+   else
+     return fl, y, kernel(C, side = :left)
+   end
+end
+
+# Solves A x = B with A in upper triangular shape of full rank, so something
+# like
+#   ( + * * * * )
+#   ( 0 0 + * * )
+#   ( 0 0 0 + * )
+# where + is non-zero and * is anything.
+# This is a helper functions because flint can only do the case where the
+# diagonal entries are non-zero.
+function _solve_triu_right(A::FqMatrix, B::FqMatrix)
+   @assert nrows(A) == nrows(B)
+   pivot_cols = Int[]
+   next_pivot_col = ncols(A) + 1
+   for r in nrows(A):-1:1
+      for c in r:next_pivot_col - 1
+         if is_zero_entry(A, r, c)
+            if c == next_pivot_col - 1
+               error("Matrix is not in upper triangular shape")
+            end
+            continue
+         end
+         push!(pivot_cols, c)
+         next_pivot_col = c
+         break
+      end
+   end
+   reverse!(pivot_cols)
+   AA = reduce(hcat, view(A, 1:nrows(A), c:c) for c in pivot_cols; init = zero(A, nrows(A), 0))
+   xx = similar(B, nrows(A), ncols(B))
+   ccall((:fq_default_mat_solve_triu, libflint), Nothing,
+         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Int, Ref{FqField}),
+         xx, AA, B, 0, base_ring(A))
+   x = zero(B, ncols(A), ncols(B))
+   for i in 1:nrows(xx)
+     view(x, pivot_cols[i]:pivot_cols[i], :) .= view(xx, i:i, :)
+   end
+   return x
 end
 
 ################################################################################

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -122,6 +122,7 @@ function iszero(a::FqMatrix)
 end
 
 @inline function is_zero_entry(A::FqMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = fq_default_mat_entry_ptr(A, i, j)
       return ccall((:fq_default_is_zero, libflint), Bool, (Ptr{FqFieldElem}, Ref{FqField}), x, base_ring(A))

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -124,7 +124,8 @@ end
    @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = fq_default_mat_entry_ptr(A, i, j)
-      return ccall((:fq_default_is_zero, libflint), Bool, (Ptr{FqFieldElem}, Ref{FqField}), x, base_ring(A))
+      return ccall((:fq_default_is_zero, libflint), Bool,
+                   (Ptr{FqFieldElem}, Ref{FqField}), x, base_ring(A))
    end
 end
 
@@ -452,15 +453,15 @@ end
 # different matrix types
 function _solve_tril_right_flint!(x::FqMatrix, L::FqMatrix, B::FqMatrix, unit::Bool)
    ccall((:fq_default_mat_solve_tril, libflint), Nothing,
-         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Int, Ref{FqField}),
-         x, L, B, Int(unit), base_ring(L))
+         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Cint, Ref{FqField}),
+         x, L, B, Cint(unit), base_ring(L))
    return nothing
 end
 
 function _solve_triu_right_flint!(x::FqMatrix, U::FqMatrix, B::FqMatrix, unit::Bool)
    ccall((:fq_default_mat_solve_triu, libflint), Nothing,
-         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Int, Ref{FqField}),
-         x, U, B, Int(unit), base_ring(U))
+         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Cint, Ref{FqField}),
+         x, U, B, Cint(unit), base_ring(U))
    return nothing
 end
 

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -40,6 +40,16 @@ zero(m::FqPolyRepMatrix, R::FqPolyRepField, r::Int, c::Int) = FqPolyRepMatrix(r,
 #
 ################################################################################
 
+function getindex!(v::FqPolyRepFieldElem, a::FqPolyRepMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(a, i, j)
+   GC.@preserve a begin
+      z = ccall((:fq_mat_entry, libflint), Ptr{FqPolyRepFieldElem},
+                (Ref{FqPolyRepMatrix}, Int, Int), a, i - 1, j - 1)
+      ccall((:fq_set, libflint), Nothing, (Ref{FqPolyRepFieldElem}, Ptr{FqPolyRepFieldElem}), v, z)
+   end
+   return v
+end
+
 @inline function getindex(a::FqPolyRepMatrix, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
@@ -103,6 +113,14 @@ function iszero(a::FqPolyRepMatrix)
    r = ccall((:fq_mat_is_zero, libflint), Cint,
              (Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), a, base_ring(a))
   return Bool(r)
+end
+
+@inline function is_zero_entry(A::FqPolyRepMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
+   GC.@preserve A begin
+      x = mat_entry_ptr(A, i, j)
+      return ccall((:fq_is_zero, libflint), Bool, (Ptr{FqPolyRepFieldElem}, Ref{FqPolyRepField}), x, base_ring(A))
+   end
 end
 
 ################################################################################
@@ -437,6 +455,22 @@ function Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, b::FqPolyRepMatr
       return Bool(fl), x, zero(A, 0, 0)
    end
    return Bool(fl), x, kernel(A, side = :right)
+end
+
+# Direct interface to the C functions to be able to write 'generic' code for
+# different matrix types
+function _solve_tril_right_flint!(x::FqPolyRepMatrix, L::FqPolyRepMatrix, B::FqPolyRepMatrix, unit::Bool)
+   ccall((:fq_mat_solve_tril, libflint), Nothing,
+         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Int, Ref{FqPolyRepField}),
+         x, L, B, Int(unit), base_ring(L))
+   return nothing
+end
+
+function _solve_triu_right_flint!(x::FqPolyRepMatrix, U::FqPolyRepMatrix, B::FqPolyRepMatrix, unit::Bool)
+   ccall((:fq_mat_solve_triu, libflint), Nothing,
+         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Int, Ref{FqPolyRepField}),
+         x, U, B, Int(unit), base_ring(U))
+   return nothing
 end
 
 ################################################################################
@@ -783,3 +817,13 @@ function nullspace(M::FqPolyRepMatrix)
                   (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), N, M, base_ring(M))
   return nullity, view(N, 1:nrows(N), 1:nullity)
 end
+
+################################################################################
+#
+#  Entry pointers
+#
+################################################################################
+
+@inline mat_entry_ptr(A::FqPolyRepMatrix, i::Int, j::Int) =
+   ccall((:fq_mat_entry, libflint),
+      Ptr{FqPolyRepFieldElem}, (Ref{FqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -119,7 +119,8 @@ end
    @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = mat_entry_ptr(A, i, j)
-      return ccall((:fq_is_zero, libflint), Bool, (Ptr{FqPolyRepFieldElem}, Ref{FqPolyRepField}), x, base_ring(A))
+      return ccall((:fq_is_zero, libflint), Bool,
+                   (Ptr{FqPolyRepFieldElem}, Ref{FqPolyRepField}), x, base_ring(A))
    end
 end
 
@@ -825,5 +826,5 @@ end
 ################################################################################
 
 @inline mat_entry_ptr(A::FqPolyRepMatrix, i::Int, j::Int) =
-   ccall((:fq_mat_entry, libflint),
-      Ptr{FqPolyRepFieldElem}, (Ref{FqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)
+   ccall((:fq_mat_entry, libflint), Ptr{FqPolyRepFieldElem},
+         (Ref{FqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -45,7 +45,8 @@ function getindex!(v::FqPolyRepFieldElem, a::FqPolyRepMatrix, i::Int, j::Int)
    GC.@preserve a begin
       z = ccall((:fq_mat_entry, libflint), Ptr{FqPolyRepFieldElem},
                 (Ref{FqPolyRepMatrix}, Int, Int), a, i - 1, j - 1)
-      ccall((:fq_set, libflint), Nothing, (Ref{FqPolyRepFieldElem}, Ptr{FqPolyRepFieldElem}), v, z)
+      ccall((:fq_set, libflint), Nothing,
+            (Ref{FqPolyRepFieldElem}, Ptr{FqPolyRepFieldElem}), v, z)
    end
    return v
 end
@@ -462,15 +463,17 @@ end
 # different matrix types
 function _solve_tril_right_flint!(x::FqPolyRepMatrix, L::FqPolyRepMatrix, B::FqPolyRepMatrix, unit::Bool)
    ccall((:fq_mat_solve_tril, libflint), Nothing,
-         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Int, Ref{FqPolyRepField}),
-         x, L, B, Int(unit), base_ring(L))
+         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix},
+          Cint, Ref{FqPolyRepField}),
+         x, L, B, Cint(unit), base_ring(L))
    return nothing
 end
 
 function _solve_triu_right_flint!(x::FqPolyRepMatrix, U::FqPolyRepMatrix, B::FqPolyRepMatrix, unit::Bool)
    ccall((:fq_mat_solve_triu, libflint), Nothing,
-         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Int, Ref{FqPolyRepField}),
-         x, U, B, Int(unit), base_ring(U))
+         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix},
+          Cint, Ref{FqPolyRepField}),
+         x, U, B, Cint(unit), base_ring(U))
    return nothing
 end
 

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -40,6 +40,16 @@ zero(::fqPolyRepMatrix, R::fqPolyRepField, r::Int, c::Int) = fqPolyRepMatrix(r, 
 #
 ################################################################################
 
+function getindex!(v::fqPolyRepFieldElem, a::fqPolyRepMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(a, i, j)
+   GC.@preserve a begin
+      z = ccall((:fq_nmod_mat_entry, libflint), Ptr{fqPolyRepFieldElem},
+                (Ref{fqPolyRepMatrix}, Int, Int), a, i - 1, j - 1)
+      ccall((:fq_nmod_set, libflint), Nothing, (Ref{fqPolyRepFieldElem}, Ptr{fqPolyRepFieldElem}), v, z)
+   end
+   return v
+end
+
 @inline function getindex(a::fqPolyRepMatrix, i::Int, j::Int)
    @boundscheck Generic._checkbounds(a, i, j)
    GC.@preserve a begin
@@ -103,6 +113,14 @@ function iszero(a::fqPolyRepMatrix)
    r = ccall((:fq_nmod_mat_is_zero, libflint), Cint,
              (Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), a, base_ring(a))
   return Bool(r)
+end
+
+@inline function is_zero_entry(A::fqPolyRepMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
+   GC.@preserve A begin
+      x = mat_entry_ptr(A, i, j)
+      return ccall((:fq_nmod_is_zero, libflint), Bool, (Ptr{fqPolyRepFieldElem}, Ref{fqPolyRepField}), x, base_ring(A))
+   end
 end
 
 ################################################################################
@@ -425,6 +443,22 @@ function Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, b::fqPolyRepMatr
       return Bool(fl), x, zero(A, 0, 0)
    end
    return Bool(fl), x, kernel(A, side = :right)
+end
+
+# Direct interface to the C functions to be able to write 'generic' code for
+# different matrix types
+function _solve_tril_right_flint!(x::fqPolyRepMatrix, L::fqPolyRepMatrix, B::fqPolyRepMatrix, unit::Bool)
+   ccall((:fq_nmod_mat_solve_tril, libflint), Nothing,
+         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Int, Ref{fqPolyRepField}),
+         x, L, B, Int(unit), base_ring(L))
+   return nothing
+end
+
+function _solve_triu_right_flint!(x::fqPolyRepMatrix, U::fqPolyRepMatrix, B::fqPolyRepMatrix, unit::Bool)
+   ccall((:fq_nmod_mat_solve_triu, libflint), Nothing,
+         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Int, Ref{fqPolyRepField}),
+         x, U, B, Int(unit), base_ring(U))
+   return nothing
 end
 
 ################################################################################
@@ -771,3 +805,13 @@ function nullspace(M::fqPolyRepMatrix)
                   (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), N, M, base_ring(M))
   return nullity, view(N, 1:nrows(N), 1:nullity)
 end
+
+################################################################################
+#
+#  Entry pointers
+#
+################################################################################
+
+@inline mat_entry_ptr(A::fqPolyRepMatrix, i::Int, j::Int) =
+   ccall((:fq_nmod_mat_entry, libflint),
+      Ptr{fqPolyRepFieldElem}, (Ref{fqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -45,7 +45,8 @@ function getindex!(v::fqPolyRepFieldElem, a::fqPolyRepMatrix, i::Int, j::Int)
    GC.@preserve a begin
       z = ccall((:fq_nmod_mat_entry, libflint), Ptr{fqPolyRepFieldElem},
                 (Ref{fqPolyRepMatrix}, Int, Int), a, i - 1, j - 1)
-      ccall((:fq_nmod_set, libflint), Nothing, (Ref{fqPolyRepFieldElem}, Ptr{fqPolyRepFieldElem}), v, z)
+      ccall((:fq_nmod_set, libflint), Nothing,
+            (Ref{fqPolyRepFieldElem}, Ptr{fqPolyRepFieldElem}), v, z)
    end
    return v
 end
@@ -119,7 +120,8 @@ end
    @boundscheck Generic._checkbounds(A, i, j)
    GC.@preserve A begin
       x = mat_entry_ptr(A, i, j)
-      return ccall((:fq_nmod_is_zero, libflint), Bool, (Ptr{fqPolyRepFieldElem}, Ref{fqPolyRepField}), x, base_ring(A))
+      return ccall((:fq_nmod_is_zero, libflint), Bool,
+                   (Ptr{fqPolyRepFieldElem}, Ref{fqPolyRepField}), x, base_ring(A))
    end
 end
 
@@ -813,5 +815,5 @@ end
 ################################################################################
 
 @inline mat_entry_ptr(A::fqPolyRepMatrix, i::Int, j::Int) =
-   ccall((:fq_nmod_mat_entry, libflint),
-      Ptr{fqPolyRepFieldElem}, (Ref{fqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)
+   ccall((:fq_nmod_mat_entry, libflint), Ptr{fqPolyRepFieldElem},
+         (Ref{fqPolyRepMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -451,15 +451,17 @@ end
 # different matrix types
 function _solve_tril_right_flint!(x::fqPolyRepMatrix, L::fqPolyRepMatrix, B::fqPolyRepMatrix, unit::Bool)
    ccall((:fq_nmod_mat_solve_tril, libflint), Nothing,
-         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Int, Ref{fqPolyRepField}),
-         x, L, B, Int(unit), base_ring(L))
+         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix},
+          Cint, Ref{fqPolyRepField}),
+         x, L, B, Cint(unit), base_ring(L))
    return nothing
 end
 
 function _solve_triu_right_flint!(x::fqPolyRepMatrix, U::fqPolyRepMatrix, B::fqPolyRepMatrix, unit::Bool)
    ccall((:fq_nmod_mat_solve_triu, libflint), Nothing,
-         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Int, Ref{fqPolyRepField}),
-         x, U, B, Int(unit), base_ring(U))
+         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix},
+          Cint, Ref{fqPolyRepField}),
+         x, U, B, Cint(unit), base_ring(U))
    return nothing
 end
 

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -34,6 +34,16 @@ end
 #
 ################################################################################
 
+function getindex!(v::FpFieldElem, a::FpMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(a, i, j)
+   GC.@preserve a begin
+      z = ccall((:fmpz_mod_mat_entry, libflint), Ptr{ZZRingElem},
+                (Ref{FpMatrix}, Int, Int), a, i - 1, j - 1)
+      ccall((:fmpz_mod_set_fmpz, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}, Ref{FpField}), v.data, z, base_ring(a))
+   end
+   return v
+end
+
 # return plain ZZRingElem, no bounds checking
 @inline function getindex_raw(a::FpMatrix, i::Int, j::Int)
   u = ZZRingElem()
@@ -105,6 +115,14 @@ end
 function iszero(a::FpMatrix)
   r = ccall((:fmpz_mod_mat_is_zero, libflint), Cint, (Ref{FpMatrix}, ), a)
   return Bool(r)
+end
+
+@inline function is_zero_entry(A::FpMatrix, i::Int, j::Int)
+   @boundscheck Generic._checkbounds(A, i, j)
+   GC.@preserve A begin
+      x = mat_entry_ptr(A, i, j)
+      return ccall((:fmpz_is_zero, libflint), Bool, (Ptr{ZZRingElem},), x)
+   end
 end
 
 ################################################################################
@@ -398,3 +416,77 @@ function Solve._can_solve_internal_no_check(A::FpMatrix, b::FpMatrix, task::Symb
    end
    return Bool(fl), x, kernel(A, side = :right)
 end
+
+# Direct interface to the C functions to be able to write 'generic' code for
+# different matrix types
+function _solve_tril_right_flint!(x::FpMatrix, L::FpMatrix, B::FpMatrix, unit::Bool)
+   ccall((:fmpz_mod_mat_solve_tril, libflint), Nothing,
+         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Int),
+         x, L, B, Int(unit))
+   return nothing
+end
+
+function _solve_triu_right_flint!(x::FpMatrix, U::FpMatrix, B::FpMatrix, unit::Bool)
+   ccall((:fmpz_mod_mat_solve_triu, libflint), Nothing,
+         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Int),
+         x, U, B, Int(unit))
+   return nothing
+end
+
+################################################################################
+#
+#  LU decomposition
+#
+################################################################################
+
+function lu!(P::Generic.Perm, x::FpMatrix)
+   P.d .-= 1
+
+   rank = ccall((:fmpz_mod_mat_lu, libflint), Int,
+                (Ptr{Int}, Ref{FpMatrix}, Int),
+                P.d, x, 0)
+
+  P.d .+= 1
+
+  # flint does x == PLU instead of Px == LU (docs are wrong)
+  inv!(P)
+
+  return rank
+end
+
+function lu(x::FpMatrix, P = SymmetricGroup(nrows(x)))
+   m = nrows(x)
+   n = ncols(x)
+   P.n != m && error("Permutation does not match matrix")
+   p = one(P)
+   R = base_ring(x)
+   U = deepcopy(x)
+
+   L = similar(x, m, m)
+
+   rank = lu!(p, U)
+
+   for i = 1:m
+      for j = 1:n
+         if i > j
+            L[i, j] = U[i, j]
+            U[i, j] = R()
+         elseif i == j
+            L[i, j] = one(R)
+         elseif j <= m
+            L[i, j] = R()
+         end
+      end
+   end
+   return rank, p, L, U
+end
+
+################################################################################
+#
+#  Entry pointers
+#
+################################################################################
+
+@inline mat_entry_ptr(A::FpMatrix, i::Int, j::Int) =
+   ccall((:fmpz_mod_mat_entry, libflint),
+      Ptr{ZZRingElem}, (Ref{FpMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -422,15 +422,15 @@ end
 # different matrix types
 function _solve_tril_right_flint!(x::FpMatrix, L::FpMatrix, B::FpMatrix, unit::Bool)
    ccall((:fmpz_mod_mat_solve_tril, libflint), Nothing,
-         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Int),
-         x, L, B, Int(unit))
+         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Cint),
+         x, L, B, Cint(unit))
    return nothing
 end
 
 function _solve_triu_right_flint!(x::FpMatrix, U::FpMatrix, B::FpMatrix, unit::Bool)
    ccall((:fmpz_mod_mat_solve_triu, libflint), Nothing,
-         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Int),
-         x, U, B, Int(unit))
+         (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FpMatrix}, Cint),
+         x, U, B, Cint(unit))
    return nothing
 end
 
@@ -444,8 +444,8 @@ function lu!(P::Generic.Perm, x::FpMatrix)
    P.d .-= 1
 
    rank = ccall((:fmpz_mod_mat_lu, libflint), Int,
-                (Ptr{Int}, Ref{FpMatrix}, Int),
-                P.d, x, 0)
+                (Ptr{Int}, Ref{FpMatrix}, Cint),
+                P.d, x, Cint(false))
 
    P.d .+= 1
 

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -39,7 +39,8 @@ function getindex!(v::FpFieldElem, a::FpMatrix, i::Int, j::Int)
    GC.@preserve a begin
       z = ccall((:fmpz_mod_mat_entry, libflint), Ptr{ZZRingElem},
                 (Ref{FpMatrix}, Int, Int), a, i - 1, j - 1)
-      ccall((:fmpz_mod_set_fmpz, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}, Ref{FpField}), v.data, z, base_ring(a))
+      ccall((:fmpz_mod_set_fmpz, libflint), Nothing,
+            (Ref{ZZRingElem}, Ptr{ZZRingElem}, Ref{FpField}), v.data, z, base_ring(a))
    end
    return v
 end
@@ -446,12 +447,12 @@ function lu!(P::Generic.Perm, x::FpMatrix)
                 (Ptr{Int}, Ref{FpMatrix}, Int),
                 P.d, x, 0)
 
-  P.d .+= 1
+   P.d .+= 1
 
-  # flint does x == PLU instead of Px == LU (docs are wrong)
-  inv!(P)
+   # flint does x == PLU instead of Px == LU (docs are wrong)
+   inv!(P)
 
-  return rank
+   return rank
 end
 
 function lu(x::FpMatrix, P = SymmetricGroup(nrows(x)))
@@ -488,5 +489,5 @@ end
 ################################################################################
 
 @inline mat_entry_ptr(A::FpMatrix, i::Int, j::Int) =
-   ccall((:fmpz_mod_mat_entry, libflint),
-      Ptr{ZZRingElem}, (Ref{FpMatrix}, Int, Int), A, i - 1, j - 1)
+   ccall((:fmpz_mod_mat_entry, libflint), Ptr{ZZRingElem},
+         (Ref{FpMatrix}, Int, Int), A, i - 1, j - 1)

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -78,9 +78,9 @@ function one(a::fpMatrixSpace)
 end
 
 @inline function is_zero_entry(A::fpMatrix, i::Int, j::Int)
-  @boundscheck Generic._checkbounds(A, i, j)
+   @boundscheck Generic._checkbounds(A, i, j)
    x = ccall((:nmod_mat_get_entry, libflint), UInt,
-            (Ref{fpMatrix}, Int, Int), A, i - 1, j - 1)
+             (Ref{fpMatrix}, Int, Int), A, i - 1, j - 1)
    return x == 0
 end
 
@@ -539,12 +539,12 @@ function lu!(P::Generic.Perm, x::fpMatrix)
                 (Ptr{Int}, Ref{fpMatrix}, Int),
                 P.d, x, 0)
 
-  P.d .+= 1
+   P.d .+= 1
 
-  # flint does x == PLU instead of Px == LU (docs are wrong)
-  inv!(P)
+   # flint does x == PLU instead of Px == LU (docs are wrong)
+   inv!(P)
 
-  return rank
+   return rank
 end
 
 function lu(x::fpMatrix, P = SymmetricGroup(nrows(x)))

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -321,15 +321,15 @@ end
 # different matrix types
 function _solve_tril_right_flint!(x::fpMatrix, L::fpMatrix, B::fpMatrix, unit::Bool)
    ccall((:nmod_mat_solve_tril, libflint), Nothing,
-         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Int),
-         x, L, B, Int(unit))
+         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Cint),
+         x, L, B, Cint(unit))
    return nothing
 end
 
 function _solve_triu_right_flint!(x::fpMatrix, U::fpMatrix, B::fpMatrix, unit::Bool)
    ccall((:nmod_mat_solve_triu, libflint), Nothing,
-         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Int),
-         x, U, B, Int(unit))
+         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Cint),
+         x, U, B, Cint(unit))
    return nothing
 end
 
@@ -536,8 +536,8 @@ function lu!(P::Generic.Perm, x::fpMatrix)
    P.d .-= 1
 
    rank = ccall((:nmod_mat_lu, libflint), Int,
-                (Ptr{Int}, Ref{fpMatrix}, Int),
-                P.d, x, 0)
+                (Ptr{Int}, Ref{fpMatrix}, Cint),
+                P.d, x, Cint(false))
 
    P.d .+= 1
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -36,6 +36,9 @@ zero(m::fpMatrix, R::fpField, r::Int, c::Int) = similar(m, R, r, c)
 #
 ################################################################################
 
+# v.data is immutable so we can't do anything in-place
+getindex!(v::fpFieldElem, a::fpMatrix, i::Int, j::Int) = getindex(a, i, j)
+
 @inline function getindex(a::fpMatrix, i::Int, j::Int)
   @boundscheck Generic._checkbounds(a, i, j)
   u = ccall((:nmod_mat_get_entry, libflint), UInt,
@@ -72,6 +75,13 @@ function one(a::fpMatrixSpace)
   z = a()
   ccall((:nmod_mat_one, libflint), Nothing, (Ref{fpMatrix}, ), z)
   return z
+end
+
+@inline function is_zero_entry(A::fpMatrix, i::Int, j::Int)
+  @boundscheck Generic._checkbounds(A, i, j)
+   x = ccall((:nmod_mat_get_entry, libflint), UInt,
+            (Ref{fpMatrix}, Int, Int), A, i - 1, j - 1)
+   return x == 0
 end
 
 ################################################################################
@@ -307,6 +317,22 @@ function Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMatrix, task::Symb
    return Bool(fl), x, kernel(A, side = :right)
 end
 
+# Direct interface to the C functions to be able to write 'generic' code for
+# different matrix types
+function _solve_tril_right_flint!(x::fpMatrix, L::fpMatrix, B::fpMatrix, unit::Bool)
+   ccall((:nmod_mat_solve_tril, libflint), Nothing,
+         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Int),
+         x, L, B, Int(unit))
+   return nothing
+end
+
+function _solve_triu_right_flint!(x::fpMatrix, U::fpMatrix, B::fpMatrix, unit::Bool)
+   ccall((:nmod_mat_solve_triu, libflint), Nothing,
+         (Ref{fpMatrix}, Ref{fpMatrix}, Ref{fpMatrix}, Int),
+         x, U, B, Int(unit))
+   return nothing
+end
+
 ################################################################################
 #
 #  Parent object overloading
@@ -498,4 +524,52 @@ function nullspace(M::fpMatrix)
   nullity = ccall((:nmod_mat_nullspace, libflint), Int,
                   (Ref{fpMatrix}, Ref{fpMatrix}), N, M)
   return nullity, view(N, 1:nrows(N), 1:nullity)
+end
+
+################################################################################
+#
+#  LU decomposition
+#
+################################################################################
+
+function lu!(P::Generic.Perm, x::fpMatrix)
+   P.d .-= 1
+
+   rank = ccall((:nmod_mat_lu, libflint), Int,
+                (Ptr{Int}, Ref{fpMatrix}, Int),
+                P.d, x, 0)
+
+  P.d .+= 1
+
+  # flint does x == PLU instead of Px == LU (docs are wrong)
+  inv!(P)
+
+  return rank
+end
+
+function lu(x::fpMatrix, P = SymmetricGroup(nrows(x)))
+   m = nrows(x)
+   n = ncols(x)
+   P.n != m && error("Permutation does not match matrix")
+   p = one(P)
+   R = base_ring(x)
+   U = deepcopy(x)
+
+   L = similar(x, m, m)
+
+   rank = lu!(p, U)
+
+   for i = 1:m
+      for j = 1:n
+         if i > j
+            L[i, j] = U[i, j]
+            U[i, j] = R()
+         elseif i == j
+            L[i, j] = one(R)
+         elseif j <= m
+            L[i, j] = R()
+         end
+      end
+   end
+   return rank, p, L, U
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -10,7 +10,7 @@ const _MatTypes = Union{_FieldMatTypes, ZZMatrix, zzModMatrix, ZZModMatrix}
 
 # MatrixView{MatrixType, ElemType}
 struct MatrixView{S, T} <: AbstractVector{T}
-  A::S
+   A::S
 end
 
 Base.length(V::MatrixView) = length(V.A)
@@ -24,13 +24,13 @@ Base.setindex!(V::MatrixView, z, i::Int) = setindex!(V, ZZ(z), i)
 Base.size(V::MatrixView) = (length(V.A), )
 
 function Base.view(x::_MatTypes, r::Int, c::UnitRange{Int})
-  A = view(x, r:r, c)
-	return MatrixView{typeof(x), elem_type(base_ring(x))}(A)
+   A = view(x, r:r, c)
+   return MatrixView{typeof(x), elem_type(base_ring(x))}(A)
 end
 
 function Base.view(x::_MatTypes, r::UnitRange{Int}, c::Int)
-  A = view(x, r, c:c)
-	return MatrixView{typeof(x), elem_type(base_ring(x))}(A)
+   A = view(x, r, c:c)
+   return MatrixView{typeof(x), elem_type(base_ring(x))}(A)
 end
 
 ################################################################################
@@ -40,14 +40,14 @@ end
 ################################################################################
 
 function kernel(A::_FieldMatTypes; side::Symbol = :left)
-  Solve.check_option(side, [:right, :left], "side")
+   Solve.check_option(side, [:right, :left], "side")
 
-  if side === :left
-    K = kernel(transpose(A), side = :right)
-    return transpose(K)
-  end
+   if side === :left
+      K = kernel(transpose(A), side = :right)
+      return transpose(K)
+   end
 
-  return nullspace(A)[2]
+   return nullspace(A)[2]
 end
 
 ################################################################################
@@ -57,7 +57,7 @@ end
 ################################################################################
 
 function solve_init(A::_FieldMatTypes)
-  return Solve.SolveCtx{elem_type(base_ring(A)), typeof(A), typeof(A)}(A)
+   return Solve.SolveCtx{elem_type(base_ring(A)), typeof(A), typeof(A)}(A)
 end
 
 ################################################################################
@@ -119,12 +119,12 @@ function permuted_matrix_of_transpose_lu(C::Solve.SolveCtx{T, MatT}) where {T <:
 end
 
 function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{T, MatT}, b::MatT, task::Symbol; side::Symbol = :left) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
-  # Split up in separate functions to make the compiler happy
-  if side === :right
-    return Solve._can_solve_internal_no_check_right(C, b, task)
-  else
-    return Solve._can_solve_internal_no_check_left(C, b, task)
-  end
+   # Split up in separate functions to make the compiler happy
+   if side === :right
+      return Solve._can_solve_internal_no_check_right(C, b, task)
+   else
+      return Solve._can_solve_internal_no_check_left(C, b, task)
+   end
 end
 
 function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{T, MatT}, b::MatT, task::Symbol) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
@@ -136,22 +136,23 @@ function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{T, MatT}, b:
    # Let A = matrix(C) be m x n of rank r. Then LU is build as follows (modulo
    # the permutation p).
    # For example, m = 5, n = 6, r = 3:
-   #   (d u u u u u)
-   #   (l d u u u u)
-   #   (l l d u u u)
-   #   (l l l 0 0 0)
-   #   (l l l 0 0 0)
+   #   (d b b b b b)
+   #   (a d b b b b)
+   #   (a a d b b b)
+   #   (a a a 0 0 0)
+   #   (a a a 0 0 0)
+   #
    # L is the m x r matrix
    #   (1 0 0)
-   #   (l 1 0)
-   #   (l l 1)
-   #   (l l l)
-   #   (l l l)
+   #   (a 1 0)
+   #   (a a 1)
+   #   (a a a)
+   #   (a a a)
    #
    # and U is the r x n matrix
-   #   (d u u u u u)
-   #   (0 d u u u u)
-   #   (0 0 d u u u)
+   #   (d b b b b b)
+   #   (0 d b b b b)
+   #   (0 0 d b b b)
    # Notice that the diagonal entries d need not be non-zero!
 
    # Would be great if there were a `*_solve_lu_precomp` for the finite field
@@ -260,10 +261,10 @@ end
 Return the eigenvalues of `M`.
 """
 function eigenvalues(M::MatElem{T}) where T <: FieldElem
-  @assert is_square(M)
-  K = base_ring(M)
-  f = charpoly(M)
-  return roots(f)
+   @assert is_square(M)
+   K = base_ring(M)
+   f = charpoly(M)
+   return roots(f)
 end
 
 @doc raw"""
@@ -273,12 +274,12 @@ Return the eigenvalues of `M` together with their algebraic multiplicities as a
 vector of tuples.
 """
 function eigenvalues_with_multiplicities(M::MatElem{T}) where T <: FieldElem
-  @assert is_square(M)
-  K = base_ring(M)
-  Kx, x = polynomial_ring(K, "x", cached = false)
-  f = charpoly(Kx, M)
-  r = roots(f)
-  return [ (a, valuation(f, x - a)) for a in r ]
+   @assert is_square(M)
+   K = base_ring(M)
+   Kx, x = polynomial_ring(K, "x", cached = false)
+   f = charpoly(Kx, M)
+   r = roots(f)
+   return [ (a, valuation(f, x - a)) for a in r ]
 end
 
 @doc raw"""
@@ -287,9 +288,9 @@ end
 Return the eigenvalues of `M` over the field `L`.
 """
 function eigenvalues(L::Field, M::MatElem{T}) where T <: RingElem
-  @assert is_square(M)
-  M1 = change_base_ring(L, M)
-  return eigenvalues(M1)
+   @assert is_square(M)
+   M1 = change_base_ring(L, M)
+   return eigenvalues(M1)
 end
 
 @doc raw"""
@@ -299,9 +300,9 @@ Return the eigenvalues of `M` over the field `L` together with their algebraic
 multiplicities as a vector of tuples.
 """
 function eigenvalues_with_multiplicities(L::Field, M::MatElem{T}) where T <: RingElem
-  @assert is_square(M)
-  M1 = change_base_ring(L, M)
-  return eigenvalues_with_multiplicities(M1)
+   @assert is_square(M)
+   M1 = change_base_ring(L, M)
+   return eigenvalues_with_multiplicities(M1)
 end
 
 @doc raw"""
@@ -314,12 +315,12 @@ $Mv = \lambda v$. If side is `:left`, the left eigenspace is computed, i.e. vect
 $v$ such that $vM = \lambda v$.
 """
 function eigenspace(M::MatElem{T}, lambda::T; side::Symbol = :left) where T <: FieldElem
-  @assert is_square(M)
-  N = deepcopy(M)
-  for i = 1:ncols(N)
-    N[i, i] -= lambda
-  end
-  return kernel(N, side = side)
+   @assert is_square(M)
+   N = deepcopy(M)
+   for i = 1:ncols(N)
+      N[i, i] -= lambda
+   end
+   return kernel(N, side = side)
 end
 
 @doc raw"""
@@ -335,12 +336,12 @@ See also `eigenspace`.
 """
 function eigenspaces(M::MatElem{T}; side::Symbol = :left) where T<:FieldElem
 
-  S = eigenvalues(M)
-  L = Dict{elem_type(base_ring(M)), typeof(M)}()
-  for k in S
-    push!(L, k => vcat(eigenspace(M, k, side = side)))
-  end
-  return L
+   S = eigenvalues(M)
+   L = Dict{elem_type(base_ring(M)), typeof(M)}()
+   for k in S
+      push!(L, k => vcat(eigenspace(M, k, side = side)))
+   end
+   return L
 end
 
 ###############################################################################
@@ -366,7 +367,7 @@ function *(x::_FieldMatTypes, P::Perm)
    t = base_ring(x)()
    @inbounds for i = 1:nrows(x)
       for j = 1:ncols(x)
-        z[i, P[j]] = getindex!(t, x, i, j)
+         z[i, P[j]] = getindex!(t, x, i, j)
       end
    end
    return z

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -2,7 +2,6 @@
 const _FieldMatTypes = Union{QQMatrix, fpMatrix, FpMatrix, FqMatrix, fqPolyRepMatrix, FqPolyRepMatrix}
 const _MatTypes = Union{_FieldMatTypes, ZZMatrix, zzModMatrix, ZZModMatrix}
 
-
 ################################################################################
 #
 #  Support for view(A, :, i) and view(A, i, :)
@@ -351,7 +350,7 @@ end
 ###############################################################################
 
 # Unfortunately, there is no fmpq_mat_set_perm etc. in flint
-function *(P::Perm, x::_MatTypes)
+function *(P::Perm, x::_FieldMatTypes)
    z = similar(x)
    t = base_ring(x)()
    @inbounds for i = 1:nrows(x)
@@ -362,7 +361,7 @@ function *(P::Perm, x::_MatTypes)
    return z
 end
 
-function *(x::_MatTypes, P::Perm)
+function *(x::_FieldMatTypes, P::Perm)
    z = similar(x)
    t = base_ring(x)()
    @inbounds for i = 1:nrows(x)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -76,7 +76,7 @@ function Solve._init_reduce_transpose(C::Solve.SolveCtx{S, T}) where {S <: Field
   return nothing
 end
 
-function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{S, T}, b::T, task::Symbol; side::Symbol = :left) where {S <: FieldElem, T <: _FieldMatTypes}
+function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{S, T}, b::T, task::Symbol; side::Symbol = :left) where {S <: FieldElem, T <: Union{fpMatrix, FpMatrix, FqMatrix, fqPolyRepMatrix, FqPolyRepMatrix}}
   if side === :right
     fl, sol = Solve._can_solve_with_rref(b, Solve.transformation_matrix(C), rank(C), Solve.pivot_and_non_pivot_cols(C), task)
   else
@@ -90,7 +90,7 @@ function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{S, T}, b::T, task:
   return true, sol, kernel(C, side = side)
 end
 
-function Solve.kernel(C::Solve.SolveCtx{S, T}; side::Symbol = :left) where {S <: FieldElem, T <: _FieldMatTypes}
+function Solve.kernel(C::Solve.SolveCtx{S, T}; side::Symbol = :left) where {S <: FieldElem, T <: Union{fpMatrix, FpMatrix, FqMatrix, fqPolyRepMatrix, FqPolyRepMatrix}}
   Solve.check_option(side, [:right, :left], "side")
 
   if side === :right

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -103,6 +103,171 @@ end
 
 ################################################################################
 #
+#  Solve context for matrices over finite fields
+#
+################################################################################
+
+function Solve._init_reduce(C::Solve.SolveCtx{T}) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}}
+   if isdefined(C, :red) && isdefined(C, :lu_perm)
+      return nothing
+   end
+
+   LU = deepcopy(matrix(C))
+   p = Generic.Perm(1:nrows(LU))
+   r = lu!(p, LU)
+
+   Solve.set_rank!(C, r)
+   C.red = LU
+   C.lu_perm = p
+   if r < nrows(C)
+      pA = p*matrix(C)
+      set_attribute!(C, :permuted_matrix_lu => view(pA, r + 1:nrows(C), :))
+   else
+      set_attribute!(C, :permuted_matrix_lu => zero(matrix(C), 0, ncols(C)))
+   end
+   return nothing
+end
+
+function permuted_matrix_lu(C::Solve.SolveCtx{T, MatT}) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
+   Solve._init_reduce(C)
+   return get_attribute(C, :permuted_matrix_lu)::MatT
+end
+
+function Solve._init_reduce_transpose(C::Solve.SolveCtx{T}) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}}
+   if isdefined(C, :red_transp) && isdefined(C, :lu_perm_transp)
+      return nothing
+   end
+
+   LU = transpose(matrix(C))
+   p = Generic.Perm(1:nrows(LU))
+   r = lu!(p, LU)
+
+   Solve.set_rank!(C, r)
+   C.red_transp = LU
+   C.lu_perm_transp = p
+   if r < ncols(C)
+      Ap = matrix(C)*p
+      set_attribute!(C, :permuted_matrix_of_transpose_lu => view(Ap, :, r + 1:ncols(C)))
+   else
+      set_attribute!(C, :permuted_matrix_of_transpose_lu => zero(matrix(C), nrows(C), 0))
+   end
+   return nothing
+end
+
+function permuted_matrix_of_transpose_lu(C::Solve.SolveCtx{T, MatT}) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
+   Solve._init_reduce_transpose(C)
+   return get_attribute(C, :permuted_matrix_of_transpose_lu)::MatT
+end
+
+function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{T, MatT}, b::MatT, task::Symbol; side::Symbol = :left) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
+  # Split up in separate functions to make the compiler happy
+  if side === :right
+    return Solve._can_solve_internal_no_check_right(C, b, task)
+  else
+    return Solve._can_solve_internal_no_check_left(C, b, task)
+  end
+end
+
+function Solve._can_solve_internal_no_check_right(C::Solve.SolveCtx{T, MatT}, b::MatT, task::Symbol) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
+   LU = Solve.reduced_matrix(C)
+   p = Solve.lu_permutation(C)
+   pb = p*b
+   r = rank(C)
+
+   x = similar(b, r, ncols(b))
+   # Solve L x = b for the first r rows. We tell flint to pretend that there
+   # are ones on the diagonal of LU (fourth argument)
+   _solve_tril_right_flint!(x, view(LU, 1:r, 1:r), view(pb, 1:r, :), true)
+
+   # Check whether x solves Lx = b also for the lower part of L
+   if r < nrows(C) && view(LU, r + 1:nrows(LU), 1:r)*x != view(pb, r + 1:nrows(b), :)
+      return false, zero(b, 0, 0), zero(b, 0, 0)
+   end
+
+   # Solve U y = x. We need to take extra care as U might have non-pivot columns.
+   y = _solve_triu_right(view(LU, 1:r, :), x)
+
+   fl = true
+   if r < nrows(C)
+      fl = permuted_matrix_lu(C)*y == view(pb, r + 1:nrows(C), :)
+   end
+
+   if task !== :with_kernel
+      return fl, y, zero(b, 0, 0)
+   else
+      return fl, y, kernel(C, side = :right)
+   end
+end
+
+function Solve._can_solve_internal_no_check_left(C::Solve.SolveCtx{T, MatT}, b::MatT, task::Symbol) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}, MatT}
+   LU = Solve.reduced_matrix_of_transpose(C)
+   p = Solve.lu_permutation_of_transpose(C)
+   pbt = p*transpose(b)
+   r = rank(C)
+
+   x = similar(b, r, nrows(b))
+   _solve_tril_right_flint!(x, view(LU, 1:r, 1:r), view(pbt, 1:r, :), true)
+
+   # Check whether x solves Lx = b also for the lower part of L
+   if r < ncols(C) && view(LU, r + 1:nrows(LU), 1:r)*x != view(pbt, r + 1:nrows(pbt), :)
+      return false, zero(b, 0, 0), zero(b, 0, 0)
+   end
+
+   # Solve U y = x. We need to take extra care as U might have non-pivot columns.
+   yy = _solve_triu_right(view(LU, 1:r, :), x)
+   y = transpose(yy)
+
+   fl = true
+   if r < ncols(C)
+      bp = b*p
+      fl = y*permuted_matrix_of_transpose_lu(C) == view(bp, :, r + 1:ncols(C))
+   end
+
+   if task !== :with_kernel
+      return fl, y, zero(b, 0, 0)
+   else
+      return fl, y, kernel(C, side = :left)
+   end
+end
+
+# Solves A x = B with A in upper triangular shape of full rank, so something
+# like
+#   ( + * * * * )
+#   ( 0 0 + * * )
+#   ( 0 0 0 + * )
+# where + is non-zero and * is anything.
+# This is a helper functions because flint can only do the case where the
+# diagonal entries are non-zero.
+function _solve_triu_right(A::MatT, B::MatT) where {MatT <: Union{fpMatrix, FpMatrix, FqMatrix, fqPolyRepMatrix, FqPolyRepMatrix}}
+   @assert nrows(A) == nrows(B)
+   pivot_cols = Int[]
+   next_pivot_col = ncols(A) + 1
+   for r in nrows(A):-1:1
+      for c in r:next_pivot_col - 1
+         if is_zero_entry(A, r, c)
+            if c == next_pivot_col - 1
+               error("Matrix is not in upper triangular shape")
+            end
+            continue
+         end
+         push!(pivot_cols, c)
+         next_pivot_col = c
+         break
+      end
+   end
+   reverse!(pivot_cols)
+   AA = reduce(hcat, view(A, 1:nrows(A), c:c) for c in pivot_cols; init = zero(A, nrows(A), 0))
+   xx = similar(B, nrows(A), ncols(B))
+   _solve_triu_right_flint!(xx, AA, B, false)
+   x = zero(B, ncols(A), ncols(B))
+   for i in 1:nrows(xx)
+      view(x, pivot_cols[i]:pivot_cols[i], :) .= view(xx, i:i, :)
+   end
+   return x
+end
+
+################################################################################
+#
 #  Eigenvalues and eigenspaces
 #
 ################################################################################

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -675,22 +675,89 @@ end
 
    @test_throws ArgumentError can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError can_solve(A, B, side = :garbage)
+end
 
-   A = matrix(QQ, [1 2 3; 4 5 6])
+@testset "QQMatrix.solve_context" begin
+   A = matrix(QQ, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
    C = solve_init(A)
-   B = matrix(QQ, 2, 1, [1, 1])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
-   @test fl
-   @test A*x == B
-   @test is_zero(A*K)
-   @test ncols(K) + rank(A) == ncols(A)
 
-   B = matrix(QQ, 1, 3, [1, 2, 3])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B)
+   @test_throws ErrorException solve(C, [ QQ(1) ])
+   @test_throws ErrorException solve(C, [ QQ(1) ], side = :right)
+   @test_throws ErrorException solve(C, matrix(QQ, 1, 1, [ QQ(1) ]))
+   @test_throws ErrorException solve(C, matrix(QQ, 1, 1, [ QQ(1) ]), side = :right)
+   @test_throws ArgumentError solve(C, [ QQ(1), QQ(2), QQ(3) ], side = :test)
+   @test_throws ArgumentError solve(C, matrix(QQ, 3, 1, [ QQ(1), QQ(2), QQ(3) ]), side = :test)
+
+   for b in [ [ QQ(1), QQ(2), QQ(3) ],
+              matrix(QQ, 3, 1, [ QQ(1), QQ(2), QQ(3) ]),
+              matrix(QQ, 3, 2, [ QQ(1), QQ(2), QQ(3), QQ(4), QQ(5), QQ(6) ]) ]
+      @test @inferred can_solve(C, b, side = :right)
+      x = @inferred solve(C, b, side = :right)
+      @test A*x == b
+      fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+      K = @inferred kernel(C, side = :right)
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+   end
+
+   for b in [ [ QQ(1), QQ(1), QQ(1), QQ(1), QQ(1) ],
+              matrix(QQ, 1, 5, [ QQ(1), QQ(1), QQ(1), QQ(1), QQ(1) ]),
+              matrix(QQ, 2, 5, [ QQ(1), QQ(1), QQ(1), QQ(1), QQ(1),
+                                 QQ(1), QQ(1), QQ(1), QQ(1), QQ(1) ]) ]
+      @test_throws ArgumentError solve(C, b)
+      @test @inferred !can_solve(C, b)
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test !fl
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test !fl
+   end
+
+   for b in [ [ QQ(1), QQ(2), QQ(3), QQ(4), QQ(5) ],
+              matrix(QQ, 1, 5, [ QQ(1), QQ(2), QQ(3), QQ(4), QQ(5)]),
+              matrix(QQ, 2, 5, [ QQ(1), QQ(2), QQ(3), QQ(4), QQ(5),
+                                 QQ(0), QQ(0), QQ(8), QQ(9), QQ(10) ]) ]
+      @test @inferred can_solve(C, b)
+      x = @inferred solve(C, b)
+      @test x*A == b
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test fl
+      @test x*A == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test fl
+      @test x*A == b
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+      K = @inferred kernel(C)
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+   end
+
+   N = zero_matrix(QQ, 2, 1)
+   C = solve_init(N)
+   b = zeros(QQ, 2)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
-   @test x*A == B
-   @test is_zero(K*A)
-   @test nrows(K) + rank(A) == nrows(A)
+   @test N*x == b
+   @test K == identity_matrix(QQ, 1)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(QQ, 1)
+
+   N = zero_matrix(QQ, 1, 2)
+   C = solve_init(N)
+   b = zeros(QQ, 1)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+   @test fl
+   @test N*x == b
+   @test K == identity_matrix(QQ, 2) || K == swap_cols!(identity_matrix(QQ, 2), 1, 2)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(QQ, 2) || K == swap_cols!(identity_matrix(QQ, 2), 1, 2)
 end
 
 @testset "QQMatrix.kernel" begin

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -642,22 +642,90 @@ end
 
    @test_throws ArgumentError can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError can_solve(A, B, side = :garbage)
+end
 
-   A = matrix(F17, [1 2 3; 4 5 6])
+@testset "FqMatrix.solve_context" begin
+   F = GF(101)
+   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
    C = solve_init(A)
-   B = matrix(F17, 2, 1, [1, 1])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
-   @test fl
-   @test A*x == B
-   @test is_zero(A*K)
-   @test ncols(K) + rank(A) == ncols(A)
 
-   B = matrix(F17, 1, 3, [1, 2, 3])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B)
+   @test_throws ErrorException solve(C, [ F(1) ])
+   @test_throws ErrorException solve(C, [ F(1) ], side = :right)
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]))
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]), side = :right)
+   @test_throws ArgumentError solve(C, [ F(1), F(2), F(3) ], side = :test)
+   @test_throws ArgumentError solve(C, matrix(F, 3, 1, [ F(1), F(2), F(3) ]), side = :test)
+
+   for b in [ [ F(1), F(2), F(3) ],
+              matrix(F, 3, 1, [ F(1), F(2), F(3) ]),
+              matrix(F, 3, 2, [ F(1), F(2), F(3), F(4), F(5), F(6) ]) ]
+      @test @inferred can_solve(C, b, side = :right)
+      x = @inferred solve(C, b, side = :right)
+      @test A*x == b
+      fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+      K = @inferred kernel(C, side = :right)
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+   end
+
+   for b in [ [ F(1), F(1), F(1), F(1), F(1) ],
+              matrix(F, 1, 5, [ F(1), F(1), F(1), F(1), F(1) ]),
+              matrix(F, 2, 5, [ F(1), F(1), F(1), F(1), F(1),
+                                 F(1), F(1), F(1), F(1), F(1) ]) ]
+      @test_throws ArgumentError solve(C, b)
+      @test @inferred !can_solve(C, b)
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test !fl
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test !fl
+   end
+
+   for b in [ [ F(1), F(2), F(3), F(4), F(5) ],
+              matrix(F, 1, 5, [ F(1), F(2), F(3), F(4), F(5)]),
+              matrix(F, 2, 5, [ F(1), F(2), F(3), F(4), F(5),
+                                 F(0), F(0), F(8), F(9), F(10) ]) ]
+      @test @inferred can_solve(C, b)
+      x = @inferred solve(C, b)
+      @test x*A == b
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test fl
+      @test x*A == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test fl
+      @test x*A == b
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+      K = @inferred kernel(C)
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+   end
+
+   N = zero_matrix(F, 2, 1)
+   C = solve_init(N)
+   b = zeros(F, 2)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
-   @test x*A == B
-   @test is_zero(K*A)
-   @test nrows(K) + rank(A) == nrows(A)
+   @test N*x == b
+   @test K == identity_matrix(F, 1)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 1)
+
+   N = zero_matrix(F, 1, 2)
+   C = solve_init(N)
+   b = zeros(F, 1)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+   @test fl
+   @test N*x == b
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
 end
 
 @testset "FqMatrix.kernel" begin

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -630,22 +630,90 @@ end
 
    @test_throws ArgumentError can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError can_solve(A, B, side = :garbage)
+end
 
-   A = matrix(F17, [1 2 3; 4 5 6])
+@testset "FqPolyRepMatrix.solve_context" begin
+   F, _ = Native.finite_field(ZZRingElem(101), 1, "a")
+   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
    C = solve_init(A)
-   B = matrix(F17, 2, 1, [1, 1])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
-   @test fl
-   @test A*x == B
-   @test is_zero(A*K)
-   @test ncols(K) + rank(A) == ncols(A)
 
-   B = matrix(F17, 1, 3, [1, 2, 3])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B)
+   @test_throws ErrorException solve(C, [ F(1) ])
+   @test_throws ErrorException solve(C, [ F(1) ], side = :right)
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]))
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]), side = :right)
+   @test_throws ArgumentError solve(C, [ F(1), F(2), F(3) ], side = :test)
+   @test_throws ArgumentError solve(C, matrix(F, 3, 1, [ F(1), F(2), F(3) ]), side = :test)
+
+   for b in [ [ F(1), F(2), F(3) ],
+              matrix(F, 3, 1, [ F(1), F(2), F(3) ]),
+              matrix(F, 3, 2, [ F(1), F(2), F(3), F(4), F(5), F(6) ]) ]
+      @test @inferred can_solve(C, b, side = :right)
+      x = @inferred solve(C, b, side = :right)
+      @test A*x == b
+      fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+      K = @inferred kernel(C, side = :right)
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+   end
+
+   for b in [ [ F(1), F(1), F(1), F(1), F(1) ],
+              matrix(F, 1, 5, [ F(1), F(1), F(1), F(1), F(1) ]),
+              matrix(F, 2, 5, [ F(1), F(1), F(1), F(1), F(1),
+                                 F(1), F(1), F(1), F(1), F(1) ]) ]
+      @test_throws ArgumentError solve(C, b)
+      @test @inferred !can_solve(C, b)
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test !fl
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test !fl
+   end
+
+   for b in [ [ F(1), F(2), F(3), F(4), F(5) ],
+              matrix(F, 1, 5, [ F(1), F(2), F(3), F(4), F(5)]),
+              matrix(F, 2, 5, [ F(1), F(2), F(3), F(4), F(5),
+                                 F(0), F(0), F(8), F(9), F(10) ]) ]
+      @test @inferred can_solve(C, b)
+      x = @inferred solve(C, b)
+      @test x*A == b
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test fl
+      @test x*A == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test fl
+      @test x*A == b
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+      K = @inferred kernel(C)
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+   end
+
+   N = zero_matrix(F, 2, 1)
+   C = solve_init(N)
+   b = zeros(F, 2)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
-   @test x*A == B
-   @test is_zero(K*A)
-   @test nrows(K) + rank(A) == nrows(A)
+   @test N*x == b
+   @test K == identity_matrix(F, 1)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 1)
+
+   N = zero_matrix(F, 1, 2)
+   C = solve_init(N)
+   b = zeros(F, 1)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+   @test fl
+   @test N*x == b
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
 end
 
 @testset "FqPolyRepMatrix.lu" begin

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -630,22 +630,90 @@ end
 
    @test_throws ArgumentError can_solve_with_solution(A, B, side = :garbage)
    @test_throws ArgumentError can_solve(A, B, side = :garbage)
+end
 
-   A = matrix(F17, [1 2 3; 4 5 6])
+@testset "fqPolyRepMatrix.solve_context" begin
+   F, _ = Native.finite_field(101, 1, "a")
+   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
    C = solve_init(A)
-   B = matrix(F17, 2, 1, [1, 1])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
-   @test fl
-   @test A*x == B
-   @test is_zero(A*K)
-   @test ncols(K) + rank(A) == ncols(A)
 
-   B = matrix(F17, 1, 3, [1, 2, 3])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B)
+   @test_throws ErrorException solve(C, [ F(1) ])
+   @test_throws ErrorException solve(C, [ F(1) ], side = :right)
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]))
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]), side = :right)
+   @test_throws ArgumentError solve(C, [ F(1), F(2), F(3) ], side = :test)
+   @test_throws ArgumentError solve(C, matrix(F, 3, 1, [ F(1), F(2), F(3) ]), side = :test)
+
+   for b in [ [ F(1), F(2), F(3) ],
+              matrix(F, 3, 1, [ F(1), F(2), F(3) ]),
+              matrix(F, 3, 2, [ F(1), F(2), F(3), F(4), F(5), F(6) ]) ]
+      @test @inferred can_solve(C, b, side = :right)
+      x = @inferred solve(C, b, side = :right)
+      @test A*x == b
+      fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+      K = @inferred kernel(C, side = :right)
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+   end
+
+   for b in [ [ F(1), F(1), F(1), F(1), F(1) ],
+              matrix(F, 1, 5, [ F(1), F(1), F(1), F(1), F(1) ]),
+              matrix(F, 2, 5, [ F(1), F(1), F(1), F(1), F(1),
+                                 F(1), F(1), F(1), F(1), F(1) ]) ]
+      @test_throws ArgumentError solve(C, b)
+      @test @inferred !can_solve(C, b)
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test !fl
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test !fl
+   end
+
+   for b in [ [ F(1), F(2), F(3), F(4), F(5) ],
+              matrix(F, 1, 5, [ F(1), F(2), F(3), F(4), F(5)]),
+              matrix(F, 2, 5, [ F(1), F(2), F(3), F(4), F(5),
+                                 F(0), F(0), F(8), F(9), F(10) ]) ]
+      @test @inferred can_solve(C, b)
+      x = @inferred solve(C, b)
+      @test x*A == b
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test fl
+      @test x*A == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test fl
+      @test x*A == b
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+      K = @inferred kernel(C)
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+   end
+
+   N = zero_matrix(F, 2, 1)
+   C = solve_init(N)
+   b = zeros(F, 2)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
-   @test x*A == B
-   @test is_zero(K*A)
-   @test nrows(K) + rank(A) == nrows(A)
+   @test N*x == b
+   @test K == identity_matrix(F, 1)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 1)
+
+   N = zero_matrix(F, 1, 2)
+   C = solve_init(N)
+   b = zeros(F, 1)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+   @test fl
+   @test N*x == b
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
 end
 
 @testset "fqPolyRepMatrix.lu" begin

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -695,22 +695,90 @@ end
    K = @inferred kernel(A)
    @test is_zero(K*A)
    @test nrows(K) == 1
+end
 
-   A = matrix(Z17, [1 2 3; 4 5 6])
+@testset "fpMatrix.solve_context" begin
+   F = Native.GF(101)
+   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
    C = solve_init(A)
-   B = matrix(Z17, 2, 1, [1, 1])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
-   @test fl
-   @test A*x == B
-   @test is_zero(A*K)
-   @test ncols(K) + rank(A) == ncols(A)
 
-   B = matrix(Z17, 1, 3, [1, 2, 3])
-   fl, x, K = can_solve_with_solution_and_kernel(C, B)
+   @test_throws ErrorException solve(C, [ F(1) ])
+   @test_throws ErrorException solve(C, [ F(1) ], side = :right)
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]))
+   @test_throws ErrorException solve(C, matrix(F, 1, 1, [ F(1) ]), side = :right)
+   @test_throws ArgumentError solve(C, [ F(1), F(2), F(3) ], side = :test)
+   @test_throws ArgumentError solve(C, matrix(F, 3, 1, [ F(1), F(2), F(3) ]), side = :test)
+
+   for b in [ [ F(1), F(2), F(3) ],
+              matrix(F, 3, 1, [ F(1), F(2), F(3) ]),
+              matrix(F, 3, 2, [ F(1), F(2), F(3), F(4), F(5), F(6) ]) ]
+      @test @inferred can_solve(C, b, side = :right)
+      x = @inferred solve(C, b, side = :right)
+      @test A*x == b
+      fl, x = @inferred can_solve_with_solution(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+      @test fl
+      @test A*x == b
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+      K = @inferred kernel(C, side = :right)
+      @test is_zero(A*K)
+      @test ncols(K) == 2
+   end
+
+   for b in [ [ F(1), F(1), F(1), F(1), F(1) ],
+              matrix(F, 1, 5, [ F(1), F(1), F(1), F(1), F(1) ]),
+              matrix(F, 2, 5, [ F(1), F(1), F(1), F(1), F(1),
+                                 F(1), F(1), F(1), F(1), F(1) ]) ]
+      @test_throws ArgumentError solve(C, b)
+      @test @inferred !can_solve(C, b)
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test !fl
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test !fl
+   end
+
+   for b in [ [ F(1), F(2), F(3), F(4), F(5) ],
+              matrix(F, 1, 5, [ F(1), F(2), F(3), F(4), F(5)]),
+              matrix(F, 2, 5, [ F(1), F(2), F(3), F(4), F(5),
+                                 F(0), F(0), F(8), F(9), F(10) ]) ]
+      @test @inferred can_solve(C, b)
+      x = @inferred solve(C, b)
+      @test x*A == b
+      fl, x = @inferred can_solve_with_solution(C, b)
+      @test fl
+      @test x*A == b
+      fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b)
+      @test fl
+      @test x*A == b
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+      K = @inferred kernel(C)
+      @test is_zero(K*A)
+      @test nrows(K) == 0
+   end
+
+   N = zero_matrix(F, 2, 1)
+   C = solve_init(N)
+   b = zeros(F, 2)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
    @test fl
-   @test x*A == B
-   @test is_zero(K*A)
-   @test nrows(K) + rank(A) == nrows(A)
+   @test N*x == b
+   @test K == identity_matrix(F, 1)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 1)
+
+   N = zero_matrix(F, 1, 2)
+   C = solve_init(N)
+   b = zeros(F, 1)
+   fl, x, K = @inferred can_solve_with_solution_and_kernel(C, b, side = :right)
+   @test fl
+   @test N*x == b
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
+   K = @inferred kernel(C, side = :right)
+   @test K == identity_matrix(F, 2) || K == swap_cols!(identity_matrix(F, 2), 1, 2)
 end
 
 @testset "fpMatrix.kernel" begin


### PR DESCRIPTION
Use (FF)LU decomposition in the solve context for `QQMatrix` and the finite field types and do as much as possible in flint.
I hope I did not mess up the pointers too badly.
