### PR TITLE
Sort out deprecations and aliases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.43.2"
+version = "0.43.3"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.43.3"
+version = "0.43.2"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.40.0"
+AbstractAlgebra = "0.40.6"
 Antic_jll = "~0.201.500"
 Arb_jll = "~200.2300.000"
 Calcium_jll = "~0.401.100"

--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -1,38 +1,25 @@
-include(joinpath(pathof(AbstractAlgebra), "..", "Aliases.jl"))
+# alternative names for some functions from Base
+# (this list contained stuff along the lines of `@alias is_equal isequal`, but everything has moved to AbstractAlgebra)
 
-# make some Julia names compatible with our naming conventions
-@alias is_equal isequal
-@alias is_finite isfinite
-@alias is_inf isinf
-@alias is_integer isinteger
-@alias is_less isless
-@alias is_real isreal
 
+# TODO: next breaking release: remove the if guard around the block
+if @__MODULE__() == Nemo
+
+    # alternative names for some functions from LinearAlgebra
+    # we don't use the `@alias` macro here because we provide custom
+    # docstrings for these aliases
+    const eigenvalues = eigvals
+end
+
+# predeclare some functions to allow defining aliases for some of our own functions
+function eigenvalues_simple end
 @alias eigvals_simple eigenvalues_simple # for consistency with eigvals/eigenvalues
 
-# renamed for 0.40.0
-Base.@deprecate_binding FlintPadicField PadicField
-Base.@deprecate_binding padic PadicFieldElem
-Base.@deprecate_binding FlintQadicField QadicField
-Base.@deprecate_binding qadic QadicFieldElem
 
-# renamed for 0.41.0
-Base.@deprecate_binding arb_poly ArbPolyRingElem
-Base.@deprecate_binding arb_mat ArbMatrix
-Base.@deprecate_binding arb ArbFieldElem
-Base.@deprecate_binding acb_poly AcbPolyRingElem
-Base.@deprecate_binding acb_mat AcbMatrix
-Base.@deprecate_binding acb AcbFieldElem
-Base.@deprecate_binding ca CalciumFieldElem
-Base.@deprecate_binding Loc LocalizedEuclideanRing
-Base.@deprecate_binding LocElem LocalizedEuclideanRingElem
-Base.@deprecate_binding lll_ctx LLLContext
-Base.@deprecate_binding qqbar QQBarFieldElem
-Base.@deprecate_binding CalciumQQBarField QQBarField
-Base.@deprecate_binding FlintQQiField Nemo.QQiField false
-Base.@deprecate_binding fmpqi Nemo.QQiFieldElem false
-Base.@deprecate_binding FlintZZiRing Nemo.ZZiRing false
-Base.@deprecate_binding fmpzi Nemo.ZZiRingElem false
-Base.@deprecate_binding fmpzUnitRange ZZRingElemUnitRange
-Base.@deprecate_binding AnticNumberField AbsSimpleNumField
-Base.@deprecate_binding nf_elem AbsSimpleNumFieldElem
+# TODO: next breaking release: remove this block
+# Oscar includes this file for historical reasons, but expects it to contain the Base.@deprecate_binding calls.
+# Until this is changed and released there, we thus need to include the deprecations here.
+@static if Symbol(@__MODULE__()) in [:Hecke, :Oscar]
+    Nemo.@include_deprecated_bindings()
+end
+

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -1,5 +1,63 @@
-# Deprecated in 0.39.*
+###############################################################################
+#
+#   Aliases
+#
+###############################################################################
 
+# ALL aliases here are only a temporary measure to allow for a smooth transition downstream.
+# they will be replaced by deprecations eventually
+
+#= currently none =#
+
+###############################################################################
+#
+#   Deprecated bindings
+#
+###############################################################################
+
+# Deprecated bindings don't get reexported automatically in Hecke/Oscar/etc.
+# By calling this macro from the respective packages, we can ensure that the deprecated bindings are available there.
+macro include_deprecated_bindings()
+    return esc(quote
+        # renamed and deprecated for 0.40.0
+        Base.@deprecate_binding FlintPadicField PadicField
+        Base.@deprecate_binding padic PadicFieldElem
+        Base.@deprecate_binding FlintQadicField QadicField
+        Base.@deprecate_binding qadic QadicFieldElem
+
+        # renamed and deprecated for 0.41.0
+        Base.@deprecate_binding arb_poly ArbPolyRingElem
+        Base.@deprecate_binding arb_mat ArbMatrix
+        Base.@deprecate_binding arb ArbFieldElem
+        Base.@deprecate_binding acb_poly AcbPolyRingElem
+        Base.@deprecate_binding acb_mat AcbMatrix
+        Base.@deprecate_binding acb AcbFieldElem
+        Base.@deprecate_binding ca CalciumFieldElem
+        Base.@deprecate_binding Loc LocalizedEuclideanRing
+        Base.@deprecate_binding LocElem LocalizedEuclideanRingElem
+        Base.@deprecate_binding lll_ctx LLLContext
+        Base.@deprecate_binding qqbar QQBarFieldElem
+        Base.@deprecate_binding CalciumQQBarField QQBarField
+        Base.@deprecate_binding FlintQQiField Nemo.QQiField false
+        Base.@deprecate_binding fmpqi Nemo.QQiFieldElem false
+        Base.@deprecate_binding FlintZZiRing Nemo.ZZiRing false
+        Base.@deprecate_binding fmpzi Nemo.ZZiRingElem false
+        Base.@deprecate_binding fmpzUnitRange ZZRingElemUnitRange
+        Base.@deprecate_binding AnticNumberField AbsSimpleNumField
+        Base.@deprecate_binding nf_elem AbsSimpleNumFieldElem
+
+    end)
+end
+
+@include_deprecated_bindings()
+
+###############################################################################
+#
+#   Deprecations
+#
+###############################################################################
+
+# Deprecated in 0.39.*
 @deprecate divisible(x::Int, y::Int) is_divisible_by(x, y)
 @deprecate divisible(x::ZZRingElem, y::Int) is_divisible_by(x, y)
 @deprecate divisible(x::ZZRingElem, y::ZZRingElem) is_divisible_by(x, y)

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -192,9 +192,11 @@ import AbstractAlgebra: Set
 import AbstractAlgebra: set_attribute!
 import AbstractAlgebra: Solve
 
+AbstractAlgebra.@include_deprecated_bindings()
+
 include("Exports.jl")
 
-const eigenvalues = eigvals # alternative name for the function from LinearAlgebra
+include("Aliases.jl")
 
 ###############################################################################
 #
@@ -665,8 +667,6 @@ end
 ################################################################################
 
 include("Deprecations.jl")
-
-include("Aliases.jl")
 
 include("Native.jl")
 


### PR DESCRIPTION
Same as in AA: move aliases to aliases.jl and deprecations to deprecations.jl. Duplicate aliases are removed.

@fingolfin this is my suggestion for the inclusion problem (https://github.com/oscar-system/Oscar.jl/blob/39a24f20cb9a8f2ed3bea6e02022e90031f25180/src/aliases.jl#L13). it is very similar to the one in AA.

Edit: doesn't work right now. I have another idea to discuss tomorrow.