### PR TITLE
ci: stage the downstream tests

### DIFF
--- a/.github/workflows/hecke.yml
+++ b/.github/workflows/hecke.yml
@@ -1,0 +1,112 @@
+name: HeckeCI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  generatematrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      PR_NUMBER: ${{github.event.number || '0' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: "Set up Julia"
+      uses: julia-actions/setup-julia@v1
+      with:
+        version: '1.10'
+    - name: OscarDevTools - CI
+      if: github.repository == 'oscar-system/OscarDevTools.jl'
+      run: |
+        julia --project=oscar-dev -e "using Pkg;
+                                      Pkg.develop(PackageSpec(path=\".\"));
+                                      Pkg.instantiate();"
+    - name: fetch OscarDevTools
+      if: github.repository != 'oscar-system/OscarDevTools.jl'
+      run: |
+        julia --project=oscar-dev -e "using Pkg;
+                                      Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
+                                      Pkg.instantiate();"
+    - id: set-matrix
+      run: |
+        julia --project=oscar-dev -e "using OscarDevTools.OscarCI;
+                 ciprefs = parse_meta(\"HeckeCI.toml\");
+                 cimat = ci_matrix(ciprefs;
+                                   pr=${PR_NUMBER},
+                                   active_repo=\"${GITHUB_REPOSITORY}\");
+                 @show cimat;
+                 println(github_json(cimat));"
+
+  test-oscar:
+    needs: generatematrix
+    name: ${{ join(matrix.*.name) }} - ${{ matrix.os }}, julia ${{ matrix.julia-version}}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    env:
+      PR_NUMBER: ${{github.event.number}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix: ${{fromJSON(needs.generatematrix.outputs.matrix)}}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: re-using OscarDevTools checkout
+        if: github.repository == 'oscar-system/OscarDevTools.jl'
+        run: |
+          julia --project=oscar-dev -e "using Pkg;
+                                        Pkg.develop(PackageSpec(path=\".\"));
+                                        Pkg.instantiate();"
+      - name: fetch OscarDevTools
+        if: github.repository != 'oscar-system/OscarDevTools.jl'
+        run: |
+          julia --project=oscar-dev -e "using Pkg;
+                                        Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
+                                        Pkg.instantiate();"
+      - name: "Set up Oscar-dev configuration"
+        id: setupdev
+        env:
+          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+        run: |
+          echo "$MATRIX_CONTEXT"
+          julia --project=oscar-dev -e "using OscarDevTools, OscarDevTools.OscarCI;
+                   meta = job_meta_env(\"MATRIX_CONTEXT\");
+                   oscar_develop(job_pkgs(meta);
+                                 dir=\"oscar-dev\",
+                                 active_repo=\"${GITHUB_REPOSITORY}\");
+                   github_env_runtests(meta;
+                                       varname=\"oscar_run_tests\",
+                                       filename=\"${GITHUB_ENV}\");
+                   github_env_run_doctests(meta;
+                                           varname=\"oscar_run_doctests\",
+                                           filename=\"${GITHUB_ENV}\");"
+
+      - name: "Run tests"
+        if: steps.setupdev.outputs.skiptests != 'true'
+        run: |
+          echo '${{ env.oscar_run_tests }}'
+          julia --color=yes --project=oscar-dev/project/ -e '${{ env.oscar_run_tests }}'
+      - name: "Run doctests"
+        if: steps.setupdev.outputs.skiptests != 'true'
+        run: |
+          echo '${{ env.oscar_run_doctests }}'
+          julia --color=yes --project=oscar-dev/project/ -e '${{ env.oscar_run_doctests }}'

--- a/.github/workflows/singular.yml
+++ b/.github/workflows/singular.yml
@@ -1,0 +1,112 @@
+name: SingularCI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  generatematrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      PR_NUMBER: ${{github.event.number || '0' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: "Set up Julia"
+      uses: julia-actions/setup-julia@v1
+      with:
+        version: '1.10'
+    - name: OscarDevTools - CI
+      if: github.repository == 'oscar-system/OscarDevTools.jl'
+      run: |
+        julia --project=oscar-dev -e "using Pkg;
+                                      Pkg.develop(PackageSpec(path=\".\"));
+                                      Pkg.instantiate();"
+    - name: fetch OscarDevTools
+      if: github.repository != 'oscar-system/OscarDevTools.jl'
+      run: |
+        julia --project=oscar-dev -e "using Pkg;
+                                      Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
+                                      Pkg.instantiate();"
+    - id: set-matrix
+      run: |
+        julia --project=oscar-dev -e "using OscarDevTools.OscarCI;
+                 ciprefs = parse_meta(\"SingularCI.toml\");
+                 cimat = ci_matrix(ciprefs;
+                                   pr=${PR_NUMBER},
+                                   active_repo=\"${GITHUB_REPOSITORY}\");
+                 @show cimat;
+                 println(github_json(cimat));"
+
+  test-oscar:
+    needs: generatematrix
+    name: ${{ join(matrix.*.name) }} - ${{ matrix.os }}, julia ${{ matrix.julia-version}}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    env:
+      PR_NUMBER: ${{github.event.number}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix: ${{fromJSON(needs.generatematrix.outputs.matrix)}}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: re-using OscarDevTools checkout
+        if: github.repository == 'oscar-system/OscarDevTools.jl'
+        run: |
+          julia --project=oscar-dev -e "using Pkg;
+                                        Pkg.develop(PackageSpec(path=\".\"));
+                                        Pkg.instantiate();"
+      - name: fetch OscarDevTools
+        if: github.repository != 'oscar-system/OscarDevTools.jl'
+        run: |
+          julia --project=oscar-dev -e "using Pkg;
+                                        Pkg.add(PackageSpec(name=\"OscarDevTools\",version=\"0.2\"));
+                                        Pkg.instantiate();"
+      - name: "Set up Oscar-dev configuration"
+        id: setupdev
+        env:
+          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+        run: |
+          echo "$MATRIX_CONTEXT"
+          julia --project=oscar-dev -e "using OscarDevTools, OscarDevTools.OscarCI;
+                   meta = job_meta_env(\"MATRIX_CONTEXT\");
+                   oscar_develop(job_pkgs(meta);
+                                 dir=\"oscar-dev\",
+                                 active_repo=\"${GITHUB_REPOSITORY}\");
+                   github_env_runtests(meta;
+                                       varname=\"oscar_run_tests\",
+                                       filename=\"${GITHUB_ENV}\");
+                   github_env_run_doctests(meta;
+                                           varname=\"oscar_run_doctests\",
+                                           filename=\"${GITHUB_ENV}\");"
+
+      - name: "Run tests"
+        if: steps.setupdev.outputs.skiptests != 'true'
+        run: |
+          echo '${{ env.oscar_run_tests }}'
+          julia --color=yes --project=oscar-dev/project/ -e '${{ env.oscar_run_tests }}'
+      - name: "Run doctests"
+        if: steps.setupdev.outputs.skiptests != 'true'
+        run: |
+          echo '${{ env.oscar_run_doctests }}'
+          julia --color=yes --project=oscar-dev/project/ -e '${{ env.oscar_run_doctests }}'

--- a/HeckeCI.toml
+++ b/HeckeCI.toml
@@ -1,4 +1,4 @@
-title = "metadata for Oscar CI run"
+title = "metadata for Hecke CI run"
 
 [env]
 # os = [ "ubuntu-latest" ]
@@ -6,11 +6,5 @@ title = "metadata for Oscar CI run"
 # branches = [ "<matching>", "release" ]
 
 [pkgs]
-  [pkgs.Oscar]
-  test = true
-
-  [pkgs.Singular]
-  test = false
-
   [pkgs.Hecke]
-  test = false
+  test = true

--- a/SingularCI.toml
+++ b/SingularCI.toml
@@ -1,4 +1,4 @@
-title = "metadata for Oscar CI run"
+title = "metadata for Singular CI run"
 
 [env]
 # os = [ "ubuntu-latest" ]
@@ -6,11 +6,5 @@ title = "metadata for Oscar CI run"
 # branches = [ "<matching>", "release" ]
 
 [pkgs]
-  [pkgs.Oscar]
-  test = true
-
   [pkgs.Singular]
-  test = false
-
-  [pkgs.Hecke]
-  test = false
+  test = true


### PR DESCRIPTION
https://github.com/Nemocas/AbstractAlgebra.jl/pull/1599 for Nemo.
Splits up the big OscarCI job into three separate ones for the Hecke, Singular, and Oscar tests.

After merging, someone with admin rights needs to adapt the required CI job.