### PR TITLE
Ensure MatElem subtypes T have `T(R::Ring, ::UndefInitializer, r::Int, c::Int)` constructor

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -782,6 +782,9 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
   rows::Ptr{Nothing}
   #base_ring::ArbField
 
+  # MatElem interface
+  RealMatrix(::RealField, r::Int, c::Int) = RealMatrix(r, c)
+
   function RealMatrix(r::Int, c::Int)
     z = new()
     @ccall libflint.arb_mat_init(z::Ref{RealMatrix}, r::Int, c::Int)::Nothing
@@ -866,6 +869,13 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   c::Int
   rows::Ptr{Nothing}
   base_ring::ArbField
+
+  # MatElem interface
+  function ArbMatrix(R::ArbField, r::Int, c::Int)
+    z = ArbMatrix(r, c)
+    z.base_ring = R
+    return z
+  end
 
   function ArbMatrix(r::Int, c::Int)
     z = new()
@@ -955,6 +965,9 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
   c::Int
   rows::Ptr{Nothing}
   #base_ring::AcbField
+
+  # MatElem interface
+  ComplexMatrix(::ComplexField, r::Int, c::Int) = ComplexMatrix(r, c)
 
   function ComplexMatrix(r::Int, c::Int)
     z = new()
@@ -1140,6 +1153,13 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   c::Int
   rows::Ptr{Nothing}
   base_ring::AcbField
+
+  # MatElem interface
+  function AcbMatrix(R::AcbField, r::Int, c::Int)
+    z = AcbMatrix(r, c)
+    z.base_ring = R
+    return z
+  end
 
   function AcbMatrix(r::Int, c::Int)
     z = new()

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -783,7 +783,7 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
   #base_ring::ArbField
 
   # MatElem interface
-  RealMatrix(::RealField, r::Int, c::Int) = RealMatrix(r, c)
+  RealMatrix(::RealField, ::UndefInitializer, r::Int, c::Int) = RealMatrix(r, c)
 
   function RealMatrix(r::Int, c::Int)
     z = new()
@@ -871,7 +871,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
   base_ring::ArbField
 
   # MatElem interface
-  function ArbMatrix(R::ArbField, r::Int, c::Int)
+  function ArbMatrix(R::ArbField, ::UndefInitializer, r::Int, c::Int)
     z = ArbMatrix(r, c)
     z.base_ring = R
     return z
@@ -967,7 +967,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
   #base_ring::AcbField
 
   # MatElem interface
-  ComplexMatrix(::ComplexField, r::Int, c::Int) = ComplexMatrix(r, c)
+  ComplexMatrix(::ComplexField, ::UndefInitializer, r::Int, c::Int) = ComplexMatrix(r, c)
 
   function ComplexMatrix(r::Int, c::Int)
     z = new()
@@ -1155,7 +1155,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
   base_ring::AcbField
 
   # MatElem interface
-  function AcbMatrix(R::AcbField, r::Int, c::Int)
+  function AcbMatrix(R::AcbField, ::UndefInitializer, r::Int, c::Int)
     z = AcbMatrix(r, c)
     z.base_ring = R
     return z

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -11,8 +11,7 @@
 ###############################################################################
 
 function similar(::AcbMatrix, R::AcbField, r::Int, c::Int)
-  z = AcbMatrix(r, c)
-  z.base_ring = R
+  z = AcbMatrix(R, r, c)
   return z
 end
 
@@ -694,8 +693,7 @@ end
 ###############################################################################
 
 function (x::AcbMatrixSpace)()
-  z = AcbMatrix(nrows(x), ncols(x))
-  z.base_ring = x.base_ring
+  z = AcbMatrix(base_ring(x), nrows(x), ncols(x))
   return z
 end
 
@@ -840,8 +838,7 @@ function zero_matrix(R::AcbField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = AcbMatrix(r, c)
-  z.base_ring = R
+  z = AcbMatrix(R, r, c)
   return z
 end
 
@@ -855,9 +852,7 @@ function identity_matrix(R::AcbField, n::Int)
   if n < 0
     error("dimension must not be negative")
   end
-  z = one!(AcbMatrix(n, n))
-  z.base_ring = R
-  return z
+  return one!(AcbMatrix(R, n, n))
 end
 
 ################################################################################

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -11,7 +11,7 @@
 ###############################################################################
 
 function similar(::AcbMatrix, R::AcbField, r::Int, c::Int)
-  z = AcbMatrix(R, r, c)
+  z = AcbMatrix(R, undef, r, c)
   return z
 end
 
@@ -693,7 +693,7 @@ end
 ###############################################################################
 
 function (x::AcbMatrixSpace)()
-  z = AcbMatrix(base_ring(x), nrows(x), ncols(x))
+  z = AcbMatrix(base_ring(x), undef, nrows(x), ncols(x))
   return z
 end
 
@@ -838,7 +838,7 @@ function zero_matrix(R::AcbField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = AcbMatrix(R, r, c)
+  z = AcbMatrix(R, undef, r, c)
   return z
 end
 
@@ -852,7 +852,7 @@ function identity_matrix(R::AcbField, n::Int)
   if n < 0
     error("dimension must not be negative")
   end
-  return one!(AcbMatrix(R, n, n))
+  return one!(AcbMatrix(R, undef, n, n))
 end
 
 ################################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -11,7 +11,7 @@
 ###############################################################################
 
 function similar(::ArbMatrix, R::ArbField, r::Int, c::Int)
-  z = ArbMatrix(R, r, c)
+  z = ArbMatrix(R, undef, r, c)
   return z
 end
 
@@ -78,7 +78,7 @@ number_of_rows(a::ArbMatrix) = a.r
 number_of_columns(a::ArbMatrix) = a.c
 
 function deepcopy_internal(x::ArbMatrix, dict::IdDict)
-  z = ArbMatrix(base_ring(x), nrows(x), ncols(x))
+  z = ArbMatrix(base_ring(x), undef, nrows(x), ncols(x))
   @ccall libflint.arb_mat_set(z::Ref{ArbMatrix}, x::Ref{ArbMatrix})::Nothing
   return z
 end
@@ -661,7 +661,7 @@ end
 ###############################################################################
 
 function (x::ArbMatrixSpace)()
-  z = ArbMatrix(base_ring(x), nrows(x), ncols(x))
+  z = ArbMatrix(base_ring(x), undef, nrows(x), ncols(x))
   return z
 end
 
@@ -736,7 +736,7 @@ function zero_matrix(R::ArbField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = ArbMatrix(R, r, c)
+  z = ArbMatrix(R, undef, r, c)
   return z
 end
 
@@ -750,7 +750,7 @@ function identity_matrix(R::ArbField, n::Int)
   if n < 0
     error("dimension must not be negative")
   end
-  return one!(ArbMatrix(R, n, n))
+  return one!(ArbMatrix(R, undef, n, n))
 end
 
 ################################################################################

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -11,8 +11,7 @@
 ###############################################################################
 
 function similar(::ArbMatrix, R::ArbField, r::Int, c::Int)
-  z = ArbMatrix(r, c)
-  z.base_ring = R
+  z = ArbMatrix(R, r, c)
   return z
 end
 
@@ -79,9 +78,8 @@ number_of_rows(a::ArbMatrix) = a.r
 number_of_columns(a::ArbMatrix) = a.c
 
 function deepcopy_internal(x::ArbMatrix, dict::IdDict)
-  z = ArbMatrix(nrows(x), ncols(x))
+  z = ArbMatrix(base_ring(x), nrows(x), ncols(x))
   @ccall libflint.arb_mat_set(z::Ref{ArbMatrix}, x::Ref{ArbMatrix})::Nothing
-  z.base_ring = x.base_ring
   return z
 end
 
@@ -663,8 +661,7 @@ end
 ###############################################################################
 
 function (x::ArbMatrixSpace)()
-  z = ArbMatrix(nrows(x), ncols(x))
-  z.base_ring = x.base_ring
+  z = ArbMatrix(base_ring(x), nrows(x), ncols(x))
   return z
 end
 
@@ -739,8 +736,7 @@ function zero_matrix(R::ArbField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = ArbMatrix(r, c)
-  z.base_ring = R
+  z = ArbMatrix(R, r, c)
   return z
 end
 
@@ -754,9 +750,7 @@ function identity_matrix(R::ArbField, n::Int)
   if n < 0
     error("dimension must not be negative")
   end
-  z = one!(ArbMatrix(n, n))
-  z.base_ring = R
-  return z
+  return one!(ArbMatrix(R, n, n))
 end
 
 ################################################################################

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4047,7 +4047,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   view_parent
 
   # MatElem interface
-  QQMatrix(::QQField, r::Int, c::Int) = QQMatrix(r, c)
+  QQMatrix(::QQField, ::UndefInitializer, r::Int, c::Int) = QQMatrix(r, c)
 
   # Used by view, not finalised!!
   function QQMatrix()
@@ -4091,7 +4091,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   view_parent
 
   # MatElem interface
-  ZZMatrix(::ZZRing, r::Int, c::Int) = ZZMatrix(r, c)
+  ZZMatrix(::ZZRing, ::UndefInitializer, r::Int, c::Int) = ZZMatrix(r, c)
 
   # Used by view, not finalised!!
   function ZZMatrix()
@@ -4137,7 +4137,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   view_parent
 
   # MatElem interface
-  function zzModMatrix(R::zzModRing, r::Int, c::Int)
+  function zzModMatrix(R::zzModRing, ::UndefInitializer, r::Int, c::Int)
     z = zzModMatrix(r, c, R.n)
     z.base_ring = R
     return z
@@ -4274,7 +4274,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   view_parent
 
   # MatElem interface
-  function ZZModMatrix(R::ZZModRing, r::Int, c::Int)
+  function ZZModMatrix(R::ZZModRing, ::UndefInitializer, r::Int, c::Int)
     z = ZZModMatrix(r, c, R.ninv)
     z.base_ring = R
     return z
@@ -4425,7 +4425,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   view_parent
 
   # MatElem interface
-  function FpMatrix(R::FpField, r::Int, c::Int)
+  function FpMatrix(R::FpField, ::UndefInitializer, r::Int, c::Int)
     z = FpMatrix(r, c, R.ninv)
     z.base_ring = R
     return z
@@ -4530,7 +4530,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   view_parent
 
   # MatElem interface
-  function fpMatrix(R::fpField, r::Int, c::Int)
+  function fpMatrix(R::fpField, ::UndefInitializer, r::Int, c::Int)
     z = fpMatrix(r, c, R.n)
     z.base_ring = R
     return z
@@ -5017,7 +5017,7 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
   view_parent
 
   # MatElem interface
-  function FqMatrix(R::FqField, r::Int, c::Int)
+  function FqMatrix(R::FqField, ::UndefInitializer, r::Int, c::Int)
     return FqMatrix(r, c, R)
   end
 
@@ -5115,7 +5115,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
   view_parent
 
   # MatElem interface
-  function FqPolyRepMatrix(R::FqPolyRepField, r::Int, c::Int)
+  function FqPolyRepMatrix(R::FqPolyRepField, ::UndefInitializer, r::Int, c::Int)
     return FqPolyRepMatrix(r, c, R)
   end
 
@@ -5196,7 +5196,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   view_parent
 
   # MatElem interface
-  function fqPolyRepMatrix(R::fqPolyRepField, r::Int, c::Int)
+  function fqPolyRepMatrix(R::fqPolyRepField, ::UndefInitializer, r::Int, c::Int)
     return fqPolyRepMatrix(r, c, R)
   end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4046,7 +4046,10 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   rows::Ptr{Ptr{QQFieldElem}}
   view_parent
 
-  # used by windows, not finalised!!
+  # MatElem interface
+  QQMatrix(::QQField, r::Int, c::Int) = QQMatrix(r, c)
+
+  # Used by view, not finalised!!
   function QQMatrix()
     return new()
   end
@@ -4086,6 +4089,9 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   c::Int
   rows::Ptr{Ptr{ZZRingElem}}
   view_parent
+
+  # MatElem interface
+  ZZMatrix(::ZZRing, r::Int, c::Int) = ZZMatrix(r, c)
 
   # Used by view, not finalised!!
   function ZZMatrix()
@@ -4130,10 +4136,16 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   base_ring::zzModRing
   view_parent
 
+  # MatElem interface
+  function zzModMatrix(R::zzModRing, r::Int, c::Int)
+    z = zzModMatrix(r, c, R.n)
+    z.base_ring = R
+    return z
+  end
+
   # Used by view, not finalised!!
   function zzModMatrix()
-    z = new()
-    return z
+    return new()
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt)
@@ -4261,10 +4273,16 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   base_ring::ZZModRing
   view_parent
 
+  # MatElem interface
+  function ZZModMatrix(R::ZZModRing, r::Int, c::Int)
+    z = ZZModMatrix(r, c, R.ninv)
+    z.base_ring = R
+    return z
+  end
+
   # Used by view, not finalised!!
   function ZZModMatrix()
-    z = new()
-    return z
+    return new()
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct)
@@ -4406,10 +4424,16 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   base_ring::FpField
   view_parent
 
+  # MatElem interface
+  function FpMatrix(R::FpField, r::Int, c::Int)
+    z = FpMatrix(r, c, R.ninv)
+    z.base_ring = R
+    return z
+  end
+
   # Used by view, not finalised!!
   function FpMatrix()
-    z = new()
-    return z
+    return new()
   end
 
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct)
@@ -4505,10 +4529,16 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   base_ring::fpField
   view_parent
 
+  # MatElem interface
+  function fpMatrix(R::fpField, r::Int, c::Int)
+    z = fpMatrix(r, c, R.n)
+    z.base_ring = R
+    return z
+  end
+
   # Used by view, not finalised!!
   function fpMatrix()
-    z = new()
-    return z
+    return new()
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt)
@@ -4986,7 +5016,12 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
   base_ring::FqField
   view_parent
 
-  # used by windows, not finalised!!
+  # MatElem interface
+  function FqMatrix(R::FqField, r::Int, c::Int)
+    return FqMatrix(r, c, R)
+  end
+
+  # Used by view, not finalised!!
   function FqMatrix()
     return new()
   end
@@ -5079,7 +5114,12 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
   base_ring::FqPolyRepField
   view_parent
 
-  # used by windows, not finalised!!
+  # MatElem interface
+  function FqPolyRepMatrix(R::FqPolyRepField, r::Int, c::Int)
+    return FqPolyRepMatrix(r, c, R)
+  end
+
+  # Used by view, not finalised!!
   function FqPolyRepMatrix()
     return new()
   end
@@ -5155,7 +5195,12 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   base_ring::fqPolyRepField
   view_parent
 
-  # used by windows, not finalised!!
+  # MatElem interface
+  function fqPolyRepMatrix(R::fqPolyRepField, r::Int, c::Int)
+    return fqPolyRepMatrix(r, c, R)
+  end
+
+  # Used by view, not finalised!!
   function fqPolyRepMatrix()
     return new()
   end

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -19,8 +19,7 @@ dense_matrix_type(::Type{ZZModRingElem}) = ZZModMatrix
 ###############################################################################
 
 function similar(::MatElem, R::ZZModRing, r::Int, c::Int)
-  z = ZZModMatrix(r, c, R.ninv)
-  z.base_ring = R
+  z = ZZModMatrix(R, r, c)
   return z
 end
 
@@ -697,8 +696,7 @@ promote_rule(::Type{ZZModMatrix}, ::Type{ZZRingElem}) = ZZModMatrix
 ################################################################################
 
 function (a::ZZModMatrixSpace)()
-  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv)
-  z.base_ring = a.base_ring
+  z = ZZModMatrix(base_ring(a), nrows(a), ncols(a))
   return z
 end
 
@@ -762,9 +760,8 @@ end
 
 function (a::ZZModMatrixSpace)(b::ZZMatrix)
   (ncols(a) != b.c || nrows(a) != b.r) && error("Dimensions do not fit")
-  z = ZZModMatrix(b.r, b.c, base_ring(a).ninv)
+  z = ZZModMatrix(base_ring(a), b.r, b.c)
   @ccall libflint.fmpz_mod_mat_set_fmpz_mat(z::Ref{ZZModMatrix}, b::Ref{ZZMatrix}, base_ring(a).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  z.base_ring = a.base_ring
   return z
 end
 
@@ -797,8 +794,7 @@ function zero_matrix(R::ZZModRing, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = ZZModMatrix(r, c, R.ninv)
-  z.base_ring = R
+  z = ZZModMatrix(R, r, c)
   return z
 end
 

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -19,7 +19,7 @@ dense_matrix_type(::Type{ZZModRingElem}) = ZZModMatrix
 ###############################################################################
 
 function similar(::MatElem, R::ZZModRing, r::Int, c::Int)
-  z = ZZModMatrix(R, r, c)
+  z = ZZModMatrix(R, undef, r, c)
   return z
 end
 
@@ -696,7 +696,7 @@ promote_rule(::Type{ZZModMatrix}, ::Type{ZZRingElem}) = ZZModMatrix
 ################################################################################
 
 function (a::ZZModMatrixSpace)()
-  z = ZZModMatrix(base_ring(a), nrows(a), ncols(a))
+  z = ZZModMatrix(base_ring(a), undef, nrows(a), ncols(a))
   return z
 end
 
@@ -760,7 +760,7 @@ end
 
 function (a::ZZModMatrixSpace)(b::ZZMatrix)
   (ncols(a) != b.c || nrows(a) != b.r) && error("Dimensions do not fit")
-  z = ZZModMatrix(base_ring(a), b.r, b.c)
+  z = ZZModMatrix(base_ring(a), undef, b.r, b.c)
   @ccall libflint.fmpz_mod_mat_set_fmpz_mat(z::Ref{ZZModMatrix}, b::Ref{ZZMatrix}, base_ring(a).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
   return z
 end
@@ -794,7 +794,7 @@ function zero_matrix(R::ZZModRing, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = ZZModMatrix(R, r, c)
+  z = ZZModMatrix(R, undef, r, c)
   return z
 end
 

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -19,8 +19,7 @@ dense_matrix_type(::Type{FpFieldElem}) = FpMatrix
 ###############################################################################
 
 function similar(::MatElem, R::FpField, r::Int, c::Int)
-  z = FpMatrix(r, c, R.ninv)
-  z.base_ring = R
+  z = FpMatrix(R, r, c)
   return z
 end
 
@@ -210,8 +209,7 @@ end
 ################################################################################
 
 function (a::FpMatrixSpace)()
-  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv)
-  z.base_ring = a.base_ring
+  z = FpMatrix(base_ring(a), nrows(a), ncols(a))
   return z
 end
 
@@ -311,8 +309,7 @@ function zero_matrix(R::FpField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = FpMatrix(r, c, R.ninv)
-  z.base_ring = R
+  z = FpMatrix(R, r, c)
   return z
 end
 

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -19,7 +19,7 @@ dense_matrix_type(::Type{FpFieldElem}) = FpMatrix
 ###############################################################################
 
 function similar(::MatElem, R::FpField, r::Int, c::Int)
-  z = FpMatrix(R, r, c)
+  z = FpMatrix(R, undef, r, c)
   return z
 end
 
@@ -209,7 +209,7 @@ end
 ################################################################################
 
 function (a::FpMatrixSpace)()
-  z = FpMatrix(base_ring(a), nrows(a), ncols(a))
+  z = FpMatrix(base_ring(a), undef, nrows(a), ncols(a))
   return z
 end
 
@@ -309,7 +309,7 @@ function zero_matrix(R::FpField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = FpMatrix(R, r, c)
+  z = FpMatrix(R, undef, r, c)
   return z
 end
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -19,8 +19,7 @@ dense_matrix_type(::Type{fpFieldElem}) = fpMatrix
 ###############################################################################
 
 function similar(::fpMatrix, R::fpField, r::Int, c::Int)
-  z = fpMatrix(r, c, R.n)
-  z.base_ring = R
+  z = fpMatrix(R, r, c)
   return z
 end
 
@@ -282,8 +281,7 @@ end
 ################################################################################
 
 function (a::fpMatrixSpace)()
-  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
-  z.base_ring = a.base_ring
+  z = fpMatrix(base_ring(a), nrows(a), ncols(a))
   return z
 end
 
@@ -381,8 +379,7 @@ function zero_matrix(R::fpField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = fpMatrix(r, c, R.n)
-  z.base_ring = R
+  z = fpMatrix(R, r, c)
   return z
 end
 

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -19,7 +19,7 @@ dense_matrix_type(::Type{fpFieldElem}) = fpMatrix
 ###############################################################################
 
 function similar(::fpMatrix, R::fpField, r::Int, c::Int)
-  z = fpMatrix(R, r, c)
+  z = fpMatrix(R, undef, r, c)
   return z
 end
 
@@ -281,7 +281,7 @@ end
 ################################################################################
 
 function (a::fpMatrixSpace)()
-  z = fpMatrix(base_ring(a), nrows(a), ncols(a))
+  z = fpMatrix(base_ring(a), undef, nrows(a), ncols(a))
   return z
 end
 
@@ -379,7 +379,7 @@ function zero_matrix(R::fpField, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = fpMatrix(R, r, c)
+  z = fpMatrix(R, undef, r, c)
   return z
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -19,8 +19,7 @@ dense_matrix_type(::Type{zzModRingElem}) = zzModMatrix
 ###############################################################################
 
 function similar(::zzModMatrix, R::zzModRing, r::Int, c::Int)
-  z = zzModMatrix(r, c, R.n)
-  z.base_ring = R
+  z = zzModMatrix(R, r, c)
   return z
 end
 
@@ -720,8 +719,7 @@ promote_rule(::Type{zzModMatrix}, ::Type{ZZRingElem}) = zzModMatrix
 ################################################################################
 
 function (a::zzModMatrixSpace)()
-  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)))
-  z.base_ring = a.base_ring
+  z = zzModMatrix(base_ring(a), nrows(a), ncols(a))
   return z
 end
 
@@ -819,8 +817,7 @@ function zero_matrix(R::zzModRing, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = zzModMatrix(r, c, R.n)
-  z.base_ring = R
+  z = zzModMatrix(R, r, c)
   return z
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -18,10 +18,7 @@ dense_matrix_type(::Type{zzModRingElem}) = zzModMatrix
 #
 ###############################################################################
 
-function similar(::zzModMatrix, R::zzModRing, r::Int, c::Int)
-  z = zzModMatrix(R, r, c)
-  return z
-end
+similar(::zzModMatrix, R::zzModRing, r::Int, c::Int) = zzModMatrix(R, undef, r, c)
 
 zero(m::zzModMatrix, R::zzModRing, r::Int, c::Int) = similar(m, R, r, c)
 
@@ -719,7 +716,7 @@ promote_rule(::Type{zzModMatrix}, ::Type{ZZRingElem}) = zzModMatrix
 ################################################################################
 
 function (a::zzModMatrixSpace)()
-  z = zzModMatrix(base_ring(a), nrows(a), ncols(a))
+  z = zzModMatrix(base_ring(a), undef, nrows(a), ncols(a))
   return z
 end
 
@@ -817,8 +814,7 @@ function zero_matrix(R::zzModRing, r::Int, c::Int)
   if r < 0 || c < 0
     error("dimensions must not be negative")
   end
-  z = zzModMatrix(R, r, c)
-  return z
+  return zzModMatrix(R, undef, r, c)
 end
 
 ################################################################################


### PR DESCRIPTION
This would be a step towards resurrecting https://github.com/Nemocas/AbstractAlgebra.jl/pull/558 i.e. to reduce the code `MatElem` subtypes *must* implement.

In particular the new constructors would by default produce *uninitialized* matrices and then other constructors like `zero_matrix`, `identity_matrix` or [`ones_matrix`](https://github.com/Nemocas/AbstractAlgebra.jl/pull/1725) could be built atop. (In the first mentioned PR there is also a type trait `is_zero_initialized(T::Type{<:MatrixElem})` which can be used to "optimize" e.g. `zero_matrix` or `identity_matrix` for matrix types where the new matrices are zero matrices anyway).

I am marking this as a draft because there are some call sites that could be adjusted, but before putting into any more effort into this, I wanted to check if this is a direction we want to go into to begin with.