### PR TITLE
Unify and crossref docstrings for `GF` and `finite_field`

### DIFF
--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -847,7 +847,7 @@ end
     finite_field(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, check::Bool = true)
 
 Return a tuple $(K, x)$ of a finite field $K$ of order $q = p^d$, where $p$ is a prime,
-and a finite field generator $x$ of $K$.
+and a generator $x$ of $K$ (see [`gen`](@ref) for a definition).
 The identifier $s$ is used to designate how the finite field generator will be printed.
 
 If a polynomial $f \in k[X]$ over a finite field $k$ is specified,

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -848,7 +848,7 @@ end
 
 Return a tuple $(K, x)$ of a finite field $K$ of order $q = p^d$, where $p$ is a prime,
 and an algebra generator $x$ of $K$.
-The string $s$ is used to designate how the finite field generator will be printed.
+The identifier $s$ is used to designate how the finite field generator will be printed.
 
 If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
@@ -901,7 +901,7 @@ end
     GF(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, check::Bool = true)
 
 Return a finite field $K$ of order $q = p^d$, where $p$ is a prime.
-The string $s$ is used to designate how the finite field generator will be printed.
+The identifier $s$ is used to designate how the finite field generator will be printed.
 
 If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -854,7 +854,7 @@ If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
 field with base field $k$.
 
-See also [`GF`](@ref), that only returns $K$.
+See also [`GF`](@ref) which only returns $K$.
 
 # Examples
 
@@ -907,7 +907,7 @@ If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
 field with base field $k$.
 
-See also [`finite_field`](@ref), that additionally returns an algebra generator of $K$.
+See also [`finite_field`](@ref) which additionally returns an algebra generator of $K$.
 
 # Examples
 

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -842,16 +842,19 @@ end
 ###############################################################################
 
 @doc raw"""
-    finite_field(p::IntegerUnion, d::Int, s::VarName; cached = true, check = true)
-    finite_field(q::IntegerUnion, s::VarName; cached = true, check = true)
-    finite_field(f::FqPolyElem, s::VarName; cached = true, check = true)
+    finite_field(p::IntegerUnion, d::Int, s::VarName = :o; cached::Bool = true, check::Bool = true)
+    finite_field(q::IntegerUnion, s::VarName = :o; cached::Bool = true, check::Bool = true)
+    finite_field(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, check::Bool = true)
 
-Return a tuple $K, a$ consisting of a finite field $K$ of order $q = p^d$ and
-algebra generator $x$. The string $s$ is used to designate how the finite field
-generator will be printed.
+Return a tuple $(K, x)$ of a finite field $K$ of order $q = p^d$, where $p$ is a prime,
+and an algebra generator $x$ of $K$.
+The string $s$ is used to designate how the finite field generator will be printed.
 
-If a polynomial $f \in k[X]$ over a finite field $k$ is specified, the relative finite field
-$K = k[X]/(f)$ will be constructed as a finite field with base field $k$.
+If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
+the finite field $K = k[X]/(f)$ will be constructed as a finite
+field with base field $k$.
+
+See also [`GF`](@ref), that only returns $K$.
 
 # Examples
 
@@ -893,16 +896,18 @@ function finite_field(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, c
 end
 
 @doc raw"""
-    GF(p::IntegerUnion, d::Int, s::String; cached::Bool, check::Bool)
-    GF(q::IntegerUnion, s::String; cached::Bool, check::Bool)
-    GF(f::FqPolyRingElem; s::String; cached::Bool, check::Bool)
+    GF(p::IntegerUnion, d::Int, s::VarName = :o; cached::Bool = true, check::Bool = true)
+    GF(q::IntegerUnion, s::VarName = :o; cached::Bool = true, check::Bool = true)
+    GF(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, check::Bool = true)
 
-Return a finite field $K$ of order $q = p^d$. The string $s$ is
-used to designate how the finite field generator will be printed.
+Return a finite field $K$ of order $q = p^d$, where $p$ is a prime.
+The string $s$ is used to designate how the finite field generator will be printed.
 
 If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
 field with base field $k$.
+
+See also [`finite_field`](@ref), that additionally returns an algebra generator of $K$.
 
 # Examples
 
@@ -921,8 +926,8 @@ Finite field of degree 3 over GF(3, 2)
 """
 GF
 
-function GF(a::IntegerUnion, s::VarName = :o; cached::Bool = true, check::Bool = true)
-  return finite_field(a, s; cached = cached, check = check)[1]
+function GF(q::IntegerUnion, s::VarName = :o; cached::Bool = true, check::Bool = true)
+  return finite_field(q, s; cached = cached, check = check)[1]
 end
 
 function GF(p::IntegerUnion, d::Int, s::VarName = :o; cached::Bool = true, check::Bool = true)

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -907,7 +907,7 @@ If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
 field with base field $k$.
 
-See also [`finite_field`](@ref) which additionally returns a finite field generator generator of $K$.
+See also [`finite_field`](@ref) which additionally returns a finite field generator of $K$.
 
 # Examples
 

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -847,7 +847,7 @@ end
     finite_field(f::FqPolyRingElem, s::VarName = :o; cached::Bool = true, check::Bool = true)
 
 Return a tuple $(K, x)$ of a finite field $K$ of order $q = p^d$, where $p$ is a prime,
-and an algebra generator $x$ of $K$.
+and a finite field generator $x$ of $K$.
 The identifier $s$ is used to designate how the finite field generator will be printed.
 
 If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
@@ -907,7 +907,7 @@ If a polynomial $f \in k[X]$ over a finite field $k$ is specified,
 the finite field $K = k[X]/(f)$ will be constructed as a finite
 field with base field $k$.
 
-See also [`finite_field`](@ref) which additionally returns an algebra generator of $K$.
+See also [`finite_field`](@ref) which additionally returns a finite field generator generator of $K$.
 
 # Examples
 


### PR DESCRIPTION
Resolves https://github.com/oscar-system/Oscar.jl/issues/3669.