### PR TITLE
Only check equality of base rings

### DIFF
--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -512,7 +512,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::ZZModMatrix, b::ZZModMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -442,7 +442,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::FqMatrix, b::FqMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -455,7 +455,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::FqPolyRepMatrix, b::FqPolyRepMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -443,7 +443,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::fqPolyRepMatrix, b::fqPolyRepMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -387,7 +387,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::FpMatrix, b::FpMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -316,7 +316,7 @@ end
 ################################################################################
 
 function Solve._can_solve_internal_no_check(A::fpMatrix, b::fpMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -520,7 +520,7 @@ function AbstractAlgebra._solve_tril!(A::T, B::T, C::T, unit::Int = 0) where T <
 end
 
 function Solve._can_solve_internal_no_check(A::zzModMatrix, b::zzModMatrix, task::Symbol; side::Symbol = :left)
-  check_parent(A, b)
+  @assert base_ring(A) === base_ring(b) "Base rings do not match"
   if side === :left
     fl, sol, K = Solve._can_solve_internal_no_check(transpose(A), transpose(b), task, side = :right)
     return fl, transpose(sol), transpose(K)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -110,6 +110,7 @@ function Solve._init_reduce_transpose(C::Solve.SolveCtx{T}) where {T <: Union{fp
 end
 
 function Solve._can_solve_internal_no_check(C::Solve.SolveCtx{T}, b::MatElem{T}, task::Symbol; side::Symbol = :left) where {T <: Union{fpFieldElem, FpFieldElem, FqFieldElem, fqPolyRepFieldElem, FqPolyRepFieldElem}}
+  @assert base_ring(matrix(C)) === base_ring(b) "Base rings do not match"
   # Split up in separate functions to make the compiler happy
   if side === :right
     return Solve._can_solve_internal_no_check_right(C, b, task)


### PR DESCRIPTION
Fixes the faulty `check_parent` calls discovered in #1784. This works locally together with #1784. Feel free to cherry-pick the commit.
