### PR TITLE
Reduce duplication between constructors

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -99,27 +99,21 @@ mutable struct RealFieldElem <: FieldElem
   end
 
   function RealFieldElem(x::Union{Real, ZZRingElem, QQFieldElem, AbstractString, RealFieldElem}, p::Int)
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{RealFieldElem}, ), z)
+    z = RealFieldElem()
     _arb_set(z, x, p)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
   function RealFieldElem(x::Union{Real, ZZRingElem})
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{RealFieldElem}, ), z)
+    z = RealFieldElem()
     _arb_set(z, x)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
   function RealFieldElem(mid::RealFieldElem, rad::RealFieldElem)
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{RealFieldElem}, ), z)
+    z = RealFieldElem()
     ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, rad)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
@@ -163,35 +157,27 @@ mutable struct ArbFieldElem <: FieldElem
   end
 
   function ArbFieldElem(x::Union{Real, ZZRingElem, QQFieldElem, AbstractString, ArbFieldElem}, p::Int)
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{ArbFieldElem}, ), z)
+    z = ArbFieldElem()
     _arb_set(z, x, p)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
   function ArbFieldElem(x::Union{Real, ZZRingElem, ArbFieldElem})
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{ArbFieldElem}, ), z)
+    z = ArbFieldElem()
     _arb_set(z, x)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
   function ArbFieldElem(mid::ArbFieldElem, rad::ArbFieldElem)
-    z = new()
-    ccall((:arb_init, libflint), Nothing, (Ref{ArbFieldElem}, ), z)
+    z = ArbFieldElem()
     ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, rad)
-    finalizer(_arb_clear_fn, z)
     return z
   end
 
   #function ArbFieldElem(x::arf)
-  #  z = new()
-  #  ccall((:arb_init, libflint), Nothing, (Ref{ArbFieldElem}, ), z)
+  #  z = ArbFieldElem()
   #  ccall((:arb_set_arf, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{arf}), z, x)
-  #  finalizer(_arb_clear_fn, z)
   #  return z
   #end
 end
@@ -232,26 +218,20 @@ mutable struct ComplexFieldElem <: FieldElem
   end
 
   function ComplexFieldElem(x::Union{Number, ZZRingElem, RealFieldElem, ComplexFieldElem})
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{ComplexFieldElem}, ), z)
+    z = ComplexFieldElem()
     _acb_set(z, x)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 
   function ComplexFieldElem(x::Union{Number, ZZRingElem, QQFieldElem, RealFieldElem, ComplexFieldElem, AbstractString}, p::Int)
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{ComplexFieldElem}, ), z)
+    z = ComplexFieldElem()
     _acb_set(z, x, p)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 
   function ComplexFieldElem(x::T, y::T, p::Int) where {T <: Union{Real, ZZRingElem, QQFieldElem, AbstractString, RealFieldElem}}
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{ComplexFieldElem}, ), z)
+    z = ComplexFieldElem()
     _acb_set(z, x, y, p)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 end
@@ -389,34 +369,26 @@ mutable struct AcbFieldElem <: FieldElem
   end
 
   function AcbFieldElem(x::Union{Number, ZZRingElem, ArbFieldElem, AcbFieldElem})
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{AcbFieldElem}, ), z)
+    z = AcbFieldElem()
     _acb_set(z, x)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 
   function AcbFieldElem(x::Union{Number, ZZRingElem, QQFieldElem, ArbFieldElem, AcbFieldElem, AbstractString}, p::Int)
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{AcbFieldElem}, ), z)
+    z = AcbFieldElem()
     _acb_set(z, x, p)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 
   #function AcbFieldElem{T <: Union{Int, UInt, Float64, ZZRingElem, BigFloat, ArbFieldElem}}(x::T, y::T)
-  #  z = new()
-  #  ccall((:acb_init, libflint), Nothing, (Ref{AcbFieldElem}, ), z)
+  #  z = AcbFieldElem()
   #  _acb_set(z, x, y)
-  #  finalizer(_acb_clear_fn, z)
   #  return z
   #end
 
   function AcbFieldElem(x::T, y::T, p::Int) where {T <: Union{Real, ZZRingElem, QQFieldElem, AbstractString, ArbFieldElem}}
-    z = new()
-    ccall((:acb_init, libflint), Nothing, (Ref{AcbFieldElem}, ), z)
+    z = AcbFieldElem()
     _acb_set(z, x, y, p)
-    finalizer(_acb_clear_fn, z)
     return z
   end
 end
@@ -483,57 +455,45 @@ mutable struct RealPoly <: PolyRingElem{RealFieldElem}
   end
 
   function RealPoly(x::RealFieldElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     ccall((:arb_poly_set_coeff_arb, libflint), Nothing,
           (Ref{RealPoly}, Int, Ref{RealFieldElem}), z, 0, x)
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 
   function RealPoly(x::Vector{RealFieldElem}, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     for i = 1:length(x)
       ccall((:arb_poly_set_coeff_arb, libflint), Nothing,
             (Ref{RealPoly}, Int, Ref{RealFieldElem}), z, i - 1, x[i])
     end
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 
   function RealPoly(x::RealPoly)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     ccall((:arb_poly_set, libflint), Nothing, (Ref{RealPoly}, Ref{RealPoly}), z, x)
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 
   function RealPoly(x::RealPoly, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     ccall((:arb_poly_set_round, libflint), Nothing,
           (Ref{RealPoly}, Ref{RealPoly}, Int), z, x, p)
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 
   function RealPoly(x::ZZPolyRingElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     ccall((:arb_poly_set_fmpz_poly, libflint), Nothing,
           (Ref{RealPoly}, Ref{ZZPolyRingElem}, Int), z, x, p)
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 
   function RealPoly(x::QQPolyRingElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{RealPoly}, ), z)
+    z = RealPoly()
     ccall((:arb_poly_set_fmpq_poly, libflint), Nothing,
           (Ref{RealPoly}, Ref{QQPolyRingElem}, Int), z, x, p)
-    finalizer(_RealPoly_clear_fn, z)
     return z
   end
 end
@@ -577,57 +537,45 @@ mutable struct ArbPolyRingElem <: PolyRingElem{ArbFieldElem}
   end
 
   function ArbPolyRingElem(x::ArbFieldElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     ccall((:arb_poly_set_coeff_arb, libflint), Nothing,
           (Ref{ArbPolyRingElem}, Int, Ref{ArbFieldElem}), z, 0, x)
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function ArbPolyRingElem(x::Vector{ArbFieldElem}, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     for i = 1:length(x)
       ccall((:arb_poly_set_coeff_arb, libflint), Nothing,
             (Ref{ArbPolyRingElem}, Int, Ref{ArbFieldElem}), z, i - 1, x[i])
     end
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function ArbPolyRingElem(x::ArbPolyRingElem)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     ccall((:arb_poly_set, libflint), Nothing, (Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}), z, x)
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function ArbPolyRingElem(x::ArbPolyRingElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     ccall((:arb_poly_set_round, libflint), Nothing,
           (Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}, Int), z, x, p)
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function ArbPolyRingElem(x::ZZPolyRingElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     ccall((:arb_poly_set_fmpz_poly, libflint), Nothing,
           (Ref{ArbPolyRingElem}, Ref{ZZPolyRingElem}, Int), z, x, p)
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 
   function ArbPolyRingElem(x::QQPolyRingElem, p::Int)
-    z = new() 
-    ccall((:arb_poly_init, libflint), Nothing, (Ref{ArbPolyRingElem}, ), z)
+    z = ArbPolyRingElem()
     ccall((:arb_poly_set_fmpq_poly, libflint), Nothing,
           (Ref{ArbPolyRingElem}, Ref{QQPolyRingElem}, Int), z, x, p)
-    finalizer(_arb_poly_clear_fn, z)
     return z
   end
 end
@@ -676,68 +624,54 @@ mutable struct ComplexPoly <: PolyRingElem{ComplexFieldElem}
   end
 
   function ComplexPoly(x::ComplexFieldElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set_coeff_acb, libflint), Nothing,
           (Ref{ComplexPoly}, Int, Ref{ComplexFieldElem}), z, 0, x)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::Vector{ComplexFieldElem}, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     for i = 1:length(x)
       ccall((:acb_poly_set_coeff_acb, libflint), Nothing,
             (Ref{ComplexPoly}, Int, Ref{ComplexFieldElem}), z, i - 1, x[i])
     end
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::ComplexPoly)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set, libflint), Nothing, (Ref{ComplexPoly}, Ref{ComplexPoly}), z, x)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::RealPoly, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set_arb_poly, libflint), Nothing,
           (Ref{ComplexPoly}, Ref{ArbPolyRingElem}, Int), z, x, p)
     ccall((:acb_poly_set_round, libflint), Nothing,
           (Ref{ComplexPoly}, Ref{ComplexPoly}, Int), z, z, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::ComplexPoly, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set_round, libflint), Nothing,
           (Ref{ComplexPoly}, Ref{ComplexPoly}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::ZZPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set_fmpz_poly, libflint), Nothing,
           (Ref{ComplexPoly}, Ref{ZZPolyRingElem}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function ComplexPoly(x::QQPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{ComplexPoly}, ), z)
+    z = ComplexPoly()
     ccall((:acb_poly_set_fmpq_poly, libflint), Nothing,
           (Ref{ComplexPoly}, Ref{QQPolyRingElem}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 end
@@ -781,68 +715,54 @@ mutable struct AcbPolyRingElem <: PolyRingElem{AcbFieldElem}
   end
 
   function AcbPolyRingElem(x::AcbFieldElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set_coeff_acb, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Int, Ref{AcbFieldElem}), z, 0, x)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::Vector{AcbFieldElem}, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     for i = 1:length(x)
       ccall((:acb_poly_set_coeff_acb, libflint), Nothing,
             (Ref{AcbPolyRingElem}, Int, Ref{AcbFieldElem}), z, i - 1, x[i])
     end
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::AcbPolyRingElem)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set, libflint), Nothing, (Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}), z, x)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::ArbPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set_arb_poly, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Ref{ArbPolyRingElem}, Int), z, x, p)
     ccall((:acb_poly_set_round, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Int), z, z, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::AcbPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set_round, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::ZZPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set_fmpz_poly, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Ref{ZZPolyRingElem}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 
   function AcbPolyRingElem(x::QQPolyRingElem, p::Int)
-    z = new() 
-    ccall((:acb_poly_init, libflint), Nothing, (Ref{AcbPolyRingElem}, ), z)
+    z = AcbPolyRingElem()
     ccall((:acb_poly_set_fmpq_poly, libflint), Nothing,
           (Ref{AcbPolyRingElem}, Ref{QQPolyRingElem}, Int), z, x, p)
-    finalizer(_acb_poly_clear_fn, z)
     return z
   end
 end
@@ -884,30 +804,21 @@ mutable struct RealMat <: MatElem{RealFieldElem}
   end
 
   function RealMat(a::ZZMatrix)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{RealMat}, Int, Int), z, a.r, a.c)
+    z = RealMat(a.r, a.c)
     ccall((:arb_mat_set_fmpz_mat, libflint), Nothing,
           (Ref{RealMat}, Ref{ZZMatrix}), z, a)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 
   function RealMat(a::ZZMatrix, prec::Int)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{RealMat}, Int, Int), z, a.r, a.c)
+    z = RealMat(a.r, a.c)
     ccall((:arb_mat_set_round_fmpz_mat, libflint), Nothing,
           (Ref{RealMat}, Ref{ZZMatrix}, Int), z, a, prec)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 
   function RealMat(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{Int, UInt, ZZRingElem, Float64, BigFloat, RealFieldElem}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{RealMat}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = RealMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{RealFieldElem},
@@ -919,10 +830,7 @@ mutable struct RealMat <: MatElem{RealFieldElem}
   end
 
   function RealMat(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{Int, UInt, ZZRingElem, Float64, BigFloat, RealFieldElem}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{RealMat}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = RealMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{RealFieldElem},
@@ -934,10 +842,7 @@ mutable struct RealMat <: MatElem{RealFieldElem}
   end
 
   function RealMat(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, RealFieldElem, AbstractString}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{RealMat}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = RealMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{RealFieldElem},
@@ -949,10 +854,7 @@ mutable struct RealMat <: MatElem{RealFieldElem}
   end
 
   function RealMat(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, RealFieldElem, AbstractString}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{RealMat}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = RealMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{RealFieldElem},
@@ -964,12 +866,9 @@ mutable struct RealMat <: MatElem{RealFieldElem}
   end
 
   function RealMat(a::QQMatrix, prec::Int)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{RealMat}, Int, Int), z, a.r, a.c)
+    z = RealMat(a.r, a.c)
     ccall((:arb_mat_set_fmpq_mat, libflint), Nothing,
           (Ref{RealMat}, Ref{QQMatrix}, Int), z, a, prec)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 end
@@ -997,30 +896,21 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   end
 
   function ArbMatrix(a::ZZMatrix)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{ArbMatrix}, Int, Int), z, a.r, a.c)
+    z = ArbMatrix(a.r, a.c)
     ccall((:arb_mat_set_fmpz_mat, libflint), Nothing,
           (Ref{ArbMatrix}, Ref{ZZMatrix}), z, a)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 
   function ArbMatrix(a::ZZMatrix, prec::Int)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{ArbMatrix}, Int, Int), z, a.r, a.c)
+    z = ArbMatrix(a.r, a.c)
     ccall((:arb_mat_set_round_fmpz_mat, libflint), Nothing,
           (Ref{ArbMatrix}, Ref{ZZMatrix}, Int), z, a, prec)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 
   function ArbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{Int, UInt, ZZRingElem, Float64, BigFloat, ArbFieldElem}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{ArbMatrix}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = ArbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{ArbFieldElem},
@@ -1032,10 +922,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   end
 
   function ArbMatrix(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{Int, UInt, ZZRingElem, Float64, BigFloat, ArbFieldElem}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{ArbMatrix}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = ArbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{ArbFieldElem},
@@ -1047,10 +934,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   end
 
   function ArbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, ArbFieldElem, AbstractString}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{ArbMatrix}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = ArbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{ArbFieldElem},
@@ -1062,10 +946,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   end
 
   function ArbMatrix(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, ArbFieldElem, AbstractString}}
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing, 
-          (Ref{ArbMatrix}, Int, Int), z, r, c)
-    finalizer(_arb_mat_clear_fn, z)
+    z = ArbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:arb_mat_entry_ptr, libflint), Ptr{ArbFieldElem},
@@ -1077,12 +958,9 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   end
 
   function ArbMatrix(a::QQMatrix, prec::Int)
-    z = new()
-    ccall((:arb_mat_init, libflint), Nothing,
-          (Ref{ArbMatrix}, Int, Int), z, a.r, a.c)
+    z = ArbMatrix(a.r, a.c)
     ccall((:arb_mat_set_fmpq_mat, libflint), Nothing,
           (Ref{ArbMatrix}, Ref{QQMatrix}, Int), z, a, prec)
-    finalizer(_arb_mat_clear_fn, z)
     return z
   end
 end
@@ -1114,50 +992,35 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(a::ZZMatrix)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{ComplexMat}, Int, Int), z, a.r, a.c)
+    z = ComplexMat(a.r, a.c)
     ccall((:acb_mat_set_fmpz_mat, libflint), Nothing,
           (Ref{ComplexMat}, Ref{ZZMatrix}), z, a)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function ComplexMat(a::ZZMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{ComplexMat}, Int, Int), z, a.r, a.c)
+    z = ComplexMat(a.r, a.c)
     ccall((:acb_mat_set_round_fmpz_mat, libflint), Nothing,
           (Ref{ComplexMat}, Ref{ZZMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function ComplexMat(a::RealMat)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{ComplexMat}, Int, Int), z, a.r, a.c)
+    z = ComplexMat(a.r, a.c)
     ccall((:acb_mat_set_arb_mat, libflint), Nothing,
           (Ref{ComplexMat}, Ref{ArbMatrix}), z, a)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function ComplexMat(a::ArbMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{ComplexMat}, Int, Int), z, a.r, a.c)
+    z = ComplexMat(a.r, a.c)
     ccall((:acb_mat_set_round_arb_mat, libflint), Nothing,
           (Ref{ComplexMat}, Ref{ArbMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1169,10 +1032,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{BigFloat, ComplexFieldElem, RealFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1184,10 +1044,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1199,10 +1056,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{BigFloat, ComplexFieldElem, RealFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1214,10 +1068,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1229,10 +1080,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{BigFloat, RealFieldElem, AbstractString, ComplexFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1244,10 +1092,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1259,10 +1104,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{BigFloat, RealFieldElem, AbstractString, ComplexFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1274,11 +1116,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{Tuple{T, T}}, prec::Int) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1290,11 +1128,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractMatrix{Tuple{T, T}}, prec::Int) where {T <: Union{QQFieldElem, BigFloat, RealFieldElem, AbstractString}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1306,11 +1140,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{Tuple{T, T}}, prec::Int) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1322,11 +1152,7 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(r::Int, c::Int, arr::AbstractVector{Tuple{T, T}}, prec::Int) where {T <: Union{QQFieldElem, BigFloat, RealFieldElem, AbstractString}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{ComplexMat}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = ComplexMat(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},
@@ -1338,12 +1164,9 @@ mutable struct ComplexMat <: MatElem{ComplexFieldElem}
   end
 
   function ComplexMat(a::QQMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{ComplexMat}, Int, Int), z, a.r, a.c)
+    z = ComplexMat(a.r, a.c)
     ccall((:acb_mat_set_fmpq_mat, libflint), Nothing,
           (Ref{ComplexMat}, Ref{QQMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 end
@@ -1371,50 +1194,35 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(a::ZZMatrix)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{AcbMatrix}, Int, Int), z, a.r, a.c)
+    z = AcbMatrix(a.r, a.c)
     ccall((:acb_mat_set_fmpz_mat, libflint), Nothing,
           (Ref{AcbMatrix}, Ref{ZZMatrix}), z, a)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function AcbMatrix(a::ZZMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{AcbMatrix}, Int, Int), z, a.r, a.c)
+    z = AcbMatrix(a.r, a.c)
     ccall((:acb_mat_set_round_fmpz_mat, libflint), Nothing,
           (Ref{AcbMatrix}, Ref{ZZMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function AcbMatrix(a::ArbMatrix)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{AcbMatrix}, Int, Int), z, a.r, a.c)
+    z = AcbMatrix(a.r, a.c)
     ccall((:acb_mat_set_arb_mat, libflint), Nothing,
           (Ref{AcbMatrix}, Ref{ArbMatrix}), z, a)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function AcbMatrix(a::ArbMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{AcbMatrix}, Int, Int), z, a.r, a.c)
+    z = AcbMatrix(a.r, a.c)
     ccall((:acb_mat_set_round_arb_mat, libflint), Nothing,
           (Ref{AcbMatrix}, Ref{ArbMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1426,10 +1234,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Union{BigFloat, AcbFieldElem, ArbFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1441,10 +1246,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1456,10 +1258,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Union{BigFloat, AcbFieldElem, ArbFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1471,10 +1270,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1486,10 +1282,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, prec::Int) where {T <: Union{BigFloat, ArbFieldElem, AbstractString, AcbFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1501,10 +1294,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{Int, UInt, ZZRingElem, QQFieldElem, Float64}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1516,10 +1306,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{T}, prec::Int) where {T <: Union{BigFloat, ArbFieldElem, AbstractString, AcbFieldElem}}
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1531,11 +1318,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{Tuple{T, T}}, prec::Int) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1547,11 +1330,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractMatrix{Tuple{T, T}}, prec::Int) where {T <: Union{QQFieldElem, BigFloat, ArbFieldElem, AbstractString}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1563,11 +1342,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{Tuple{T, T}}, prec::Int) where {T <: Union{Int, UInt, Float64, ZZRingElem}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1579,11 +1354,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(r::Int, c::Int, arr::AbstractVector{Tuple{T, T}}, prec::Int) where {T <: Union{QQFieldElem, BigFloat, ArbFieldElem, AbstractString}}
-
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing, 
-          (Ref{AcbMatrix}, Int, Int), z, r, c)
-    finalizer(_acb_mat_clear_fn, z)
+    z = AcbMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},
@@ -1595,12 +1366,9 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   end
 
   function AcbMatrix(a::QQMatrix, prec::Int)
-    z = new()
-    ccall((:acb_mat_init, libflint), Nothing,
-          (Ref{AcbMatrix}, Int, Int), z, a.r, a.c)
+    z = AcbMatrix(a.r, a.c)
     ccall((:acb_mat_set_fmpq_mat, libflint), Nothing,
           (Ref{AcbMatrix}, Ref{QQMatrix}, Int), z, a, prec)
-    finalizer(_acb_mat_clear_fn, z)
     return z
   end
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -65,27 +65,21 @@ mutable struct ZZRingElem <: RingElem
   end
 
   function ZZRingElem(x::BigInt)
-    z = new()
-    ccall((:fmpz_init, libflint), Nothing, (Ref{ZZRingElem},), z)
+    z = ZZRingElem()
     ccall((:fmpz_set_mpz, libflint), Nothing, (Ref{ZZRingElem}, Ref{BigInt}), z, x)
-    finalizer(_fmpz_clear_fn, z)
     return z
   end
 
   function ZZRingElem(x::Ptr{Culong}, len::Clong)
-    z = new()
-    ccall((:fmpz_init, libflint), Nothing, (Ref{ZZRingElem},), z)
+    z = ZZRingElem()
     ccall((:fmpz_set_ui_array, libflint), Nothing, (Ref{ZZRingElem}, Ptr{Culong}, Clong), z, x, len)
-    finalizer(_fmpz_clear_fn, z)
     return z
   end
 
   function ZZRingElem(x::Float64)
     !isinteger(x) && throw(InexactError(:convert, ZZRingElem, x))
-    z = new()
-    ccall((:fmpz_init, libflint), Nothing, (Ref{ZZRingElem},), z)
+    z = ZZRingElem()
     ccall((:fmpz_set_d, libflint), Nothing, (Ref{ZZRingElem}, Cdouble), z, x)
-    finalizer(_fmpz_clear_fn, z)
     return z
   end
 
@@ -187,31 +181,26 @@ mutable struct QQFieldElem <: FracElem{ZZRingElem}
 
   function QQFieldElem(a::ZZRingElem, b::ZZRingElem)
     iszero(b) && throw(DivideError())
-    z = new()
-    ccall((:fmpq_init, libflint), Nothing, (Ref{QQFieldElem},), z)
+    z = QQFieldElem()
     ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
           (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, a, b)
-    finalizer(_fmpq_clear_fn, z)
     return z
   end
 
   function QQFieldElem(a::ZZRingElem)
-    z = new()
-    ccall((:fmpq_init, libflint), Nothing, (Ref{QQFieldElem},), z)
+    z = QQFieldElem()
     b = ZZRingElem(1)
     ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
           (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, a, b)
-    finalizer(_fmpq_clear_fn, z)
     return z
   end
 
   function QQFieldElem(a::Int, b::Int)
     b == 0 && throw(DivideError())
-    z = new()
+    z = QQFieldElem()
     if b == typemin(Int) || (b < 0 && a == typemin(Int))
       bz = -ZZ(b)
       az = -ZZ(a)
-      ccall((:fmpq_init, libflint), Nothing, (Ref{QQFieldElem},), z)
       ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
             (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, az, bz)
     else
@@ -219,20 +208,16 @@ mutable struct QQFieldElem <: FracElem{ZZRingElem}
         b = -b
         a = -a
       end
-      ccall((:fmpq_init, libflint), Nothing, (Ref{QQFieldElem},), z)
       ccall((:fmpq_set_si, libflint), Nothing,
             (Ref{QQFieldElem}, Int, Int), z, a, b)
     end
-    finalizer(_fmpq_clear_fn, z)
     return z
   end
 
   function QQFieldElem(a::Int)
-    z = new()
-    ccall((:fmpq_init, libflint), Nothing, (Ref{QQFieldElem},), z)
+    z = QQFieldElem()
     ccall((:fmpq_set_si, libflint), Nothing,
           (Ref{QQFieldElem}, Int, Int), z, a, 1)
-    finalizer(_fmpq_clear_fn, z)
     return z
   end
 
@@ -285,28 +270,22 @@ mutable struct ZZPolyRingElem <: PolyRingElem{ZZRingElem}
   end
 
   function ZZPolyRingElem(a::Int)
-    z = new()
-    ccall((:fmpz_poly_init, libflint), Nothing, (Ref{ZZPolyRingElem},), z)
+    z = ZZPolyRingElem()
     ccall((:fmpz_poly_set_si, libflint), Nothing, (Ref{ZZPolyRingElem}, Int), z, a)
-    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
   function ZZPolyRingElem(a::ZZRingElem)
-    z = new()
-    ccall((:fmpz_poly_init, libflint), Nothing, (Ref{ZZPolyRingElem},), z)
+    z = ZZPolyRingElem()
     ccall((:fmpz_poly_set_fmpz, libflint), Nothing,
           (Ref{ZZPolyRingElem}, Ref{ZZRingElem}), z, a)
-    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
   function ZZPolyRingElem(a::ZZPolyRingElem)
-    z = new()
-    ccall((:fmpz_poly_init, libflint), Nothing, (Ref{ZZPolyRingElem},), z)
+    z = ZZPolyRingElem()
     ccall((:fmpz_poly_set, libflint), Nothing,
           (Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}), z, a)
-    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 end
@@ -384,46 +363,36 @@ mutable struct QQPolyRingElem <: PolyRingElem{QQFieldElem}
   end
 
   function QQPolyRingElem(a::Int)
-    z = new()
-    ccall((:fmpq_poly_init, libflint), Nothing, (Ref{QQPolyRingElem},), z)
+    z = QQPolyRingElem()
     ccall((:fmpq_poly_set_si, libflint), Nothing, (Ref{QQPolyRingElem}, Int), z, a)
-    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
   function QQPolyRingElem(a::ZZRingElem)
-    z = new()
-    ccall((:fmpq_poly_init, libflint), Nothing, (Ref{QQPolyRingElem},), z)
+    z = QQPolyRingElem()
     ccall((:fmpq_poly_set_fmpz, libflint), Nothing,
           (Ref{QQPolyRingElem}, Ref{ZZRingElem}), z, a)
-    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
   function QQPolyRingElem(a::QQFieldElem)
-    z = new()
-    ccall((:fmpq_poly_init, libflint), Nothing, (Ref{QQPolyRingElem},), z)
+    z = QQPolyRingElem()
     ccall((:fmpq_poly_set_fmpq, libflint), Nothing,
           (Ref{QQPolyRingElem}, Ref{QQFieldElem}), z, a)
-    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
   function QQPolyRingElem(a::ZZPolyRingElem)
-    z = new()
-    ccall((:fmpq_poly_init, libflint), Nothing, (Ref{QQPolyRingElem},), z)
+    z = QQPolyRingElem()
     ccall((:fmpq_poly_set_fmpz_poly, libflint), Nothing,
           (Ref{QQPolyRingElem}, Ref{ZZPolyRingElem}), z, a)
-    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
   function QQPolyRingElem(a::QQPolyRingElem)
-    z = new()
-    ccall((:fmpq_poly_init, libflint), Nothing, (Ref{QQPolyRingElem},), z)
+    z = QQPolyRingElem()
     ccall((:fmpq_poly_set, libflint), Nothing,
           (Ref{QQPolyRingElem}, Ref{QQPolyRingElem}), z, a)
-    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4758,10 +4758,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 
   function QQMatrix(r::Int, c::Int, arr::AbstractMatrix{QQFieldElem})
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4773,10 +4770,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 
   function QQMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem})
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     b = ZZRingElem(1)
     GC.@preserve z for i = 1:r
       for j = 1:c
@@ -4790,10 +4784,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
 
 
   function QQMatrix(r::Int, c::Int, arr::AbstractVector{QQFieldElem})
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4805,10 +4796,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 
   function QQMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     b = ZZRingElem(1)
     GC.@preserve z for i = 1:r
       for j = 1:c
@@ -4822,10 +4810,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
 
 
   function QQMatrix(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Integer}
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4837,10 +4822,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 
   function QQMatrix(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Integer}
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4852,10 +4834,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 
   function QQMatrix(r::Int, c::Int, d::QQFieldElem)
-    z = new()
-    ccall((:fmpq_mat_init, libflint), Nothing,
-          (Ref{QQMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpq_mat_clear_fn, z)
+    z = QQMatrix(r, c)
     GC.@preserve z for i = 1:min(r, c)
       el = mat_entry_ptr(z, i, i)
       ccall((:fmpq_set, libflint), Nothing,
@@ -4908,10 +4887,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   end
 
   function ZZMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem})
-    z = new()
-    ccall((:fmpz_mat_init, libflint), Nothing,
-          (Ref{ZZMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpz_mat_clear_fn, z)
+    z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4923,10 +4899,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   end
 
   function ZZMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:fmpz_mat_init, libflint), Nothing,
-          (Ref{ZZMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpz_mat_clear_fn, z)
+    z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4938,10 +4911,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   end
 
   function ZZMatrix(r::Int, c::Int, arr::AbstractMatrix{T}) where {T <: Integer}
-    z = new()
-    ccall((:fmpz_mat_init, libflint), Nothing,
-          (Ref{ZZMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpz_mat_clear_fn, z)
+    z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4953,10 +4923,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   end
 
   function ZZMatrix(r::Int, c::Int, arr::AbstractVector{T}) where {T <: Integer}
-    z = new()
-    ccall((:fmpz_mat_init, libflint), Nothing,
-          (Ref{ZZMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpz_mat_clear_fn, z)
+    z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -4968,10 +4935,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   end
 
   function ZZMatrix(r::Int, c::Int, d::ZZRingElem)
-    z = new()
-    ccall((:fmpz_mat_init, libflint), Nothing,
-          (Ref{ZZMatrix}, Int, Int), z, r, c)
-    finalizer(_fmpz_mat_clear_fn, z)
+    z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:min(r, c)
       el = mat_entry_ptr(z, i, i)
       ccall((:fmpz_set, libflint), Nothing,
@@ -5027,10 +4991,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5043,10 +5004,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{UInt})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, mod(arr[(i - 1) * c + j], n), i, j)
@@ -5056,10 +5014,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5075,10 +5030,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
@@ -5101,10 +5053,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{zzModRingElem}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5117,10 +5066,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{zzModRingElem})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{zzModMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_nmod_mat_clear_fn, z)
+    z = zzModMatrix(r, c, n)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[(i - 1) * c + j].data, i, j) # no reduction necessary
@@ -5193,10 +5139,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5213,10 +5156,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}, transpose::Bool = false) where T <: Integer
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5234,10 +5174,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZModRingElem}, transpose::Bool = false)
     # FIXME: Check compatibility between ctx and arr?
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5254,10 +5191,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(arr[(i - 1)*c + j], ctx), i, j)
@@ -5271,10 +5205,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{T}) where T <: Integer
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(ZZRingElem(arr[(i - 1)*c + j]), ctx), i, j)
@@ -5289,10 +5220,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{ZZModRingElem})
     # FIXME: Check compatibility between ctx and arr?
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{ZZModMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_fmpz_mod_mat_clear_fn, z)
+    z = ZZModMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[(i - 1)*c + j].data, i, j)
@@ -5365,10 +5293,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   end
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5381,10 +5306,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   end
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}, transpose::Bool = false) where T <: Integer
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5398,10 +5320,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{FpFieldElem}, transpose::Bool = false)
     # FIXME: Check compatibility between ctx and arr?
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5414,10 +5333,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   end
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(arr[(i - 1)*c + j], ctx), i, j)
@@ -5427,10 +5343,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   end
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{T}) where T <: Integer
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(ZZRingElem(arr[(i - 1)*c + j]), ctx), i, j)
@@ -5441,10 +5354,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{FpFieldElem})
     # FIXME: Check compatibility between ctx and arr?
-    z = new()
-    ccall((:fmpz_mod_mat_init, libflint), Nothing,
-          (Ref{FpMatrix}, Int, Int, Ref{fmpz_mod_ctx_struct}), z, r, c, ctx)
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    z = FpMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[(i - 1)*c + j].data, i, j)
@@ -5493,10 +5403,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5509,10 +5416,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{UInt})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, mod(arr[(i - 1) * c + j], n), i, j)
@@ -5522,10 +5426,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5541,10 +5442,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{ZZRingElem})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
@@ -5567,10 +5465,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{fpFieldElem}, transpose::Bool = false)
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     if transpose
       arr = Base.transpose(arr)
     end
@@ -5583,10 +5478,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{fpFieldElem})
-    z = new()
-    ccall((:nmod_mat_init, libflint), Nothing,
-          (Ref{fpMatrix}, Int, Int, UInt), z, r, c, n)
-    finalizer(_gfp_mat_clear_fn, z)
+    z = fpMatrix(r, c, n)
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[(i - 1) * c + j].data, i, j) # no reduction necessary
@@ -6090,10 +5982,7 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{FqFieldElem}, ctx::FqField)
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set, libflint), Nothing,
@@ -6102,16 +5991,11 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{FqFieldElem}, ctx::FqField)
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set, libflint), Nothing,
@@ -6120,16 +6004,11 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqField)
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set_fmpz, libflint), Nothing,
@@ -6138,16 +6017,11 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqField)
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set_fmpz, libflint), Nothing,
@@ -6156,16 +6030,11 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqField) where {T <: Integer}
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set, libflint), Nothing,
@@ -6174,16 +6043,11 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, ctx(arr[i, j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqField) where {T <: Integer}
-    z = new()
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:r
       for j = 1:c
         ccall((:fq_default_mat_entry_set, libflint), Nothing,
@@ -6192,84 +6056,57 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
               z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(r::Int, c::Int, d::FqFieldElem)
-    z = new()
     ctx = parent(d)
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     for i = 1:min(r, c)
       ccall((:fq_default_mat_entry_set, libflint), Nothing,
             (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
              Ref{FqField}), z, i - 1, i - 1, d, ctx)
     end
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(m::ZZMatrix, ctx::FqField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     ccall((:fq_default_mat_set_fmpz_mat, libflint), Nothing,
           (Ref{FqMatrix}, Ref{ZZMatrix}, Ref{FqField}),
           z, m, ctx)
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(m::ZZModMatrix, ctx::FqField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     ccall((:fq_default_mat_set_fmpz_mod_mat, libflint), Nothing,
           (Ref{FqMatrix}, Ref{ZZModMatrix}, Ref{FqField}),
           z, m, ctx)
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(m::zzModMatrix, ctx::FqField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     ccall((:fq_default_mat_set_nmod_mat, libflint), Nothing,
           (Ref{FqMatrix}, Ref{zzModMatrix}, Ref{FqField}),
           z, m, ctx)
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 
   function FqMatrix(m::fpMatrix, ctx::FqField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_default_mat_init, libflint), Nothing,
-          (Ref{FqMatrix}, Int, Int, Ref{FqField}),
-          z, r, c, ctx)
+    z = FqMatrix(r, c, ctx)
     ccall((:fq_default_mat_set_nmod_mat, libflint), Nothing,
           (Ref{FqMatrix}, Ref{fpMatrix}, Ref{FqField}),
           z, m, ctx)
-    z.base_ring = ctx
-    finalizer(_fq_default_mat_clear_fn, z)
     return z
   end
 end
@@ -6310,9 +6147,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{FqPolyRepFieldElem}, ctx::FqPolyRepField)
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_mat_entry_set, libflint), Nothing,
@@ -6320,15 +6155,11 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               z, i - 1, j - 1, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{FqPolyRepFieldElem}, ctx::FqPolyRepField)
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_mat_entry_set, libflint), Nothing,
@@ -6336,15 +6167,11 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqPolyRepField)
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -6352,15 +6179,11 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               (Ptr{FqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{FqPolyRepField}), el, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqPolyRepField)
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -6368,15 +6191,11 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               (Ptr{FqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{FqPolyRepField}), el, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqPolyRepField) where {T <: Integer}
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_mat_entry_set, libflint), Nothing,
@@ -6384,15 +6203,11 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               z, i - 1, j - 1, ctx(arr[i, j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqPolyRepField) where {T <: Integer}
-    z = new()
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_mat_entry_set, libflint), Nothing,
@@ -6400,31 +6215,23 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, d::FqPolyRepFieldElem)
-    z = new()
     ctx = parent(d)
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:min(r, c)
       ccall((:fq_mat_entry_set, libflint), Nothing,
             (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, i - 1, i- 1, d, ctx)
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 
   function FqPolyRepMatrix(m::ZZMatrix, ctx::FqPolyRepField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_mat_init, libflint), Nothing,
-          (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepField}), z, r, c, ctx)
+    z = FqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el1 = mat_entry_ptr(z, i, j)
@@ -6434,8 +6241,6 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
               (Ptr{FqPolyRepFieldElem}, Ptr{ZZRingElem}, Ref{FqPolyRepField}), el1, el2, ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_mat_clear_fn, z)
     return z
   end
 end
@@ -6475,9 +6280,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{fqPolyRepFieldElem}, ctx::fqPolyRepField)
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
@@ -6485,15 +6288,11 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               z, i - 1, j - 1, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{fqPolyRepFieldElem}, ctx::fqPolyRepField)
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
@@ -6501,15 +6300,11 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::fqPolyRepField)
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -6517,15 +6312,11 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               (Ptr{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}), el, arr[i, j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::fqPolyRepField)
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
@@ -6533,15 +6324,11 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               (Ptr{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}), el, arr[(i - 1) * c + j], ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::fqPolyRepField) where {T <: Integer}
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
@@ -6549,15 +6336,11 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               z, i - 1, j - 1, ctx(arr[i, j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::fqPolyRepField) where {T <: Integer}
-    z = new()
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
@@ -6565,31 +6348,23 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, d::fqPolyRepFieldElem)
-    z = new()
     ctx = parent(d)
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:min(r, c)
       ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
             (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, i - 1, i- 1, d, ctx)
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 
   function fqPolyRepMatrix(m::ZZMatrix, ctx::fqPolyRepField)
-    z = new()
     r = nrows(m)
     c = ncols(m)
-    ccall((:fq_nmod_mat_init, libflint), Nothing,
-          (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepField}), z, r, c, ctx)
+    z = fqPolyRepMatrix(r, c, ctx)
     GC.@preserve z for i = 1:r
       for j = 1:c
         el1 = mat_entry_ptr(z, i, j)
@@ -6599,8 +6374,6 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
               (Ptr{fqPolyRepFieldElem}, Ptr{ZZRingElem}, Ref{fqPolyRepField}), el1, el2, ctx)
       end
     end
-    z.base_ring = ctx
-    finalizer(_fq_nmod_mat_clear_fn, z)
     return z
   end
 end


### PR DESCRIPTION
As a rough proxy, consider:

Before:
```
$ git grep finalizer | wc -l
     429
```
After:
```
$ git grep finalizer | wc -l
     263
```