### PR TITLE
Add `fit!` for all `MPolyRingElem` subtypes

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -139,6 +139,11 @@ function denominator(a::QQMPolyRingElem)
   return c
 end
 
+function fit!(a::QQMPolyRingElem, n::Int)
+  # needs to exist for the MPoly interface
+  return nothing
+end
+
 ################################################################################
 #
 #  Getting coefficients

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -145,6 +145,11 @@ for (etype, rtype, ftype, ctype) in (
                         a, parent(a)))
     end
 
+    function fit!(a::($etype), n::Int)
+      # needs to exist for the MPoly interface
+      return nothing
+    end
+
     # TODO move this
     function expressify(a::($rtype); context = nothing)
       return Expr(:sequence, Expr(:text, "Multivariate Polynomial Ring in "),

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -124,6 +124,11 @@ function is_constant(a::ZZMPolyRingElem)
   return Bool(b)
 end
 
+function fit!(a::ZZMPolyRingElem, n::Int)
+  # needs to exist for the MPoly interface
+  return nothing
+end
+
 ################################################################################
 #
 #  Getting coefficients

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -78,6 +78,11 @@ function is_constant(a::FqMPolyRingElem)
   return is_constant(a.data)
 end
 
+function fit!(a::FqMPolyRingElem, n::Int)
+  # needs to exist for the MPoly interface
+  return nothing
+end
+
 ###############################################################################
 #
 #   AbstractString I/O

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -130,6 +130,11 @@ function is_constant(a::fqPolyRepMPolyRingElem)
   return Bool(b)
 end
 
+function fit!(a::fqPolyRepMPolyRingElem, n::Int)
+  # needs to exist for the MPoly interface
+  return nothing
+end
+
 ################################################################################
 #
 #  Getting coefficients

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -139,6 +139,11 @@ for (etype, rtype, ftype, ctype, utype) in (
                         a, parent(a)))
     end
 
+    function fit!(a::($etype), n::Int)
+      # needs to exist for the MPoly interface
+      return nothing
+    end
+
     ################################################################################
     #
     #  Getting coefficients


### PR DESCRIPTION
The MPoly interface (https://nemocas.github.io/AbstractAlgebra.jl/dev/mpoly_interface/#Unsafe-functions) states that these must exist. When trying to run the UnivPoly testsuite from AA with Nemo rings to verify the correctness of my changes for https://github.com/Nemocas/AbstractAlgebra.jl/issues/1746, there were a lot of MethodErrors due to these missing.
One could potentially look in FLINT if there are corresponding functions there that can be hooked up, but that is not needed currently.