### PR TITLE
Wrap fmpq_reconstruct_fmpz_2..

### DIFF
--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -118,7 +118,7 @@ reconstruct(::ZZRingElem, ::ZZRingElem)
 ```
 
 ```@docs
-reconstruct2(::ZZRingElem, ::ZZRingElem, ::ZZRingElem, ::ZZRingElem)
+reconstruct(::ZZRingElem, ::ZZRingElem, ::ZZRingElem, ::ZZRingElem)
 ```
 
 ## Rational enumeration

--- a/docs/src/fraction.md
+++ b/docs/src/fraction.md
@@ -117,6 +117,10 @@ Rational reconstruction is available for rational numbers.
 reconstruct(::ZZRingElem, ::ZZRingElem)
 ```
 
+```@docs
+reconstruct2(::ZZRingElem, ::ZZRingElem, ::ZZRingElem, ::ZZRingElem)
+```
+
 ## Rational enumeration
 
 Various methods exist to enumerate rationals.

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -529,7 +529,6 @@ export RealMatSpace
 export RealPoly
 export RealPolyRing
 export reconstruct
-export reconstruct2
 export reduce_mod
 export reduce_mod!
 export rem

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -529,6 +529,7 @@ export RealMatSpace
 export RealPoly
 export RealPolyRing
 export reconstruct
+export reconstruct2
 export reduce_mod
 export reduce_mod!
 export rem

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -755,16 +755,16 @@ reconstruct(a::Integer, m::ZZRingElem) =  reconstruct(ZZRingElem(a), m)
 reconstruct(a::Integer, m::Integer) =  reconstruct(ZZRingElem(a), ZZRingElem(m))
 
 @doc raw"""
-    reconstruct2(a::ZZRingElem, m::ZZRingElem, N::ZZRingElem, D::ZZRingElem)
+    reconstruct(a::ZZRingElem, m::ZZRingElem, N::ZZRingElem, D::ZZRingElem)
 
 Attempt to return a rational number $n/d$ such that $0 \leq |n| \leq N$ and $0 < d \leq D$
 such that $2 N D < m$, gcd$(n, d) = 1$, and $a \equiv nd^{-1} \pmod{m}$.
 
 Returns a tuple (`success`, `n/d`), where `success` signals the success of reconstruction.
 """
-function reconstruct2(a::ZZRingElem, m::ZZRingElem, N::ZZRingElem, D::ZZRingElem)
+function reconstruct(a::ZZRingElem, m::ZZRingElem, N::ZZRingElem, D::ZZRingElem)
   c = QQFieldElem()
-  success = Bool(ccall((:fmpq_reconstruct_fmpz_2, Nemo.libflint), Cint,
+  success = Bool(ccall((:fmpq_reconstruct_fmpz_2, libflint), Cint,
     (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}),
     c, a, m, N, D))
   return success, c

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -542,11 +542,11 @@ end
 
   a, m = ZZRingElem(397284476), ZZRingElem(2^30 + 3)
   N = D = isqrt((m >> 1) - 1)
-  flag, nd = reconstruct2(a, m, N, D)
+  flag, nd = reconstruct(a, m, N, D)
   @test nd == ZZRingElem(1)//ZZRingElem(100)
 
   N = D = ZZRingElem(50)
-  flag, nd = reconstruct2(a, m, N, D)
+  flag, nd = reconstruct(a, m, N, D)
   @test !flag
 
   @test reconstruct(123, ZZRingElem(237)) == ZZRingElem(9)//2

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -540,6 +540,15 @@ end
 
   @test reconstruct(ZZRingElem(123), ZZRingElem(237)) == ZZRingElem(9)//2
 
+  a, m = ZZRingElem(397284476), ZZRingElem(2^30 + 3)
+  N = D = isqrt((m >> 1) - 1)
+  flag, nd = reconstruct2(a, m, N, D)
+  @test nd == ZZRingElem(1)//ZZRingElem(100)
+
+  N = D = ZZRingElem(50)
+  flag, nd = reconstruct2(a, m, N, D)
+  @test !flag
+
   @test reconstruct(123, ZZRingElem(237)) == ZZRingElem(9)//2
 
   flag, nd = Nemo.unsafe_reconstruct(ZZRingElem(123), ZZRingElem(237))


### PR DESCRIPTION
..because it can be faster when the bound is precomputed.

```julia
using Nemo, BenchmarkTools, Primes
m = ZZRingElem(prod(nextprimes(BigInt(2)^30, 1_000)));
n, d = ZZRingElem(1), ZZRingElem(100)
N = D = isqrt((m >> 1) - 1);
a = mod(n * invmod(d, m), m);

@btime reconstruct($a,$m)
#  17.160 μs (17 allocations: 29.23 KiB)

@btime reconstruct2($a,$m,$N,$N)
#  4.656 μs (15 allocations: 25.58 KiB)
```

BTW, perhaps `Nemo.reconstruct` can be changed to do the same as `Nemo.unsafe_reconstruct` (and `Nemo.unsafe_reconstruct` be removed).