### PR TITLE
Make dim check in matrix space creation consistent

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -872,6 +872,7 @@ struct RealMatSpace <: MatSpace{RealFieldElem}
   ncols::Int
 
   function RealMatSpace(R::RealField, r::Int, c::Int)
+    (r < 0 || c < 0) && throw(_err_dim_negative)
     return new(r, c)
   end
 end
@@ -995,6 +996,7 @@ struct ArbMatSpace <: MatSpace{ArbFieldElem}
   base_ring::ArbField
 
   function ArbMatSpace(R::ArbField, r::Int, c::Int)
+    (r < 0 || c < 0) && throw(_err_dim_negative)
     return new(r, c, R)
   end
 end
@@ -1122,6 +1124,7 @@ struct ComplexMatSpace <: MatSpace{ComplexFieldElem}
   #base_ring::AcbField
 
   function ComplexMatSpace(R::ComplexField, r::Int, c::Int)
+    (r < 0 || c < 0) && throw(_err_dim_negative)
     return new(r, c)
   end
 end
@@ -1389,6 +1392,7 @@ struct AcbMatSpace <: MatSpace{AcbFieldElem}
   base_ring::AcbField
 
   function AcbMatSpace(R::AcbField, r::Int, c::Int)
+    (r < 0 || c < 0) && throw(_err_dim_negative)
     return new(r, c, R)
   end
 end

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -1093,6 +1093,5 @@ end
 
 function matrix_space(R::ComplexField, r::Int, c::Int; cached = true)
   # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-  (r <= 0 || c <= 0) && error("Dimensions must be positive")
   return ComplexMatSpace(R, r, c)
 end

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -844,6 +844,5 @@ promote_rule(::Type{RealMat}, ::Type{QQMatrix}) = RealMat
 
 function matrix_space(R::RealField, r::Int, c::Int; cached = true)
   # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-  (r <= 0 || c <= 0) && error("Dimensions must be positive")
   return RealMatSpace(R, r, c)
 end

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -1107,6 +1107,5 @@ end
 
 function matrix_space(R::AcbField, r::Int, c::Int; cached = true)
   # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-  (r <= 0 || c <= 0) && error("Dimensions must be positive")
   return AcbMatSpace(R, r, c)
 end

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -879,6 +879,5 @@ promote_rule(::Type{ArbMatrix}, ::Type{QQMatrix}) = ArbMatrix
 
 function matrix_space(R::ArbField, r::Int, c::Int; cached = true)
   # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-  (r <= 0 || c <= 0) && error("Dimensions must be positive")
   return ArbMatSpace(R, r, c)
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4829,6 +4829,7 @@ struct QQMatrixSpace <: MatSpace{QQFieldElem}
    ncols::Int
 
    function QQMatrixSpace(r::Int, c::Int)
+      (r < 0 || c < 0) && throw(_err_dim_negative)
       return new(r, c)
    end
 end
@@ -4992,7 +4993,8 @@ struct ZZMatrixSpace <: MatSpace{ZZRingElem}
    ncols::Int
 
    function ZZMatrixSpace(r::Int, c::Int)
-      return new(r, c)
+    (r < 0 || c < 0) && throw(_err_dim_negative)
+    return new(r, c)
    end
 end
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -537,7 +537,7 @@ end
 
 function matrix_space(R::fpField, r::Int, c::Int; cached::Bool = true)
    # TODO/FIXME: `cached` is ignored and only exists for backwards compatibility
-  fpMatrixSpace(R, r, c)
+   fpMatrixSpace(R, r, c)
 end
 
 ################################################################################


### PR DESCRIPTION
Alternative to and thus closes https://github.com/Nemocas/Nemo.jl/pull/1711.

All matrix space methods now check `r` and `c` in the constructor of the type.