### PR TITLE
Remove `norm(::ArbMatrix)`

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -64,10 +64,6 @@ function evaluate!(z::fqPolyRepFieldElem, f::ZZPolyRingElem, r::fqPolyRepFieldEl
 end
 
 
-function norm(v::ArbMatrix)
-  return sqrt(sum([a^2 for a in v]))
-end
-
 function real(tau::AcbMatrix)
   return map(real, tau)
 end


### PR DESCRIPTION
This is the only matrix type with a norm function, and this is not even a vector-norm induced matrix norm, so not what most people want.

Let's see if this is used downstream, anyway we should wait for the next minor release.