### PR TITLE
More set! methods for fqPolyRepFieldElem

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -695,12 +695,6 @@ function ^(a::ResElem, f::ZZRingElem)
   return b
 end
 
-function set!(z::fqPolyRepFieldElem, x::fqPolyRepFieldElem)
-  ccall((:fq_nmod_set, libflint), Nothing,
-        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-        z, x, parent(z))
-end
-
 characteristic(F::EuclideanRingResidueField{ZZRingElem}) = abs(F.modulus)
 
 function mul!(res::QQMPolyRingElem, a::QQMPolyRingElem, c::ZZRingElem)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2273,6 +2273,7 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     d = new()
     ccall((:fq_nmod_init2, libflint), Nothing,
           (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, ctx)
+    d.parent = ctx
     finalizer(_fq_nmod_clear_fn, d)
     return d
   end
@@ -2281,9 +2282,9 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     d = new()
     ccall((:fq_nmod_init2, libflint), Nothing,
           (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, ctx)
+    d.parent = ctx
     finalizer(_fq_nmod_clear_fn, d)
-    ccall((:fq_nmod_set_si, libflint), Nothing,
-          (Ref{fqPolyRepFieldElem}, Int, Ref{fqPolyRepField}), d, x, ctx)
+    set!(d, x)
     return d
   end
 
@@ -2291,9 +2292,9 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     d = new()
     ccall((:fq_nmod_init2, libflint), Nothing,
           (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, ctx)
+    d.parent = ctx
     finalizer(_fq_nmod_clear_fn, d)
-    ccall((:fq_nmod_set_fmpz, libflint), Nothing,
-          (Ref{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}), d, x, ctx)
+    set!(d, x)
     return d
   end
 
@@ -2301,9 +2302,9 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     d = new()
     ccall((:fq_nmod_init2, libflint), Nothing,
           (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, ctx)
+    d.parent = ctx
     finalizer(_fq_nmod_clear_fn, d)
-    ccall((:fq_nmod_set, libflint), Nothing,
-          (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, x, ctx)
+    set!(d, x)
     return d
   end
 
@@ -2311,10 +2312,9 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     d = new()
     ccall((:fq_nmod_init2, libflint), Nothing,
           (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, ctx)
+    d.parent = ctx
     finalizer(_fq_nmod_clear_fn, d)
-    ccall((:fq_nmod_set_nmod_poly, libflint), Nothing,
-          (Ref{fqPolyRepFieldElem}, Ref{fpPolyRingElem}, Ref{fqPolyRepField}),
-          d, x, ctx)
+    set!(d, x)
     return d
   end
 end

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -116,7 +116,6 @@ end
 
 function deepcopy_internal(d::fqPolyRepFieldElem, dict::IdDict)
   z = fqPolyRepFieldElem(parent(d), d)
-  z.parent = parent(d)
   return z
 end
 
@@ -460,6 +459,36 @@ end
 #
 ###############################################################################
 
+function set!(z::fqPolyRepFieldElem, x::fqPolyRepFieldElem)
+  ccall((:fq_nmod_set, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, x, parent(z))
+end
+
+function set!(z::fqPolyRepFieldElem, x::ZZRingElem)
+  ccall((:fq_nmod_set_fmpz, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}),
+        z, x, parent(z))
+end
+
+function set!(z::fqPolyRepFieldElem, x::Int)
+  ccall((:fq_nmod_set_si, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Int, Ref{fqPolyRepField}),
+        z, x, parent(z))
+end
+
+function set!(z::fqPolyRepFieldElem, x::UInt)
+  ccall((:fq_nmod_set_ui, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, UInt, Ref{fqPolyRepField}),
+        z, x, parent(z))
+end
+
+function set!(z::fqPolyRepFieldElem, x::fpPolyRingElem)
+  ccall((:fq_nmod_set_nmod_poly, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fpPolyRingElem}, Ref{fqPolyRepField}),
+        z, x, parent(z))
+end
+
 function zero!(z::fqPolyRepFieldElem)
   ccall((:fq_nmod_zero, libflint), Nothing,
         (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, z.parent)
@@ -633,7 +662,6 @@ promote_rule(::Type{fqPolyRepFieldElem}, ::Type{fpFieldElem}) = fqPolyRepFieldEl
 
 function (a::fqPolyRepField)()
   z = fqPolyRepFieldElem(a)
-  z.parent = a
   return z
 end
 
@@ -641,13 +669,11 @@ end
 
 function (a::fqPolyRepField)(b::Int)
   z = fqPolyRepFieldElem(a, b)
-  z.parent = a
   return z
 end
 
 function (a::fqPolyRepField)(b::ZZRingElem)
   z = fqPolyRepFieldElem(a, b)
-  z.parent = a
   return z
 end
 
@@ -674,7 +700,6 @@ function (a::fqPolyRepField)(b::Vector{<:IntegerUnion})
   da == db || error("Coercion impossible")
   F = Native.GF(Int(characteristic(a)), cached = false)
   z = fqPolyRepFieldElem(a, polynomial(F, b))
-  z.parent = a
   return z
 end
 


### PR DESCRIPTION
Also set parent already in the constructors.

Note how all those constructors using set! now have identical implementation besides the differing argument types.