### PR TITLE
Optimize is_unit/is_zero/is_one for ZZRingElem

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -57,6 +57,16 @@ is_domain_type(::Type{ZZRingElem}) = true
 
 ###############################################################################
 #
+#   Internal data
+#
+###############################################################################
+
+data(a::ZZRingElem) = a.d
+data(a::Ref{ZZRingElem}) = a[].d
+data(a::Ptr{ZZRingElem}) = unsafe_load(reinterpret(Ptr{Int}, a))
+
+###############################################################################
+#
 #   Ranges
 #
 ###############################################################################
@@ -249,15 +259,11 @@ Return the number of limbs required to store the absolute value of $a$.
 """
 size(a::ZZRingElem) = Int(ccall((:fmpz_size, libflint), Cint, (Ref{ZZRingElem},), a))
 
-is_unit(a::ZZRingElem) = ccall((:fmpz_is_pm1, libflint), Bool, (Ref{ZZRingElem},), a)
+is_unit(a::ZZRingElemOrPtr) = data(a) == 1 || data(a) == -1
 
-iszero(a::ZZRingElem) = ccall((:fmpz_is_zero, libflint), Bool, (Ref{ZZRingElem},), a)
+is_zero(a::ZZRingElemOrPtr) = data(a) == 0
 
-function iszero(a::Ref{ZZRingElem})
-  return unsafe_load(reinterpret(Ptr{Int}, a)) == 0
-end
-
-isone(a::ZZRingElem) = ccall((:fmpz_is_one, libflint), Bool, (Ref{ZZRingElem},), a)
+is_one(a::ZZRingElemOrPtr) = data(a) == 1
 
 isinteger(::ZZRingElem) = true
 

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -160,7 +160,7 @@ isone(a::ZZMatrix) = ccall((:fmpz_mat_is_one, libflint), Bool,
   @boundscheck _checkbounds(A, i, j)
   GC.@preserve A begin
     x = mat_entry_ptr(A, i, j)
-    return ccall((:fmpz_is_zero, libflint), Bool, (Ptr{ZZRingElem},), x)
+    return is_zero(x)
   end
 end
 

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -120,7 +120,7 @@ end
   @boundscheck _checkbounds(A, i, j)
   GC.@preserve A begin
     x = mat_entry_ptr(A, i, j)
-    return ccall((:fmpz_is_zero, libflint), Bool, (Ptr{ZZRingElem},), x)
+    return is_zero(x)
   end
 end
 


### PR DESCRIPTION
... and also is_zero_entry for ZZMatrix and FpMatrix.

Moreover, low-level accessors for ZZRingElem now also work for Ref{ZZRingElem} in addition to Ptr{ZZRingElem} and ZZRingElem.