### PR TITLE
Drop redundant check_parent methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.41.8"
+AbstractAlgebra = "0.41.9"
 FLINT_jll = "^300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -35,10 +35,6 @@ the generator of the given number field.
 """
 var(a::AbsSimpleNumField) = a.S
 
-function check_parent(a::AbsSimpleNumFieldElem, b::AbsSimpleNumFieldElem)
-  a.parent != b.parent && error("Incompatible number field elements")
-end
-
 characteristic(::AbsSimpleNumField) = 0
 
 defining_polynomial(K::AbsSimpleNumField) = K.pol

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -72,10 +72,6 @@ end
 
 # TODO: implement hash
 
-function check_parent(a::ComplexFieldElem, b::ComplexFieldElem)
-  return true
-end
-
 characteristic(::ComplexField) = 0
 
 ################################################################################

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -27,12 +27,6 @@ base_ring(a::ComplexMat) = ComplexField()
 
 dense_matrix_type(::Type{ComplexFieldElem}) = ComplexMat
 
-function check_parent(x::ComplexMat, y::ComplexMat, throw::Bool = true)
-  fl = (nrows(x) != nrows(y) || ncols(x) != ncols(y) || base_ring(x) != base_ring(y))
-  fl && throw && error("Incompatible matrices")
-  return !fl
-end
-
 function getindex!(z::ComplexFieldElem, x::ComplexMat, r::Int, c::Int)
   GC.@preserve x begin
     v = ccall((:acb_mat_entry_ptr, libflint), Ptr{ComplexFieldElem},

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -53,10 +53,6 @@ function canonical_unit(x::RealFieldElem)
   return x
 end
 
-function check_parent(a::RealFieldElem, b::RealFieldElem)
-  return true
-end
-
 characteristic(::RealField) = 0
 
 ################################################################################

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -27,12 +27,6 @@ base_ring(a::RealMat) = RealField()
 
 dense_matrix_type(::Type{RealFieldElem}) = RealMat
 
-function check_parent(x::RealMat, y::RealMat, throw::Bool = true)
-  fl = (nrows(x) != nrows(y) || ncols(x) != ncols(y) || base_ring(x) != base_ring(y))
-  fl && throw && error("Incompatible matrices")
-  return !fl
-end
-
 function getindex!(z::ArbFieldElem, x::RealMat, r::Int, c::Int)
   GC.@preserve x begin
     v = ccall((:arb_mat_entry_ptr, libflint), Ptr{RealFieldElem},

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -75,11 +75,6 @@ end
 
 # TODO: implement hash
 
-function check_parent(a::AcbFieldElem, b::AcbFieldElem)
-  parent(a) != parent(b) &&
-  error("Incompatible AcbFieldElem elements")
-end
-
 characteristic(::AcbField) = 0
 
 ################################################################################

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -30,12 +30,6 @@ dense_matrix_type(::Type{AcbFieldElem}) = AcbMatrix
 
 precision(x::AcbMatSpace) = precision(base_ring(x))
 
-function check_parent(x::AcbMatrix, y::AcbMatrix, throw::Bool = true)
-  fl = (nrows(x) != nrows(y) || ncols(x) != ncols(y) || base_ring(x) != base_ring(y))
-  fl && throw && error("Incompatible matrices")
-  return !fl
-end
-
 function getindex!(z::AcbFieldElem, x::AcbMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = ccall((:acb_mat_entry_ptr, libflint), Ptr{AcbFieldElem},

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -54,11 +54,6 @@ function canonical_unit(x::ArbFieldElem)
   return x
 end
 
-function check_parent(a::ArbFieldElem, b::ArbFieldElem)
-  parent(a) != parent(b) &&
-  error("Incompatible ArbFieldElem elements")
-end
-
 characteristic(::ArbField) = 0
 
 ################################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -30,12 +30,6 @@ dense_matrix_type(::Type{ArbFieldElem}) = ArbMatrix
 
 precision(x::ArbMatSpace) = precision(x.base_ring)
 
-function check_parent(x::ArbMatrix, y::ArbMatrix, throw::Bool = true)
-  fl = (nrows(x) != nrows(y) || ncols(x) != ncols(y) || base_ring(x) != base_ring(y))
-  fl && throw && error("Incompatible matrices")
-  return !fl
-end
-
 function getindex!(z::ArbFieldElem, x::ArbMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = ccall((:arb_mat_entry_ptr, libflint), Ptr{ArbFieldElem},

--- a/src/calcium/ca.jl
+++ b/src/calcium/ca.jl
@@ -30,12 +30,6 @@ function deepcopy_internal(a::CalciumFieldElem, dict::IdDict)
   return r
 end
 
-function check_parent(a::CalciumFieldElem, b::CalciumFieldElem, throw::Bool = true)
-  b = (parent(a) != parent(b))
-  b && throw && error("Different parents")
-  return !b
-end
-
 function _isspecial(a::CalciumFieldElem)
   return (a.field & 3) != 0
 end

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -22,8 +22,6 @@ base_ring(::QQBarField) = Union{}
 
 is_domain_type(::Type{QQBarFieldElem}) = true
 
-check_parent(a::QQBarFieldElem, b::QQBarFieldElem, throw::Bool = true) = true
-
 characteristic(::QQBarField) = 0
 
 ###############################################################################

--- a/src/flint/flint_puiseux_series.jl
+++ b/src/flint/flint_puiseux_series.jl
@@ -58,11 +58,6 @@ end
 
 is_exact_type(a::Type{T}) where T <: FlintPuiseuxSeriesElem = false
 
-function check_parent(a::FlintPuiseuxSeriesElem, b::FlintPuiseuxSeriesElem)
-  parent(a) != parent(b) &&
-  error("Incompatible Puiseux series rings in Puiseux series operation")
-end
-
 function characteristic(R::FlintPuiseuxSeriesRing{T}) where T <: RingElem
   return characteristic(base_ring(R))
 end

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -14,12 +14,6 @@ base_ring(a::QQMatrix) = QQ
 
 dense_matrix_type(::Type{QQFieldElem}) = QQMatrix
 
-function check_parent(a::QQMatrix, b::QQMatrix, throw::Bool = true)
-  fl = (nrows(a) != nrows(b) || ncols(a) != ncols(b) || base_ring(a) != base_ring(b))
-  fl && throw && error("Incompatible matrices")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -20,10 +20,6 @@ symbols(a::QQMPolyRing) = a.S
 
 parent(a::QQMPolyRingElem) = a.parent
 
-function check_parent(a::QQMPolyRingElem, b::QQMPolyRingElem)
-  parent(a) != parent(b) &&
-  error("Incompatible polynomial rings in polynomial operation")
-end
 
 number_of_variables(a::QQMPolyRing) = ccall((:fmpq_mpoly_ctx_nvars, libflint), Int,
                                             (Ref{QQMPolyRing}, ), a)

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -38,11 +38,6 @@ is_exact_type(a::Type{ZZLaurentSeriesRingElem}) = false
 
 var(a::ZZLaurentSeriesRing) = a.S
 
-function check_parent(a::ZZLaurentSeriesRingElem, b::ZZLaurentSeriesRingElem)
-  parent(a) != parent(b) &&
-  error("Incompatible power series rings in Laurent series operation")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -14,12 +14,6 @@ base_ring(a::ZZMatrix) = ZZ
 
 dense_matrix_type(::Type{ZZRingElem}) = ZZMatrix
 
-function check_parent(a::ZZMatrix, b::ZZMatrix, throw::Bool = true)
-  b = (nrows(a) != nrows(b) || ncols(a) != ncols(b))
-  b && throw && error("Incompatible matrices")
-  return !b
-end
-
 ###############################################################################
 #
 #   similar & zero

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -20,10 +20,6 @@ base_ring(a::ZZModRing) = ZZ
 
 parent(a::ZZModRingElem) = a.parent
 
-function check_parent(a::ZZModRingElem, b::ZZModRingElem)
-  a.parent != b.parent && error("Operations on distinct residue rings not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -12,15 +12,6 @@
 
 dense_matrix_type(::Type{ZZModRingElem}) = ZZModMatrix
 
-function check_parent(x::T, y::T, throw::Bool = true) where T <: Zmod_fmpz_mat
-  fl = base_ring(x) != base_ring(y)
-  fl && throw && error("Residue rings must be equal")
-  fl && return false
-  fl = (ncols(x) != ncols(y)) && (nrows(x) != nrows(y))
-  fl && throw && error("Matrices have wrong dimensions")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -25,11 +25,6 @@ for (etype, rtype, ftype, ctype) in (
 
     parent(a::($etype)) = a.parent
 
-    function check_parent(a::($etype), b::($etype))
-      parent(a) != parent(b) &&
-      error("Incompatible polynomial rings in polynomial operation")
-    end
-
     number_of_variables(a::($rtype)) = a.nvars
 
     base_ring(a::($rtype)) = a.base_ring

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -20,11 +20,6 @@ parent_type(::Type{ZZModPolyRingElem}) = ZZModPolyRing
 
 dense_poly_type(::Type{ZZModRingElem}) = ZZModPolyRingElem
 
-function check_parent(x::T, y::T) where {T <: Zmodn_fmpz_poly}
-  parent(x) != parent(y) && error("Parents must coincide")
-  nothing
-end
-
 function _is_one_or_throw(f, y)
   R = base_ring(y)
   if !isone(f)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -20,11 +20,6 @@ symbols(a::ZZMPolyRing) = a.S
 
 parent(a::ZZMPolyRingElem) = a.parent
 
-function check_parent(a::ZZMPolyRingElem, b::ZZMPolyRingElem)
-  parent(a) != parent(b) &&
-  error("Incompatible polynomial rings in polynomial operation")
-end
-
 number_of_variables(a::ZZMPolyRing) = ccall((:fmpz_mpoly_ctx_nvars, libflint), Int,
                                             (Ref{ZZMPolyRing}, ), a)
 

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -22,10 +22,6 @@ parent(a::FqPolyRepFieldElem) = a.parent
 
 is_domain_type(::Type{FqPolyRepFieldElem}) = true
 
-function check_parent(a::FqPolyRepFieldElem, b::FqPolyRepFieldElem)
-  a.parent != b.parent && error("Operations on distinct finite fields not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -22,10 +22,6 @@ parent(a::FqFieldElem) = a.parent
 
 is_domain_type(::Type{FqFieldElem}) = true
 
-function check_parent(a::FqFieldElem, b::FqFieldElem)
-  a.parent != b.parent && error("Operations on distinct finite fields not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -12,15 +12,6 @@
 
 dense_matrix_type(::Type{FqFieldElem}) = FqMatrix
 
-function check_parent(x::FqMatrix, y::FqMatrix, throw::Bool = true)
-  fl = base_ring(x) != base_ring(y)
-  fl && throw && error("Residue rings must be equal")
-  fl && return false
-  fl = (ncols(x) != ncols(y)) && (nrows(x) != nrows(y))
-  fl && throw && error("Matrices have wrong dimensions")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -23,11 +23,6 @@ parent(a::FqPolyRingElem) = a.parent
 
 var(a::FqPolyRing) = a.S
 
-function check_parent(a::FqPolyRingElem, b::FqPolyRingElem)
-  a.parent != b.parent &&
-  error("Operations on distinct polynomial rings not supported")
-end
-
 ################################################################################
 #
 #   Basic manipulation

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -12,15 +12,6 @@
 
 dense_matrix_type(::Type{FqPolyRepFieldElem}) = FqPolyRepMatrix
 
-function check_parent(x::FqPolyRepMatrix, y::FqPolyRepMatrix, throw::Bool = true)
-  fl = base_ring(x) != base_ring(y)
-  fl && throw && error("Residue rings must be equal")
-  fl && return false
-  fl = (ncols(x) != ncols(y)) && (nrows(x) != nrows(y))
-  fl && throw && error("Matrices have wrong dimensions")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -22,10 +22,6 @@ parent(a::fqPolyRepFieldElem) = a.parent
 
 is_domain_type(::Type{fqPolyRepFieldElem}) = true
 
-function check_parent(a::fqPolyRepFieldElem, b::fqPolyRepFieldElem)
-  a.parent != b.parent && error("Operations on distinct finite fields not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -12,15 +12,6 @@
 
 dense_matrix_type(::Type{fqPolyRepFieldElem}) = fqPolyRepMatrix
 
-function check_parent(x::fqPolyRepMatrix, y::fqPolyRepMatrix, throw::Bool = true)
-  fl = base_ring(x) != base_ring(y)
-  fl && throw && error("Residue rings must be equal")
-  fl && return false
-  fl = (ncols(x) != ncols(y)) && (nrows(x) != nrows(y))
-  fl && throw && error("Matrices have wrong dimensions")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -20,11 +20,6 @@ symbols(a::fqPolyRepMPolyRing) = a.S
 
 parent(a::fqPolyRepMPolyRingElem) = a.parent
 
-function check_parent(a::fqPolyRepMPolyRingElem, b::fqPolyRepMPolyRingElem)
-  parent(a) != parent(b) &&
-  error("Incompatible polynomial rings in polynomial operation")
-end
-
 number_of_variables(a::fqPolyRepMPolyRing) = a.nvars
 
 base_ring(a::fqPolyRepMPolyRing) = a.base_ring

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -22,11 +22,6 @@ parent(a::fqPolyRepPolyRingElem) = a.parent
 
 var(a::fqPolyRepPolyRing) = a.S
 
-function check_parent(a::fqPolyRepPolyRingElem, b::fqPolyRepPolyRingElem)
-  a.parent != b.parent &&
-  error("Operations on distinct polynomial rings not supported")
-end
-
 ################################################################################
 #
 #   Basic manipulation

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -22,11 +22,6 @@ parent(a::FqPolyRepPolyRingElem) = a.parent
 
 var(a::FqPolyRepPolyRing) = a.S
 
-function check_parent(a::FqPolyRepPolyRingElem, b::FqPolyRepPolyRingElem)
-  a.parent != b.parent &&
-  error("Operations on distinct polynomial rings not supported")
-end
-
 ################################################################################
 #
 #   Basic manipulation

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -20,10 +20,6 @@ base_ring(a::fpField) = Union{}
 
 parent(a::fpFieldElem) = a.parent
 
-function check_parent(a::fpFieldElem, b::fpFieldElem)
-  a.parent != b.parent && error("Operations on distinct Galois fields not supported")
-end
-
 is_domain_type(::Type{fpFieldElem}) = true
 
 ###############################################################################

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -20,10 +20,6 @@ base_ring(a::FpField) = Union{}
 
 parent(a::FpFieldElem) = a.parent
 
-function check_parent(a::FpFieldElem, b::FpFieldElem)
-  a.parent != b.parent && error("Operations on distinct residue rings not supported")
-end
-
 is_domain_type(::Type{FpFieldElem}) = true
 
 ###############################################################################

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -20,10 +20,6 @@ base_ring(a::zzModRing) = ZZ
 
 parent(a::zzModRingElem) = a.parent
 
-function check_parent(a::zzModRingElem, b::zzModRingElem)
-  a.parent != b.parent && error("Operations on distinct residue rings not supported")
-end
-
 ###############################################################################
 #
 #   Basic manipulation

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -12,15 +12,6 @@
 
 dense_matrix_type(::Type{zzModRingElem}) = zzModMatrix
 
-function check_parent(x::T, y::T, throw::Bool = true) where T <: Zmodn_mat
-  fl = base_ring(x) != base_ring(y)
-  fl && throw && error("Residue rings must be equal")
-  fl && return false
-  fl = (ncols(x) != ncols(y)) && (nrows(x) != nrows(y))
-  fl && throw && error("Matrices have wrong dimensions")
-  return !fl
-end
-
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -25,11 +25,6 @@ for (etype, rtype, ftype, ctype, utype) in (
 
     parent(a::($etype)) = a.parent
 
-    function check_parent(a::($etype), b::($etype))
-      parent(a) != parent(b) &&
-      error("Incompatible polynomial rings in polynomial operation")
-    end
-
     number_of_variables(a::($rtype)) = a.nvars
 
     base_ring(a::($rtype)) = a.base_ring

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -20,11 +20,6 @@ elem_type(::Type{zzModPolyRing}) = zzModPolyRingElem
 
 dense_poly_type(::Type{zzModRingElem}) = zzModPolyRingElem
 
-function check_parent(x::T, y::T) where T <: Zmodn_poly
-  parent(x) != parent(y) && error("Parents must coincide")
-  nothing
-end
-
 ################################################################################
 #
 #   Basic helper

--- a/src/flint/padic.jl
+++ b/src/flint/padic.jl
@@ -77,11 +77,6 @@ is_domain_type(::Type{PadicFieldElem}) = true
 
 is_exact_type(R::Type{PadicFieldElem}) = false
 
-function check_parent(a::PadicFieldElem, b::PadicFieldElem)
-  parent(a) != parent(b) &&
-  error("Incompatible padic rings in padic operation")
-end
-
 parent_type(::Type{PadicFieldElem}) = PadicField
 
 ###############################################################################

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -77,11 +77,6 @@ is_domain_type(::Type{QadicFieldElem}) = true
 
 is_exact_type(R::Type{QadicFieldElem}) = false
 
-function check_parent(a::QadicFieldElem, b::QadicFieldElem)
-  parent(a) != parent(b) &&
-  error("Incompatible qadic rings in qadic operation")
-end
-
 parent_type(::Type{QadicFieldElem}) = QadicField
 
 function _prime(R::QadicField, n::Int = 1)


### PR DESCRIPTION
... in favor of generic one from AA 0.41.9

Some removed methods are for matrices, and didn't check the parent, but instead the base ring, ncols, nrows -- but they should be fine performance-wise because the `check_parent(a::MatrixElem, b::MatrixElem, throw::Bool = true)` method from AA should kick in which does just that.

Alas in practice it seems something is still broken, tests fail, so I assume I screwed something up. But I am posting this as a draft here now so I won't forget about it.