### PR TITLE
Remove some trace methods

### DIFF
--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -415,8 +415,8 @@ function tr(a::T) where T <: Zmod_fmpz_mat
   r = ZZRingElem()
   ccall((:fmpz_mod_mat_trace, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
-        r, a, base_ring(a).ninv)
-  return ZZModRingElem(r, R)
+        r, a, R.ninv)
+  return elem_type(R)(r, R)
 end
 
 ################################################################################

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -377,22 +377,6 @@ function rref!(a::FqMatrix)
   return r
 end
 
-#################################################################################
-#
-#  Trace
-#
-#################################################################################
-
-function tr(a::FqMatrix)
-  !is_square(a) && error("Non-square matrix")
-  n = nrows(a)
-  t = zero(base_ring(a))
-  for i in 1:nrows(a)
-    add!(t, t, a[i, i])
-  end
-  return t
-end
-
 ################################################################################
 #
 #  Determinant

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -368,22 +368,6 @@ function rref!(a::FqPolyRepMatrix)
   return r
 end
 
-#################################################################################
-#
-#  Trace
-#
-#################################################################################
-
-function tr(a::FqPolyRepMatrix)
-  !is_square(a) && error("Non-square matrix")
-  n = nrows(a)
-  t = zero(base_ring(a))
-  for i in 1:nrows(a)
-    add!(t, t, a[i, i])
-  end
-  return t
-end
-
 ################################################################################
 #
 #  Determinant

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -357,22 +357,6 @@ function rref!(a::fqPolyRepMatrix)
   return r
 end
 
-#################################################################################
-#
-#  Trace
-#
-#################################################################################
-
-function tr(a::fqPolyRepMatrix)
-  !is_square(a) && error("Non-square matrix")
-  n = nrows(a)
-  t = zero(base_ring(a))
-  for i in 1:nrows(a)
-    add!(t, t, a[i, i])
-  end
-  return t
-end
-
 ################################################################################
 #
 #  Determinant

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -156,23 +156,6 @@ end
 
 ################################################################################
 #
-#  Trace
-#
-################################################################################
-
-function tr(a::FpMatrix)
-  !is_square(a) && error("Matrix must be a square matrix")
-  R = base_ring(a)
-  r = ZZRingElem()
-  ccall((:fmpz_mod_mat_trace, libflint), Nothing,
-        (Ref{ZZRingElem}, Ref{FpMatrix}, Ref{fmpz_mod_ctx_struct}),
-        r, a, base_ring(a).ninv)
-  return FpFieldElem(r, R)
-end
-
-
-################################################################################
-#
 #  Windowing
 #
 ################################################################################


### PR DESCRIPTION
They are either equal to the default implementation in AA, or already covered by the Zmod_fmpz_mat case.