### PR TITLE
Make `set_precision` reduce the element

### DIFF
--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -116,6 +116,13 @@ end
 
 characteristic(::QQAbsPowerSeriesRing) = 0
 
+function set_precision!(z::QQAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+  z = truncate!(z, k)
+  z.prec = k
+  return z
+end
+
 ###############################################################################
 #
 #   Similar
@@ -340,17 +347,20 @@ end
 #
 ###############################################################################
 
-function truncate(x::QQAbsPowerSeriesRingElem, prec::Int)
-  prec < 0 && throw(DomainError(prec, "Precision must be non-negative"))
-  if x.prec <= prec
+function truncate(x::QQAbsPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::QQAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
     return x
   end
-  z = parent(x)()
-  z.prec = prec
-  ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-        (Ref{QQAbsPowerSeriesRingElem}, Ref{QQAbsPowerSeriesRingElem}, Int),
-        z, x, prec)
-  return z
+  ccall((:fmpq_poly_truncate, libflint), Nothing,
+        (Ref{QQAbsPowerSeriesRingElem}, Int),
+        x, k)
+  x.prec = k
+  return x
 end
 
 ###############################################################################

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -115,6 +115,13 @@ end
 
 characteristic(::ZZAbsPowerSeriesRing) = 0
 
+function set_precision!(z::ZZAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+  z = truncate!(z, k)
+  z.prec = k
+  return z
+end
+
 ###############################################################################
 #
 #   Similar
@@ -328,17 +335,20 @@ end
 #
 ###############################################################################
 
-function truncate(x::ZZAbsPowerSeriesRingElem, prec::Int)
-  prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-  if x.prec <= prec
+function truncate(x::ZZAbsPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::ZZAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
     return x
   end
-  z = parent(x)()
-  z.prec = prec
-  ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-        (Ref{ZZAbsPowerSeriesRingElem}, Ref{ZZAbsPowerSeriesRingElem}, Int),
-        z, x, prec)
-  return z
+  ccall((:fmpz_poly_truncate, libflint), Nothing,
+        (Ref{ZZAbsPowerSeriesRingElem}, Int),
+        x, k)
+  x.prec = k
+  return x
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -135,6 +135,13 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     characteristic(R::($rtype)) = characteristic(base_ring(R))
 
+    function set_precision!(z::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+      z = truncate!(z, k)
+      z.prec = k
+      return z
+    end
+
     ###############################################################################
     #
     #   Similar
@@ -345,18 +352,20 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), prec::Int)
-      prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-      if x.prec <= prec
+    function truncate(x::($etype), k::Int)
+      return truncate!(deepcopy(x), k)
+    end
+
+    function truncate!(x::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Index must be non-negative"))
+      if precision(x) <= k
         return x
       end
-      z = parent(x)()
-      z.prec = prec
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int,
-             Ref{($ctype)}),
-            z, x, prec, x.parent.base_ring.ninv)
-      return z
+      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+            (Ref{($etype)}, Int, Ref{($ctype)}),
+            x, k, x.parent.base_ring.ninv)
+      x.prec = k
+      return x
     end
 
     ###############################################################################

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -109,6 +109,16 @@ end
 
 characteristic(::ZZRelPowerSeriesRing) = 0
 
+function set_precision!(z::ZZRelPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+  z = truncate!(z, k)
+  z.prec = k
+  if is_zero(z)
+    z.val = k
+  end
+  return z
+end
+
 ###############################################################################
 #
 #   Similar
@@ -357,27 +367,25 @@ end
 #
 ###############################################################################
 
-function truncate(x::ZZRelPowerSeriesRingElem, prec::Int)
-  prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-  xlen = pol_length(x)
-  xprec = precision(x)
-  xval = valuation(x)
-  if xprec + xval <= prec
+function truncate(x::ZZRelPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::ZZRelPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
     return x
   end
-  z = parent(x)()
-  z.prec = prec
-  if prec <= xval
-    z = parent(x)()
-    z.val = prec
-    z.prec = prec
+  if k <= valuation(x)
+    x = zero!(x)
+    x.val = k
   else
-    z.val = xval
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, x, min(prec - xval, xlen))
+    ccall((:fmpz_poly_truncate, libflint), Nothing,
+          (Ref{ZZRelPowerSeriesRingElem}, Int),
+          x, k - valuation(x))
   end
-  return z
+  x.prec = k
+  return x
 end
 
 ###############################################################################

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -128,6 +128,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
 
     characteristic(R::($rtype)) = characteristic(base_ring(R))
 
+    function set_precision!(z::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+      z = truncate!(z, k)
+      z.prec = k
+      return z
+    end
+
     ###############################################################################
     #
     #   Similar
@@ -305,17 +312,20 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), prec::Int)
-      prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-      if x.prec <= prec
+    function truncate(x::($etype), k::Int)
+      return truncate!(deepcopy(x), k)
+    end
+
+    function truncate!(x::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Index must be non-negative"))
+      if precision(x) <= k
         return x
       end
-      z = parent(x)()
-      z.prec = prec
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
-            z, x, prec, base_ring(x))
-      return z
+      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+            (Ref{($etype)}, Int, Ref{($ctype)}),
+            x, k, base_ring(x))
+      x.prec = k
+      return x
     end
 
     ###############################################################################

--- a/src/flint/fq_default_abs_series.jl
+++ b/src/flint/fq_default_abs_series.jl
@@ -121,6 +121,13 @@ end
 
 characteristic(R::FqAbsPowerSeriesRing) = characteristic(base_ring(R))
 
+function set_precision!(z::FqAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+  z = truncate!(z, k)
+  z.prec = k
+  return z
+end
+
 ###############################################################################
 #
 #   Similar
@@ -290,17 +297,20 @@ end
 #
 ###############################################################################
 
-function truncate(x::FqAbsPowerSeriesRingElem, prec::Int)
-  prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-  if x.prec <= prec
+function truncate(x::FqAbsPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::FqAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
     return x
   end
-  z = parent(x)()
-  z.prec = prec
-  ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-        (Ref{FqAbsPowerSeriesRingElem}, Ref{FqAbsPowerSeriesRingElem}, Int, Ref{FqField}),
-        z, x, prec, base_ring(x))
-  return z
+  ccall((:fq_default_poly_truncate, libflint), Nothing,
+        (Ref{FqAbsPowerSeriesRingElem}, Int, Ref{FqField}),
+        x, k, base_ring(x))
+  x.prec = k
+  return x
 end
 
 ###############################################################################

--- a/src/flint/fq_default_abs_series.jl
+++ b/src/flint/fq_default_abs_series.jl
@@ -254,6 +254,38 @@ end
 
 *(x::FqAbsPowerSeriesRingElem, y::FqFieldElem) = y * x
 
+*(x::ZZRingElem, y::FqAbsPowerSeriesRingElem) = base_ring(parent(y))(x) * y
+
+*(x::FqAbsPowerSeriesRingElem, y::ZZRingElem) = y * x
+
+*(x::Integer, y::FqAbsPowerSeriesRingElem) = base_ring(parent(y))(x) * y
+
+*(x::FqAbsPowerSeriesRingElem, y::Integer) = y * x
+
++(x::FqFieldElem, y::FqAbsPowerSeriesRingElem) = parent(y)(x) + y
+
++(x::FqAbsPowerSeriesRingElem, y::FqFieldElem) = y + x
+
++(x::ZZRingElem, y::FqAbsPowerSeriesRingElem) = base_ring(parent(y))(x) + y
+
++(x::FqAbsPowerSeriesRingElem, y::ZZRingElem) = y + x
+
++(x::FqAbsPowerSeriesRingElem, y::Integer) = x + base_ring(parent(x))(y)
+
++(x::Integer, y::FqAbsPowerSeriesRingElem) = y + x
+
+-(x::FqFieldElem, y::FqAbsPowerSeriesRingElem) = parent(y)(x) - y
+
+-(x::FqAbsPowerSeriesRingElem, y::FqFieldElem) = x - parent(x)(y)
+
+-(x::ZZRingElem, y::FqAbsPowerSeriesRingElem) = base_ring(parent(y))(x) - y
+
+-(x::FqAbsPowerSeriesRingElem, y::ZZRingElem) = x - base_ring(parent(x))(y)
+
+-(x::FqAbsPowerSeriesRingElem, y::Integer) = x - base_ring(parent(x))(y)
+
+-(x::Integer, y::FqAbsPowerSeriesRingElem) = base_ring(parent(y))(x) - y
+
 ###############################################################################
 #
 #   Shifting

--- a/src/flint/fq_default_rel_series.jl
+++ b/src/flint/fq_default_rel_series.jl
@@ -317,6 +317,38 @@ end
 
 *(x::FqRelPowerSeriesRingElem, y::FqFieldElem) = y * x
 
+*(x::ZZRingElem, y::FqRelPowerSeriesRingElem) = base_ring(parent(y))(x) * y
+
+*(x::FqRelPowerSeriesRingElem, y::ZZRingElem) = y * x
+
+*(x::Integer, y::FqRelPowerSeriesRingElem) = base_ring(parent(y))(x) * y
+
+*(x::FqRelPowerSeriesRingElem, y::Integer) = y * x
+
++(x::FqFieldElem, y::FqRelPowerSeriesRingElem) = parent(y)(x) + y
+
++(x::FqRelPowerSeriesRingElem, y::FqFieldElem) = y + x
+
++(x::ZZRingElem, y::FqRelPowerSeriesRingElem) = base_ring(parent(y))(x) + y
+
++(x::FqRelPowerSeriesRingElem, y::ZZRingElem) = y + x
+
++(x::FqRelPowerSeriesRingElem, y::Integer) = x + base_ring(parent(x))(y)
+
++(x::Integer, y::FqRelPowerSeriesRingElem) = y + x
+
+-(x::FqFieldElem, y::FqRelPowerSeriesRingElem) = parent(y)(x) - y
+
+-(x::FqRelPowerSeriesRingElem, y::FqFieldElem) = x - parent(x)(y)
+
+-(x::ZZRingElem, y::FqRelPowerSeriesRingElem) = base_ring(parent(y))(x) - y
+
+-(x::FqRelPowerSeriesRingElem, y::ZZRingElem) = x - base_ring(parent(x))(y)
+
+-(x::FqRelPowerSeriesRingElem, y::Integer) = x - base_ring(parent(x))(y)
+
+-(x::Integer, y::FqRelPowerSeriesRingElem) = base_ring(parent(y))(x) - y
+
 ###############################################################################
 #
 #   Shifting

--- a/src/flint/nmod_abs_series.jl
+++ b/src/flint/nmod_abs_series.jl
@@ -122,6 +122,13 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
 
     characteristic(R::($rtype)) = characteristic(base_ring(R))
 
+    function set_precision!(z::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+      z = truncate!(z, k)
+      z.prec = k
+      return z
+    end
+
     ###############################################################################
     #
     #   Similar
@@ -322,17 +329,20 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), prec::Int)
-      prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-      if x.prec <= prec
+    function truncate(x::($etype), k::Int)
+      return truncate!(deepcopy(x), k)
+    end
+
+    function truncate!(x::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Index must be non-negative"))
+      if precision(x) <= k
         return x
       end
-      z = parent(x)()
-      z.prec = prec
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int),
-            z, x, prec)
-      return z
+      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+            (Ref{($etype)}, Int),
+            x, k)
+      x.prec = k
+      return x
     end
 
     ###############################################################################

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -115,6 +115,16 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
 
     characteristic(R::($rtype)) = modulus(R)
 
+    function set_precision!(z::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Precision must be non-negative"))
+      z = truncate!(z, k)
+      z.prec = k
+      if is_zero(z)
+        z.val = k
+      end
+      return z
+    end
+
     ###############################################################################
     #
     #   Similar
@@ -381,27 +391,25 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), prec::Int)
-      prec < 0 && throw(DomainError(prec, "Index must be non-negative"))
-      xlen = pol_length(x)
-      xprec = precision(x)
-      xval = valuation(x)
-      if xprec + xval <= prec
+    function truncate(x::($etype), k::Int)
+      return truncate!(deepcopy(x), k)
+    end
+
+    function truncate!(x::($etype), k::Int)
+      k < 0 && throw(DomainError(k, "Index must be non-negative"))
+      if precision(x) <= k
         return x
       end
-      z = parent(x)()
-      z.prec = prec
-      if prec <= xval
-        z = parent(x)()
-        z.val = prec
-        z.prec = prec
+      if k <= valuation(x)
+        x = zero!(x)
+        x.val = k
       else
-        z.val = xval
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, x, min(prec - xval, xlen))
+        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+              (Ref{($etype)}, Int),
+              x, k - valuation(x))
       end
-      return z
+      x.prec = k
+      return x
     end
 
     ###############################################################################

--- a/test/flint/fmpq_abs_series-test.jl
+++ b/test/flint/fmpq_abs_series-test.jl
@@ -347,6 +347,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -357,6 +358,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 end
 
 @testset "QQAbsPowerSeriesRingElem.exact_division" begin
@@ -495,4 +498,24 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "QQAbsPowerSeriesRingElem.set_precision" begin
+  R, x = power_series_ring(QQ, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fmpq_rel_series-test.jl
+++ b/test/flint/fmpq_rel_series-test.jl
@@ -429,6 +429,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -439,6 +440,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test isequal(truncate(e, 2), O(x^2))
 end
 
 @testset "QQRelPowerSeriesRingElem.exact_division" begin
@@ -573,4 +576,24 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "QQRelPowerSeriesRingElem.set_precision" begin
+  R, x = power_series_ring(QQ, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fmpz_abs_series-test.jl
+++ b/test/flint/fmpz_abs_series-test.jl
@@ -275,6 +275,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -285,6 +286,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 end
 
 @testset "ZZAbsPowerSeriesRingElem.exact_division" begin
@@ -404,4 +407,24 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "ZZAbsPowerSeriesRingElem.set_precision" begin
+  R, x = power_series_ring(ZZ, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fmpz_mod_abs_series-test.jl
+++ b/test/flint/fmpz_mod_abs_series-test.jl
@@ -297,6 +297,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -305,6 +306,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 
@@ -423,4 +426,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "ZZModAbsPowerSeriesRingElem.set_precision" begin
+  S, = residue_ring(ZZ, 123456789012345678949)
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fmpz_mod_rel_series-test.jl
+++ b/test/flint/fmpz_mod_rel_series-test.jl
@@ -480,6 +480,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -488,6 +489,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -607,4 +610,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "ZZModRelPowerSeriesRingElem.set_precision" begin
+  R, = residue_ring(ZZ, 123456789012345678949)
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fmpz_rel_series-test.jl
+++ b/test/flint/fmpz_rel_series-test.jl
@@ -392,6 +392,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -400,6 +401,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -521,4 +524,24 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "ZZRelPowerSeriesRingElem.set_precision" begin
+  R, x = power_series_ring(ZZ, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fq_abs_series-test.jl
+++ b/test/flint/fq_abs_series-test.jl
@@ -298,6 +298,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -306,6 +307,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -472,4 +475,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "FqPolyRepAbsPowerSeriesRingElem.set_precision" begin
+  S, t = Native.finite_field(ZZRingElem(23), 5, "t")
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fq_default_abs_series-test.jl
+++ b/test/flint/fq_default_abs_series-test.jl
@@ -291,6 +291,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -299,6 +300,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -447,3 +450,22 @@ end
   end
 end
 
+@testset "FqAbsPowerSeriesRingElem.set_precision" begin
+  S, x = power_series_ring(GF(23, 5), 30, "x", model = :capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
+end

--- a/test/flint/fq_default_abs_series-test.jl
+++ b/test/flint/fq_default_abs_series-test.jl
@@ -203,6 +203,11 @@ end
   @test c*2 == 2 + 2*x + 6*x^2 + O(x^5)
 
   @test d*ZZ(3) == 3x^2 + 9x^3 - 3x^4
+
+  @test a + ZZ(3) == 3 + 2*x + x^3
+  @test ZZ(3) + a == 3 + 2*x + x^3
+  @test a - ZZ(3) == 20 + 2*x + x^3
+  @test ZZ(3) - a == 3 + 21*x + 22*x^3
 end
 
 @testset "FqAbsPowerSeriesRingElem.comparison" begin

--- a/test/flint/fq_default_rel_series-test.jl
+++ b/test/flint/fq_default_rel_series-test.jl
@@ -344,6 +344,11 @@ end
   @test isequal(c*2, 2 + 2*x + 6*x^2 + O(x^5))
 
   @test isequal(d*ZZRingElem(3), 3x^2 + 9x^3 - 3x^4 + O(x^32))
+
+  @test isequal(a + ZZ(3), 3 + 2*x + x^3)
+  @test isequal(ZZ(3) + a, 3 + 2*x + x^3)
+  @test isequal(a - ZZ(3), 20 + 2*x + x^3)
+  @test isequal(ZZ(3) - a, 3 + 21*x + 22*x^3)
 end
 
 @testset "FqRelPowerSeriesRingElem.comparison" begin

--- a/test/flint/fq_default_rel_series-test.jl
+++ b/test/flint/fq_default_rel_series-test.jl
@@ -436,6 +436,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -444,6 +445,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -603,4 +606,24 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "FqRelPowerSeriesRingElem.set_precision" begin
+  S, x = power_series_ring(GF(23, 5), 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fq_nmod_abs_series-test.jl
+++ b/test/flint/fq_nmod_abs_series-test.jl
@@ -298,6 +298,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -306,6 +307,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -452,4 +455,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "fqPolyRepAbsPowerSeriesRingElem.set_precision" begin
+  S, t = Native.finite_field(23, 5, "t")
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fq_nmod_rel_series-test.jl
+++ b/test/flint/fq_nmod_rel_series-test.jl
@@ -438,6 +438,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -446,6 +447,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -604,4 +607,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "fqPolyRepRelPowerSeriesRingElem.set_precision" begin
+  R, t = Native.finite_field(23, 5, "t")
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/fq_rel_series-test.jl
+++ b/test/flint/fq_rel_series-test.jl
@@ -443,6 +443,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -451,6 +452,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -611,3 +614,23 @@ end
   end
 end
 
+@testset "FqPolyRepRelPowerSeriesRingElem.set_precision" begin
+  R, t = Native.finite_field(ZZRingElem(23), 5, "t")
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
+end

--- a/test/flint/gfp_abs_series-test.jl
+++ b/test/flint/gfp_abs_series-test.jl
@@ -293,6 +293,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -301,6 +302,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 
@@ -464,4 +467,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "fpAbsPowerSeriesRingElem.set_precision" begin
+  S = Native.GF(23)
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/gfp_fmpz_abs_series-test.jl
+++ b/test/flint/gfp_fmpz_abs_series-test.jl
@@ -290,6 +290,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -298,6 +299,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 
@@ -457,4 +460,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "FpAbsPowerSeriesRingElem.set_precision" begin
+  S = Native.GF(ZZ(123456789012345678949))
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/gfp_fmpz_rel_series-test.jl
+++ b/test/flint/gfp_fmpz_rel_series-test.jl
@@ -473,6 +473,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -481,6 +482,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -643,3 +646,23 @@ end
   end
 end
 
+@testset "FpRelPowerSeriesRingElem.set_precision" begin
+  R = Native.GF(ZZ(123456789012345678949))
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
+end

--- a/test/flint/gfp_rel_series-test.jl
+++ b/test/flint/gfp_rel_series-test.jl
@@ -444,6 +444,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -452,6 +453,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -612,4 +615,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "fpRelPowerSeriesRingElem.set_precision" begin
+  R = Native.GF(17)
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/nmod_abs_series-test.jl
+++ b/test/flint/nmod_abs_series-test.jl
@@ -298,6 +298,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test truncate(a, 3) == 2*x + O(x^3)
 
@@ -306,6 +307,8 @@ end
   @test truncate(c, 5) == 2*x^2+x+1+O(x^5)
 
   @test truncate(d, 5) == x^3+2*x+O(x^4)
+
+  @test truncate(e, 2) == O(x^2)
 
   @test_throws DomainError truncate(a, -1)
 
@@ -424,4 +427,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "zzModAbsPowerSeriesRingElem.set_precision" begin
+  S, = residue_ring(ZZ, 23)
+  R, x = power_series_ring(S, 30, "x", model=:capped_absolute)
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test set_precision(a, 3) == 2*x + O(x^3)
+  @test set_precision(b, 2) == O(x^2)
+  @test set_precision(b, 10) == O(x^10)
+  @test set_precision(c, 5) == 2*x^2+x+1+O(x^5)
+  @test set_precision(c, 10) == 2*x^2+x+1+O(x^10)
+  @test set_precision(d, 5) == x^3+2*x+O(x^5)
+  @test set_precision(e, 2) == O(x^2)
+
+  @test_throws DomainError set_precision(a, -1)
 end

--- a/test/flint/nmod_rel_series-test.jl
+++ b/test/flint/nmod_rel_series-test.jl
@@ -449,6 +449,7 @@ end
   b = O(x^4)
   c = 1 + x + 2x^2 + O(x^5)
   d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
 
   @test isequal(truncate(a, 3), 2*x + O(x^3))
 
@@ -457,6 +458,8 @@ end
   @test isequal(truncate(c, 5), 2*x^2+x+1+O(x^5))
 
   @test isequal(truncate(d, 5), x^3+2*x+O(x^4))
+
+  @test isequal(truncate(e, 2), O(x^2))
 
   @test_throws DomainError truncate(a, -1)
 end
@@ -576,4 +579,25 @@ end
     h = zero!(h)
     @test isequal(h, R())
   end
+end
+
+@testset "zzModRelPowerSeriesRingElem.set_precision" begin
+  R, = residue_ring(ZZ, 17)
+  S, x = power_series_ring(R, 30, "x")
+
+  a = 2x + x^3
+  b = O(x^4)
+  c = 1 + x + 2x^2 + O(x^5)
+  d = 2x + x^3 + O(x^4)
+  e = x^3 + O(x^10)
+
+  @test isequal(set_precision(a, 3), 2*x + O(x^3))
+  @test isequal(set_precision(b, 2), O(x^2))
+  @test isequal(set_precision(b, 10), O(x^10))
+  @test isequal(set_precision(c, 5), 2*x^2+x+1+O(x^5))
+  @test isequal(set_precision(c, 10), 2*x^2+x+1+O(x^10))
+  @test isequal(set_precision(d, 5), x^3+2*x+O(x^5))
+  @test isequal(set_precision(e, 2), O(x^2))
+
+  @test_throws DomainError set_precision(a, -1)
 end


### PR DESCRIPTION
This is a proposal to fix what I think is an issue with `set_precision!` for power series.

The issue is:
Currently, `set_precision!` doesn't do anything for power series apart from setting the `.prec` field. First of all, this leads to weird prints:
```
julia> R, x = power_series_ring(GF(5), 10, "x")
(Univariate power series ring over GF(5), x + O(x^11))

julia> f = x^4 + x^5
x^4 + x^5 + O(x^14)

julia> set_precision(f, 3)
x^4 + x^5 + O(x^3)
```
So it's `x^4 + O(x^3)`?! There is also an actual error when multiplying such elements:
```
julia> g = set_precision(f, 3)
x^4 + x^5 + O(x^3)

julia> g*g

[2717431] signal (11.1): Speicherzugriffsfehler
in expression starting at REPL[6]:1
_nmod_poly_normalise at /workspace/srcdir/flint/./src/nmod_poly.h:127 [inlined]
nmod_poly_mullow at /workspace/srcdir/flint/src/nmod_poly/mullow.c:117
* at /home/johannes/.julia/packages/Nemo/u9kPx/src/flint/fq_default_rel_series.jl:284
unknown function (ip: 0x72cba04c6869)
[...]
```
~(This works with the generic `AbstractAlgebra` types though.)~

I would say that `set_precision!` should also modify the underlying polynomial, if the new precision is smaller than the current one and this is what I now implemented for one flint type:
```
julia> f = x^4 + x^5
x^4 + x^5 + O(x^14)

julia> set_precision(f, 3)
O(x^3)
```
Is this what we want? Or am I just using it wrong?
I can change this for the other power series types, but wanted to get feedback first.

CC @thofma
