### PR TITLE
Add is_zero_entry method; remove is_zero_row methods

### DIFF
--- a/src/HeckeMiscMatrix.jl
+++ b/src/HeckeMiscMatrix.jl
@@ -29,31 +29,6 @@ function Array(a::ZZMatrix; S::Type{T}=ZZRingElem) where {T}
   return A
 end
 
-function is_zero_row(M::ZZMatrix, i::Int)
-  !(1 <= i <= nrows(M)) && error("Not a valid index")
-  GC.@preserve M begin
-    for j = 1:ncols(M)
-      m = ccall((:fmpz_mat_entry, libflint), Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), M, i - 1, j - 1)
-      fl = ccall((:fmpz_is_zero, libflint), Bool, (Ptr{ZZRingElem},), m)
-      if !fl
-        return false
-      end
-    end
-  end
-  return true
-end
-
-function is_zero_row(M::zzModMatrix, i::Int)
-  zero = UInt(0)
-  for j in 1:ncols(M)
-    t = ccall((:nmod_mat_get_entry, libflint), Base.GMP.Limb, (Ref{zzModMatrix}, Int, Int), M, i - 1, j - 1)
-    if t != zero
-      return false
-    end
-  end
-  return true
-end
-
 ################################################################################
 #
 ################################################################################

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -73,13 +73,6 @@ function one(a::fpMatrixSpace)
   return z
 end
 
-@inline function is_zero_entry(A::fpMatrix, i::Int, j::Int)
-  @boundscheck _checkbounds(A, i, j)
-  x = ccall((:nmod_mat_get_entry, libflint), UInt,
-            (Ref{fpMatrix}, Int, Int), A, i - 1, j - 1)
-  return x == 0
-end
-
 ################################################################################
 #
 #  Ad hoc binary operators

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -34,8 +34,7 @@ zero(m::zzModMatrix, R::zzModRing, r::Int, c::Int) = similar(m, R, r, c)
 
 @inline function getindex(a::zzModMatrix, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
-  u = ccall((:nmod_mat_get_entry, libflint), UInt,
-            (Ref{zzModMatrix}, Int, Int), a, i - 1 , j - 1)
+  u = getindex_raw(a, i, j)
   return zzModRingElem(u, base_ring(a)) # no reduction needed
 end
 
@@ -114,6 +113,11 @@ end
 function iszero(a::T) where T <: Zmodn_mat
   r = ccall((:nmod_mat_is_zero, libflint), Cint, (Ref{T}, ), a)
   return Bool(r)
+end
+
+@inline function is_zero_entry(A::T, i::Int, j::Int) where T <: Zmodn_mat
+  @boundscheck _checkbounds(A, i, j)
+  return is_zero(getindex_raw(A, i, j))
 end
 
 ################################################################################

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -156,7 +156,14 @@ end
 @testset "QQMatrix.is_zero_entry" begin
   M = matrix(QQ, [1 2 3;4 0 6;0 8 9])
   for i in 1:3, j in 1:3
-    @test is_zero_entry(M, i, j) == (M[i, j] == 0)
+    @test is_zero_entry(M, i, j) == is_zero(M[i, j])
+  end
+end
+
+@testset "QQMatrix.is_zero_row" begin
+  M = matrix(QQ, [1 2 3;4 0 6;0 8 9;0 0 0])
+  for i in 1:nrows(M)
+    @test is_zero_row(M, i) == all(j -> is_zero(M[i, j]), 1:ncols(M))
   end
 end
 

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -120,7 +120,14 @@ end
 @testset "ZZMatrix.is_zero_entry" begin
   M = matrix(ZZ, [1 2 3;4 0 6;0 8 9])
   for i in 1:3, j in 1:3
-    @test is_zero_entry(M, i, j) == (M[i, j] == 0)
+    @test is_zero_entry(M, i, j) == is_zero(M[i, j])
+  end
+end
+
+@testset "ZZMatrix.is_zero_row" begin
+  M = matrix(ZZ, [1 2 3;4 0 6;0 8 9;0 0 0])
+  for i in 1:nrows(M)
+    @test is_zero_row(M, i) == all(j -> is_zero(M[i, j]), 1:ncols(M))
   end
 end
 

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -201,6 +201,22 @@ end
   end
 end
 
+@testset "fpMatrix.is_zero_entry" begin
+  R = Native.GF(13)
+  M = matrix(R, [1 2 3;4 0 6;0 8 9])
+  for i in 1:3, j in 1:3
+    @test is_zero_entry(M, i, j) == is_zero(M[i, j])
+  end
+end
+
+@testset "fpMatrix.is_zero_row" begin
+  R = Native.GF(13)
+  M = matrix(R, [1 2 3;4 0 6;0 8 9;0 0 0])
+  for i in 1:nrows(M)
+    @test is_zero_row(M, i) == all(j -> is_zero(M[i, j]), 1:ncols(M))
+  end
+end
+
 @testset "fpMatrix.printing" begin
   Z2 = Native.GF(2)
   R = fpMatrixSpace(Z2, 2, 2)

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -197,6 +197,22 @@ end
   end
 end
 
+@testset "zzModMatrix.is_zero_entry" begin
+  R, = residue_ring(ZZ, 13)
+  M = matrix(R, [1 2 3;4 0 6;0 8 9])
+  for i in 1:3, j in 1:3
+    @test is_zero_entry(M, i, j) == is_zero(M[i, j])
+  end
+end
+
+@testset "zzModMatrix.is_zero_row" begin
+  R, = residue_ring(ZZ, 13)
+  M = matrix(R, [1 2 3;4 0 6;0 8 9;0 0 0])
+  for i in 1:nrows(M)
+    @test is_zero_row(M, i) == all(j -> is_zero(M[i, j]), 1:ncols(M))
+  end
+end
+
 @testset "zzModMatrix.printing" begin
   Z2, = residue_ring(ZZ, 2)
   R = zzModMatrixSpace(Z2, 2, 2)


### PR DESCRIPTION
With the addition of the new is_zero_entry method, the removed
is_zero_row methods are not faster than the generic one. Also add some
tests, which were also used for benchmarking, together with

    @benchmark Nemo.is_zero_row($M,4)
