### PR TITLE
add `coeff` methods for `fpFieldElem` and `FpFieldElem`

### DIFF
--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -35,6 +35,13 @@ end
 
 data(a::fpFieldElem) = a.data
 
+function coeff(x::fpFieldElem, n::Int)
+  n < 0 && throw(DomainError(n, "Index must be non-negative"))
+  n == 0 && return data(a)
+  return UInt(0)
+end
+
+
 lift(a::fpFieldElem) = ZZRingElem(data(a))
 lift(::ZZRing, x::fpFieldElem) = lift(x)
 

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -37,7 +37,7 @@ data(a::fpFieldElem) = a.data
 
 function coeff(x::fpFieldElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
-  n == 0 && return data(a)
+  n == 0 && return data(x)
   return UInt(0)
 end
 

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -37,7 +37,7 @@ data(a::FpFieldElem) = a.data
 
 function coeff(x::FpFieldElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
-  n == 0 && return data(a)
+  n == 0 && return data(x)
   return UInt(0)
 end
 

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -38,7 +38,7 @@ data(a::FpFieldElem) = a.data
 function coeff(x::FpFieldElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   n == 0 && return data(x)
-  return UInt(0)
+  return zero(ZZ)
 end
 
 lift(a::FpFieldElem) = data(a)

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -35,6 +35,12 @@ end
 
 data(a::FpFieldElem) = a.data
 
+function coeff(x::FpFieldElem, n::Int)
+  n < 0 && throw(DomainError(n, "Index must be non-negative"))
+  n == 0 && return data(a)
+  return UInt(0)
+end
+
 lift(a::FpFieldElem) = data(a)
 lift(::ZZRing, x::FpFieldElem) = lift(x)
 

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -112,6 +112,8 @@ end
 
   @test deepcopy(R(3)) == R(3)
 
+  @test coeff(R(2), 0) == 2
+
   R1 = Native.GF(13)
 
   @test R === R1

--- a/test/flint/gfp-test.jl
+++ b/test/flint/gfp-test.jl
@@ -113,6 +113,7 @@ end
   @test deepcopy(R(3)) == R(3)
 
   @test coeff(R(2), 0) == 2
+  @test coeff(R(2), 1) == 0
 
   R1 = Native.GF(13)
 

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -95,6 +95,8 @@ end
 
   @test deepcopy(R(3)) == R(3)
 
+  @test coeff(R(2), 0) == 2
+
   R1 = Native.GF(ZZ(13))
 
   @test R === R1

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -96,6 +96,7 @@ end
   @test deepcopy(R(3)) == R(3)
 
   @test coeff(R(2), 0) == 2
+  @test coeff(R(2), 1) == 0
 
   R1 = Native.GF(ZZ(13))
 


### PR DESCRIPTION
This adds `coeff` methods for these finite field types to be consistent with the other finite field types.

Fixes thofma/Hecke.jl#1546