### PR TITLE
Fix outdated docs warning in very old versions

### DIFF
--- a/release-0.6/about/index.html
+++ b/release-0.6/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/acb/index.html
+++ b/release-0.6/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/arb/index.html
+++ b/release-0.6/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/classgroup/index.html
+++ b/release-0.6/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/constructors/index.html
+++ b/release-0.6/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/factor/index.html
+++ b/release-0.6/factor/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/finitefield/index.html
+++ b/release-0.6/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/fraction/index.html
+++ b/release-0.6/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/index.html
+++ b/release-0.6/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/integer/index.html
+++ b/release-0.6/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/matrix/index.html
+++ b/release-0.6/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/maximalorder/index.html
+++ b/release-0.6/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/numberfield/index.html
+++ b/release-0.6/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/padic/index.html
+++ b/release-0.6/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/perm/index.html
+++ b/release-0.6/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/polynomial/index.html
+++ b/release-0.6/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/rational/index.html
+++ b/release-0.6/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/residue/index.html
+++ b/release-0.6/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/search.html
+++ b/release-0.6/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/series/index.html
+++ b/release-0.6/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/release-0.6/types/index.html
+++ b/release-0.6/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/about/index.html
+++ b/v0.5.0/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/base.html
+++ b/v0.5.0/base.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/breadcrumbs.html
+++ b/v0.5.0/breadcrumbs.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/acb/index.html
+++ b/v0.5.0/build/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/arb/index.html
+++ b/v0.5.0/build/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/classgroup/index.html
+++ b/v0.5.0/build/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/finitefield/index.html
+++ b/v0.5.0/build/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/fraction/index.html
+++ b/v0.5.0/build/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/integer/index.html
+++ b/v0.5.0/build/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/matrix/index.html
+++ b/v0.5.0/build/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/maximalorder/index.html
+++ b/v0.5.0/build/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/numberfield/index.html
+++ b/v0.5.0/build/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/padic/index.html
+++ b/v0.5.0/build/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/perm/index.html
+++ b/v0.5.0/build/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/polynomial/index.html
+++ b/v0.5.0/build/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/rational/index.html
+++ b/v0.5.0/build/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/residue/index.html
+++ b/v0.5.0/build/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/build/series/index.html
+++ b/v0.5.0/build/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/constructors/index.html
+++ b/v0.5.0/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/footer.html
+++ b/v0.5.0/footer.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/index.html
+++ b/v0.5.0/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/search.html
+++ b/v0.5.0/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/searchbox.html
+++ b/v0.5.0/searchbox.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/base.html
+++ b/v0.5.0/site/base.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/breadcrumbs.html
+++ b/v0.5.0/site/breadcrumbs.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/footer.html
+++ b/v0.5.0/site/footer.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/search.html
+++ b/v0.5.0/site/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/searchbox.html
+++ b/v0.5.0/site/searchbox.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/toc.html
+++ b/v0.5.0/site/toc.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/site/versions.html
+++ b/v0.5.0/site/versions.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/toc.html
+++ b/v0.5.0/toc.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/types/index.html
+++ b/v0.5.0/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.0/versions.html
+++ b/v0.5.0/versions.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/about/index.html
+++ b/v0.5.1/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/base.html
+++ b/v0.5.1/base.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/breadcrumbs.html
+++ b/v0.5.1/breadcrumbs.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/acb/index.html
+++ b/v0.5.1/build/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/arb/index.html
+++ b/v0.5.1/build/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/classgroup/index.html
+++ b/v0.5.1/build/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/finitefield/index.html
+++ b/v0.5.1/build/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/fraction/index.html
+++ b/v0.5.1/build/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/integer/index.html
+++ b/v0.5.1/build/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/matrix/index.html
+++ b/v0.5.1/build/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/maximalorder/index.html
+++ b/v0.5.1/build/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/numberfield/index.html
+++ b/v0.5.1/build/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/padic/index.html
+++ b/v0.5.1/build/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/perm/index.html
+++ b/v0.5.1/build/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/polynomial/index.html
+++ b/v0.5.1/build/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/rational/index.html
+++ b/v0.5.1/build/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/residue/index.html
+++ b/v0.5.1/build/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/build/series/index.html
+++ b/v0.5.1/build/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/constructors/index.html
+++ b/v0.5.1/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/footer.html
+++ b/v0.5.1/footer.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/index.html
+++ b/v0.5.1/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/search.html
+++ b/v0.5.1/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/searchbox.html
+++ b/v0.5.1/searchbox.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/base.html
+++ b/v0.5.1/site/base.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/breadcrumbs.html
+++ b/v0.5.1/site/breadcrumbs.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/footer.html
+++ b/v0.5.1/site/footer.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/search.html
+++ b/v0.5.1/site/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/searchbox.html
+++ b/v0.5.1/site/searchbox.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/toc.html
+++ b/v0.5.1/site/toc.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/site/versions.html
+++ b/v0.5.1/site/versions.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/toc.html
+++ b/v0.5.1/toc.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/types/index.html
+++ b/v0.5.1/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.5.1/versions.html
+++ b/v0.5.1/versions.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/about/index.html
+++ b/v0.6.0/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/acb/index.html
+++ b/v0.6.0/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/arb/index.html
+++ b/v0.6.0/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/classgroup/index.html
+++ b/v0.6.0/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/constructors/index.html
+++ b/v0.6.0/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/factor/index.html
+++ b/v0.6.0/factor/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/finitefield/index.html
+++ b/v0.6.0/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/fraction/index.html
+++ b/v0.6.0/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/index.html
+++ b/v0.6.0/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/integer/index.html
+++ b/v0.6.0/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/matrix/index.html
+++ b/v0.6.0/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/maximalorder/index.html
+++ b/v0.6.0/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/numberfield/index.html
+++ b/v0.6.0/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/padic/index.html
+++ b/v0.6.0/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/perm/index.html
+++ b/v0.6.0/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/polynomial/index.html
+++ b/v0.6.0/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/rational/index.html
+++ b/v0.6.0/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/residue/index.html
+++ b/v0.6.0/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/search.html
+++ b/v0.6.0/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/series/index.html
+++ b/v0.6.0/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.0/types/index.html
+++ b/v0.6.0/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/about/index.html
+++ b/v0.6.1/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/acb/index.html
+++ b/v0.6.1/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/arb/index.html
+++ b/v0.6.1/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/classgroup/index.html
+++ b/v0.6.1/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/constructors/index.html
+++ b/v0.6.1/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/factor/index.html
+++ b/v0.6.1/factor/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/finitefield/index.html
+++ b/v0.6.1/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/fraction/index.html
+++ b/v0.6.1/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/index.html
+++ b/v0.6.1/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/integer/index.html
+++ b/v0.6.1/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/matrix/index.html
+++ b/v0.6.1/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/maximalorder/index.html
+++ b/v0.6.1/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/numberfield/index.html
+++ b/v0.6.1/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/padic/index.html
+++ b/v0.6.1/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/perm/index.html
+++ b/v0.6.1/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/polynomial/index.html
+++ b/v0.6.1/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/rational/index.html
+++ b/v0.6.1/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/residue/index.html
+++ b/v0.6.1/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/search.html
+++ b/v0.6.1/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/series/index.html
+++ b/v0.6.1/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.1/types/index.html
+++ b/v0.6.1/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/about/index.html
+++ b/v0.6.2/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/acb/index.html
+++ b/v0.6.2/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/arb/index.html
+++ b/v0.6.2/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/classgroup/index.html
+++ b/v0.6.2/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/constructors/index.html
+++ b/v0.6.2/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/factor/index.html
+++ b/v0.6.2/factor/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/finitefield/index.html
+++ b/v0.6.2/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/fraction/index.html
+++ b/v0.6.2/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/index.html
+++ b/v0.6.2/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/integer/index.html
+++ b/v0.6.2/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/matrix/index.html
+++ b/v0.6.2/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/maximalorder/index.html
+++ b/v0.6.2/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/numberfield/index.html
+++ b/v0.6.2/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/padic/index.html
+++ b/v0.6.2/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/perm/index.html
+++ b/v0.6.2/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/polynomial/index.html
+++ b/v0.6.2/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/rational/index.html
+++ b/v0.6.2/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/residue/index.html
+++ b/v0.6.2/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/search.html
+++ b/v0.6.2/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/series/index.html
+++ b/v0.6.2/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.2/types/index.html
+++ b/v0.6.2/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/about/index.html
+++ b/v0.6.3/about/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/acb/index.html
+++ b/v0.6.3/acb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/arb/index.html
+++ b/v0.6.3/arb/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/classgroup/index.html
+++ b/v0.6.3/classgroup/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/constructors/index.html
+++ b/v0.6.3/constructors/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/factor/index.html
+++ b/v0.6.3/factor/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/finitefield/index.html
+++ b/v0.6.3/finitefield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/fraction/index.html
+++ b/v0.6.3/fraction/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/index.html
+++ b/v0.6.3/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/integer/index.html
+++ b/v0.6.3/integer/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/matrix/index.html
+++ b/v0.6.3/matrix/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/maximalorder/index.html
+++ b/v0.6.3/maximalorder/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/numberfield/index.html
+++ b/v0.6.3/numberfield/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/padic/index.html
+++ b/v0.6.3/padic/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/perm/index.html
+++ b/v0.6.3/perm/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/polynomial/index.html
+++ b/v0.6.3/polynomial/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/rational/index.html
+++ b/v0.6.3/rational/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/residue/index.html
+++ b/v0.6.3/residue/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/search.html
+++ b/v0.6.3/search.html
@@ -27,8 +27,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/series/index.html
+++ b/v0.6.3/series/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);

--- a/v0.6.3/types/index.html
+++ b/v0.6.3/types/index.html
@@ -32,8 +32,15 @@
         document.body.removeChild(div);
     });
     let href = '/stable';
-    if (window.documenterBaseURL) {
-        href = window.documenterBaseURL + '/../stable';
+    if (window.mkdocs_page_url) {
+        let level = window.mkdocs_page_url.split('/').length;
+        if (window.mkdocs_page_url[0] === '/') {
+            level -= 1;
+        }
+        if (window.mkdocs_page_url.slice(-1) === '/') {
+            level -= 1;
+        }
+        href = "." + "/..".repeat(level) + '/../stable';
     }
     div.innerHTML = 'This documentation is not for the latest version. <br> <a href="' + href + '">Go to the latest documentation</a>.';
     div.appendChild(closer);


### PR DESCRIPTION
Resolves #1820, resolves #1816.

The problem was that the Javascript code expected the existence of some variable set by Documenter. But since these very old documentation versions used some other system, these variables are not set.
I hacked something together by the best of my js knowledge (spoiler: not very much) and then copied it to all files of this older structure.
Local experiments show this as working. 