### PR TITLE
Implement is_squarefree for QQ/ZZPolyRingElem

### DIFF
--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -558,9 +558,26 @@ for (factor_fn, factor_fn_inner, flint_fn) in
        end)
 end
 
+################################################################################
+#
+#  Irreducibility
+#
+################################################################################
+
 function is_irreducible(x::QQPolyRingElem)
   res, _ = _factor(x)
   return length(res) == 1 && first(values(res)) == 1
+end
+
+################################################################################
+#
+#  Squarefree testing
+#
+################################################################################
+
+function is_squarefree(x::QQPolyRingElem)
+   iszero(x) && return false
+   return Bool(@ccall libflint.fmpq_poly_is_squarefree(x::Ref{QQPolyRingElem})::Cint)
 end
 
 ###############################################################################

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1535,6 +1535,7 @@ function is_squarefree(n::Union{Int, ZZRingElem})
   end
   return isone(maximum(values(factor(n).fac); init = 1))
 end
+
 ################################################################################
 #
 #   Factor trial range

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -607,6 +607,12 @@ for (factor_fn, factor_fn_inner, flint_fn) in
        end)
 end
 
+################################################################################
+#
+#  Irreducibility
+#
+################################################################################
+
 function is_irreducible(x::ZZPolyRingElem)
   if degree(x) == 0
     return is_prime(coeff(x, 0))
@@ -617,6 +623,18 @@ function is_irreducible(x::ZZPolyRingElem)
   else
     return false
   end
+end
+
+################################################################################
+#
+#  Squarefree testing
+#
+################################################################################
+
+function is_squarefree(x::ZZPolyRingElem)
+   iszero(x) && return false
+   is_squarefree(content(x)) || return false   # Nemo ignores the content
+   return Bool(@ccall libflint.fmpz_poly_is_squarefree(x::Ref{ZZPolyRingElem})::Cint)
 end
 
 ###############################################################################


### PR DESCRIPTION
Cleaning out old branches; I made this last November, not sure
why I never submitted. The new methods replace generic code,
so this is purely about making things a bit faster.

Before:

    julia> S, y = polynomial_ring(QQ, :y); g = 2*(y+1)^2;

    julia> @btime is_squarefree(g)
      516.927 ns (10 allocations: 400 bytes)
    false

    julia> R, x = polynomial_ring(ZZ, :x); f = 4*(x^2+1);

    julia> @btime is_squarefree(f)
      1.329 μs (38 allocations: 1.82 KiB)
    false

After:

    julia> S, y = polynomial_ring(QQ, :y); g = 2*(y+1)^2;

    julia> @btime is_squarefree(g)
      53.596 ns (0 allocations: 0 bytes)
    false

    julia> R, x = polynomial_ring(ZZ, :x); f = 4*(x^2+1);

    julia> @btime is_squarefree(f)
      209.386 ns (4 allocations: 64 bytes)
    false