### PR TITLE
Conform Nemo to new FLINT random struct

### DIFF
--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -2108,22 +2108,22 @@ function rand(r::RealField, prec::Int = precision(Balls); randtype::Symbol=:uran
 
   if randtype == :urandom
     ccall((:arb_urandom, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int), x, state.ptr, prec)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int), x, state, prec)
   elseif randtype == :randtest
     ccall((:arb_randtest, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, prec, 30)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int, Int), x, state, prec, 30)
   elseif randtype == :randtest_exact
     ccall((:arb_randtest_exact, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, prec, 30)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int, Int), x, state, prec, 30)
   elseif randtype == :randtest_precise
     ccall((:arb_randtest_precise, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, prec, 30)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int, Int), x, state, prec, 30)
   elseif randtype == :randtest_wide
     ccall((:arb_randtest_wide, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, prec, 30)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int, Int), x, state, prec, 30)
   elseif randtype == :randtest_special
     ccall((:arb_randtest_special, libflint), Nothing,
-          (Ref{RealFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, prec, 30)
+          (Ref{RealFieldElem}, Ref{rand_ctx}, Int, Int), x, state, prec, 30)
   else
     error("Arb random generation `" * String(randtype) * "` is not defined")
   end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -2123,22 +2123,22 @@ function rand(r::ArbField; randtype::Symbol=:urandom)
 
   if randtype == :urandom
     ccall((:arb_urandom, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int), x, state.ptr, r.prec)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int), x, state, r.prec)
   elseif randtype == :randtest
     ccall((:arb_randtest, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int, Int), x, state, r.prec, 30)
   elseif randtype == :randtest_exact
     ccall((:arb_randtest_exact, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int, Int), x, state, r.prec, 30)
   elseif randtype == :randtest_precise
     ccall((:arb_randtest_precise, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int, Int), x, state, r.prec, 30)
   elseif randtype == :randtest_wide
     ccall((:arb_randtest_wide, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int, Int), x, state, r.prec, 30)
   elseif randtype == :randtest_special
     ccall((:arb_randtest_special, libflint), Nothing,
-          (Ref{ArbFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, r.prec, 30)
+          (Ref{ArbFieldElem}, Ref{rand_ctx}, Int, Int), x, state, r.prec, 30)
   else
     error("Arb random generation `" * String(randtype) * "` is not defined")
   end

--- a/src/calcium/ca.jl
+++ b/src/calcium/ca.jl
@@ -139,16 +139,16 @@ function rand(C::CalciumField; depth::Int, bits::Int,
 
    if randtype == :null
       ccall((:ca_randtest, libflint), Nothing,
-          (Ref{CalciumFieldElem}, Ptr{Cvoid}, Int, Int, Ref{CalciumField}),
-                x, state.ptr, depth, bits, C)
+          (Ref{CalciumFieldElem}, Ref{rand_ctx}, Int, Int, Ref{CalciumField}),
+                x, state, depth, bits, C)
    elseif randtype == :rational
       ccall((:ca_randtest_rational, libflint), Nothing,
-          (Ref{CalciumFieldElem}, Ptr{Cvoid}, Int, Ref{CalciumField}),
-                x, state.ptr, bits, C)
+          (Ref{CalciumFieldElem}, Ref{rand_ctx}, Int, Ref{CalciumField}),
+                x, state, bits, C)
    elseif randtype == :special
       ccall((:ca_randtest_special, libflint), Nothing,
-          (Ref{CalciumFieldElem}, Ptr{Cvoid}, Int, Int, Ref{CalciumField}),
-                x, state.ptr, depth, bits, C)
+          (Ref{CalciumFieldElem}, Ref{rand_ctx}, Int, Int, Ref{CalciumField}),
+                x, state, depth, bits, C)
    else
       error("randtype not defined")
    end

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -341,14 +341,14 @@ function rand(R::QQBarField; degree::Int, bits::Int,
 
    if randtype == :null
       ccall((:qqbar_randtest, libflint), Nothing,
-          (Ref{QQBarFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, degree, bits)
+          (Ref{QQBarFieldElem}, Ref{rand_ctx}, Int, Int), x, state, degree, bits)
    elseif randtype == :real
       ccall((:qqbar_randtest_real, libflint), Nothing,
-          (Ref{QQBarFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, degree, bits)
+          (Ref{QQBarFieldElem}, Ref{rand_ctx}, Int, Int), x, state, degree, bits)
    elseif randtype == :nonreal
       degree < 2 && error("nonreal requires degree >= 2")
       ccall((:qqbar_randtest_nonreal, libflint), Nothing,
-          (Ref{QQBarFieldElem}, Ptr{Cvoid}, Int, Int), x, state.ptr, degree, bits)
+          (Ref{QQBarFieldElem}, Ref{rand_ctx}, Int, Int), x, state, degree, bits)
    else
       error("randtype not defined")
    end

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1155,8 +1155,8 @@ denominator can be smaller than $b$ bits.
 function rand_bits(::QQField, b::Int)
    b > 0 || throw(DomainError(b, "Bit count must be positive"))
    z = QQFieldElem()
-   ccall((:fmpq_randbits, libflint), Nothing, (Ref{QQFieldElem}, Ptr{Cvoid}, Int),
-         z, _flint_rand_states[Threads.threadid()].ptr, b)
+   ccall((:fmpq_randbits, libflint), Nothing, (Ref{QQFieldElem}, Ref{rand_ctx}, Int),
+         z, _flint_rand_states[Threads.threadid()], b)
    return z
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1499,8 +1499,8 @@ function _ecm(a::ZZRingElem, B1::UInt, B2::UInt, ncrv::UInt,
              rnd = _flint_rand_states[Threads.threadid()])
   f = ZZRingElem()
   r = ccall((:fmpz_factor_ecm, libflint), Int32,
-            (Ref{ZZRingElem}, UInt, UInt, UInt, Ptr{Cvoid}, Ref{ZZRingElem}),
-            f, ncrv, B1, B2, rnd.ptr, a)
+            (Ref{ZZRingElem}, UInt, UInt, UInt, Ref{rand_ctx}, Ref{ZZRingElem}),
+            f, ncrv, B1, B2, rnd, a)
   return r, f
 end
 
@@ -2741,8 +2741,8 @@ Return a random signed integer whose absolute value has $b$ bits.
 function rand_bits(::ZZRing, b::Int)
    b >= 0 || throw(DomainError(b, "Bit count must be non-negative"))
    z = ZZRingElem()
-   ccall((:fmpz_randbits, libflint), Nothing,(Ref{ZZRingElem}, Ptr{Cvoid}, Int),
-         z, _flint_rand_states[Threads.threadid()].ptr, b)
+   ccall((:fmpz_randbits, libflint), Nothing,(Ref{ZZRingElem}, Ref{rand_ctx}, Int),
+         z, _flint_rand_states[Threads.threadid()], b)
    return z
 end
 
@@ -2756,8 +2756,8 @@ function rand_bits_prime(::ZZRing, n::Int, proved::Bool = true)
    n < 2 && throw(DomainError(n, "No primes with that many bits"))
    z = ZZRingElem()
    ccall((:fmpz_randprime, libflint), Nothing,
-	 (Ref{ZZRingElem}, Ptr{Cvoid}, Int, Cint),
-	  z, _flint_rand_states[Threads.threadid()].ptr, n, Cint(proved))
+	 (Ref{ZZRingElem}, Ref{rand_ctx}, Int, Cint),
+	  z, _flint_rand_states[Threads.threadid()], n, Cint(proved))
    return z
 end
 


### PR DESCRIPTION
Due to https://github.com/flintlib/flint/pull/1964:

* The GMP-state in a FLINT random context structure will no longer be expanded inside the struct, but rather a pointer to it. Hence, make Nemo compatible with this.

* Do not use `flint_rand_alloc` and `flint_rand_free` for allocating the FLINT random context structure. This is in order to be able to use the same code for the new version of FLINT as well as the old version.

* Use the new symbol names for the FLINT random functions if they are available. This is checked during the initialization of Nemo, where we check for the new symbol `flint_rand_init`.