### PR TITLE
Optimize mat_entry_ptr for ZZMatrix

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4854,10 +4854,10 @@ const ZZMatrixSpace = AbstractAlgebra.Generic.MatSpace{ZZRingElem}
 ZZMatrixSpace(r::Int, c::Int) = ZZMatrixSpace(ZZ, r, c)
 
 mutable struct ZZMatrix <: MatElem{ZZRingElem}
-  entries::Ptr{Nothing}
+  entries::Ptr{ZZRingElem}
   r::Int
   c::Int
-  rows::Ptr{Nothing}
+  rows::Ptr{Ptr{ZZRingElem}}
   view_parent
 
   # Used by view, not finalised!!

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -2102,6 +2102,4 @@ end
 #
 ################################################################################
 
-@inline mat_entry_ptr(A::ZZMatrix, i::Int, j::Int) = 
-ccall((:fmpz_mat_entry, libflint), 
-      Ptr{ZZRingElem}, (Ref{ZZMatrix}, Int, Int), A, i-1, j-1)
+@inline mat_entry_ptr(A::ZZMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(UInt)


### PR DESCRIPTION
... by replacing a ccall with a direct address computation. This allows the Julia compiler to understand what's going on and thus enables further optimizations.