### PR TITLE
Add more `set!` methods for ZZRingElem and QQFieldElem and use them

### DIFF
--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -70,7 +70,7 @@ function maximum(a::ZZMatrix)
     end
   end
   r = ZZRingElem()
-  ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), r, m)
+  set!(r, m)
   return r
 end
 
@@ -85,7 +85,7 @@ function minimum(a::ZZMatrix)
     end
   end
   r = ZZRingElem()
-  ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), r, m)
+  set!(r, m)
   return r
 end
 
@@ -117,7 +117,7 @@ function lift(a::ZZModMatrix)
       for j in 1:ncols(a)
         m = mat_entry_ptr(z, i, j)
         n = mat_entry_ptr(a, i, j)
-        ccall((:fmpz_set, libflint), Nothing, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, n)
+        set!(m, n)
         #z[i, j] = lift(a[i, j])
       end
     end

--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -45,47 +45,53 @@ end
 ################################################################################
 
 function maximum(f::typeof(abs), a::ZZMatrix)
-  m = mat_entry_ptr(a, 1, 1)
-  for i = 1:nrows(a)
-    for j = 1:ncols(a)
-      z = mat_entry_ptr(a, i, j)
-      if ccall((:fmpz_cmpabs, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) < 0
-        m = z
+  r = ZZRingElem()
+  GC.@preserve a r begin
+    m = mat_entry_ptr(a, 1, 1)
+    for i = 1:nrows(a)
+      for j = 1:ncols(a)
+        z = mat_entry_ptr(a, i, j)
+        if ccall((:fmpz_cmpabs, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) < 0
+          m = z
+        end
       end
     end
+    ccall((:fmpz_abs, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), r, m)
   end
-  r = ZZRingElem()
-  ccall((:fmpz_abs, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), r, m)
   return r
 end
 
 function maximum(a::ZZMatrix)
-  m = mat_entry_ptr(a, 1, 1)
-  for i = 1:nrows(a)
-    for j = 1:ncols(a)
-      z = mat_entry_ptr(a, i, j)
-      if ccall((:fmpz_cmp, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) < 0
-        m = z
+  r = ZZRingElem()
+  GC.@preserve a r begin
+    m = mat_entry_ptr(a, 1, 1)
+    for i = 1:nrows(a)
+      for j = 1:ncols(a)
+        z = mat_entry_ptr(a, i, j)
+        if ccall((:fmpz_cmp, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) < 0
+          m = z
+        end
       end
     end
+    set!(r, m)
   end
-  r = ZZRingElem()
-  set!(r, m)
   return r
 end
 
 function minimum(a::ZZMatrix)
-  m = mat_entry_ptr(a, 1, 1)
-  for i = 1:nrows(a)
-    for j = 1:ncols(a)
-      z = mat_entry_ptr(a, i, j)
-      if ccall((:fmpz_cmp, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) > 0
-        m = z
+  r = ZZRingElem()
+  GC.@preserve a r begin
+    m = mat_entry_ptr(a, 1, 1)
+    for i = 1:nrows(a)
+      for j = 1:ncols(a)
+        z = mat_entry_ptr(a, i, j)
+        if ccall((:fmpz_cmp, libflint), Cint, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), m, z) > 0
+          m = z
+        end
       end
     end
+    set!(r, m)
   end
-  r = ZZRingElem()
-  set!(r, m)
   return r
 end
 
@@ -160,8 +166,10 @@ end
 
 #Returns a positive integer if A[i, j] > b, negative if A[i, j] < b, 0 otherwise
 function compare_index(A::ZZMatrix, i::Int, j::Int, b::ZZRingElem)
-  a = mat_entry_ptr(A, i, j)
-  return ccall((:fmpz_cmp, libflint), Int32, (Ptr{ZZRingElem}, Ref{ZZRingElem}), a, b)
+  GC.@preserve A begin
+    a = mat_entry_ptr(A, i, j)
+    return ccall((:fmpz_cmp, libflint), Int32, (Ptr{ZZRingElem}, Ref{ZZRingElem}), a, b)
+  end
 end
 
 function round!(b::ZZMatrix, a::ArbMatrix)
@@ -176,13 +184,15 @@ end
 
 
 function shift!(g::ZZMatrix, l::Int)
-  for i = 1:nrows(g)
-    for j = 1:ncols(g)
-      z = mat_entry_ptr(g, i, j)
-      if l > 0
-        ccall((:fmpz_mul_2exp, libflint), Nothing, (Ptr{ZZRingElem}, Ptr{ZZRingElem}, Int), z, z, l)
-      else
-        ccall((:fmpz_tdiv_q_2exp, libflint), Nothing, (Ptr{ZZRingElem}, Ptr{ZZRingElem}, Int), z, z, -l)
+  GC.@preserve g begin
+    for i = 1:nrows(g)
+      for j = 1:ncols(g)
+        z = mat_entry_ptr(g, i, j)
+        if l > 0
+          ccall((:fmpz_mul_2exp, libflint), Nothing, (Ptr{ZZRingElem}, Ptr{ZZRingElem}, Int), z, z, l)
+        else
+          ccall((:fmpz_tdiv_q_2exp, libflint), Nothing, (Ptr{ZZRingElem}, Ptr{ZZRingElem}, Int), z, z, -l)
+        end
       end
     end
   end

--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -1241,12 +1241,12 @@ function derivative(x::AcbPolyRingElem, n::Int64)
 end
 
 function lift!(x::fpFieldElem, z::ZZRingElem)
-  ccall((:fmpz_set_ui, libflint), Nothing, (Ref{ZZRingElem}, UInt), z, x.data)
+  set!(z, x.data)
   return z
 end
 
 function lift!(x::EuclideanRingResidueFieldElem{ZZRingElem}, z::ZZRingElem)
-  ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}), z, x.data)
+  set!(z, x.data)
   return z
 end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4891,8 +4891,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpz_set, libflint), Nothing,
-              (Ptr{ZZRingElem}, Ref{ZZRingElem}), el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -4903,8 +4902,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpz_set, libflint), Nothing,
-              (Ptr{ZZRingElem}, Ref{ZZRingElem}), el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -4915,8 +4913,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpz_set, libflint), Nothing,
-              (Ptr{ZZRingElem}, Ref{ZZRingElem}), el, ZZRingElem(arr[i, j]))
+        set!(el, ZZRingElem(arr[i, j]))
       end
     end
     return z
@@ -4927,8 +4924,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpz_set, libflint), Nothing,
-              (Ptr{ZZRingElem}, Ref{ZZRingElem}), el, ZZRingElem(arr[(i-1)*c+j]))
+        set!(el, ZZRingElem(arr[(i-1)*c+j]))
       end
     end
     return z
@@ -4938,8 +4934,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     z = ZZMatrix(r, c)
     GC.@preserve z for i = 1:min(r, c)
       el = mat_entry_ptr(z, i, i)
-      ccall((:fmpz_set, libflint), Nothing,
-            (Ptr{ZZRingElem}, Ref{ZZRingElem}), el, d)
+      set!(el, d)
     end
     return z
   end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -182,16 +182,13 @@ mutable struct QQFieldElem <: FracElem{ZZRingElem}
   function QQFieldElem(a::ZZRingElem, b::ZZRingElem)
     iszero(b) && throw(DivideError())
     z = QQFieldElem()
-    ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
-          (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, a, b)
+    set!(z, a, b)
     return z
   end
 
   function QQFieldElem(a::ZZRingElem)
     z = QQFieldElem()
-    b = ZZRingElem(1)
-    ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
-          (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, a, b)
+    set!(z, a)
     return z
   end
 
@@ -201,23 +198,20 @@ mutable struct QQFieldElem <: FracElem{ZZRingElem}
     if b == typemin(Int) || (b < 0 && a == typemin(Int))
       bz = -ZZ(b)
       az = -ZZ(a)
-      ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
-            (Ref{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, az, bz)
+      set!(z, az, bz)
     else
       if b < 0 # Flint requires positive denominator
         b = -b
         a = -a
       end
-      ccall((:fmpq_set_si, libflint), Nothing,
-            (Ref{QQFieldElem}, Int, Int), z, a, b)
+      set!(z, a, UInt(b))
     end
     return z
   end
 
   function QQFieldElem(a::Int)
     z = QQFieldElem()
-    ccall((:fmpq_set_si, libflint), Nothing,
-          (Ref{QQFieldElem}, Int, Int), z, a, 1)
+    set!(z, a)
     return z
   end
 
@@ -4762,8 +4756,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{QQFieldElem}), el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -4775,8 +4768,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), el, arr[i, j], b)
+        set!(el, arr[i, j], b)
       end
     end
     return z
@@ -4788,8 +4780,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{QQFieldElem}), el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -4801,8 +4792,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set_fmpz_frac, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), el, arr[(i-1)*c+j], b)
+        set!(el, arr[(i-1)*c+j], b)
       end
     end
     return z
@@ -4814,8 +4804,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{QQFieldElem}), el, QQFieldElem(arr[i, j]))
+        set!(el, QQFieldElem(arr[i, j]))
       end
     end
     return z
@@ -4826,8 +4815,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        ccall((:fmpq_set, libflint), Nothing,
-              (Ptr{QQFieldElem}, Ref{QQFieldElem}), el, QQFieldElem(arr[(i-1)*c+j]))
+        set!(el, QQFieldElem(arr[(i-1)*c+j]))
       end
     end
     return z
@@ -4837,8 +4825,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
     z = QQMatrix(r, c)
     GC.@preserve z for i = 1:min(r, c)
       el = mat_entry_ptr(z, i, i)
-      ccall((:fmpq_set, libflint), Nothing,
-            (Ptr{QQFieldElem}, Ref{QQFieldElem}), el, d)
+      set!(el, d)
     end
     return z
   end

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -14,7 +14,7 @@ QQFieldElem(a::Rational{BigInt}) = QQFieldElem(ZZRingElem(a.num), ZZRingElem(a.d
 
 function QQFieldElem(a::Rational{Int})
   r = QQFieldElem()
-  ccall((:fmpq_set_si, libflint), Nothing, (Ref{QQFieldElem}, Int64, UInt64), r, numerator(a), denominator(a))
+  set!(r, numerator(a), UInt(denominator(a)))
   return r
 end
 
@@ -153,7 +153,7 @@ end
 
 function deepcopy_internal(a::QQFieldElem, dict::IdDict)
   z = QQFieldElem()
-  ccall((:fmpq_set, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}), z, a)
+  set!(z, a)
   return z
 end
 
@@ -1093,9 +1093,44 @@ end
 #
 ###############################################################################
 
-function zero!(c::QQFieldElem)
-  ccall((:fmpq_zero, libflint), Nothing,
-        (Ref{QQFieldElem},), c)
+const QQFieldElemOrPtr = Union{QQFieldElem, Ptr{QQFieldElem}}
+
+_num_ptr(c::QQFieldElem) = Ptr{ZZRingElem}(pointer_from_objref(c))
+_num_ptr(c::Ptr{QQFieldElem}) = Ptr{ZZRingElem}(c)
+_den_ptr(c::QQFieldElemOrPtr) = _num_ptr(c) + sizeof(ZZRingElem)
+
+function zero!(c::QQFieldElemOrPtr)
+  @ccall libflint.fmpq_zero(c::Ref{QQFieldElem})::Nothing
+  return c
+end
+
+function one!(c::QQFieldElemOrPtr)
+  set!(c, 1)
+end
+
+function set!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
+  @ccall libflint.fmpq_set(c::Ref{QQFieldElem}, a::Ref{QQFieldElem})::Nothing
+  return c
+end
+
+function set!(c::QQFieldElemOrPtr, a::Int, b::UInt = UInt(1))
+  @ccall libflint.fmpq_set_si(c::Ref{QQFieldElem}, a::Int, b::UInt)::Nothing
+  return c
+end
+
+function set!(c::QQFieldElemOrPtr, a::UInt, b::UInt = UInt(1))
+  @ccall libflint.fmpq_set_ui(c::Ref{QQFieldElem}, a::UInt, b::UInt)::Nothing
+  return c
+end
+
+function set!(c::QQFieldElemOrPtr, a::ZZRingElem, b::ZZRingElem)
+  @ccall libflint.fmpq_set_fmpz_frac(c::Ref{QQFieldElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
+  return c
+end
+
+function set!(c::QQFieldElemOrPtr, a::ZZRingElem)
+  set!(_num_ptr(c), a)
+  one!(_den_ptr(c))
   return c
 end
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1128,7 +1128,15 @@ function set!(c::QQFieldElemOrPtr, a::ZZRingElem, b::ZZRingElem)
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::ZZRingElem)
+function set!(c::QQFieldElem, a::ZZRingElem)
+  GC.@preserve c begin
+    set!(_num_ptr(c), a)
+    one!(_den_ptr(c))
+  end
+  return c
+end
+
+function set!(c::Ptr{QQFieldElem}, a::ZZRingElem)
   set!(_num_ptr(c), a)
   one!(_den_ptr(c))
   return c

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -91,7 +91,7 @@ getindex(x::QQMatrix, r::AbstractUnitRange{Int}, c::AbstractUnitRange{Int}) = su
 function getindex!(v::QQFieldElem, a::QQMatrix, r::Int, c::Int)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpq_set, libflint), Nothing, (Ref{QQFieldElem}, Ptr{QQFieldElem}), v, z)
+    set!(v, z)
   end
   return v
 end
@@ -101,7 +101,7 @@ end
   v = QQFieldElem()
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpq_set, libflint), Nothing, (Ref{QQFieldElem}, Ptr{QQFieldElem}), v, z)
+    set!(v, z)
   end
   return v
 end
@@ -109,12 +109,8 @@ end
 @inline function setindex!(a::QQMatrix, d::ZZRingElem, r::Int, c::Int)
   @boundscheck Generic._checkbounds(a, r, c)
   GC.@preserve a begin
-    z = ccall((:fmpq_mat_entry_num, libflint), Ptr{ZZRingElem},
-              (Ref{QQMatrix}, Int, Int), a, r - 1, c - 1)
+    z = mat_entry_ptr(a, r, c)
     set!(z, d)
-    z = ccall((:fmpq_mat_entry_den, libflint), Ptr{ZZRingElem},
-              (Ref{QQMatrix}, Int, Int), a, r - 1, c - 1)
-    one!(z)
   end
 end
 
@@ -122,19 +118,19 @@ end
   @boundscheck Generic._checkbounds(a, r, c)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpq_set, libflint), Nothing, (Ptr{QQFieldElem}, Ref{QQFieldElem}), z, d)
+    set!(z, d)
   end
 end
 
 Base.@propagate_inbounds setindex!(a::QQMatrix, d::Integer,
                                    r::Int, c::Int) =
-setindex!(a, QQFieldElem(d), r, c)
+  setindex!(a, ZZRingElem(d), r, c)
 
 @inline function setindex!(a::QQMatrix, d::Int, r::Int, c::Int)
   @boundscheck Generic._checkbounds(a, r, c)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpq_set_si, libflint), Nothing, (Ptr{QQFieldElem}, Int, Int), z, d, 1)
+    set!(z, d)
   end
 end
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -111,10 +111,10 @@ end
   GC.@preserve a begin
     z = ccall((:fmpq_mat_entry_num, libflint), Ptr{ZZRingElem},
               (Ref{QQMatrix}, Int, Int), a, r - 1, c - 1)
-    ccall((:fmpz_set, libflint), Nothing, (Ptr{ZZRingElem}, Ref{ZZRingElem}), z, d)
+    set!(z, d)
     z = ccall((:fmpq_mat_entry_den, libflint), Ptr{ZZRingElem},
               (Ref{QQMatrix}, Int, Int), a, r - 1, c - 1)
-    ccall((:fmpz_set_si, libflint), Nothing, (Ptr{ZZRingElem}, Int), z, 1)
+    one!(z)
   end
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -184,7 +184,7 @@ end
 
 function deepcopy_internal(a::ZZRingElem, dict::IdDict)
   z = ZZRingElem()
-  ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}), z, a)
+  set!(z, a)
   return z
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2599,23 +2599,29 @@ end
 #
 ###############################################################################
 
-function zero!(z::ZZRingElem)
-  ccall((:fmpz_zero, libflint), Nothing,
-        (Ref{ZZRingElem},), z)
+const ZZRingElemOrPtr = Union{ZZRingElem, Ptr{ZZRingElem}}
+
+function zero!(z::ZZRingElemOrPtr)
+  @ccall libflint.fmpz_zero(z::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function one!(z::ZZRingElem)
-  ccall((:fmpz_set_ui, libflint), Nothing,
-        (Ref{ZZRingElem}, UInt),
-        z, 1)
+function one!(z::ZZRingElemOrPtr)
+  set!(z, UInt(1))
+end
+
+function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+  @ccall libflint.fmpz_set(z::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function set!(z::ZZRingElem, a::ZZRingElem)
-  ccall((:fmpz_set, libflint), Nothing,
-        (Ref{ZZRingElem}, Ref{ZZRingElem}),
-        z, a)
+function set!(z::ZZRingElemOrPtr, a::Int)
+  @ccall libflint.fmpz_set_si(z::Ref{ZZRingElem}, a::Int)::Nothing
+  return z
+end
+
+function set!(z::ZZRingElemOrPtr, a::UInt)
+  @ccall libflint.fmpz_set_ui(z::Ref{ZZRingElem}, a::UInt)::Nothing
   return z
 end
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -112,7 +112,7 @@ getindex(x::ZZMatrix, r::AbstractUnitRange{Int}, c::AbstractUnitRange{Int}) = su
 function getindex!(v::ZZRingElem, a::ZZMatrix, r::Int, c::Int)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), v, z)
+    set!(v, z)
   end
 end
 
@@ -121,7 +121,7 @@ end
   v = ZZRingElem()
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpz_set, libflint), Nothing, (Ref{ZZRingElem}, Ptr{ZZRingElem}), v, z)
+    set!(v, z)
   end
   return v
 end
@@ -130,7 +130,7 @@ end
   @boundscheck Generic._checkbounds(a, r, c)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpz_set, libflint), Nothing, (Ptr{ZZRingElem}, Ref{ZZRingElem}), z, d)
+    set!(z, d)
   end
 end
 
@@ -140,7 +140,7 @@ end
   @boundscheck Generic._checkbounds(a, r, c)
   GC.@preserve a begin
     z = mat_entry_ptr(a, r, c)
-    ccall((:fmpz_set_si, libflint), Nothing, (Ptr{ZZRingElem}, Int), z, d)
+    set!(z, d)
   end
 end
 
@@ -812,7 +812,7 @@ function hadamard_bound2(M::ZZMatrix)
   r = ZZ(0)
   n = nrows(M)
   for i in 1:n
-    ccall((:fmpz_set_si, Nemo.libflint), Cvoid, (Ref{ZZRingElem}, Int), r, 0)
+    zero!(r)
     M_ptr = Nemo.mat_entry_ptr(M, i, 1)
     for j in 1:n
       ccall((:fmpz_addmul, Nemo.libflint), Cvoid, (Ref{ZZRingElem}, Ptr{ZZRingElem}, Ptr{ZZRingElem}), r, M_ptr, M_ptr)
@@ -1544,7 +1544,7 @@ function Base.cat(A::ZZMatrix...;dims)
         A_ptr = mat_entry_ptr(Ai, k, 1)
         X_ptr = mat_entry_ptr(X, start_row + k, start_col+1)
         for l = 1:ncols(Ai)
-          ccall((:fmpz_set, libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), X_ptr, A_ptr)
+          set!(X_ptr, A_ptr)
           X_ptr += sizeof(ZZRingElem)
           A_ptr += sizeof(ZZRingElem)
         end
@@ -1569,7 +1569,7 @@ function AbstractAlgebra._vcat(A::AbstractVector{ZZMatrix})
         M_ptr = mat_entry_ptr(M, s+j, 1)
         N_ptr = mat_entry_ptr(N, j, 1)
         for k in 1:ncols(N)
-          ccall((:fmpz_set, libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), M_ptr, N_ptr)
+          set!(M_ptr, N_ptr)
           M_ptr += sizeof(ZZRingElem)
           N_ptr += sizeof(ZZRingElem)
         end
@@ -1594,7 +1594,7 @@ function AbstractAlgebra._hcat(A::AbstractVector{ZZMatrix})
         M_ptr = mat_entry_ptr(M, j, s+1)
         N_ptr = mat_entry_ptr(N, j, 1)
         for k in 1:ncols(N)
-          ccall((:fmpz_set, libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), M_ptr, N_ptr)
+          set!(M_ptr, N_ptr)
           M_ptr += sizeof(ZZRingElem)
           N_ptr += sizeof(ZZRingElem)
         end
@@ -1661,7 +1661,7 @@ function _solve_triu_left(U::ZZMatrix, b::ZZMatrix)
       tmp_p = mat_entry_ptr(tmp, 1, 1)
       X_p = mat_entry_ptr(X, i, 1)
       for j = 1:n
-        ccall((:fmpz_set, Nemo.libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), tmp_p, X_p)
+        set!(tmp_p, X_p)
         X_p += sizeof(ZZRingElem)
         tmp_p += sizeof(ZZRingElem)
       end
@@ -1682,7 +1682,7 @@ function _solve_triu_left(U::ZZMatrix, b::ZZMatrix)
       tmp_p = mat_entry_ptr(tmp, 1, 1)
       X_p = mat_entry_ptr(X, i, 1)
       for j = 1:n
-        ccall((:fmpz_set, Nemo.libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), X_p, tmp_p)
+        set!(X_p, tmp_p)
         X_p += sizeof(ZZRingElem)
         tmp_p += sizeof(ZZRingElem)
       end
@@ -1703,7 +1703,7 @@ function _solve_triu(U::ZZMatrix, b::ZZMatrix)
       tmp_ptr = mat_entry_ptr(tmp, 1, 1)
       for j = 1:n
         X_ptr = mat_entry_ptr(X, j, i)
-        ccall((:fmpz_set, Nemo.libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), tmp_ptr, X_ptr)
+        set!(tmp_ptr, X_ptr)
         tmp_ptr += sizeof(ZZRingElem)
       end
       for j = n:-1:1
@@ -1727,7 +1727,7 @@ function _solve_triu(U::ZZMatrix, b::ZZMatrix)
       tmp_ptr = mat_entry_ptr(tmp, 1, 1)
       for j = 1:n
         X_ptr = mat_entry_ptr(X, j, i)
-        ccall((:fmpz_set, Nemo.libflint), Cvoid, (Ptr{ZZRingElem}, Ptr{ZZRingElem}), X_ptr, tmp_ptr)
+        set!(X_ptr, tmp_ptr)
         tmp_ptr += sizeof(ZZRingElem)
       end
     end

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -339,8 +339,7 @@ end
 ###############################################################################
 
 function zero!(z::ZZModRingElem)
-  ccall((:fmpz_set_ui, libflint), Nothing,
-        (Ref{ZZRingElem}, UInt), z.data, UInt(0))
+  zero!(z.data)
   return z
 end
 

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -348,8 +348,7 @@ end
 ###############################################################################
 
 function zero!(z::FpFieldElem)
-  ccall((:fmpz_set_ui, libflint), Nothing,
-        (Ref{ZZRingElem}, UInt), z.data, UInt(0))
+  zero!(z.data)
   return z
 end
 


### PR DESCRIPTION
Had this sitting time, used my "time off" to just clean it up and submit:

my hope is that with this and further additions of `mat_entry_ptr` and `set!` methods, we can enable more people to to write efficient *and legible* code interacting with these. E.g. this code in Hecke
```julia
  if Nemo.__fmpz_is_small(b) && Nemo.__fmpz_is_small(a.ar[a.l])
    a.ar[a.l] = b
  else
    ccall((:fmpz_set_si, Nemo.libflint), Cvoid, (Ptr{Int}, Int), get_ptr(a, length(a)), b)
  end
```
can now be rewritten as
```julia
  if Nemo.__fmpz_is_small(b) && Nemo.__fmpz_is_small(a.ar[a.l])
    a.ar[a.l] = b
  else
    Nemo.set!(get_ptr(a, length(a)), b)
  end
```

Next we could teach `set!` methods about `_fmpz_is_small`, then the above Hecke code could be further simplified to just
```julia
  Nemo.set!(get_ptr(a, length(a)), b)
```

Of course the code works so this simplification alone is not the point; but rather that now we can have this optimization for free in lots of other places.
