### PR TITLE
Remove two functions which exist in AbstractAlgebra

### DIFF
--- a/src/HeckeMiscPoly.jl
+++ b/src/HeckeMiscPoly.jl
@@ -407,62 +407,8 @@ function mulhigh(a::PolyRingElem{T}, b::PolyRingElem{T}, n::Int) where {T}
   return mulhigh_n(a, b, degree(a) + degree(b) - n)
 end
 
-function mod(f::AbstractAlgebra.PolyRingElem{T}, g::AbstractAlgebra.PolyRingElem{T}) where {T<:RingElem}
-  check_parent(f, g)
-  if length(g) == 0
-    throw(DivideError())
-  end
-  if length(f) >= length(g)
-    f = deepcopy(f)
-    b = leading_coefficient(g)
-    g = inv(b) * g
-    c = base_ring(f)()
-    while length(f) >= length(g)
-      l = -leading_coefficient(f)
-      for i = 1:length(g)
-        c = mul!(c, coeff(g, i - 1), l)
-        u = coeff(f, i + length(f) - length(g) - 1)
-        u = addeq!(u, c)
-        f = setcoeff!(f, i + length(f) - length(g) - 1, u)
-      end
-      set_length!(f, normalise(f, length(f) - 1))
-    end
-  end
-  return f
-end
-
 normalise(f::ZZPolyRingElem, ::Int) = degree(f) + 1
 set_length!(f::ZZPolyRingElem, ::Int) = nothing
-
-function Base.divrem(f::AbstractAlgebra.PolyRingElem{T}, g::AbstractAlgebra.PolyRingElem{T}) where {T<:RingElem}
-  check_parent(f, g)
-  if length(g) == 0
-    throw(DivideError())
-  end
-  if length(f) < length(g)
-    return zero(parent(f)), f
-  end
-  f = deepcopy(f)
-  binv = inv(leading_coefficient(g))
-  g = divexact(g, leading_coefficient(g))
-  qlen = length(f) - length(g) + 1
-  q = zero(parent(f))
-  fit!(q, qlen)
-  c = zero(base_ring(f))
-  while length(f) >= length(g)
-    q1 = leading_coefficient(f)
-    l = -q1
-    q = setcoeff!(q, length(f) - length(g), q1 * binv)
-    for i = 1:length(g)
-      c = mul!(c, coeff(g, i - 1), l)
-      u = coeff(f, i + length(f) - length(g) - 1)
-      u = addeq!(u, c)
-      f = setcoeff!(f, i + length(f) - length(g) - 1, u)
-    end
-    set_length!(f, normalise(f, length(f) - 1))
-  end
-  return q, f
-end
 
 ################################################################################
 #


### PR DESCRIPTION
The functions `mod(::PolyRingElem, ::PolyRingElem)` and `divrem(::PolyRingElem, ::PolyRingElem)` are verbatim in AbstractAlgebra, see https://github.com/Nemocas/AbstractAlgebra.jl/blob/2235d6a60348cbb60f4af97332a0dbe49ae24a51/src/Poly.jl#L1420 and https://github.com/Nemocas/AbstractAlgebra.jl/blob/2235d6a60348cbb60f4af97332a0dbe49ae24a51/src/Poly.jl#L1448 .
