### PR TITLE
Add `*OrPtr` unions for all flint types

### DIFF
--- a/src/antic/AnticTypes.jl
+++ b/src/antic/AnticTypes.jl
@@ -104,3 +104,12 @@ function _nf_elem_clear_fn(a::AbsSimpleNumFieldElem)
   ccall((:nf_elem_clear, libflint), Nothing, 
         (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), a, a.parent)
 end
+
+
+################################################################################
+#
+#   Type unions
+#
+################################################################################
+
+const AbsSimpleNumFieldElemOrPtr = Union{AbsSimpleNumFieldElem, Ref{AbsSimpleNumFieldElem}, Ptr{AbsSimpleNumFieldElem}}

--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -1377,3 +1377,24 @@ function _acb_mat_clear_fn(x::AcbMatrix)
   ccall((:acb_mat_clear, libflint), Nothing, (Ref{AcbMatrix}, ), x)
 end
 
+
+################################################################################
+#
+#   Type unions
+#
+################################################################################
+
+const RealFieldElemOrPtr = Union{RealFieldElem, Ref{RealFieldElem}, Ptr{RealFieldElem}}
+const ArbFieldElemOrPtr = Union{ArbFieldElem, Ref{ArbFieldElem}, Ptr{ArbFieldElem}}
+const ComplexFieldElemOrPtr = Union{ComplexFieldElem, Ref{ComplexFieldElem}, Ptr{ComplexFieldElem}}
+const AcbFieldElemOrPtr = Union{AcbFieldElem, Ref{AcbFieldElem}, Ptr{AcbFieldElem}}
+
+const RealPolyOrPtr = Union{RealPoly, Ref{RealPoly}, Ptr{RealPoly}}
+const ArbPolyRingElemOrPtr = Union{ArbPolyRingElem, Ref{ArbPolyRingElem}, Ptr{ArbPolyRingElem}}
+const ComplexPolyOrPtr = Union{ComplexPoly, Ref{ComplexPoly}, Ptr{ComplexPoly}}
+const AcbPolyRingElemOrPtr = Union{AcbPolyRingElem, Ref{AcbPolyRingElem}, Ptr{AcbPolyRingElem}}
+
+const RealMatOrPtr = Union{RealMat, Ref{RealMat}, Ptr{RealMat}}
+const ArbMatrixOrPtr = Union{ArbMatrix, Ref{ArbMatrix}, Ptr{ArbMatrix}}
+const ComplexMatOrPtr = Union{ComplexMat, Ref{ComplexMat}, Ptr{ComplexMat}}
+const AcbMatrixOrPtr = Union{AcbMatrix, Ref{AcbMatrix}, Ptr{AcbMatrix}}

--- a/src/calcium/CalciumTypes.jl
+++ b/src/calcium/CalciumTypes.jl
@@ -226,3 +226,12 @@ function _ca_clear_fn(a::CalciumFieldElem)
   decrement_refcount(a.parent)
 end
 
+
+################################################################################
+#
+#   Type unions
+#
+################################################################################
+
+const QQBarFieldElemOrPtr = Union{QQBarFieldElem, Ref{QQBarFieldElem}, Ptr{QQBarFieldElem}}
+const CalciumFieldElemOrPtr = Union{CalciumFieldElem, Ref{CalciumFieldElem}, Ptr{CalciumFieldElem}}

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -6513,6 +6513,73 @@ const _fq_default_mpoly_union = Union{AbstractAlgebra.Generic.MPoly{FqPolyRepFie
                                      }
 
 
+const ZZRingElemOrPtr = Union{ZZRingElem, Ref{ZZRingElem}, Ptr{ZZRingElem}}
+const QQFieldElemOrPtr = Union{QQFieldElem, Ref{QQFieldElem}, Ptr{QQFieldElem}}
+const zzModRingElemOrPtr = Union{zzModRingElem, Ref{zzModRingElem}, Ptr{zzModRingElem}}
+const ZZModRingElemOrPtr = Union{ZZModRingElem, Ref{ZZModRingElem}, Ptr{ZZModRingElem}}
+const fpFieldElemOrPtr = Union{fpFieldElem, Ref{fpFieldElem}, Ptr{fpFieldElem}}
+const FpFieldElemOrPtr = Union{FpFieldElem, Ref{FpFieldElem}, Ptr{FpFieldElem}}
+const fqPolyRepFieldElemOrPtr = Union{fqPolyRepFieldElem, Ref{fqPolyRepFieldElem}, Ptr{fqPolyRepFieldElem}}
+const FqPolyRepFieldElemOrPtr = Union{FqPolyRepFieldElem, Ref{FqPolyRepFieldElem}, Ptr{FqPolyRepFieldElem}}
+const FqFieldElemOrPtr = Union{FqFieldElem, Ref{FqFieldElem}, Ptr{FqFieldElem}}
+
+const ZZPolyRingElemOrPtr = Union{ZZPolyRingElem, Ref{ZZPolyRingElem}, Ptr{ZZPolyRingElem}}
+const QQPolyRingElemOrPtr = Union{QQPolyRingElem, Ref{QQPolyRingElem}, Ptr{QQPolyRingElem}}
+const zzModPolyRingElemOrPtr = Union{zzModPolyRingElem, Ref{zzModPolyRingElem}, Ptr{zzModPolyRingElem}}
+const ZZModPolyRingElemOrPtr = Union{ZZModPolyRingElem, Ref{ZZModPolyRingElem}, Ptr{ZZModPolyRingElem}}
+const fpPolyRingElemOrPtr = Union{fpPolyRingElem, Ref{fpPolyRingElem}, Ptr{fpPolyRingElem}}
+const FpPolyRingElemOrPtr = Union{FpPolyRingElem, Ref{FpPolyRingElem}, Ptr{FpPolyRingElem}}
+const fqPolyRepPolyRingElemOrPtr = Union{fqPolyRepPolyRingElem, Ref{fqPolyRepPolyRingElem}, Ptr{fqPolyRepPolyRingElem}}
+const FqPolyRepPolyRingElemOrPtr = Union{FqPolyRepPolyRingElem, Ref{FqPolyRepPolyRingElem}, Ptr{FqPolyRepPolyRingElem}}
+const FqPolyRingElemOrPtr = Union{FqPolyRingElem, Ref{FqPolyRingElem}, Ptr{FqPolyRingElem}}
+
+const ZZMPolyRingElemOrPtr = Union{ZZMPolyRingElem, Ref{ZZMPolyRingElem}, Ptr{ZZMPolyRingElem}}
+const QQMPolyRingElemOrPtr = Union{QQMPolyRingElem, Ref{QQMPolyRingElem}, Ptr{QQMPolyRingElem}}
+const zzModMPolyRingElemOrPtr = Union{zzModMPolyRingElem, Ref{zzModMPolyRingElem}, Ptr{zzModMPolyRingElem}}
+# ZZModMPolyRingElem does not exits
+const fpMPolyRingElemOrPtr = Union{fpMPolyRingElem, Ref{fpMPolyRingElem}, Ptr{fpMPolyRingElem}}
+const FpMPolyRingElemOrPtr = Union{FpMPolyRingElem, Ref{FpMPolyRingElem}, Ptr{FpMPolyRingElem}}
+const fqPolyRepMPolyRingElemOrPtr = Union{fqPolyRepMPolyRingElem, Ref{fqPolyRepMPolyRingElem}, Ptr{fqPolyRepMPolyRingElem}}
+# FqPolyRepMPolyRingElem does not exits
+const FqMPolyRingElemOrPtr = Union{FqMPolyRingElem, Ref{FqMPolyRingElem}, Ptr{FqMPolyRingElem}}
+
+const ZZRelPowerSeriesRingElemOrPtr = Union{ZZRelPowerSeriesRingElem, Ref{ZZRelPowerSeriesRingElem}, Ptr{ZZRelPowerSeriesRingElem}}
+const ZZAbsPowerSeriesRingElemOrPtr = Union{ZZAbsPowerSeriesRingElem, Ref{ZZAbsPowerSeriesRingElem}, Ptr{ZZAbsPowerSeriesRingElem}}
+const QQRelPowerSeriesRingElemOrPtr = Union{QQRelPowerSeriesRingElem, Ref{QQRelPowerSeriesRingElem}, Ptr{QQRelPowerSeriesRingElem}}
+const QQAbsPowerSeriesRingElemOrPtr = Union{QQAbsPowerSeriesRingElem, Ref{QQAbsPowerSeriesRingElem}, Ptr{QQAbsPowerSeriesRingElem}}
+const zzModRelPowerSeriesRingElemOrPtr = Union{zzModRelPowerSeriesRingElem, Ref{zzModRelPowerSeriesRingElem}, Ptr{zzModRelPowerSeriesRingElem}}
+const zzModAbsPowerSeriesRingElemOrPtr = Union{zzModAbsPowerSeriesRingElem, Ref{zzModAbsPowerSeriesRingElem}, Ptr{zzModAbsPowerSeriesRingElem}}
+const ZZModRelPowerSeriesRingElemOrPtr = Union{ZZModRelPowerSeriesRingElem, Ref{ZZModRelPowerSeriesRingElem}, Ptr{ZZModRelPowerSeriesRingElem}}
+const ZZModAbsPowerSeriesRingElemOrPtr = Union{ZZModAbsPowerSeriesRingElem, Ref{ZZModAbsPowerSeriesRingElem}, Ptr{ZZModAbsPowerSeriesRingElem}}
+const fpRelPowerSeriesRingElemOrPtr = Union{fpRelPowerSeriesRingElem, Ref{fpRelPowerSeriesRingElem}, Ptr{fpRelPowerSeriesRingElem}}
+const fpAbsPowerSeriesRingElemOrPtr = Union{fpAbsPowerSeriesRingElem, Ref{fpAbsPowerSeriesRingElem}, Ptr{fpAbsPowerSeriesRingElem}}
+const FpRelPowerSeriesRingElemOrPtr = Union{FpRelPowerSeriesRingElem, Ref{FpRelPowerSeriesRingElem}, Ptr{FpRelPowerSeriesRingElem}}
+const FpAbsPowerSeriesRingElemOrPtr = Union{FpAbsPowerSeriesRingElem, Ref{FpAbsPowerSeriesRingElem}, Ptr{FpAbsPowerSeriesRingElem}}
+const fqPolyRepRelPowerSeriesRingElemOrPtr = Union{fqPolyRepRelPowerSeriesRingElem, Ref{fqPolyRepRelPowerSeriesRingElem}, Ptr{fqPolyRepRelPowerSeriesRingElem}}
+const fqPolyRepAbsPowerSeriesRingElemOrPtr = Union{fqPolyRepAbsPowerSeriesRingElem, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ptr{fqPolyRepAbsPowerSeriesRingElem}}
+const FqPolyRepRelPowerSeriesRingElemOrPtr = Union{FqPolyRepRelPowerSeriesRingElem, Ref{FqPolyRepRelPowerSeriesRingElem}, Ptr{FqPolyRepRelPowerSeriesRingElem}}
+const FqPolyRepAbsPowerSeriesRingElemOrPtr = Union{FqPolyRepAbsPowerSeriesRingElem, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ptr{FqPolyRepAbsPowerSeriesRingElem}}
+const FqRelPowerSeriesRingElemOrPtr = Union{FqRelPowerSeriesRingElem, Ref{FqRelPowerSeriesRingElem}, Ptr{FqRelPowerSeriesRingElem}}
+const FqAbsPowerSeriesRingElemOrPtr = Union{FqAbsPowerSeriesRingElem, Ref{FqAbsPowerSeriesRingElem}, Ptr{FqAbsPowerSeriesRingElem}}
+
+const ZZMatrixOrPtr = Union{ZZMatrix, Ref{ZZMatrix}, Ptr{ZZMatrix}}
+const QQMatrixOrPtr = Union{QQMatrix, Ref{QQMatrix}, Ptr{QQMatrix}}
+const zzModMatrixOrPtr = Union{zzModMatrix, Ref{zzModMatrix}, Ptr{zzModMatrix}}
+const ZZModMatrixOrPtr = Union{ZZModMatrix, Ref{ZZModMatrix}, Ptr{ZZModMatrix}}
+const fpMatrixOrPtr = Union{fpMatrix, Ref{fpMatrix}, Ptr{fpMatrix}}
+const FpMatrixOrPtr = Union{FpMatrix, Ref{FpMatrix}, Ptr{FpMatrix}}
+const fqPolyRepMatrixOrPtr = Union{fqPolyRepMatrix, Ref{fqPolyRepMatrix}, Ptr{fqPolyRepMatrix}}
+const FqPolyRepMatrixOrPtr = Union{FqPolyRepMatrix, Ref{FqPolyRepMatrix}, Ptr{FqPolyRepMatrix}}
+const FqMatrixOrPtr = Union{FqMatrix, Ref{FqMatrix}, Ptr{FqMatrix}}
+
+const ZZLaurentSeriesRingElemOrPtr = Union{ZZLaurentSeriesRingElem, Ref{ZZLaurentSeriesRingElem}, Ptr{ZZLaurentSeriesRingElem}}
+
+const FlintPuiseuxSeriesRingElemOrPtr{T <: RingElem} = Union{FlintPuiseuxSeriesRingElem{T}, Ref{FlintPuiseuxSeriesRingElem{T}}, Ptr{FlintPuiseuxSeriesRingElem{T}}}
+const FlintPuiseuxSeriesFieldElemOrPtr{T <: RingElem} = Union{FlintPuiseuxSeriesFieldElem{T}, Ref{FlintPuiseuxSeriesFieldElem{T}}, Ptr{FlintPuiseuxSeriesFieldElem{T}}}
+
+const PadicFieldElemOrPtr = Union{PadicFieldElem, Ref{PadicFieldElem}, Ptr{PadicFieldElem}}
+const QadicFieldElemOrPtr = Union{QadicFieldElem, Ref{QadicFieldElem}, Ptr{QadicFieldElem}}
+
 ###############################################################################
 #
 #   Docstrings for the systematically added types in this file

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -6412,6 +6412,12 @@ end
 #
 ###############################################################################
 
+const _fq_default_mpoly_union = Union{AbstractAlgebra.Generic.MPoly{FqPolyRepFieldElem},
+                                      fqPolyRepMPolyRingElem,
+                                      fpMPolyRingElem,
+                                      #FpMPolyRingElem
+                                     }
+
 @attributes mutable struct FqMPolyRing <: MPolyRing{FqFieldElem}
   data::Union{fpMPolyRing,
               #FpMPolyRing,
@@ -6504,13 +6510,6 @@ const Zmod_fmpz_mat = Union{ZZModMatrix, FpMatrix}
 
 const FlintMPolyUnion = Union{ZZMPolyRingElem, QQMPolyRingElem, zzModMPolyRingElem, fpMPolyRingElem,
                               fqPolyRepMPolyRingElem, FpMPolyRingElem}
-
-
-const _fq_default_mpoly_union = Union{AbstractAlgebra.Generic.MPoly{FqPolyRepFieldElem},
-                                      fqPolyRepMPolyRingElem,
-                                      fpMPolyRingElem,
-                                      #FpMPolyRingElem
-                                     }
 
 
 const ZZRingElemOrPtr = Union{ZZRingElem, Ref{ZZRingElem}, Ptr{ZZRingElem}}

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -6406,39 +6406,6 @@ else
   end
 end
 
-################################################################################
-#
-#   Type unions
-#
-################################################################################
-
-const IntegerUnion = Union{Integer, ZZRingElem}
-
-const ZmodNFmpzPolyRing = Union{ZZModPolyRing, FpPolyRing}
-
-const Zmodn_poly = Union{zzModPolyRingElem, fpPolyRingElem}
-
-const Zmodn_fmpz_poly = Union{ZZModPolyRingElem, FpPolyRingElem}
-
-const Zmodn_mpoly = Union{zzModMPolyRingElem, fpMPolyRingElem}
-
-const FlintPuiseuxSeriesElem{T} = Union{FlintPuiseuxSeriesRingElem{T},
-                                        FlintPuiseuxSeriesFieldElem{T}} where T <: RingElem
-
-const Zmodn_mat = Union{zzModMatrix, fpMatrix}
-
-const Zmod_fmpz_mat = Union{ZZModMatrix, FpMatrix}
-
-const FlintMPolyUnion = Union{ZZMPolyRingElem, QQMPolyRingElem, zzModMPolyRingElem, fpMPolyRingElem,
-                              fqPolyRepMPolyRingElem, FpMPolyRingElem}
-
-
-const _fq_default_mpoly_union = Union{AbstractAlgebra.Generic.MPoly{FqPolyRepFieldElem},
-                                      fqPolyRepMPolyRingElem,
-                                      fpMPolyRingElem,
-                                      #FpMPolyRingElem
-                                     }
-
 ###############################################################################
 #
 #   FqMPolyRing / FqMPolyRingElem
@@ -6511,6 +6478,40 @@ macro fq_default_mpoly_do_op(f, R, a...)
   end
   return res
 end
+
+################################################################################
+#
+#   Type unions
+#
+################################################################################
+
+const IntegerUnion = Union{Integer, ZZRingElem}
+
+const ZmodNFmpzPolyRing = Union{ZZModPolyRing, FpPolyRing}
+
+const Zmodn_poly = Union{zzModPolyRingElem, fpPolyRingElem}
+
+const Zmodn_fmpz_poly = Union{ZZModPolyRingElem, FpPolyRingElem}
+
+const Zmodn_mpoly = Union{zzModMPolyRingElem, fpMPolyRingElem}
+
+const FlintPuiseuxSeriesElem{T} = Union{FlintPuiseuxSeriesRingElem{T},
+                                        FlintPuiseuxSeriesFieldElem{T}} where T <: RingElem
+
+const Zmodn_mat = Union{zzModMatrix, fpMatrix}
+
+const Zmod_fmpz_mat = Union{ZZModMatrix, FpMatrix}
+
+const FlintMPolyUnion = Union{ZZMPolyRingElem, QQMPolyRingElem, zzModMPolyRingElem, fpMPolyRingElem,
+                              fqPolyRepMPolyRingElem, FpMPolyRingElem}
+
+
+const _fq_default_mpoly_union = Union{AbstractAlgebra.Generic.MPoly{FqPolyRepFieldElem},
+                                      fqPolyRepMPolyRingElem,
+                                      fpMPolyRingElem,
+                                      #FpMPolyRingElem
+                                     }
+
 
 ###############################################################################
 #

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1093,10 +1093,9 @@ end
 #
 ###############################################################################
 
-const QQFieldElemOrPtr = Union{QQFieldElem, Ptr{QQFieldElem}}
-
 _num_ptr(c::QQFieldElem) = Ptr{ZZRingElem}(pointer_from_objref(c))
 _num_ptr(c::Ptr{QQFieldElem}) = Ptr{ZZRingElem}(c)
+_num_ptr(c::Ref{QQFieldElem}) = _num_ptr(c[])
 _den_ptr(c::QQFieldElemOrPtr) = _num_ptr(c) + sizeof(ZZRingElem)
 
 function zero!(c::QQFieldElemOrPtr)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2605,8 +2605,6 @@ end
 #
 ###############################################################################
 
-const ZZRingElemOrPtr = Union{ZZRingElem, Ptr{ZZRingElem}}
-
 function zero!(z::ZZRingElemOrPtr)
   @ccall libflint.fmpz_zero(z::Ref{ZZRingElem})::Nothing
   return z


### PR DESCRIPTION
As suggested in https://github.com/Nemocas/Nemo.jl/pull/1808#discussion_r1658430937

Progress:

- [x] AnticTypes.jl
- [x] FlintTypes.jl
- [x] ArbTypes.jl
- [x] CalciumTypes.jl
- [ ] ~~EmbeddingTypes.jl~~
- [ ] (GaussianNumberTypes.jl)