### PR TITLE
Remove is_diagonal, is_(lower|upper)_triangular for ZZMatrix

### DIFF
--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -377,41 +377,6 @@ function snf_with_transform(A::ZZMatrix, l::Bool=true, r::Bool=true)
   end
 end
 
-################################################################################
-#
-#  IsUpper\Lower triangular
-#
-################################################################################
-
-function is_upper_triangular(M::ZZMatrix)
-  GC.@preserve M begin
-    for i = 2:nrows(M)
-      for j = 1:min(i - 1, ncols(M))
-        t = ccall((:fmpz_mat_entry, libflint), Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), M, i - 1, j - 1)
-        fl = ccall((:fmpz_is_zero, libflint), Bool, (Ref{ZZRingElem},), t)
-        if !fl
-          return false
-        end
-      end
-    end
-  end
-  return true
-end
-
-function is_lower_triangular(M::ZZMatrix)
-  GC.@preserve M begin
-    for i = 1:nrows(M)
-      for j = i+1:ncols(M)
-        t = ccall((:fmpz_mat_entry, libflint), Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), M, i - 1, j - 1)
-        fl = ccall((:fmpz_is_zero, libflint), Bool, (Ref{ZZRingElem},), t)
-        if !fl
-          return false
-        end
-      end
-    end
-  end
-  return true
-end
 
 #Returns a positive integer if A[i, j] > b, negative if A[i, j] < b, 0 otherwise
 function compare_index(A::ZZMatrix, i::Int, j::Int, b::ZZRingElem)
@@ -442,43 +407,6 @@ function shift!(g::ZZMatrix, l::Int)
     end
   end
   return g
-end
-
-################################################################################
-#
-#  Is diagonal
-#
-################################################################################
-
-@doc raw"""
-is_diagonal(A::Mat)
-
-Tests if $A$ is diagonal.
-"""
-function is_diagonal(A::MatElem)
-  for i = 1:ncols(A)
-    for j = 1:nrows(A)
-      if i != j && !iszero(A[j, i])
-        return false
-      end
-    end
-  end
-  return true
-end
-
-function is_diagonal(A::ZZMatrix)
-  for i = 1:ncols(A)
-    for j = 1:nrows(A)
-      if i != j
-        t = ccall((:fmpz_mat_entry, libflint), Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), A, j - 1, i - 1)
-        fl = ccall((:fmpz_is_zero, libflint), Bool, (Ref{ZZRingElem},), t)
-        if !fl
-          return false
-        end
-      end
-    end
-  end
-  return true
 end
 
 ################################################################################


### PR DESCRIPTION
The generic methods use `is_zero_entry` and thus have a
performance profile similar to the functions being removed here.

Before:

    julia> A = diagonal_matrix(ZZ(42), 10);

    julia> @btime is_diagonal(A);
      208.696 ns (0 allocations: 0 bytes)

    julia> @btime is_lower_triangular(A);
      125.095 ns (0 allocations: 0 bytes)

    julia> @btime is_upper_triangular(A);
      127.596 ns (0 allocations: 0 bytes)

    julia> A = diagonal_matrix(ZZ(42), 100);

    julia> @btime is_diagonal(A);
      19.750 μs (0 allocations: 0 bytes)

    julia> @btime is_lower_triangular(A);
      11.083 μs (0 allocations: 0 bytes)

    julia> @btime is_upper_triangular(A);
      11.125 μs (0 allocations: 0 bytes)

After:

    julia> A = diagonal_matrix(ZZ(42), 10);

    julia> @btime is_diagonal(A);
      208.708 ns (0 allocations: 0 bytes)

    julia> @btime is_lower_triangular(A);
      129.279 ns (0 allocations: 0 bytes)

    julia> @btime is_upper_triangular(A);
      124.396 ns (0 allocations: 0 bytes)

    julia> A = diagonal_matrix(ZZ(42), 100);

    julia> @btime is_diagonal(A);
      19.375 μs (0 allocations: 0 bytes)

    julia> @btime is_lower_triangular(A);
      11.166 μs (0 allocations: 0 bytes)

    julia> @btime is_upper_triangular(A);
      11.125 μs (0 allocations: 0 bytes)
