### PR TITLE
Remove four argument `mul!` for `ZZMatrix`

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1828,16 +1828,9 @@ function sub!(z::ZZMatrix, x::ZZMatrix, y::ZZMatrix)
   return z
 end
 
-function mul!(z::ZZMatrix, x::ZZMatrix, y::ZZMatrix, fl::Bool = false)
-  if fl
-    n = similar(z)
-    ccall((:fmpz_mat_mul, libflint), Nothing,
-          (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZMatrix}), n, x, y)
-    add!(z, z, n)             
-  else
-    ccall((:fmpz_mat_mul, libflint), Nothing,
-          (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZMatrix}), z, x, y)
-  end               
+function mul!(z::ZZMatrix, x::ZZMatrix, y::ZZMatrix)
+  ccall((:fmpz_mat_mul, libflint), Nothing,
+        (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZMatrix}), z, x, y)
   return z
 end
 


### PR DESCRIPTION
Remove four argument `mul!` for `ZZMatrix`. The fourth argument was a `Bool`, which if set to `true` would basically perform an `addmul!` (except that we don't have `addmul!` for matrices right now...).

This code was introduced by @fieker so pinging him in case he remembers what it was for.

I also made https://github.com/Nemocas/AbstractAlgebra.jl/pull/1801 which once merged and released should produce identical results for `ZZMatrix` inputs.