### PR TITLE
Use `fmpq_mul_si`

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -362,6 +362,15 @@ end
 
 *(a::ZZRingElem, b::QQFieldElem) = b*a
 
+function *(a::QQFieldElem, b::Int)
+  z = QQFieldElem()
+  ccall((:fmpq_mul_si, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), z, a, b)
+  return z
+end
+
+*(a::Int, b::QQFieldElem) = b*a
+
 function -(a::ZZRingElem, b::QQFieldElem)
   n = a*denominator(b) - numerator(b)
   d = denominator(b)

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -290,7 +290,7 @@ end
 
   @test a*3 == -2
 
-  @test 3a == -2
+  @test 3*a == -2
 
   @test a + ZZRingElem(3) == QQFieldElem(7, 3)
 


### PR DESCRIPTION
I noticed that `*(::QQFieldElem, ::Int)` calls generic AbstractAlgebra code instead of flint.

Before
```
julia> a = QQ(1, 2)
1//2

julia> @btime 2*a;
  116.807 ns (11 allocations: 192 bytes)
```

After
```
julia> @btime 2*a;
  20.632 ns (1 allocation: 32 bytes)
```

This is related to https://github.com/thofma/Hecke.jl/issues/1537 .
