### PR TITLE
fix a field element constructor

### DIFF
--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -665,7 +665,7 @@ function (a::fqPolyRepField)(b::Vector{<:IntegerUnion})
    da = degree(a)
    db = length(b)
    da == db || error("Coercion impossible")
-   F = GF(Int(characteristic(a)), cached = false)
+   F = Native.GF(Int(characteristic(a)), cached = false)
    z = fqPolyRepFieldElem(a, polynomial(F, b))
    z.parent = a
    return z

--- a/test/Native-test.jl
+++ b/test/Native-test.jl
@@ -26,4 +26,9 @@
 
   @test Native.GF(2, 2) isa fqPolyRepField
   @test Native.GF(ZZ(2), 2) isa FqPolyRepField
+
+  F2 = Native.GF(2, cached = false)
+  @test F2([1]) == one(F2)
+  F4 = Native.GF(2, 2)
+  @test F4([1, 0]) == one(F4)
 end


### PR DESCRIPTION
Fix `(a::fqPolyRepField)(b::Vector{<:IntegerUnion})`, add a test that fails without the change.