### PR TITLE
Fix (P/Q)adicFieldElem printing in poly ring elems

### DIFF
--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -275,9 +275,7 @@ function expressify(x::PadicFieldElem; context = nothing)
   return sum
 end
 
-function show(io::IO, a::PadicFieldElem)
-  print(io, AbstractAlgebra.obj_to_string(a, context = io))
-end
+@enable_all_show_via_expressify PadicFieldElem
 
 function show(io::IO, R::PadicField)
   @show_name(io, R)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -255,9 +255,7 @@ function expressify(b::QadicFieldElem, x = var(parent(b)); context = nothing)
   return sum
 end
 
-function show(io::IO, a::QadicFieldElem)
-  print(io, AbstractAlgebra.obj_to_string(a, context = io))
-end
+@enable_all_show_via_expressify QadicFieldElem
 
 function show(io::IO, R::QadicField)
   @show_name(io, R)

--- a/test/flint/padic-test.jl
+++ b/test/flint/padic-test.jl
@@ -62,6 +62,7 @@ end
 
 @testset "PadicFieldElem.printing" begin
   R = PadicField(7, 30)
+  Rx, x = R[:x]
 
   a = 1 + 2*7 + 4*7^2 + O(R, 7^3)
 
@@ -69,6 +70,7 @@ end
   @test get_printing_mode(PadicField) == :series
 
   @test string(a) == "7^0 + 2*7^1 + 4*7^2 + O(7^3)"
+  @test string(a*x) == "(7^0 + 2*7^1 + 4*7^2 + O(7^3))*x"
 
   set_printing_mode(PadicField, :terse)
   @test get_printing_mode(PadicField) == :terse


### PR DESCRIPTION
Resolves https://github.com/thofma/Hecke.jl/issues/1535 in a similar way to https://github.com/Nemocas/AbstractAlgebra.jl/pull/1667. The same issue was there for `PadicFieldElem` as well, and the tests for this were easier to adapt.
Let's hope that the wrong behavior is not doctested downstream.