### PR TITLE
Precision fixes for some code dealing with ArbField/AcbField

### DIFF
--- a/docs/src/acb.md
+++ b/docs/src/acb.md
@@ -5,7 +5,7 @@ DocTestSetup = quote
 end
 ```
 
-# Fixed precisioncomplex balls
+# Fixed precision complex balls
 
 Arbitrary precision complex ball arithmetic is supplied by Arb which provides a
 ball representation which tracks error bounds rigorously. Complex numbers are 
@@ -17,9 +17,9 @@ constructs the parent object for the Arb complex field.
 The types of complex boxes in Nemo are given in the following table, along with
 the libraries that provide them and the associated types of the parent objects.
 
- Library | Field                | Element type  | Parent type
----------|----------------------|---------------|--------------
-Arb      | $\mathbb{C}$ (boxes) | `AcbFieldElem`         | `AcbField`
+ Library | Field                | Element type   | Parent type
+---------|----------------------|----------------|--------------
+Arb      | $\mathbb{C}$ (boxes) | `AcbFieldElem` | `AcbField`
 
 All the complex field types belong to the `Field` abstract type and the types of
 elements in this field, i.e. complex boxes in this case, belong to the

--- a/src/calcium/ca.jl
+++ b/src/calcium/ca.jl
@@ -1339,7 +1339,7 @@ end
 
 function (R::AcbField)(a::CalciumFieldElem; parts::Bool=false)
    C = a.parent
-   prec = precision(Balls)
+   prec = precision(R)
    z = R()
    if parts
       ccall((:ca_get_acb_accurate_parts, libcalcium),
@@ -1353,16 +1353,16 @@ end
 
 function (R::ArbField)(a::CalciumFieldElem; check::Bool=true)
    C = a.parent
-   prec = precision(Balls)
+   prec = precision(R)
    if check
-      z = AcbField()(a, parts=true)
+      z = AcbField(prec)(a, parts=true)
       if isreal(z)
          return real(z)
       else
          error("unable to convert to a real number")
       end
    else
-      z = AcbField()(a, parts=false)
+      z = AcbField(prec)(a, parts=false)
       if accuracy_bits(real(z)) < prec - 5
           z = AcbField()(a, parts=true)
       end
@@ -1371,16 +1371,14 @@ function (R::ArbField)(a::CalciumFieldElem; check::Bool=true)
 end
 
 function (::Type{ComplexF64})(x::CalciumFieldElem)
-   set_precision!(Balls, 53) do
-      z = AcbField()(x)
-      x = ArbFieldElem()
-      ccall((:acb_get_real, libarb), Nothing, (Ref{ArbFieldElem}, Ref{AcbFieldElem}), x, z)
-      xx = Float64(x)
-      y = ArbFieldElem()
-      ccall((:acb_get_imag, libarb), Nothing, (Ref{ArbFieldElem}, Ref{AcbFieldElem}), y, z)
-      yy = Float64(y)
-      return ComplexF64(xx, yy)
-   end
+   z = AcbField(53, cached = false)(x)
+   x = ArbFieldElem()
+   ccall((:acb_get_real, libarb), Nothing, (Ref{ArbFieldElem}, Ref{AcbFieldElem}), x, z)
+   xx = Float64(x)
+   y = ArbFieldElem()
+   ccall((:acb_get_imag, libarb), Nothing, (Ref{ArbFieldElem}, Ref{AcbFieldElem}), y, z)
+   yy = Float64(y)
+   return ComplexF64(xx, yy)
 end
 
 ###############################################################################

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -1363,7 +1363,7 @@ may be much smaller than a worst-case bound.
 function guess end
 
 function guess(R::QQBarField, x::T, maxdeg::Int, maxbits::Int=0) where {T <: Union{AcbFieldElem, ComplexFieldElem}}
-   prec = precision(Balls)
+   prec = precision(parent(x))
    if maxbits <= 0
       maxbits = prec
    end
@@ -1378,7 +1378,7 @@ function guess(R::QQBarField, x::T, maxdeg::Int, maxbits::Int=0) where {T <: Uni
 end
 
 function guess(R::QQBarField, x::ArbFieldElem, maxdeg::Int, maxbits::Int=0)
-   CC = AcbField()
+   CC = AcbField(precision(parent(x)))
    return guess(R, CC(x), maxdeg, maxbits)
 end
 
@@ -1428,7 +1428,7 @@ Convert `a` to a real ball with the precision of the parent field `R`.
 Throws if `a` is not a real number.
 """
 function (R::RealField)(a::QQBarFieldElem)
-   prec = precision(R)
+   prec = precision(Balls)
    z = R()
    ccall((:qqbar_get_arb, libcalcium),
         Nothing, (Ref{RealFieldElem}, Ref{QQBarFieldElem}, Int), z, a, prec)
@@ -1442,7 +1442,7 @@ end
 Convert `a` to a complex ball with the precision of the parent field `R`.
 """
 function (R::ComplexField)(a::QQBarFieldElem)
-   prec = precision(R)
+   prec = precision(Balls)
    z = R()
    ccall((:qqbar_get_acb, libcalcium),
         Nothing, (Ref{ComplexFieldElem}, Ref{QQBarFieldElem}, Int), z, a, prec)

--- a/test/calcium/ca-test.jl
+++ b/test/calcium/ca-test.jl
@@ -252,8 +252,8 @@ end
    @test CalciumQQBar(c) == QQBarFieldElem(1+2im)
    @test_throws ErrorException CalciumQQBar(t)
 
-   RR = ArbField()
-   CC = AcbField()
+   RR = ArbField(64)
+   CC = AcbField(64)
 
    @test RR(h) == 0.5
    @test CC(h) == 0.5
@@ -275,6 +275,14 @@ end
 
    s = 1 * one(C) + 2 * onei(C)
    @test ComplexF64(s) == 1 + 2 * im
+
+   # verify precision bug https://github.com/Nemocas/Nemo.jl/issues/1580 is fixed
+   x = C(pi)
+   F = ArbField(333)
+   y = F(x)
+   @test radius(y) < 1e-113
+   z = F("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170680 +/- 1.79e-101")
+   @test contains(z,y)
 end
 
 @testset "CalciumFieldElem.inplace" begin


### PR DESCRIPTION
Fixes #1580 reported by @fredrik-johansson which was introduced by PR #1367 resp. commit eefcf5b9d3bb5fd74ed14aca0dd2a21ded4bd7e3.

I am not quite sure if the test I added is "right" to verify we get the desired precision, if someone can suggest a better methods, I'd be obliged. (I don't quite understand why `radius(y)` suggest a precision of about `1e-113` while the printing says `... +/- 1.79e-101` -- I wanted to check the latter, which nicely patches $\log_{10}(2^{333})$ but couldn't find a good way).

I also fixed a few other things in the same PR but did not add any tests for them.

Moreover, a few of the changed functions should probably get variants for `RealField` and `ComplexField`..