### PR TITLE
Add `solve_context_type`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.41.4"
+AbstractAlgebra = "0.41.8"
 FLINT_jll = "^300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -600,9 +600,7 @@ end
 #
 ################################################################################
 
-function solve_init(A::ComplexMat)
-  return Solve.SolveCtx{ComplexFieldElem, ComplexMat, ComplexMat, ComplexMat}(A)
-end
+AbstractAlgebra.solve_context_type(::Type{ComplexFieldElem}) = Solve.SolveCtx{ComplexFieldElem, ComplexMat, ComplexMat, ComplexMat}
 
 function Solve._init_reduce(C::Solve.SolveCtx{ComplexFieldElem})
   if isdefined(C, :red) && isdefined(C, :lu_perm)

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -542,9 +542,7 @@ end
 #
 ################################################################################
 
-function solve_init(A::RealMat)
-  return Solve.SolveCtx{RealFieldElem, RealMat, RealMat, RealMat}(A)
-end
+AbstractAlgebra.solve_context_type(::Type{RealFieldElem}) = Solve.SolveCtx{RealFieldElem, RealMat, RealMat, RealMat}
 
 function Solve._init_reduce(C::Solve.SolveCtx{RealFieldElem})
   if isdefined(C, :red) && isdefined(C, :lu_perm)

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -603,9 +603,7 @@ end
 #
 ################################################################################
 
-function solve_init(A::AcbMatrix)
-  return Solve.SolveCtx{AcbFieldElem, AcbMatrix, AcbMatrix, AcbMatrix}(A)
-end
+AbstractAlgebra.solve_context_type(::Type{AcbFieldElem}) = Solve.SolveCtx{AcbFieldElem, AcbMatrix, AcbMatrix, AcbMatrix}
 
 function Solve._init_reduce(C::Solve.SolveCtx{AcbFieldElem})
   if isdefined(C, :red) && isdefined(C, :lu_perm)

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -569,9 +569,7 @@ end
 #
 ################################################################################
 
-function solve_init(A::ArbMatrix)
-  return Solve.SolveCtx{ArbFieldElem, ArbMatrix, ArbMatrix, ArbMatrix}(A)
-end
+AbstractAlgebra.solve_context_type(::Type{ArbFieldElem}) = Solve.SolveCtx{ArbFieldElem, ArbMatrix, ArbMatrix, ArbMatrix}
 
 function Solve._init_reduce(C::Solve.SolveCtx{ArbFieldElem})
   if isdefined(C, :red) && isdefined(C, :lu_perm)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1314,9 +1314,7 @@ end
 # Overwrite some solve context functionality so that it uses `transpose` and not
 # `lazy_transpose`
 
-function solve_init(A::ZZMatrix)
-  return Solve.SolveCtx{ZZRingElem, ZZMatrix, ZZMatrix, ZZMatrix}(A)
-end
+AbstractAlgebra.solve_context_type(::Type{ZZRingElem}) = Solve.SolveCtx{ZZRingElem, ZZMatrix, ZZMatrix, ZZMatrix}
 
 function Solve._init_reduce_transpose(C::Solve.SolveCtx{ZZRingElem})
   if isdefined(C, :red_transp) && isdefined(C, :trafo_transp)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -56,8 +56,9 @@ end
 #
 ################################################################################
 
-function solve_init(A::_FieldMatTypes)
-  return Solve.SolveCtx{elem_type(base_ring(A)), typeof(A), typeof(A), typeof(A)}(A)
+function AbstractAlgebra.solve_context_type(::Type{T}) where {T <: Union{QQFieldElem, fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}}
+  MatType = dense_matrix_type(T)
+  return Solve.SolveCtx{T, MatType, MatType, MatType}
 end
 
 ################################################################################

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -475,6 +475,13 @@ end
   @test contains(transpose(y), ZZ[1 1 1])
 
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(CC))
+  @test C isa AbstractAlgebra.solve_context_type(CC())
+  @test C isa AbstractAlgebra.solve_context_type(typeof(CC))
+  @test C isa AbstractAlgebra.solve_context_type(CC)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
+
   fl, y, K = can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test overlaps(A*y, b)

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -441,6 +441,13 @@ end
   @test contains(transpose(y), ZZ[1 1 1])
 
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(RR))
+  @test C isa AbstractAlgebra.solve_context_type(RR())
+  @test C isa AbstractAlgebra.solve_context_type(typeof(RR))
+  @test C isa AbstractAlgebra.solve_context_type(RR)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
+
   fl, y, K = can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test overlaps(A*y, b)

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -475,6 +475,13 @@ end
   @test contains(transpose(y), ZZ[1 1 1])
 
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(CC))
+  @test C isa AbstractAlgebra.solve_context_type(CC())
+  @test C isa AbstractAlgebra.solve_context_type(typeof(CC))
+  @test C isa AbstractAlgebra.solve_context_type(CC)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
+
   fl, y, K = can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test overlaps(A*y, b)

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -461,6 +461,13 @@ end
   @test contains(transpose(y), ZZ[1 1 1])
 
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(elem_type(RR))
+  @test C isa AbstractAlgebra.solve_context_type(RR())
+  @test C isa AbstractAlgebra.solve_context_type(typeof(RR))
+  @test C isa AbstractAlgebra.solve_context_type(RR)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
+
   fl, y, K = can_solve_with_solution_and_kernel(C, b, side = :right)
   @test fl
   @test overlaps(A*y, b)

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -700,6 +700,12 @@ end
 @testset "QQMatrix.solve_context" begin
   A = matrix(QQ, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(QQFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(QQ())
+  @test C isa AbstractAlgebra.solve_context_type(QQField)
+  @test C isa AbstractAlgebra.solve_context_type(QQ)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ QQ(1) ])
   @test_throws ErrorException solve(C, [ QQ(1) ], side = :right)

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -736,6 +736,13 @@ end
   @test nrows(K) + rank(A) == nrows(A)
 
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(ZZRingElem)
+  @test C isa AbstractAlgebra.solve_context_type(ZZ())
+  @test C isa AbstractAlgebra.solve_context_type(ZZRing)
+  @test C isa AbstractAlgebra.solve_context_type(ZZ)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
+
   B = matrix(ZZ, 2, 1, [1, 1])
   fl, x, K = can_solve_with_solution_and_kernel(C, B, side = :right)
   @test fl

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -664,6 +664,12 @@ end
   F = GF(101)
   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(FqFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(F())
+  @test C isa AbstractAlgebra.solve_context_type(FqField)
+  @test C isa AbstractAlgebra.solve_context_type(F)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ F(1) ])
   @test_throws ErrorException solve(C, [ F(1) ], side = :right)

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -652,6 +652,12 @@ end
   F, _ = Native.finite_field(ZZRingElem(101), 1, "a")
   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(FqPolyRepFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(F())
+  @test C isa AbstractAlgebra.solve_context_type(FqPolyRepField)
+  @test C isa AbstractAlgebra.solve_context_type(F)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ F(1) ])
   @test_throws ErrorException solve(C, [ F(1) ], side = :right)

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -652,6 +652,12 @@ end
   F, _ = Native.finite_field(101, 1, "a")
   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(fqPolyRepFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(F())
+  @test C isa AbstractAlgebra.solve_context_type(fqPolyRepField)
+  @test C isa AbstractAlgebra.solve_context_type(F)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ F(1) ])
   @test_throws ErrorException solve(C, [ F(1) ], side = :right)

--- a/test/flint/gfp_fmpz_mat-test.jl
+++ b/test/flint/gfp_fmpz_mat-test.jl
@@ -876,6 +876,12 @@ end
   F, _ = Native.finite_field(ZZRingElem(101))
   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(FpFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(F())
+  @test C isa AbstractAlgebra.solve_context_type(Nemo.FpField)
+  @test C isa AbstractAlgebra.solve_context_type(F)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ F(1) ])
   @test_throws ErrorException solve(C, [ F(1) ], side = :right)

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -717,6 +717,12 @@ end
   F = Native.GF(101)
   A = matrix(F, [1 2 3 4 5; 0 0 8 9 10; 0 0 0 14 15])
   C = solve_init(A)
+  @test C isa AbstractAlgebra.solve_context_type(fpFieldElem)
+  @test C isa AbstractAlgebra.solve_context_type(F())
+  @test C isa AbstractAlgebra.solve_context_type(Nemo.fpField)
+  @test C isa AbstractAlgebra.solve_context_type(F)
+  @test C isa AbstractAlgebra.solve_context_type(typeof(A))
+  @test C isa AbstractAlgebra.solve_context_type(A)
 
   @test_throws ErrorException solve(C, [ F(1) ])
   @test_throws ErrorException solve(C, [ F(1) ], side = :right)


### PR DESCRIPTION
We could get rid of the `solve_init` functions after a AbstractAlgebra release.

EDIT: I removed the `solve_init`'s now.
