### PR TITLE
Adapt Aliases.jl for breaking release

### DIFF
--- a/src/Aliases.jl
+++ b/src/Aliases.jl
@@ -2,24 +2,12 @@
 # (this list contained stuff along the lines of `@alias is_equal isequal`, but everything has moved to AbstractAlgebra)
 
 
-# TODO: next breaking release: remove the if guard around the block
-if @__MODULE__() == Nemo
+# alternative names for some functions from LinearAlgebra
+# we don't use the `@alias` macro here because we provide custom
+# docstrings for these aliases
+const eigenvalues = eigvals
 
-    # alternative names for some functions from LinearAlgebra
-    # we don't use the `@alias` macro here because we provide custom
-    # docstrings for these aliases
-    const eigenvalues = eigvals
-end
 
 # predeclare some functions to allow defining aliases for some of our own functions
 function eigenvalues_simple end
 @alias eigvals_simple eigenvalues_simple # for consistency with eigvals/eigenvalues
-
-
-# TODO: next breaking release: remove this block
-# Oscar includes this file for historical reasons, but expects it to contain the Base.@deprecate_binding calls.
-# Until this is changed and released there, we thus need to include the deprecations here.
-@static if Symbol(@__MODULE__()) in [:Hecke, :Oscar]
-    Nemo.@include_deprecated_bindings()
-end
-


### PR DESCRIPTION
Removes the hacky workarounds introduced in https://github.com/Nemocas/Nemo.jl/pull/1704 to make it non-breaking.