### PR TITLE
Deprecate `coefficient_ring` for the p-adics

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -90,5 +90,6 @@ end
 @deprecate is_power(x::QQFieldElem) is_perfect_power_with_data(x)
 @deprecate is_power(x::Rational) is_perfect_power_with_data(x)
 
+# Deprecated in 0.47
 @deprecate coefficient_ring(k::PadicField) base_field(k)
 @deprecate coefficient_ring(k::QadicField) base_field(k)

--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -89,3 +89,6 @@ end
 @deprecate is_power(x::IntegerUnion) is_perfect_power_with_data(x)
 @deprecate is_power(x::QQFieldElem) is_perfect_power_with_data(x)
 @deprecate is_power(x::Rational) is_perfect_power_with_data(x)
+
+@deprecate coefficient_ring(k::PadicField) base_field(k)
+@deprecate coefficient_ring(k::QadicField) base_field(k)

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -89,9 +89,6 @@ degree(::PadicField) = 1
 
 base_field(k::PadicField) = k
 
-# TODO: Remove in the next minor/breaking release
-coefficient_ring(k::PadicField) = base_field(k)
-
 # Return generators of k "over" K
 function gens(k::PadicField, K::PadicField)
   @assert k === K

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -86,9 +86,7 @@ function _prime(R::QadicField, n::Int = 1)
   return z
 end
 
-# TODO: For the next minor/breaking release, rename this to base_field and
-# deprecate coefficient_ring (and remove the corresponding base_field in Hecke)
-function coefficient_ring(K::QadicField)
+function base_field(K::QadicField)
   L = get_attribute!(K, :base_field) do
     return PadicField(prime(K), precision(K), cached = false)
   end::PadicField
@@ -226,7 +224,7 @@ function var(Q::QadicField)
 end
 
 function expressify(b::QadicFieldElem, x = var(parent(b)); context = nothing)
-  R = coefficient_ring(parent(b))
+  R = base_field(parent(b))
   if iszero(b)
     return 0
   end
@@ -678,13 +676,13 @@ end
 ###############################################################################
 
 function tr(r::QadicFieldElem)
-  t = coefficient_ring(parent(r))()
+  t = base_field(parent(r))()
   ccall((:qadic_trace, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
   return t
 end
 
 function norm(r::QadicFieldElem)
-  t = coefficient_ring(parent(r))()
+  t = base_field(parent(r))()
   ccall((:qadic_norm, libflint), Nothing, (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Ref{QadicField}), t, r, parent(r))
   return t
 end
@@ -844,7 +842,7 @@ function (Rx::Generic.PolyRing{PadicFieldElem})(a::QadicFieldElem)
 end
 
 function coeff(x::QadicFieldElem, i::Int)
-  R = coefficient_ring(parent(x))
+  R = base_field(parent(x))
   c = R()
   ccall((:padic_poly_get_coeff_padic, libflint), Nothing,
         (Ref{PadicFieldElem}, Ref{QadicFieldElem}, Int, Ref{QadicField}), c, x, i, parent(x))
@@ -861,7 +859,7 @@ function setcoeff!(x::QadicFieldElem, i::Int, y::UInt)
 end
 
 function setcoeff!(x::QadicFieldElem, i::Int, y::ZZRingElem)
-  R = coefficient_ring(parent(x))
+  R = base_field(parent(x))
   Y = R(ZZRingElem(y))
   ccall((:padic_poly_set_coeff_padic, libflint), Nothing,
         (Ref{QadicFieldElem}, Int, Ref{PadicFieldElem}, Ref{QadicField}), x, i, Y, parent(x))
@@ -938,7 +936,7 @@ end
 
 function setprecision!(Q::QadicField, n::Int)
   Q.prec_max = n
-  setprecision!(coefficient_ring(Q), n)
+  setprecision!(base_field(Q), n)
   return Q
 end
 
@@ -962,14 +960,14 @@ end
 function with_precision(f, K::QadicField, n::Int)
   @assert n >= 0
   old = precision(K)
-  old_base = precision(coefficient_ring(K))
+  old_base = precision(base_field(K))
   setprecision!(K, n)
-  setprecision!(coefficient_ring(K), n)
+  setprecision!(base_field(K), n)
   v = try
     f()
   finally
     setprecision!(K, old)
-    setprecision!(coefficient_ring(K), old_base)
+    setprecision!(base_field(K), old_base)
   end
   return v
 end

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -21,7 +21,7 @@
   Qp = padic_field(7, cached = false)
   K, _ = unramified_extension(Qp, 2)
   @test isa(K, QadicField)
-  @test coefficient_ring(K) === Qp
+  @test base_field(K) === Qp
 
   R, _ = qadic_field(7, 1, precision = 30)
 
@@ -396,8 +396,8 @@ end
 
 @testset "QadicFieldElem.base_field" begin
   L, _ = QadicField(7, 2, 10)
-  @test coefficient_ring(L) isa PadicField
-  @test prime(coefficient_ring(L)) == 7
+  @test base_field(L) isa PadicField
+  @test prime(base_field(L)) == 7
 end
 
 @testset "QadicField.setprecision" begin
@@ -421,7 +421,7 @@ end
     a = one(K)
     return coeff(a, 0) + 1
   end
-  @test parent(b) === coefficient_ring(K)
+  @test parent(b) === base_field(K)
   @test precision(b) == 30
 
   a = 1 + 2 + 2^2 + O(K, 2^3)
@@ -444,7 +444,7 @@ end
 
 @testset "QadicField.as_polynomial" begin
   L, _ = qadic_field(5, 4)
-  K = coefficient_ring(L)
+  K = base_field(L)
   Kx, x = K["x"]
 
   for i in 1:100


### PR DESCRIPTION
Goes with thofma/Hecke.jl#1605.
