### PR TITLE
Remove obsolete sentence from devdocs

### DIFF
--- a/docs/src/developer/conventions.md
+++ b/docs/src/developer/conventions.md
@@ -127,9 +127,6 @@ name, e.g. `FlintTypes.jl`. This is because Julia must be aware of all types
 before they are used. Separation of types from implementations makes it easy
 to ensure this happens.
 
-Abstract types should be put in the file called `AbstractTypes.jl` at the top
-level of the `src` directory.
-
 Most implementation files present functions in a particular order, which is as
 follows:
 


### PR DESCRIPTION
The file AbstractTypes.jl lives in AbstractAlgebra, not Nemo
