### PR TITLE
p-adics done right

### DIFF
--- a/docs/src/padic.md
+++ b/docs/src/padic.md
@@ -10,7 +10,7 @@ end
 P-adic fields are provided in Nemo by Flint. This allows construction of
 $p$-adic fields for any prime $p$.
 
-P-adic fields are constructed using the `PadicField` function. 
+P-adic fields are constructed using the `padic_field` function. 
 
 The types of $p$-adic fields in Nemo are given in the following table, along
 with the libraries that provide them and the associated types of the parent
@@ -39,18 +39,8 @@ the $p$-adic field itself. This is accomplished with one of the following
 constructors.
 
 ```@docs
-PadicField(::Integer, ::Int)
+padic_field
 ```
-
-It is also possible to call the inner constructor directly. It has the following
-form.
-
-```
-PadicField(p::ZZRingElem, prec::Int)
-```
-
-Returns the parent object for the $p$-adic field for given prime $p$, where
-the default absolute precision of elements of the field is given by `prec`.
 
 Here are some examples of creating $p$-adic fields and making use of the
 resulting parent objects to coerce various elements into those fields.
@@ -58,10 +48,10 @@ resulting parent objects to coerce various elements into those fields.
 **Examples**
 
 ```jldoctest
-julia> R = PadicField(7, 30)
+julia> R = padic_field(7, precision = 30)
 Field of 7-adic numbers
 
-julia> S = PadicField(ZZ(65537), 30)
+julia> S = padic_field(ZZ(65537), precision = 30)
 Field of 65537-adic numbers
 
 julia> a = R()
@@ -95,10 +85,10 @@ $p^n$ as in the examples.
 **Examples**
 
 ```jldoctest
-julia> R = PadicField(7, 30)
+julia> R = padic_field(7, precision = 30)
 Field of 7-adic numbers
 
-julia> S = PadicField(ZZ(65537), 30)
+julia> S = padic_field(ZZ(65537), precision = 30)
 Field of 65537-adic numbers
 
 julia> c = 1 + 2*7 + 4*7^2 + O(R, 7^3)
@@ -138,7 +128,7 @@ lift(::QQField, ::PadicFieldElem)
 **Examples**
 
 ```jldoctest
-julia> R = PadicField(7, 30)
+julia> R = padic_field(7, precision = 30)
 Field of 7-adic numbers
 
 julia> a = 1 + 2*7 + 4*7^2 + O(R, 7^3)
@@ -175,7 +165,7 @@ Base.sqrt(::PadicFieldElem)
 **Examples**
 
 ```jldoctest
-julia> R = PadicField(7, 30)
+julia> R = padic_field(7, precision = 30)
 Field of 7-adic numbers
 
 julia> a = 1 + 7 + 2*7^2 + O(R, 7^3)
@@ -220,7 +210,7 @@ teichmuller(::PadicFieldElem)
 **Examples**
 
 ```jldoctest
-julia> R = PadicField(7, 30)
+julia> R = padic_field(7, precision = 30)
 Field of 7-adic numbers
 
 julia> a = 1 + 7 + 2*7^2 + O(R, 7^3)

--- a/docs/src/padic.md
+++ b/docs/src/padic.md
@@ -10,7 +10,7 @@ end
 P-adic fields are provided in Nemo by Flint. This allows construction of
 $p$-adic fields for any prime $p$.
 
-P-adic fields are constructed using the `padic_field` function. 
+P-adic fields are constructed using the `padic_field` function.
 
 The types of $p$-adic fields in Nemo are given in the following table, along
 with the libraries that provide them and the associated types of the parent

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -11,7 +11,7 @@ Q-adic fields, that is, unramified extensions of p-adic fields, are provided in
 Nemo by Flint. This allows construction of $q$-adic fields for any prime power
 $q$.
 
-Q-adic fields are constructed using the `QadicField` function.
+Q-adic fields are constructed using the `qadic_field` function.
 
 The types of $q$-adic fields in Nemo are given in the following table, along
 with the libraries that provide them and the associated types of the parent
@@ -41,19 +41,8 @@ the $q$-adic field itself. This is accomplished with one of the following
 constructors.
 
 ```@docs
-QadicField(::Integer, ::Int, ::Int)
+qadic_field
 ```
-
-It is also possible to call the inner constructor directly. It has the following
-form.
-
-```
-QadicField(p::ZZRingElem, d::Int, prec::Int)
-```
-
-Returns the parent object for the $q$-adic field for given prime $p$ and degree
-$d$, where the default absolute precision of elements of the field is given by
-`prec`. It also return the uniformizer `p` with the default precision.
 
 Here are some examples of creating $q$-adic fields and making use of the
 resulting parent objects to coerce various elements into those fields.
@@ -61,9 +50,9 @@ resulting parent objects to coerce various elements into those fields.
 **Examples**
 
 ```jldoctest
-julia> R, p = QadicField(7, 1, 30);
+julia> R, p = qadic_field(7, 1, precision = 30);
 
-julia> S, _ = QadicField(ZZ(65537), 1, 30);
+julia> S, _ = qadic_field(ZZ(65537), 1, precision = 30);
 
 julia> a = R()
 0
@@ -96,9 +85,9 @@ $p^n$ as in the examples.
 **Examples**
 
 ```jldoctest
-julia> R, _ = QadicField(7, 1, 30);
+julia> R, _ = qadic_field(7, 1, precision = 30);
 
-julia> S, _ = QadicField(ZZ(65537), 1, 30);
+julia> S, _ = qadic_field(ZZ(65537), 1, precision = 30);
 
 julia> c = 1 + 2*7 + 4*7^2 + O(R, 7^3)
 7^0 + 2*7^1 + 4*7^2 + O(7^3)
@@ -137,7 +126,7 @@ lift(::ZZPolyRing, ::QadicFieldElem)
 **Examples**
 
 ```julia
-R, _ = QadicField(7, 1, 30);
+R, _ = qadic_field(7, 1, precision = 30);
 
 a = 1 + 2*7 + 4*7^2 + O(R, 7^3)
 b = 7^2 + 3*7^3 + O(R, 7^5)
@@ -161,7 +150,7 @@ Base.sqrt(::QadicFieldElem)
 **Examples**
 
 ```jldoctest
-julia> R, _ = QadicField(7, 1, 30);
+julia> R, _ = qadic_field(7, 1, precision = 30);
 
 julia> a = 1 + 7 + 2*7^2 + O(R, 7^3)
 7^0 + 7^1 + 2*7^2 + O(7^3)
@@ -206,7 +195,7 @@ frobenius(::QadicFieldElem, ::Int)
 **Examples**
 
 ```jldoctest
-julia> R, _ = QadicField(7, 1, 30);
+julia> R, _ = qadic_field(7, 1, precision = 30);
 
 julia> a = 1 + 7 + 2*7^2 + O(R, 7^3)
 7^0 + 7^1 + 2*7^2 + O(7^3)

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -42,7 +42,7 @@ constructors.
 
 ```@docs
 qadic_field
-unramifield_extension
+unramified_extension
 ```
 
 Here are some examples of creating $q$-adic fields and making use of the

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -42,6 +42,7 @@ constructors.
 
 ```@docs
 qadic_field
+unramifield_extension
 ```
 
 Here are some examples of creating $q$-adic fields and making use of the

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -65,7 +65,7 @@ end
 # Deprecated in 0.45.*
 @deprecate defining_polynomial(Q::fqPolyRepField, P::Ring) defining_polynomial(P, Q)
 @deprecate lift(a::PadicFieldElem) lift(ZZ, a)
-@deprecate prime_field(k::PadicField) coefficient_ring(k)
+@deprecate prime_field(k::PadicField) base_field(k)
 
 function (R::QadicField)(n::ZZPolyRingElem, pr::Int)
   Base.depwarn("`(::QadicField)(::ZZPolyRingElem, ::Int)` is deprecated, use `(::QadicField)(::ZZPolyRingElem; precision::Int)` instead.", :QadicField)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -65,3 +65,5 @@ end
 # Deprecated in 0.45.*
 @deprecate defining_polynomial(Q::fqPolyRepField, P::Ring) defining_polynomial(P, Q)
 @deprecate coefficient_ring(K::QadicField) base_field(K)
+@deprecate lift(a::PadicFieldElem) lift(ZZ, a)
+@deprecate prime_field(k::PadicField) base_field(k)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -65,7 +65,7 @@ end
 # Deprecated in 0.45.*
 @deprecate defining_polynomial(Q::fqPolyRepField, P::Ring) defining_polynomial(P, Q)
 @deprecate lift(a::PadicFieldElem) lift(ZZ, a)
-@deprecate prime_field(k::PadicField) base_field(k)
+@deprecate prime_field(k::PadicField) coefficient_ring(k)
 
 function (R::QadicField)(n::ZZPolyRingElem, pr::Int)
   Base.depwarn("`(::QadicField)(::ZZPolyRingElem, ::Int)` is deprecated, use `(::QadicField)(::ZZPolyRingElem; precision::Int)` instead.", :QadicField)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -64,7 +64,6 @@ end
 
 # Deprecated in 0.45.*
 @deprecate defining_polynomial(Q::fqPolyRepField, P::Ring) defining_polynomial(P, Q)
-@deprecate coefficient_ring(K::QadicField) base_field(K)
 @deprecate lift(a::PadicFieldElem) lift(ZZ, a)
 @deprecate prime_field(k::PadicField) base_field(k)
 

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -67,3 +67,8 @@ end
 @deprecate coefficient_ring(K::QadicField) base_field(K)
 @deprecate lift(a::PadicFieldElem) lift(ZZ, a)
 @deprecate prime_field(k::PadicField) base_field(k)
+
+function (R::QadicField)(n::ZZPolyRingElem, pr::Int)
+  Base.depwarn("`(::QadicField)(::ZZPolyRingElem, ::Int)` is deprecated, use `(::QadicField)(::ZZPolyRingElem; precision::Int)` instead.", :QadicField)
+  return (R::QadicField)(n::ZZPolyRingElem; precision=pr)
+end

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -64,3 +64,4 @@ end
 
 # Deprecated in 0.45.*
 @deprecate defining_polynomial(Q::fqPolyRepField, P::Ring) defining_polynomial(P, Q)
+@deprecate coefficient_ring(K::QadicField) base_field(K)

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -627,6 +627,7 @@ export undefined
 export unique_integer
 export unit
 export unknown
+export unramified_extension
 export unsigned_infinity
 export valuation!
 export var

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -631,6 +631,7 @@ export var
 export vcat
 export weierstrass_p
 export weierstrass_p_prime
+export with_precision
 export YoungTableau
 export zero
 export zero!

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -470,6 +470,7 @@ export onei
 export options
 export order
 export overlaps
+export padic_field
 export PadicField
 export PadicFieldElem
 export parent
@@ -494,6 +495,7 @@ export prod_diagonal
 export pseudo_inv
 export pth_root
 export puiseux_series_ring
+export qadic_field
 export QadicField
 export QadicFieldElem
 export QQ

--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -483,18 +483,6 @@ function is_irreducible(a::QQMPolyRingElem)
   return !(length(af.fac) > 1 || any(x -> x > 1, values(af.fac)))
 end
 
-function shift_right(a::QadicFieldElem, n::Int)
-  b = deepcopy(a)
-  b.val -= n
-  return b
-end
-
-function shift_left(a::QadicFieldElem, n::Int)
-  b = deepcopy(a)
-  b.val += n
-  return b
-end
-
 #Assuming that the denominator of a is one, reduces all the coefficients modulo p
 # non-symmetric (positive) residue system
 function mod!(a::AbsSimpleNumFieldElem, b::ZZRingElem)
@@ -775,8 +763,6 @@ end
 
 fit!(::QQRelPowerSeriesRingElem, Int) = nothing
 fit!(::QQAbsPowerSeriesRingElem, Int) = nothing
-
-Base.length(a::QadicFieldElem) = a.length
 
 function setcoeff!(z::ZZPolyRingElem, n::Int, x::Ptr{ZZRingElem})
   ccall((:fmpz_poly_set_coeff_fmpz, libflint), Nothing,
@@ -1108,93 +1094,9 @@ function image(M::Map{D,C}, a) where {D,C}
   end
 end
 
-function tr(r::QadicFieldElem)
-    t = base_field(parent(r))()
-    ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-    return t
-end
-
-function norm(r::QadicFieldElem)
-    t = base_field(parent(r))()
-    ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-    return t
-end
-
 function setcoeff!(x::fqPolyRepFieldElem, n::Int, u::UInt)
   ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
         (Ref{fqPolyRepFieldElem}, Int, UInt), x, n, u)
-end
-
-function (Rx::Generic.PolyRing{PadicFieldElem})(a::QadicFieldElem)
-  Qq = parent(a)
-  #@assert Rx === parent(defining_polynomial(Qq))
-  R = base_ring(Rx)
-  coeffs = Vector{PadicFieldElem}(undef, degree(Qq))
-  for i = 1:length(coeffs)
-    c = R()
-    ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
-          (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, a, i - 1, parent(a))
-    coeffs[i] = c
-  end
-  return Rx(coeffs)
-end
-
-function coeff(x::QadicFieldElem, i::Int)
-    R = base_field(parent(x))
-    c = R()
-    ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
-        (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, x, i, parent(x))
-  return c
-end
-
-function setcoeff!(x::QadicFieldElem, i::Int, y::PadicFieldElem)
-  ccall((:padic_poly_set_coeff_padic, libflint), Nothing,
-        (Ref{QadicFieldElem}, Int, Ref{PadicFieldElem}, Ref{QadicField}), x, i, y, parent(x))
-end
-
-function setcoeff!(x::QadicFieldElem, i::Int, y::UInt)
-  return setcoeff!(x, i, ZZRingElem(y))
-end
-
-function setcoeff!(x::QadicFieldElem, i::Int, y::ZZRingElem)
-    R = base_field(parent(x))
-    Y = R(ZZRingElem(y))
-    ccall((:padic_poly_set_coeff_padic, libflint), Nothing,
-        (Ref{QadicFieldElem}, Int, Ref{PadicFieldElem}, Ref{QadicField}), x, i, Y, parent(x))
-end
-
-function prime(R::PadicField, i::Int)
-  p = ZZRingElem()
-  ccall((:padic_ctx_pow_ui, libflint), Nothing, (Ref{ZZRingElem}, Int, Ref{PadicField}), p, i, R)
-  return p
-end
-
-function *(A::ZZMatrix, B::MatElem{PadicFieldElem})
-  return matrix(base_ring(B), A) * B
-end
-
-^(a::QadicFieldElem, b::QadicFieldElem) = exp(b * log(a))
-^(a::PadicFieldElem, b::PadicFieldElem) = exp(b * log(a))
-
-//(a::QadicFieldElem, b::QadicFieldElem) = divexact(a, b)
-//(a::PadicFieldElem, b::QadicFieldElem) = divexact(a, b)
-//(a::QadicFieldElem, b::PadicFieldElem) = divexact(a, b)
-
-@doc raw"""
-    lift(a::PadicFieldElem) -> ZZRingElem
-
-Returns the positive canonical representative in $\mathbb{Z}$. $a$ needs
-to be integral.
-"""
-function lift(a::PadicFieldElem)
-  b = ZZRingElem()
-  R = parent(a)
-
-  if iszero(a)
-    return ZZ(0)
-  end
-  ccall((:padic_get_fmpz, libflint), Nothing, (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), b, a, R)
-  return b
 end
 
 function basis(k::fpField)
@@ -1222,14 +1124,8 @@ function root(a::FinFieldElem, n::Integer)
   return r[1]
 end
 
-prime_field(k::PadicField) = k
-
 function base_field(K::fqPolyRepField)
   return Native.GF(Int(characteristic(K)))
-end
-
-function gens(k::PadicField, K::PadicField)
-  return [k(1)]
 end
 
 function gen(k::fpField)
@@ -1240,13 +1136,6 @@ function defining_polynomial(k::fpField)
   kx, x = polynomial_ring(k, cached=false)
   return x - k(1)
 end
-
-function norm(f::PolyRingElem{PadicFieldElem})
-  return f
-end
-
-degree(::PadicField) = 1
-
 
 @doc raw"""
     mod!(A::Generic.Mat{AbsSimpleNumFieldElem}, m::ZZRingElem)
@@ -1602,9 +1491,4 @@ end
 function rem!(a::FpPolyRingElem, b::FpPolyRingElem, c::FpPolyRingElem)
   ccall((:fmpz_mod_poly_rem, libflint), Nothing, (Ref{FpPolyRingElem}, Ref{FpPolyRingElem}, Ref{FpPolyRingElem}, Ref{fmpz_mod_ctx_struct}), a, b, c, a.parent.base_ring.ninv)
   return a
-end
-
-function rem!(x::AbstractAlgebra.Generic.Poly{T}, y::AbstractAlgebra.Generic.Poly{T}, z::AbstractAlgebra.Generic.Poly{T}) where {T<:Union{PadicFieldElem,QadicFieldElem}}
-  x = rem(y, z)
-  return x
 end

--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -1108,62 +1108,6 @@ function image(M::Map{D,C}, a) where {D,C}
   end
 end
 
-function Base.setprecision(q::QadicFieldElem, N::Int)
-  r = parent(q)()
-  r.N = N
-  ccall((:padic_poly_set, libflint), Nothing, (Ref{QadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), r, q, parent(q))
-  return r
-end
-
-function Base.setprecision(q::PadicFieldElem, N::Int)
-  r = parent(q)()
-  r.N = N
-  ccall((:padic_set, libflint), Nothing, (Ref{PadicFieldElem}, Ref{PadicFieldElem}, Ref{PadicField}), r, q, parent(q))
-  return r
-end
-
-function setprecision!(q::QadicFieldElem, N::Int)
-  if N >= q.N
-    q.N = N
-  end
-  q.N = N
-  ccall((:qadic_reduce, libflint), Nothing, (Ref{QadicFieldElem}, Ref{QadicField}), q, parent(q))
-  #  @assert N >= q.N
-  return q
-end
-
-function setprecision!(Q::QadicField, n::Int)
-  Q.prec_max = n
-end
-
-function setprecision!(Q::PadicField, n::Int)
-  Q.prec_max = n
-end
-
-function Base.setprecision(f::Generic.MPoly{QadicFieldElem}, N::Int)
-  return map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
-end
-
-function setprecision!(a::AbstractArray{QadicFieldElem}, N::Int)
-  for x = a
-    setprecision!(x, N)
-  end
-end
-
-function Base.setprecision(a::AbstractArray{QadicFieldElem}, N::Int)
-  return map(x -> setprecision(x, N), a)
-end
-
-function setprecision!(a::Generic.MatSpaceElem{QadicFieldElem}, N::Int)
-  setprecision!(a.entries, N)
-end
-
-function Base.setprecision(a::Generic.MatSpaceElem{QadicFieldElem}, N::Int)
-  b = deepcopy(a)
-  setprecision!(b, N)
-  return B
-end
-
 function tr(r::QadicFieldElem)
   t = coefficient_ring(parent(r))()
   ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
@@ -1233,9 +1177,6 @@ function *(A::ZZMatrix, B::MatElem{PadicFieldElem})
   return matrix(base_ring(B), A) * B
 end
 
-Base.precision(Q::PadicField) = Q.prec_max
-Base.precision(Q::QadicField) = Q.prec_max
-
 ^(a::QadicFieldElem, b::QadicFieldElem) = exp(b * log(a))
 ^(a::PadicFieldElem, b::PadicFieldElem) = exp(b * log(a))
 
@@ -1259,24 +1200,6 @@ function lift(a::PadicFieldElem)
   ccall((:padic_get_fmpz, libflint), Nothing, (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), b, a, R)
   return b
 end
-
-function Base.setprecision(f::Generic.Poly{PadicFieldElem}, N::Int)
-  g = parent(f)()
-  fit!(g, length(f))
-  for i = 1:length(f)
-    g.coeffs[i] = setprecision!(f.coeffs[i], N)
-  end
-  set_length!(g, normalise(g, length(f)))
-  return g
-end
-
-function setprecision!(f::Generic.Poly{PadicFieldElem}, N::Int)
-  for i = 1:length(f)
-    f.coeffs[i] = setprecision!(f.coeffs[i], N)
-  end
-  return f
-end
-
 
 function basis(k::fpField)
   return [k(1)]
@@ -1688,33 +1611,4 @@ end
 function rem!(x::AbstractAlgebra.Generic.Poly{T}, y::AbstractAlgebra.Generic.Poly{T}, z::AbstractAlgebra.Generic.Poly{T}) where {T<:Union{PadicFieldElem,QadicFieldElem}}
   x = rem(y, z)
   return x
-end
-
-function setprecision!(f::Generic.Poly{QadicFieldElem}, N::Int)
-  for i = 1:length(f)
-    setprecision!(f.coeffs[i], N)
-  end
-  set_length!(f, normalise(f, length(f)))
-  return f
-end
-
-function Base.setprecision(f::Generic.Poly{QadicFieldElem}, N::Int)
-  g = map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
-  return g
-end
-
-function Base.setprecision(f::Function, K::Union{PadicField,QadicField}, n::Int)
-  old = precision(K)
-  #  @assert n>=0
-  setprecision!(K, n)
-  v = try
-    f()
-  finally
-    setprecision!(K, old)
-  end
-  return v
-end
-
-function setprecision!(a::PadicFieldElem, n::Int)
-  return setprecision(a, n)
 end

--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -1109,15 +1109,15 @@ function image(M::Map{D,C}, a) where {D,C}
 end
 
 function tr(r::QadicFieldElem)
-  t = coefficient_ring(parent(r))()
-  ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-  return t
+    t = base_field(parent(r))()
+    ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
+    return t
 end
 
 function norm(r::QadicFieldElem)
-  t = coefficient_ring(parent(r))()
-  ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-  return t
+    t = base_field(parent(r))()
+    ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
+    return t
 end
 
 function setcoeff!(x::fqPolyRepFieldElem, n::Int, u::UInt)
@@ -1140,9 +1140,9 @@ function (Rx::Generic.PolyRing{PadicFieldElem})(a::QadicFieldElem)
 end
 
 function coeff(x::QadicFieldElem, i::Int)
-  R = PadicField(prime(parent(x)), parent(x).prec_max)
-  c = R()
-  ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
+    R = base_field(parent(x))
+    c = R()
+    ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
         (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, x, i, parent(x))
   return c
 end
@@ -1157,14 +1157,10 @@ function setcoeff!(x::QadicFieldElem, i::Int, y::UInt)
 end
 
 function setcoeff!(x::QadicFieldElem, i::Int, y::ZZRingElem)
-  R = PadicField(prime(parent(x)), parent(x).prec_max)
-  Y = R(ZZRingElem(y))
-  ccall((:padic_poly_set_coeff_padic, libflint), Nothing,
+    R = base_field(parent(x))
+    Y = R(ZZRingElem(y))
+    ccall((:padic_poly_set_coeff_padic, libflint), Nothing,
         (Ref{QadicFieldElem}, Int, Ref{PadicFieldElem}, Ref{QadicField}), x, i, Y, parent(x))
-end
-
-function coefficient_ring(Q::QadicField)
-  return PadicField(prime(Q), precision(Q))
 end
 
 function prime(R::PadicField, i::Int)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3016,7 +3016,7 @@ A $p$-adic field for some prime $p$.
   end
 end
 
-const PadicBase = CacheDictType{Tuple{ZZRingElem, Int}, PadicField}()
+const PadicBase = CacheDictType{ZZRingElem, PadicField}()
 
 function _padic_ctx_clear_fn(a::PadicField)
   ccall((:padic_ctx_clear, libflint), Nothing, (Ref{PadicField},), a)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3001,8 +3001,8 @@ A $p$-adic field for some prime $p$.
   mode::Cint
   prec_max::Int
 
-  function PadicField(p::ZZRingElem, prec::Int; cached::Bool = true, check::Bool = true)
-    check && !is_probable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
+   function PadicField(p::ZZRingElem, prec::Int = 64; cached::Bool = true, check::Bool = true)
+      check && !is_probable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
 
     return get_cached!(PadicBase, (p, prec), cached) do
       d = new()
@@ -3069,7 +3069,7 @@ A $p^n$-adic field for some prime power $p^n$.
   var::Cstring   # char*
   prec_max::Int
 
-  function QadicField(p::ZZRingElem, d::Int, prec::Int, var::String = "a"; cached::Bool = true, check::Bool = true)
+   function QadicField(p::ZZRingElem, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true, check::Bool = true)
 
     check && !is_probable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3002,7 +3002,7 @@ A $p$-adic field for some prime $p$.
   prec_max::Int
 
    function PadicField(p::ZZRingElem, prec::Int = 64; cached::Bool = true, check::Bool = true)
-      check && !is_probable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
+      check && !is_probable_prime(p) && throw(DomainError(p, "Integer must be prime"))
 
     return get_cached!(PadicBase, (p, prec), cached) do
       d = new()
@@ -3071,7 +3071,7 @@ A $p^n$-adic field for some prime power $p^n$.
 
    function QadicField(p::ZZRingElem, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true, check::Bool = true)
 
-    check && !is_probable_prime(p) && throw(DomainError(p, "Characteristic must be prime"))
+      check && !is_probable_prime(p) && throw(DomainError(p, "Integer must be prime"))
 
     z = get_cached!(QadicBase, (p, d, prec), cached) do
       zz = new()

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -86,6 +86,22 @@ parent_type(::Type{PadicFieldElem}) = PadicField
 
 ###############################################################################
 #
+#   Feature parity
+#
+###############################################################################
+
+degree(::PadicField) = 1
+
+base_field(k::PadicField) = k
+
+# Return generators of k "over" K
+function gens(k::PadicField, K::PadicField)
+  @assert k === K
+  return [one(k)]
+end
+
+###############################################################################
+#
 #   Basic manipulation
 #
 ###############################################################################
@@ -112,6 +128,12 @@ function prime(R::PadicField)
   ccall((:padic_ctx_pow_ui, libflint), Nothing,
         (Ref{ZZRingElem}, Int, Ref{PadicField}), z, 1, R)
   return z
+end
+
+function _prime(R::PadicField, i::Int = 1)
+   p = ZZRingElem()
+   ccall((:padic_ctx_pow_ui, libflint), Nothing, (Ref{ZZRingElem}, Int, Ref{PadicField}), p, i, R)
+   return p
 end
 
 @doc raw"""
@@ -150,11 +172,14 @@ end
 Return a lift of the given $p$-adic field element to $\mathbb{Z}$.
 """
 function lift(R::ZZRing, a::PadicFieldElem)
-  ctx = parent(a)
-  r = ZZRingElem()
-  ccall((:padic_get_fmpz, libflint), Nothing,
-        (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), r, a, ctx)
-  return r
+    ctx = parent(a)
+    r = ZZRingElem()
+    if iszero(a)
+        return r
+    end
+    ccall((:padic_get_fmpz, libflint), Nothing,
+          (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), r, a, ctx)
+    return r
 end
 
 function zero(R::PadicField)
@@ -375,6 +400,8 @@ end
 *(a::ZZRingElem, b::PadicFieldElem) = b*a
 
 *(a::QQFieldElem, b::PadicFieldElem) = b*a
+
+^(a::PadicFieldElem, b::PadicFieldElem) = exp(b * log(a))
 
 ###############################################################################
 #

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -130,7 +130,7 @@ function prime(R::PadicField)
   return z
 end
 
-function _prime(R::PadicField, i::Int = 1)
+function prime(R::PadicField, i::Int)
    p = ZZRingElem()
    ccall((:padic_ctx_pow_ui, libflint), Nothing, (Ref{ZZRingElem}, Int, Ref{PadicField}), p, i, R)
    return p
@@ -792,7 +792,11 @@ function Base.setprecision(q::PadicFieldElem, N::Int)
   return r
 end
 
-setprecision!(a::PadicFieldElem, n::Int) = setprecision(a, n)
+function setprecision!(a::PadicFieldElem, n::Int)
+  a.N = n
+  ccall((:padic_reduce, libflint), Nothing, (Ref{PadicFieldElem}, Ref{PadicField}), a, parent(a))
+  return a
+end
 
 function setprecision!(Q::PadicField, n::Int)
   Q.prec_max = n
@@ -803,7 +807,7 @@ function Base.setprecision(f::Generic.Poly{PadicFieldElem}, N::Int)
   g = parent(f)()
   fit!(g, length(f))
   for i = 1:length(f)
-    g.coeffs[i] = setprecision!(f.coeffs[i], N)
+    g.coeffs[i] = setprecision(f.coeffs[i], N)
   end
   set_length!(g, normalise(g, length(f)))
   return g

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -836,7 +836,7 @@ function setprecision!(f::Generic.Poly{PadicFieldElem}, N::Int)
   return f
 end
 
-function with_precision(f::Function, K::PadicField, n::Int)
+function with_precision(f, K::PadicField, n::Int)
   @assert n >= 0
   old = precision(K)
   setprecision!(K, n)
@@ -848,4 +848,4 @@ function with_precision(f::Function, K::PadicField, n::Int)
   return v
 end
 
-Base.setprecision(f, K::PadicField, n::Int) = with_precision(f, K, n)
+Base.setprecision(f::Function, K::PadicField, n::Int) = with_precision(f, K, n)

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -123,17 +123,11 @@ end
 
 Return the prime $p$ for the given $p$-adic field.
 """
-function prime(R::PadicField)
-  z = ZZRingElem()
-  ccall((:padic_ctx_pow_ui, libflint), Nothing,
-        (Ref{ZZRingElem}, Int, Ref{PadicField}), z, 1, R)
-  return z
-end
-
-function prime(R::PadicField, i::Int)
-   p = ZZRingElem()
-   ccall((:padic_ctx_pow_ui, libflint), Nothing, (Ref{ZZRingElem}, Int, Ref{PadicField}), p, i, R)
-   return p
+function prime(R::PadicField, i::Int = 1)
+   z = ZZRingElem()
+   ccall((:padic_ctx_pow_ui, libflint), Nothing,
+         (Ref{ZZRingElem}, Int, Ref{PadicField}), z, i, R)
+   return z
 end
 
 @doc raw"""
@@ -606,6 +600,12 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    exp(a::PadicFieldElem)
+
+Return the $p$-adic exponential of $a$, assuming the $p$-adic exponential
+function converges at $a$.
+"""
 function Base.exp(a::PadicFieldElem)
   !iszero(a) && a.v <= 0 && throw(DomainError(a, "Valuation must be positive"))
   ctx = parent(a)
@@ -617,6 +617,12 @@ function Base.exp(a::PadicFieldElem)
   return z
 end
 
+@doc raw"""
+    log(a::PadicFieldElem)
+
+Return the $p$-adic logarithm of $a$, assuming the $p$-adic logarithm
+converges at $a$.
+"""
 function log(a::PadicFieldElem)
   ctx = parent(a)
   z = PadicFieldElem(a.N)

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -741,13 +741,13 @@ end
 # inner constructor is also used directly
 
 @doc raw"""
-    PadicField(p::Integer, prec::Int; kw...)
+    PadicField(p::Integer, prec::Int = 64; kw...)
 
-Returns the parent object for the $p$-adic field for given prime $p$, where
-the default absolute precision of elements of the field is given by `prec`.
+Returns the parent object for the $p$-adic field for given prime $p$.
+The default absolute precision of elements of the field may be set with `prec`.
 """
-function PadicField(p::Integer, prec::Int; kw...)
-  return PadicField(ZZRingElem(p), prec; kw...)
+function PadicField(p::Integer, prec::Int = 64; kw...)
+   return PadicField(ZZRingElem(p), prec; kw...)
 end
 
 ###############################################################################

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -765,16 +765,26 @@ end
 #
 ###############################################################################
 
-# inner constructor is also used directly
-
-@doc raw"""
-    PadicField(p::Integer, prec::Int = 64; kw...)
-
-Returns the parent object for the $p$-adic field for given prime $p$.
-The default absolute precision of elements of the field may be set with `prec`.
-"""
+# Kept for backwards compatibility; the user facing constructor is `padic_field`
 function PadicField(p::Integer, prec::Int = 64; kw...)
    return PadicField(ZZRingElem(p), prec; kw...)
+end
+
+@doc raw"""
+    padic_field(p::Integer; precision::Int=64, cached::Bool=true, check::Bool=true)
+    padic_field(p::ZZRingElem; precision::Int=64, cached::Bool=true, check::Bool=true)
+
+Return the $p$-adic field for the given prime $p$.
+The default absolute precision of elements of the field may be set with `precision`.
+"""
+padic_field
+
+function padic_field(p::Integer; precision::Int=64, cached::Bool=true, check::Bool=true)
+  return padic_field(ZZRingElem(p), precision=precision, cached=cached, check=check)
+end
+
+function padic_field(p::ZZRingElem; precision::Int=64, cached::Bool=true, check::Bool=true)
+  return PadicField(p, precision, cached=cached, check=check)
 end
 
 ###############################################################################

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -94,6 +94,9 @@ degree(::PadicField) = 1
 
 base_field(k::PadicField) = k
 
+# TODO: Remove in the next minor/breaking release
+coefficient_ring(k::PadicField) = base_field(k)
+
 # Return generators of k "over" K
 function gens(k::PadicField, K::PadicField)
   @assert k === K

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -124,10 +124,10 @@ end
 Return the prime $p$ for the given $p$-adic field.
 """
 function prime(R::PadicField, i::Int = 1)
-   z = ZZRingElem()
-   ccall((:padic_ctx_pow_ui, libflint), Nothing,
-         (Ref{ZZRingElem}, Int, Ref{PadicField}), z, i, R)
-   return z
+  z = ZZRingElem()
+  ccall((:padic_ctx_pow_ui, libflint), Nothing,
+        (Ref{ZZRingElem}, Int, Ref{PadicField}), z, i, R)
+  return z
 end
 
 @doc raw"""
@@ -166,28 +166,28 @@ end
 Return a lift of the given $p$-adic field element to $\mathbb{Z}$.
 """
 function lift(R::ZZRing, a::PadicFieldElem)
-    ctx = parent(a)
-    r = ZZRingElem()
-    if iszero(a)
-        return r
-    end
-    ccall((:padic_get_fmpz, libflint), Nothing,
-          (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), r, a, ctx)
+  ctx = parent(a)
+  r = ZZRingElem()
+  if iszero(a)
     return r
+  end
+  ccall((:padic_get_fmpz, libflint), Nothing,
+        (Ref{ZZRingElem}, Ref{PadicFieldElem}, Ref{PadicField}), r, a, ctx)
+  return r
 end
 
 function zero(R::PadicField; precision::Int=precision(R))
-   z = PadicFieldElem(precision)
-   ccall((:padic_zero, libflint), Nothing, (Ref{PadicFieldElem},), z)
-   z.parent = R
-   return z
+  z = PadicFieldElem(precision)
+  ccall((:padic_zero, libflint), Nothing, (Ref{PadicFieldElem},), z)
+  z.parent = R
+  return z
 end
 
 function one(R::PadicField; precision::Int=precision(R))
-   z = PadicFieldElem(precision)
-   ccall((:padic_one, libflint), Nothing, (Ref{PadicFieldElem},), z)
-   z.parent = R
-   return z
+  z = PadicFieldElem(precision)
+  ccall((:padic_one, libflint), Nothing, (Ref{PadicFieldElem},), z)
+  z.parent = R
+  return z
 end
 
 iszero(a::PadicFieldElem) = Bool(ccall((:padic_is_zero, libflint), Cint,
@@ -668,11 +668,11 @@ end
 ###############################################################################
 
 function zero!(z::PadicFieldElem; precision::Int=precision(parent(z)))
-   z.N = precision
-   ctx = parent(z)
-   ccall((:padic_zero, libflint), Nothing,
-         (Ref{PadicFieldElem}, Ref{PadicField}), z, ctx)
-   return z
+  z.N = precision
+  ctx = parent(z)
+  ccall((:padic_zero, libflint), Nothing,
+        (Ref{PadicFieldElem}, Ref{PadicField}), z, ctx)
+  return z
 end
 
 function mul!(z::PadicFieldElem, x::PadicFieldElem, y::PadicFieldElem)
@@ -721,41 +721,41 @@ promote_rule(::Type{PadicFieldElem}, ::Type{QQFieldElem}) = PadicFieldElem
 ###############################################################################
 
 function (R::PadicField)(; precision::Int=precision(R))
-   z = PadicFieldElem(precision)
-   z.parent = R
-   return z
+  z = PadicFieldElem(precision)
+  z.parent = R
+  return z
 end
 
 function (R::PadicField)(n::ZZRingElem; precision::Int=precision(R))
-   if is_one(n) || is_zero(n)
-      N = 0
-   else
-      p = prime(R)
-      N, = remove(n, p)
-   end
-   z = PadicFieldElem(N + precision)
-   ccall((:padic_set_fmpz, libflint), Nothing,
-         (Ref{PadicFieldElem}, Ref{ZZRingElem}, Ref{PadicField}), z, n, R)
-   z.parent = R
-   return z
+  if is_one(n) || is_zero(n)
+    N = 0
+  else
+    p = prime(R)
+    N, = remove(n, p)
+  end
+  z = PadicFieldElem(N + precision)
+  ccall((:padic_set_fmpz, libflint), Nothing,
+        (Ref{PadicFieldElem}, Ref{ZZRingElem}, Ref{PadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 function (R::PadicField)(n::QQFieldElem; precision::Int=precision(R))
-   m = denominator(n)
-   if isone(m)
-      return R(numerator(n); precision=precision)
-   end
-   p = prime(R)
-   if m == p
-      N = -1
-   else
-     N = -remove(m, p)[1]
-   end
-   z = PadicFieldElem(N + precision)
-   ccall((:padic_set_fmpq, libflint), Nothing,
-         (Ref{PadicFieldElem}, Ref{QQFieldElem}, Ref{PadicField}), z, n, R)
-   z.parent = R
-   return z
+  m = denominator(n)
+  if isone(m)
+    return R(numerator(n); precision=precision)
+  end
+  p = prime(R)
+  if m == p
+    N = -1
+  else
+    N = -remove(m, p)[1]
+  end
+  z = PadicFieldElem(N + precision)
+  ccall((:padic_set_fmpq, libflint), Nothing,
+        (Ref{PadicFieldElem}, Ref{QQFieldElem}, Ref{PadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 (R::PadicField)(n::Integer; precision::Int=precision(R)) = R(ZZRingElem(n); precision)
@@ -773,7 +773,7 @@ end
 
 # Kept for backwards compatibility; the user facing constructor is `padic_field`
 function PadicField(p::Integer, prec::Int = 64; kw...)
-   return PadicField(ZZRingElem(p), prec; kw...)
+  return PadicField(ZZRingElem(p), prec; kw...)
 end
 
 @doc raw"""

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -933,11 +933,14 @@ end
 function with_precision(f, K::QadicField, n::Int)
   @assert n >= 0
   old = precision(K)
+  old_base = precision(base_field(K))
   setprecision!(K, n)
+  setprecision!(base_field(K), n)
   v = try
     f()
   finally
     setprecision!(K, old)
+    setprecision!(base_field(K), old_base)
   end
   return v
 end

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -792,11 +792,12 @@ end
     QadicField(p::Integer, d::Int, prec::Int, var::String = "a")
 
 Returns the parent object for the $q$-adic field for given prime $p$ and
-degree $d$, where the default absolute precision of elements of the field
-is given by `prec` and the generator is printed as `var`.
+degree $d$.
+The default absolute precision of elements of the field may be set with `prec`
+and the generator is printed as `var`.
 """
-function QadicField(p::Integer, d::Int, prec::Int, var::String = "a"; cached::Bool = true)
-  return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
+function QadicField(p::Integer, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true)
+   return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
 end
 
 ###############################################################################

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -705,22 +705,11 @@ function (R::QadicField)()
 end
 
 function gen(R::QadicField)
-  if degree(R) == 1
-    # Work around flint limitation
-    # https://github.com/wbhart/flint2/issues/898
-    a = ZZRingElem()
-    GC.@preserve R begin
-      ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}),
-            a, reinterpret(Ptr{ZZRingElem}, R.a))
-    end
-    return R(-a)
-  end
-
-  z = QadicFieldElem(R.prec_max)
-  ccall((:qadic_gen, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{QadicField}), z, R)
-  z.parent = R
-  return z
+   z = QadicFieldElem(R.prec_max)
+   ccall((:qadic_gen, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{QadicField}), z, R)
+   z.parent = R
+   return z
 end
 
 function (R::QadicField)(a::UInt)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -233,9 +233,7 @@ function expressify(b::QadicFieldElem, x = var(parent(b)); context = nothing)
     return 0
   end
   sum = Expr(:call, :+)
-  c = with_precision(R, precision(parent(b))) do
-    R()
-  end
+  c = R(precision = precision(parent(b)))
   for i in degree(parent(b)):-1:0
     ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
           (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}),

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -91,6 +91,10 @@ function _prime(R::QadicField, n::Int = 1)
   return z
 end
 
+@attr PadicField function base_field(K::QadicField)
+  return PadicField(prime(K), precision(K), cached = false)
+end
+
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -181,17 +181,17 @@ function lift(R::ZZPolyRing, a::QadicFieldElem)
 end
 
 function zero(R::QadicField; precision::Int=precision(R))
-   z = QadicFieldElem(precision)
-   ccall((:qadic_zero, libflint), Nothing, (Ref{QadicFieldElem},), z)
-   z.parent = R
-   return z
+  z = QadicFieldElem(precision)
+  ccall((:qadic_zero, libflint), Nothing, (Ref{QadicFieldElem},), z)
+  z.parent = R
+  return z
 end
 
 function one(R::QadicField; precision::Int=precision(R))
-   z = QadicFieldElem(precision)
-   ccall((:qadic_one, libflint), Nothing, (Ref{QadicFieldElem},), z)
-   z.parent = R
-   return z
+  z = QadicFieldElem(precision)
+  ccall((:qadic_one, libflint), Nothing, (Ref{QadicFieldElem},), z)
+  z.parent = R
+  return z
 end
 
 iszero(a::QadicFieldElem) = Bool(ccall((:qadic_is_zero, libflint), Cint,
@@ -206,15 +206,15 @@ is_unit(a::QadicFieldElem) = !Bool(ccall((:qadic_is_zero, libflint), Cint,
 characteristic(R::QadicField) = 0
 
 function shift_right(a::QadicFieldElem, n::Int)
-   b = deepcopy(a)
-   b.val -= n
-   return b
+  b = deepcopy(a)
+  b.val -= n
+  return b
 end
 
 function shift_left(a::QadicFieldElem, n::Int)
-   b = deepcopy(a)
-   b.val += n
-   return b
+  b = deepcopy(a)
+  b.val += n
+  return b
 end
 
 ###############################################################################
@@ -228,27 +228,26 @@ function var(Q::QadicField)
 end
 
 function expressify(b::QadicFieldElem, x = var(parent(b)); context = nothing)
-   R = coefficient_ring(parent(b))
-   if iszero(b)
-      return 0
-   end
-   sum = Expr(:call, :+)
-   c = with_precision(R, precision(parent(b))) do
-     R()
-   end
-   for i in degree(parent(b)):-1:0
-      ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
-            (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}),
-            c, b, i, parent(b))
-      ec = expressify(c, context = context)
-      if !iszero(c)
-         if iszero(i)
-            push!(sum.args, ec)
-         elseif isone(i)
-            push!(sum.args, Expr(:call, :*, ec, x))
-         else
-            push!(sum.args, Expr(:call, :*, ec, Expr(:call, :^, x, i)))
-         end
+  R = coefficient_ring(parent(b))
+  if iszero(b)
+    return 0
+  end
+  sum = Expr(:call, :+)
+  c = with_precision(R, precision(parent(b))) do
+    R()
+  end
+  for i in degree(parent(b)):-1:0
+    ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
+          (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}),
+          c, b, i, parent(b))
+    ec = expressify(c, context = context)
+    if !iszero(c)
+      if iszero(i)
+        push!(sum.args, ec)
+      elseif isone(i)
+        push!(sum.args, Expr(:call, :*, ec, x))
+      else
+        push!(sum.args, Expr(:call, :*, ec, Expr(:call, :^, x, i)))
       end
     end
   end
@@ -636,11 +635,11 @@ end
 ###############################################################################
 
 function zero!(z::QadicFieldElem; precision::Int=precision(parent(z)))
-   z.N = precision
-   ctx = parent(z)
-   ccall((:qadic_zero, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{QadicField}), z, ctx)
-   return z
+  z.N = precision
+  ctx = parent(z)
+  ccall((:qadic_zero, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{QadicField}), z, ctx)
+  return z
 end
 
 function mul!(z::QadicFieldElem, x::QadicFieldElem, y::QadicFieldElem)
@@ -677,15 +676,15 @@ end
 ###############################################################################
 
 function tr(r::QadicFieldElem)
-    t = coefficient_ring(parent(r))()
-    ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-    return t
+  t = coefficient_ring(parent(r))()
+  ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
+  return t
 end
 
 function norm(r::QadicFieldElem)
-    t = coefficient_ring(parent(r))()
-    ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
-    return t
+  t = coefficient_ring(parent(r))()
+  ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
+  return t
 end
 
 ###############################################################################
@@ -711,108 +710,108 @@ promote_rule(::Type{QadicFieldElem}, ::Type{PadicFieldElem}) = QadicFieldElem
 ###############################################################################
 
 function (R::QadicField)(; precision::Int=precision(R))
-   z = QadicFieldElem(precision)
-   z.parent = R
-   return z
+  z = QadicFieldElem(precision)
+  z.parent = R
+  return z
 end
 
 function gen(R::QadicField; precision::Int=precision(R))
-   z = QadicFieldElem(precision)
-   ccall((:qadic_gen, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{QadicField}), z, R)
-   z.parent = R
-   return z
+  z = QadicFieldElem(precision)
+  ccall((:qadic_gen, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{QadicField}), z, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(a::UInt; precision::Int=precision(R))
-   if a == 0
-     z = QadicFieldElem(precision)
-     z.parent = R
-     return z
-   end
-   v = valuation(a, prime(R))
-   z = QadicFieldElem(precision + v)
-   ccall((:qadic_set_ui, libflint), Nothing,
-         (Ref{QadicFieldElem}, UInt, Ref{QadicField}), z, a, R)
-   z.parent = R
-   return z
+  if a == 0
+    z = QadicFieldElem(precision)
+    z.parent = R
+    return z
+  end
+  v = valuation(a, prime(R))
+  z = QadicFieldElem(precision + v)
+  ccall((:qadic_set_ui, libflint), Nothing,
+        (Ref{QadicFieldElem}, UInt, Ref{QadicField}), z, a, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(a::Int; precision::Int=precision(R))
-   if a == 0
-     z = QadicFieldElem(precision)
-     z.parent = R
-     return z
-   end
-   v = valuation(a, prime(R))
-   z = QadicFieldElem(precision + v)
-   ccall((:padic_poly_set_si, libflint), Nothing,
-         (Ref{QadicFieldElem}, Int, Ref{QadicField}), z,a, R)
-   z.parent = R
-   return z
+  if a == 0
+    z = QadicFieldElem(precision)
+    z.parent = R
+    return z
+  end
+  v = valuation(a, prime(R))
+  z = QadicFieldElem(precision + v)
+  ccall((:padic_poly_set_si, libflint), Nothing,
+        (Ref{QadicFieldElem}, Int, Ref{QadicField}), z,a, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(n::ZZRingElem; precision::Int=precision(R))
-   if iszero(n) || isone(n)
-      N = 0
-   else
-      p = prime(R)
-      N = valuation(n, p)
-   end
-   z = QadicFieldElem(N + precision)
-   ccall((:padic_poly_set_fmpz, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{ZZRingElem}, Ref{QadicField}), z, n, R)
-   z.parent = R
-   return z
+  if iszero(n) || isone(n)
+    N = 0
+  else
+    p = prime(R)
+    N = valuation(n, p)
+  end
+  z = QadicFieldElem(N + precision)
+  ccall((:padic_poly_set_fmpz, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{ZZRingElem}, Ref{QadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(n::QQFieldElem; precision::Int=precision(R))
-   m = denominator(n)
-   if isone(m)
-      return R(numerator(n); precision = precision)
-   end
-   p = prime(R)
-   if m == p
-      N = -1
-   else
-     N = -remove(m, p)[1]
-   end
-   z = QadicFieldElem(N + precision)
-   ccall((:padic_poly_set_fmpq, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{QQFieldElem}, Ref{QadicField}), z, n, R)
-   z.parent = R
-   return z
+  m = denominator(n)
+  if isone(m)
+    return R(numerator(n); precision = precision)
+  end
+  p = prime(R)
+  if m == p
+    N = -1
+  else
+    N = -remove(m, p)[1]
+  end
+  z = QadicFieldElem(N + precision)
+  ccall((:padic_poly_set_fmpq, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{QQFieldElem}, Ref{QadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(n::ZZPolyRingElem; precision::Int=precision(R))
-   z = QadicFieldElem(precision)
-   ccall((:qadic_set_fmpz_poly, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{ZZPolyRingElem}, Ref{QadicField}), z, n, R)
-   z.parent = R
-   return z
+  z = QadicFieldElem(precision)
+  ccall((:qadic_set_fmpz_poly, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{ZZPolyRingElem}, Ref{QadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(n::QQPolyRingElem; precision::Int=precision(R))
 
-   if degree(n) > degree(R) + 1
-       error("Polynomial degree larger than degree of qadic field.")
-   end
-   m = denominator(n)
-   p = prime(R)
-   if m == p
-      N = -1
-   else
-     N = -remove(m, p)[1]
-   end
-   z = QadicFieldElem(N + precision)
-   ccall((:padic_poly_set_fmpq_poly, libflint), Nothing,
-         (Ref{QadicFieldElem}, Ref{QQPolyRingElem}, Ref{QadicField}), z, n, R)
-   z.parent = R
-   return z
+  if degree(n) > degree(R) + 1
+    error("Polynomial degree larger than degree of qadic field.")
+  end
+  m = denominator(n)
+  p = prime(R)
+  if m == p
+    N = -1
+  else
+    N = -remove(m, p)[1]
+  end
+  z = QadicFieldElem(N + precision)
+  ccall((:padic_poly_set_fmpq_poly, libflint), Nothing,
+        (Ref{QadicFieldElem}, Ref{QQPolyRingElem}, Ref{QadicField}), z, n, R)
+  z.parent = R
+  return z
 end
 
 function (R::QadicField)(b::Rational{<:Integer}; precision::Int=precision(R))
-   return R(QQFieldElem(b); precision)
+  return R(QQFieldElem(b); precision)
 end
 
 (R::QadicField)(n::Integer; precision::Int=precision(R)) = R(ZZRingElem(n); precision)
@@ -876,7 +875,7 @@ Base.length(a::QadicFieldElem) = a.length
 
 # Kept for backwards compatibility; the user facing constructor is `qadic_field`
 function QadicField(p::Integer, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true)
-   return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
+  return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
 end
 
 @doc raw"""

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -94,9 +94,12 @@ end
 # TODO: For the next minor/breaking release, rename this to base_field and
 # deprecate coefficient_ring (and remove the corresponding base_field in Hecke)
 function coefficient_ring(K::QadicField)
-  return get_attribute!(K, :base_field) do
+  L = get_attribute!(K, :base_field) do
     return PadicField(prime(K), precision(K), cached = false)
   end::PadicField
+  # Should not be here, but Hecke needs it
+  setprecision!(L, precision(K))
+  return L
 end
 
 ###############################################################################
@@ -847,10 +850,6 @@ end
 
 function coeff(x::QadicFieldElem, i::Int)
   R = coefficient_ring(parent(x))
-  # TODO: This setprecision! call should go; it is only here because in Hecke
-  # parent(x).prec_max is directly modified at at least one place (as of 15 May 2024),
-  # so we cannot adjust the precision of base_field(parent(x)) accordingly.
-  setprecision!(R, precision(parent(x)))
   c = R()
   ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
         (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, x, i, parent(x))

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -381,6 +381,12 @@ end
 
 //(a::QadicFieldElem, b::QadicFieldElem) = divexact(a, b)
 
+# TODO: As of 15 May 2024 the following two methods don't work in Nemo because
+# `(::QadicField)(::PadicFieldElem)` which is needed for the promotion is in
+# Hecke
+//(a::PadicFieldElem, b::QadicFieldElem) = divexact(a, b)
+//(a::QadicFieldElem, b::PadicFieldElem) = divexact(a, b)
+
 ###############################################################################
 #
 #   Comparison

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -550,6 +550,12 @@ end
 #
 ###############################################################################
 
+@doc raw"""
+    exp(a::QadicFieldElem)
+
+Return the $p$-adic exponential of $a$, assuming the $p$-adic exponential
+function converges at $a$.
+"""
 function Base.exp(a::QadicFieldElem)
   !iszero(a) && valuation(a) <= 0 && throw(DomainError(a, "Valuation must be positive"))
   ctx = parent(a)
@@ -561,6 +567,12 @@ function Base.exp(a::QadicFieldElem)
   return z
 end
 
+@doc raw"""
+    log(a::QadicFieldElem)
+
+Return the $p$-adic logarithm of $a$, assuming the $p$-adic logarithm
+converges at $a$.
+"""
 function log(a::QadicFieldElem)
   av = valuation(a)
   (av > 0 || av < 0 || iszero(a)) && throw(DomainError(a, "Valuation must be zero"))

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -879,14 +879,16 @@ function QadicField(p::Integer, d::Int, prec::Int = 64, var::String = "a"; cache
 end
 
 @doc raw"""
-    qadic_field(p::Integer, d::Int; precision::Int=64, cached::Bool=true, check::Bool=true)
-    qadic_field(p::ZZRingElem, d::Int; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(p::Integer, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(p::ZZRingElem, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
 
 Return an unramified extension $K$ of degree $d$ of a $p$-adic field for the given
 prime $p$.
 The generator of $K$ is printed as `var`.
 
 The default absolute precision of elements of $K$ may be set with `precision`.
+
+See also [`unramified_extension`](@ref).
 """
 qadic_field
 
@@ -896,6 +898,19 @@ end
 
 function qadic_field(p::ZZRingElem, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
   return QadicField(p, d, precision, var; cached=cached, check=check)
+end
+
+@doc raw"""
+    unramified_extension(Qp::PadicField, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true)
+
+Return an unramified extension $K$ of degree $d$ of the given $p$-adic field `Qp`.
+The generator of $K$ is printed as `var`.
+
+The default absolute precision of elements of $K$ may be set with `precision`.
+"""
+function unramified_extension(K::PadicField, d::Int, var::String = "a"; precision::Int=precision(K), cached::Bool = true)
+  L, a = QadicField(prime(K), d, precision, var, cached = cached, check = false, base_field = K)
+  return L, a
 end
 
 ###############################################################################

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -865,7 +865,11 @@ function setprecision!(f::Generic.Poly{QadicFieldElem}, N::Int)
 end
 
 function Base.setprecision(f::Generic.Poly{QadicFieldElem}, N::Int)
-  g = map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
+  # map_coefficients handles the coefficient 0 weirdly, so we have to set the
+  # 'global' precision
+  g = with_precision(base_ring(f), N) do
+    map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
+  end
   return g
 end
 

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -794,3 +794,87 @@ is given by `prec` and the generator is printed as `var`.
 function QadicField(p::Integer, d::Int, prec::Int, var::String = "a"; cached::Bool = true)
   return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
 end
+
+###############################################################################
+#
+#   Precision handling
+#
+###############################################################################
+
+precision(Q::QadicField) = Q.prec_max
+
+function Base.setprecision(q::QadicFieldElem, N::Int)
+  r = parent(q)()
+  r.N = N
+  ccall((:padic_poly_set, libflint), Nothing, (Ref{QadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), r, q, parent(q))
+  return r
+end
+
+function setprecision!(q::QadicFieldElem, N::Int)
+  # TODO: What is this doing?
+  if N >= q.N
+    q.N = N
+  end
+  q.N = N
+  ccall((:qadic_reduce, libflint), Nothing, (Ref{QadicFieldElem}, Ref{QadicField}), q, parent(q))
+  #  @assert N >= q.N
+  return q
+end
+
+function setprecision!(Q::QadicField, n::Int)
+  Q.prec_max = n
+  return Q
+end
+
+function Base.setprecision(f::Generic.MPoly{QadicFieldElem}, N::Int)
+  return map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
+end
+
+function setprecision!(a::AbstractArray{QadicFieldElem}, N::Int)
+  for x in a
+    setprecision!(x, N)
+  end
+  return x
+end
+
+function Base.setprecision(a::AbstractArray{QadicFieldElem}, N::Int)
+  return map(x -> setprecision(x, N), a)
+end
+
+function setprecision!(a::Generic.MatSpaceElem{QadicFieldElem}, N::Int)
+  setprecision!(a.entries, N)
+  return a
+end
+
+function Base.setprecision(a::Generic.MatSpaceElem{QadicFieldElem}, N::Int)
+  b = deepcopy(a)
+  setprecision!(b, N)
+  return b
+end
+
+function setprecision!(f::Generic.Poly{QadicFieldElem}, N::Int)
+  for i = 1:length(f)
+    setprecision!(f.coeffs[i], N)
+  end
+  set_length!(f, normalise(f, length(f)))
+  return f
+end
+
+function Base.setprecision(f::Generic.Poly{QadicFieldElem}, N::Int)
+  g = map_coefficients(x -> setprecision(x, N), f, parent=parent(f))
+  return g
+end
+
+function with_precision(f, K::QadicField, n::Int)
+  @assert n >= 0
+  old = precision(K)
+  setprecision!(K, n)
+  v = try
+    f()
+  finally
+    setprecision!(K, old)
+  end
+  return v
+end
+
+Base.setprecision(f, K::QadicField, n::Int) = with_precision(f, K, n)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -975,4 +975,4 @@ function with_precision(f, K::QadicField, n::Int)
   return v
 end
 
-Base.setprecision(f, K::QadicField, n::Int) = with_precision(f, K, n)
+Base.setprecision(f::Function, K::QadicField, n::Int) = with_precision(f, K, n)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -873,18 +873,29 @@ Base.length(a::QadicFieldElem) = a.length
 #
 ###############################################################################
 
-# inner constructor is also used directly
-
-@doc raw"""
-    QadicField(p::Integer, d::Int, prec::Int, var::String = "a")
-
-Returns the parent object for the $q$-adic field for given prime $p$ and
-degree $d$.
-The default absolute precision of elements of the field may be set with `prec`
-and the generator is printed as `var`.
-"""
+# Kept for backwards compatibility; the user facing constructor is `qadic_field`
 function QadicField(p::Integer, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true)
    return QadicField(ZZRingElem(p), d, prec, var, cached = cached)
+end
+
+@doc raw"""
+    qadic_field(p::Integer, d::Int; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(p::ZZRingElem, d::Int; precision::Int=64, cached::Bool=true, check::Bool=true)
+
+Return an unramified extension $K$ of degree $d$ of a $p$-adic field for the given
+prime $p$.
+The generator of $K$ is printed as `var`.
+
+The default absolute precision of elements of $K$ may be set with `precision`.
+"""
+qadic_field
+
+function qadic_field(p::Integer, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+  return qadic_field(ZZRingElem(p), d, var; precision=precision, cached=cached, check=check)
+end
+
+function qadic_field(p::ZZRingElem, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+  return QadicField(p, d, precision, var; cached=cached, check=check)
 end
 
 ###############################################################################

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -847,6 +847,10 @@ end
 
 function coeff(x::QadicFieldElem, i::Int)
   R = coefficient_ring(parent(x))
+  # TODO: This setprecision! call should go; it is only here because in Hecke
+  # parent(x).prec_max is directly modified at at least one place (as of 15 May 2024),
+  # so we cannot adjust the precision of base_field(parent(x)) accordingly.
+  setprecision!(R, precision(parent(x)))
   c = R()
   ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
         (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, x, i, parent(x))
@@ -940,6 +944,7 @@ end
 
 function setprecision!(Q::QadicField, n::Int)
   Q.prec_max = n
+  setprecision!(coefficient_ring(Q), n)
   return Q
 end
 

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -176,18 +176,18 @@ function lift(R::ZZPolyRing, a::QadicFieldElem)
   return r
 end
 
-function zero(R::QadicField)
-  z = QadicFieldElem(R.prec_max)
-  ccall((:qadic_zero, libflint), Nothing, (Ref{QadicFieldElem},), z)
-  z.parent = R
-  return z
+function zero(R::QadicField; precision::Int=precision(R))
+   z = QadicFieldElem(precision)
+   ccall((:qadic_zero, libflint), Nothing, (Ref{QadicFieldElem},), z)
+   z.parent = R
+   return z
 end
 
-function one(R::QadicField)
-  z = QadicFieldElem(R.prec_max)
-  ccall((:qadic_one, libflint), Nothing, (Ref{QadicFieldElem},), z)
-  z.parent = R
-  return z
+function one(R::QadicField; precision::Int=precision(R))
+   z = QadicFieldElem(precision)
+   ccall((:qadic_one, libflint), Nothing, (Ref{QadicFieldElem},), z)
+   z.parent = R
+   return z
 end
 
 iszero(a::QadicFieldElem) = Bool(ccall((:qadic_is_zero, libflint), Cint,
@@ -623,12 +623,12 @@ end
 #
 ###############################################################################
 
-function zero!(z::QadicFieldElem)
-  z.N = parent(z).prec_max
-  ctx = parent(z)
-  ccall((:qadic_zero, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{QadicField}), z, ctx)
-  return z
+function zero!(z::QadicFieldElem; precision::Int=precision(parent(z)))
+   z.N = precision
+   ctx = parent(z)
+   ccall((:qadic_zero, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{QadicField}), z, ctx)
+   return z
 end
 
 function mul!(z::QadicFieldElem, x::QadicFieldElem, y::QadicFieldElem)
@@ -698,112 +698,112 @@ promote_rule(::Type{QadicFieldElem}, ::Type{PadicFieldElem}) = QadicFieldElem
 #
 ###############################################################################
 
-function (R::QadicField)()
-  z = QadicFieldElem(R.prec_max)
-  z.parent = R
-  return z
+function (R::QadicField)(; precision::Int=precision(R))
+   z = QadicFieldElem(precision)
+   z.parent = R
+   return z
 end
 
-function gen(R::QadicField)
-   z = QadicFieldElem(R.prec_max)
+function gen(R::QadicField; precision::Int=precision(R))
+   z = QadicFieldElem(precision)
    ccall((:qadic_gen, libflint), Nothing,
          (Ref{QadicFieldElem}, Ref{QadicField}), z, R)
    z.parent = R
    return z
 end
 
-function (R::QadicField)(a::UInt)
-  if a == 0
-    z = QadicFieldElem(R.prec_max)
-    z.parent = R
-    return z
-  end
-  v = valuation(a, prime(R))
-  z = QadicFieldElem(R.prec_max + v)
-  ccall((:qadic_set_ui, libflint), Nothing,
-        (Ref{QadicFieldElem}, UInt, Ref{QadicField}), z, a, R)
-  z.parent = R
-  return z
+function (R::QadicField)(a::UInt; precision::Int=precision(R))
+   if a == 0
+     z = QadicFieldElem(precision)
+     z.parent = R
+     return z
+   end
+   v = valuation(a, prime(R))
+   z = QadicFieldElem(precision + v)
+   ccall((:qadic_set_ui, libflint), Nothing,
+         (Ref{QadicFieldElem}, UInt, Ref{QadicField}), z, a, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(a::Int)
-  if a == 0
-    z = QadicFieldElem(R.prec_max)
-    z.parent = R
-    return z
-  end
-  v = valuation(a, prime(R))
-  z = QadicFieldElem(R.prec_max + v)
-  ccall((:padic_poly_set_si, libflint), Nothing,
-        (Ref{QadicFieldElem}, Int, Ref{QadicField}), z,a, R)
-  z.parent = R
-  return z
+function (R::QadicField)(a::Int; precision::Int=precision(R))
+   if a == 0
+     z = QadicFieldElem(precision)
+     z.parent = R
+     return z
+   end
+   v = valuation(a, prime(R))
+   z = QadicFieldElem(precision + v)
+   ccall((:padic_poly_set_si, libflint), Nothing,
+         (Ref{QadicFieldElem}, Int, Ref{QadicField}), z,a, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(n::ZZRingElem)
-  if iszero(n) || isone(n)
-    N = 0
-  else
-    p = prime(R)
-    N = valuation(n, p)
-  end
-  z = QadicFieldElem(N + R.prec_max)
-  ccall((:padic_poly_set_fmpz, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{ZZRingElem}, Ref{QadicField}), z, n, R)
-  z.parent = R
-  return z
+function (R::QadicField)(n::ZZRingElem; precision::Int=precision(R))
+   if iszero(n) || isone(n)
+      N = 0
+   else
+      p = prime(R)
+      N = valuation(n, p)
+   end
+   z = QadicFieldElem(N + precision)
+   ccall((:padic_poly_set_fmpz, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{ZZRingElem}, Ref{QadicField}), z, n, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(n::QQFieldElem)
-  m = denominator(n)
-  if isone(m)
-    return R(numerator(n))
-  end
-  p = prime(R)
-  if m == p
-    N = -1
-  else
-    N = -remove(m, p)[1]
-  end
-  z = QadicFieldElem(N + R.prec_max)
-  ccall((:padic_poly_set_fmpq, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{QQFieldElem}, Ref{QadicField}), z, n, R)
-  z.parent = R
-  return z
+function (R::QadicField)(n::QQFieldElem; precision::Int=precision(R))
+   m = denominator(n)
+   if isone(m)
+      return R(numerator(n); precision = precision)
+   end
+   p = prime(R)
+   if m == p
+      N = -1
+   else
+     N = -remove(m, p)[1]
+   end
+   z = QadicFieldElem(N + precision)
+   ccall((:padic_poly_set_fmpq, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{QQFieldElem}, Ref{QadicField}), z, n, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(n::ZZPolyRingElem, pr::Int = R.prec_max)
-  z = QadicFieldElem(pr)
-  ccall((:qadic_set_fmpz_poly, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{ZZPolyRingElem}, Ref{QadicField}), z, n, R)
-  z.parent = R
-  return z
+function (R::QadicField)(n::ZZPolyRingElem; precision::Int=precision(R))
+   z = QadicFieldElem(precision)
+   ccall((:qadic_set_fmpz_poly, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{ZZPolyRingElem}, Ref{QadicField}), z, n, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(n::QQPolyRingElem)
+function (R::QadicField)(n::QQPolyRingElem; precision::Int=precision(R))
 
-  if degree(n) > degree(R) + 1
-    error("Polynomial degree larger than degree of qadic field.")
-  end
-  m = denominator(n)
-  p = prime(R)
-  if m == p
-    N = -1
-  else
-    N = -remove(m, p)[1]
-  end
-  z = QadicFieldElem(N + R.prec_max)
-  ccall((:padic_poly_set_fmpq_poly, libflint), Nothing,
-        (Ref{QadicFieldElem}, Ref{QQPolyRingElem}, Ref{QadicField}), z, n, R)
-  z.parent = R
-  return z
+   if degree(n) > degree(R) + 1
+       error("Polynomial degree larger than degree of qadic field.")
+   end
+   m = denominator(n)
+   p = prime(R)
+   if m == p
+      N = -1
+   else
+     N = -remove(m, p)[1]
+   end
+   z = QadicFieldElem(N + precision)
+   ccall((:padic_poly_set_fmpq_poly, libflint), Nothing,
+         (Ref{QadicFieldElem}, Ref{QQPolyRingElem}, Ref{QadicField}), z, n, R)
+   z.parent = R
+   return z
 end
 
-function (R::QadicField)(b::Rational{<:Integer})
-  return R(QQFieldElem(b))
+function (R::QadicField)(b::Rational{<:Integer}; precision::Int=precision(R))
+   return R(QQFieldElem(b); precision)
 end
 
-(R::QadicField)(n::Integer) = R(ZZRingElem(n))
+(R::QadicField)(n::Integer; precision::Int=precision(R)) = R(ZZRingElem(n); precision)
 
 function (R::QadicField)(n::QadicFieldElem)
   parent(n) != R && error("Unable to coerce into q-adic field")

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -378,10 +378,6 @@ end
 
 //(a::QadicFieldElem, b::QadicFieldElem) = divexact(a, b)
 
-//(a::PadicFieldElem, b::QadicFieldElem) = divexact(a, b)
-
-//(a::QadicFieldElem, b::PadicFieldElem) = divexact(a, b)
-
 ###############################################################################
 #
 #   Comparison

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -381,3 +381,45 @@ end
 
   @test_throws DomainError teichmuller(R(7)^-1)
 end
+
+@testset "PadicField.feature_parity" begin
+  R = PadicField(2, 10)
+  @test degree(R) == 1
+  @test base_field(R) === R
+  @test gens(R, R) == [one(R)]
+  @test_throws AssertionError gens(R, PadicField(3, 10))
+end
+
+@testset "PadicField.setprecision" begin
+  K = PadicField(2, 10)
+  @test precision(K) == 10
+  setprecision!(K, 20)
+  @test precision(K) == 20
+  a = with_precision(K, 30) do
+    zero(K)
+  end
+  @test precision(a) == 30
+  @test precision(K) == 20
+  a = with_precision(K, 10) do
+    zero(K)
+  end
+  @test precision(a) == 10
+  @test precision(K) == 20
+
+  a = 1 + 2 + 2^2 + O(K, 2^3)
+  @test precision(a) == 3
+  b = setprecision(a, 5)
+  @test precision(b) == 5
+  @test precision(a) == 3
+  setprecision!(a, 5)
+  @test precision(a) == 5
+
+  Kx, x = K["x"]
+  f = x^2 + 1
+  @test all(x -> precision(x) == precision(K), coefficients(f))
+  g = setprecision(f, 30)
+  @test all(x -> precision(x) == precision(K), coefficients(f))
+  @test all(x -> precision(x) == 30, coefficients(g))
+  setprecision!(f, 30)
+  @test all(x -> precision(x) == 30, coefficients(f))
+end

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -25,7 +25,17 @@ end
 
   @test isa(S, PadicField)
 
-  @test isa(R(), PadicFieldElem)
+   R = padic_field(7)
+   @test isa(R, PadicField)
+
+   @test_throws DomainError padic_field(4)
+
+   R = padic_field(7, precision = 30)
+
+   @test isa(R, PadicField)
+   @test precision(R) == 30
+
+   @test isa(R(), PadicFieldElem)
 
   @test isa(R(1), PadicFieldElem)
 

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -101,13 +101,22 @@ end
    @test iszero(zero(R, precision = 60))
    @test precision(zero(R, precision = 60)) == 60
 
-  @test precision(a) == 3
+   d = one(R)
+   @test !iszero(d)
+   zero!(d, precision = 60)
+   @test iszero(d)
+   @test precision(d) == 60
 
-  @test prime(R) == 7
+   @test precision(a) == 3
+
+   @test prime(R) == 7
+   @test prime(R, 3) == 7^3
 
   @test valuation(b) == 2
 
-  @test lift(ZZ, a) == 211
+
+   @test lift(ZZ, a) == 211
+   @test is_zero(lift(ZZ, R()))
 
   @test lift(QQ, divexact(a, b)) == QQFieldElem(337, 49)
 

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -25,17 +25,17 @@ end
 
   @test isa(S, PadicField)
 
-   R = padic_field(7)
-   @test isa(R, PadicField)
+  R = padic_field(7)
+  @test isa(R, PadicField)
 
-   @test_throws DomainError padic_field(4)
+  @test_throws DomainError padic_field(4)
 
-   R = padic_field(7, precision = 30)
+  R = padic_field(7, precision = 30)
 
-   @test isa(R, PadicField)
-   @test precision(R) == 30
+  @test isa(R, PadicField)
+  @test precision(R) == 30
 
-   @test isa(R(), PadicFieldElem)
+  @test isa(R(), PadicFieldElem)
 
   @test isa(R(1), PadicFieldElem)
 
@@ -93,30 +93,30 @@ end
   b = 7^2 + 3*7^3 + O(R, 7^5)
   c = R(2)
 
-   @test isone(one(R))
-   @test isone(one(R, precision = 60))
-   @test precision(one(R, precision = 60)) == 60
+  @test isone(one(R))
+  @test isone(one(R, precision = 60))
+  @test precision(one(R, precision = 60)) == 60
 
-   @test iszero(zero(R))
-   @test iszero(zero(R, precision = 60))
-   @test precision(zero(R, precision = 60)) == 60
+  @test iszero(zero(R))
+  @test iszero(zero(R, precision = 60))
+  @test precision(zero(R, precision = 60)) == 60
 
-   d = one(R)
-   @test !iszero(d)
-   zero!(d, precision = 60)
-   @test iszero(d)
-   @test precision(d) == 60
+  d = one(R)
+  @test !iszero(d)
+  zero!(d, precision = 60)
+  @test iszero(d)
+  @test precision(d) == 60
 
-   @test precision(a) == 3
+  @test precision(a) == 3
 
-   @test prime(R) == 7
-   @test prime(R, 3) == 7^3
+  @test prime(R) == 7
+  @test prime(R, 3) == 7^3
 
   @test valuation(b) == 2
 
 
-   @test lift(ZZ, a) == 211
-   @test is_zero(lift(ZZ, R()))
+  @test lift(ZZ, a) == 211
+  @test is_zero(lift(ZZ, R()))
 
   @test lift(QQ, divexact(a, b)) == QQFieldElem(337, 49)
 

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -93,9 +93,13 @@ end
   b = 7^2 + 3*7^3 + O(R, 7^5)
   c = R(2)
 
-  @test isone(one(R))
+   @test isone(one(R))
+   @test isone(one(R, precision = 60))
+   @test precision(one(R, precision = 60)) == 60
 
-  @test iszero(zero(R))
+   @test iszero(zero(R))
+   @test iszero(zero(R, precision = 60))
+   @test precision(zero(R, precision = 60)) == 60
 
   @test precision(a) == 3
 
@@ -390,6 +394,31 @@ end
   @test teichmuller(b) == 2 + 4*7^1 + 6*7^2 + O(R, 7^3)
 
   @test_throws DomainError teichmuller(R(7)^-1)
+end
+
+@testset "PadicFieldElem.parent_overloading" begin
+  K = padic_field(7)
+
+  for a in [K(), K(0), K(ZZ(0)), K(QQ(0))]
+    a = K()
+    @test is_zero(a)
+    @test precision(a) == precision(K)
+  end
+  for a in [K(precision = 30), K(0, precision = 30), K(ZZ(0), precision = 30), K(QQ(0), precision = 30)]
+    @test is_zero(a)
+    @test precision(a) == 30
+  end
+
+  for a in [K(1, precision = 30), K(ZZ(1), precision = 30), K(QQ(1), precision = 30)]
+    @test is_one(a)
+    @test precision(a) == 30
+  end
+
+  a = K(7, precision = 30)
+  @test precision(a) == 31
+
+  a = K(QQ(1//7), precision = 30)
+  @test precision(a) == 29
 end
 
 @testset "PadicField.feature_parity" begin

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -93,7 +93,13 @@ end
    @test iszero(zero(R, precision = 60))
    @test precision(zero(R, precision = 60)) == 60
 
-  @test precision(a) == 3
+   d = one(R)
+   @test !iszero(d)
+   zero!(d, precision = 60)
+   @test iszero(d)
+   @test precision(d) == 60
+
+   @test precision(a) == 3
 
   @test prime(R) == 7
 
@@ -242,7 +248,8 @@ end
   c = 7^2 + 2*7^3 + O(R, 7^4)
   d = 7 + 2*7^2 + O(R, 7^5)
 
-  @test divexact(a, b) == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
+   @test divexact(a, b) == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
+   @test a//b == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
 
   @test divexact(c, d) == 1*7^1 + O(R, 7^3)
 
@@ -359,7 +366,16 @@ end
   a = K(7, precision = 30)
   @test precision(a) == 31
 
+  a = K(ZZRingElem(7), precision = 30)
+  @test precision(a) == 31
+
+  a = K(BigInt(7), precision = 30)
+  @test precision(a) == 31
+
   a = K(QQ(1//7), precision = 30)
+  @test precision(a) == 29
+
+  a = K(1//7, precision = 30)
   @test precision(a) == 29
 
   ZZx, x = polynomial_ring(ZZ, "x", cached = false)
@@ -420,7 +436,6 @@ end
   setprecision!(f, 30)
   @test all(x -> precision(x) == 30, coefficients(f))
 end
-
 
 @testset "QadicField.as_polynomial" begin
   L, _ = qadic_field(5, 4)

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -391,8 +391,8 @@ end
 
 @testset "QadicFieldElem.base_field" begin
   L, _ = QadicField(7, 2, 10)
-  @test base_field(L) isa PadicField
-  @test prime(base_field(L)) == 7
+  @test coefficient_ring(L) isa PadicField
+  @test prime(coefficient_ring(L)) == 7
 end
 
 @testset "QadicField.setprecision" begin
@@ -416,7 +416,7 @@ end
     a = one(K)
     return coeff(a, 0) + 1
   end
-  @test parent(b) === base_field(K)
+  @test parent(b) === coefficient_ring(K)
   @test precision(b) == 30
 
   a = 1 + 2 + 2^2 + O(K, 2^3)
@@ -439,7 +439,7 @@ end
 
 @testset "QadicField.as_polynomial" begin
   L, _ = qadic_field(5, 4)
-  K = base_field(L)
+  K = coefficient_ring(L)
   Kx, x = K["x"]
 
   for i in 1:100

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -13,7 +13,17 @@
 
   @test isa(S, QadicField)
 
-  @test isa(R(), QadicFieldElem)
+   R, _ = qadic_field(7, 1)
+   @test isa(R, QadicField)
+
+   @test_throws DomainError qadic_field(4, 2)
+
+   R, _ = qadic_field(7, 1, precision = 30)
+
+   @test isa(R, QadicField)
+   @test precision(R) == 30
+
+   @test isa(R(), QadicFieldElem)
 
   @test isa(R(1), QadicFieldElem)
 

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -18,6 +18,11 @@
 
   @test_throws DomainError qadic_field(4, 2)
 
+  Qp = padic_field(7, cached = false)
+  K, _ = unramified_extension(Qp, 2)
+  @test isa(K, QadicField)
+  @test coefficient_ring(K) === Qp
+
   R, _ = qadic_field(7, 1, precision = 30)
 
   @test isa(R, QadicField)

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -13,17 +13,17 @@
 
   @test isa(S, QadicField)
 
-   R, _ = qadic_field(7, 1)
-   @test isa(R, QadicField)
+  R, _ = qadic_field(7, 1)
+  @test isa(R, QadicField)
 
-   @test_throws DomainError qadic_field(4, 2)
+  @test_throws DomainError qadic_field(4, 2)
 
-   R, _ = qadic_field(7, 1, precision = 30)
+  R, _ = qadic_field(7, 1, precision = 30)
 
-   @test isa(R, QadicField)
-   @test precision(R) == 30
+  @test isa(R, QadicField)
+  @test precision(R) == 30
 
-   @test isa(R(), QadicFieldElem)
+  @test isa(R(), QadicFieldElem)
 
   @test isa(R(1), QadicFieldElem)
 
@@ -47,14 +47,14 @@
 
   @test isa(t, QadicFieldElem)
 
-   R, _ = QadicField(13, 1, 10)
-   a = gen(R)
-   @test a isa QadicFieldElem
-   a = gen(R; precision = 20)
-   @test a isa QadicFieldElem
-   @test precision(a) == 20
+  R, _ = QadicField(13, 1, 10)
+  a = gen(R)
+  @test a isa QadicFieldElem
+  a = gen(R; precision = 20)
+  @test a isa QadicFieldElem
+  @test precision(a) == 20
 
-   b = R(prime(R))
+  b = R(prime(R))
 
   Q, _ = QadicField(13, 3, 10)
   _, t = polynomial_ring(ZZ, "t")
@@ -85,21 +85,21 @@ end
   b = 7^2 + 3*7^3 + O(R, 7^5)
   c = R(2)
 
-   @test isone(one(R))
-   @test isone(one(R, precision = 60))
-   @test precision(one(R, precision = 60)) == 60
+  @test isone(one(R))
+  @test isone(one(R, precision = 60))
+  @test precision(one(R, precision = 60)) == 60
 
-   @test iszero(zero(R))
-   @test iszero(zero(R, precision = 60))
-   @test precision(zero(R, precision = 60)) == 60
+  @test iszero(zero(R))
+  @test iszero(zero(R, precision = 60))
+  @test precision(zero(R, precision = 60)) == 60
 
-   d = one(R)
-   @test !iszero(d)
-   zero!(d, precision = 60)
-   @test iszero(d)
-   @test precision(d) == 60
+  d = one(R)
+  @test !iszero(d)
+  zero!(d, precision = 60)
+  @test iszero(d)
+  @test precision(d) == 60
 
-   @test precision(a) == 3
+  @test precision(a) == 3
 
   @test prime(R) == 7
 
@@ -107,10 +107,10 @@ end
 
   @test valuation(R(0)) == precision(R(0))
 
-   @test characteristic(R) == 0
+  @test characteristic(R) == 0
 
-   @test shift_right(a, 2) == R(7)^-2 + 2*R(7)^-1 + 4*7^0 + O(R, 7^3)
-   @test shift_left(a, 2) == 7^2 + 2*7^3 + 4*7^4 + O(R, 7^5)
+  @test shift_right(a, 2) == R(7)^-2 + 2*R(7)^-1 + 4*7^0 + O(R, 7^3)
+  @test shift_left(a, 2) == 7^2 + 2*7^3 + 4*7^4 + O(R, 7^5)
 end
 
 @testset "QadicFieldElem.unary_ops" begin
@@ -248,8 +248,8 @@ end
   c = 7^2 + 2*7^3 + O(R, 7^4)
   d = 7 + 2*7^2 + O(R, 7^5)
 
-   @test divexact(a, b) == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
-   @test a//b == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
+  @test divexact(a, b) == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
+  @test a//b == 4 + 1*7^1 + 2*7^2 + O(R, 7^3)
 
   @test divexact(c, d) == 1*7^1 + O(R, 7^3)
 

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -395,6 +395,14 @@ end
   @test precision(a) == 10
   @test precision(K) == 20
 
+  # Make sure the precision of the base field is set as well
+  b = with_precision(K, 30) do
+    a = one(K)
+    return coeff(a, 0) + 1
+  end
+  @test parent(b) === base_field(K)
+  @test precision(b) == 30
+
   a = 1 + 2 + 2^2 + O(K, 2^3)
   @test precision(a) == 3
   b = setprecision(a, 5)

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -420,3 +420,22 @@ end
   setprecision!(f, 30)
   @test all(x -> precision(x) == 30, coefficients(f))
 end
+
+
+@testset "QadicField.as_polynomial" begin
+  L, _ = qadic_field(5, 4)
+  K = base_field(L)
+  Kx, x = K["x"]
+
+  for i in 1:100
+    a = L(rand(-1000:1000))
+    f = map_coefficients(y -> lift(QQ, y), Kx(a))
+    @test L(f) == a
+  end
+
+  a = 2*gen(L) + gen(L)
+  setcoeff!(a, 1, K(1))
+  @test a == gen(L)
+  setcoeff!(a, 1, UInt(2))
+  @test coeff(a, 1) == K(2)
+end

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -80,7 +80,10 @@ end
 
   @test valuation(R(0)) == precision(R(0))
 
-  @test characteristic(R) == 0
+   @test characteristic(R) == 0
+
+   @test shift_right(a, 2) == R(7)^-2 + 2*R(7)^-1 + 4*7^0 + O(R, 7^3)
+   @test shift_left(a, 2) == 7^2 + 2*7^3 + 4*7^4 + O(R, 7^5)
 end
 
 @testset "QadicFieldElem.unary_ops" begin
@@ -314,3 +317,42 @@ end
   @test a == 2
 end
 
+@testset "QadicFieldElem.base_field" begin
+  L, _ = QadicField(7, 2, 10)
+  @test base_field(L) isa PadicField
+  @test prime(base_field(L)) == 7
+end
+
+@testset "QadicField.setprecision" begin
+  K, _  = QadicField(2, 2, 10)
+  @test precision(K) == 10
+  setprecision!(K, 20)
+  @test precision(K) == 20
+  a = with_precision(K, 30) do
+    zero(K)
+  end
+  @test precision(a) == 30
+  @test precision(K) == 20
+  a = with_precision(K, 10) do
+    zero(K)
+  end
+  @test precision(a) == 10
+  @test precision(K) == 20
+
+  a = 1 + 2 + 2^2 + O(K, 2^3)
+  @test precision(a) == 3
+  b = setprecision(a, 5)
+  @test precision(b) == 5
+  @test precision(a) == 3
+  setprecision!(a, 5)
+  @test precision(a) == 5
+
+  Kx, x = K["x"]
+  f = x^2 + 1
+  @test all(x -> precision(x) == precision(K), coefficients(f))
+  g = setprecision(f, 30)
+  @test all(x -> precision(x) == precision(K), coefficients(f))
+  @test all(x -> precision(x) == 30, coefficients(g))
+  setprecision!(f, 30)
+  @test all(x -> precision(x) == 30, coefficients(f))
+end

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -47,7 +47,14 @@
 
   @test isa(t, QadicFieldElem)
 
-  @test parent(t) === R
+   R, _ = QadicField(13, 1, 10)
+   a = gen(R)
+   @test a isa QadicFieldElem
+   a = gen(R; precision = 20)
+   @test a isa QadicFieldElem
+   @test precision(a) == 20
+
+   b = R(prime(R))
 
   Q, _ = QadicField(13, 3, 10)
   _, t = polynomial_ring(ZZ, "t")
@@ -78,9 +85,13 @@ end
   b = 7^2 + 3*7^3 + O(R, 7^5)
   c = R(2)
 
-  @test isone(one(R))
+   @test isone(one(R))
+   @test isone(one(R, precision = 60))
+   @test precision(one(R, precision = 60)) == 60
 
-  @test iszero(zero(R))
+   @test iszero(zero(R))
+   @test iszero(zero(R, precision = 60))
+   @test precision(zero(R, precision = 60)) == 60
 
   @test precision(a) == 3
 
@@ -325,6 +336,41 @@ end
   a = 1 + 7 + 2*7^2 + O(R, 7^3)
   setcoeff!(a, 0, ZZ(2))
   @test a == 2
+end
+
+@testset "QadicFieldElem.parent_overloading" begin
+  K, _ = qadic_field(7, 2)
+
+  for a in [K(), K(0), K(ZZ(0)), K(QQ(0))]
+    a = K()
+    @test is_zero(a)
+    @test precision(a) == precision(K)
+  end
+  for a in [K(precision = 30), K(UInt(0), precision = 30), K(0, precision = 30), K(ZZ(0), precision = 30), K(QQ(0), precision = 30)]
+    @test is_zero(a)
+    @test precision(a) == 30
+  end
+
+  for a in [K(UInt(1), precision = 30), K(1, precision = 30), K(ZZ(1), precision = 30), K(QQ(1), precision = 30)]
+    @test is_one(a)
+    @test precision(a) == 30
+  end
+
+  a = K(7, precision = 30)
+  @test precision(a) == 31
+
+  a = K(QQ(1//7), precision = 30)
+  @test precision(a) == 29
+
+  ZZx, x = polynomial_ring(ZZ, "x", cached = false)
+  z = gen(K)
+  @test K(x + 1) == z + 1
+  @test K(x + 1, precision = 30) == gen(K, precision = 30) + one(K, precision = 30)
+
+  QQx, x = polynomial_ring(QQ, "x", cached = false)
+  z = gen(K)
+  @test K(x + 1) == z + 1
+  @test K(x + 1, precision = 30) == gen(K, precision = 30) + one(K, precision = 30)
 end
 
 @testset "QadicFieldElem.base_field" begin


### PR DESCRIPTION
* Cache p-adic and q-adic fields only via the prime number and degree
* Move some code from `HeckeMoreStuff` to the correct file + some tests
* Introduce user facing constructors `padic_field` and `qadic_field` where the precision is a keyword argument
* Add `precision` keyword arguments to all constructors which take exact input
* Deprecate some functionality like `prime_field` (should never have been called like that) or `lift(::PadicFieldElem)` (lifts to ZZ, so one should call `lift(ZZ, ...)`) + more.
