### PR TITLE
Add more QQFieldElem and ZZRingElem ccalls

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -137,6 +137,7 @@ export degree_fmpz
 export degrees
 export degrees_fit_int
 export degrees_fmpz
+export denominator!
 export derivative
 export det
 export det_divisor
@@ -464,6 +465,7 @@ export nullspace_right_rational
 export number_field
 export number_of_partitions
 export numpart
+export numerator!
 export oct
 export one
 export one!

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -137,7 +137,7 @@ export degree_fmpz
 export degrees
 export degrees_fit_int
 export degrees_fmpz
-export denominator!
+#export denominator!  # not exported for now to avoid clash with Hecke
 export derivative
 export det
 export det_divisor
@@ -465,7 +465,7 @@ export nullspace_right_rational
 export number_field
 export number_of_partitions
 export numpart
-export numerator!
+#export numerator!  # not exported for now to avoid clash with Hecke
 export oct
 export one
 export one!

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -345,7 +345,7 @@ function cmp(a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
 end
 
 function cmp(a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
-  @ccall libflint.fmpq_cmp_fmpz(a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Cint
+  @ccall libflint.fmpq_cmp_fmpz(a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Cint
 end
 
 function cmp(a::QQFieldElemOrPtr, b::Int)

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -356,7 +356,9 @@ function cmp(a::QQFieldElemOrPtr, b::UInt)
   @ccall libflint.fmpq_cmp_ui(a::Ref{QQFieldElem}, b::UInt)::Cint
 end
 
-cmp(a::Union{ZZRingElemOrPtr, Int, UInt}, b::QQFieldElemOrPtr) = -cmp(b, a)
+cmp(a::QQFieldElemOrPtr, b::Integer) = cmp(a, ZZRingElem(b))
+
+cmp(a::Union{ZZRingElemOrPtr, Integer}, b::QQFieldElemOrPtr) = -cmp(b, a)
 
 function ==(a::QQFieldElem, b::QQFieldElem)
   return ccall((:fmpq_equal, libflint), Bool,

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -113,17 +113,13 @@ zero(::Type{QQFieldElem}) = QQFieldElem(0)
 one(::Type{QQFieldElem}) = QQFieldElem(1)
 
 
-function isone(a::QQFieldElem)
-  return Bool(ccall((:fmpq_is_one, libflint), Cint, (Ref{QQFieldElem}, ), a))
-end
+is_one(a::QQFieldElem) = isinteger(a) && is_one(_num_ptr(a))
 
-function iszero(a::QQFieldElem)
-  return Bool(ccall((:fmpq_is_zero, libflint), Cint, (Ref{QQFieldElem}, ), a))
-end
+is_zero(a::QQFieldElem) = is_zero(_num_ptr(a))
 
 is_unit(a::QQFieldElem) = !iszero(a)
 
-isinteger(a::QQFieldElem) = isone(denominator(a))
+isinteger(a::QQFieldElem) = is_one(_den_ptr(a))
 
 isfinite(::QQFieldElem) = true
 
@@ -274,11 +270,7 @@ end
 #
 ###############################################################################
 
-function -(a::QQFieldElem)
-  z = QQFieldElem()
-  ccall((:fmpq_neg, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}), z, a)
-  return z
-end
+-(a::QQFieldElem) = neg!(QQFieldElem(), a)
 
 conj(x::QQFieldElem) = x
 
@@ -288,23 +280,11 @@ conj(x::QQFieldElem) = x
 #
 ###############################################################################
 
-function +(a::QQFieldElem, b::QQFieldElem)
-  z = QQFieldElem()
-  add!(z, a, b)
-  return z
-end
++(a::QQFieldElem, b::QQFieldElem) = add!(QQFieldElem(), a, b)
 
-function -(a::QQFieldElem, b::QQFieldElem)
-  z = QQFieldElem()
-  sub!(z, a, b)
-  return z
-end
+-(a::QQFieldElem, b::QQFieldElem) = sub!(QQFieldElem(), a, b)
 
-function *(a::QQFieldElem, b::QQFieldElem)
-  z = QQFieldElem()
-  mul!(z, a, b)
-  return z
-end
+*(a::QQFieldElem, b::QQFieldElem) = mul!(QQFieldElem(), a, b)
 
 ###############################################################################
 #
@@ -312,73 +292,43 @@ end
 #
 ###############################################################################
 
-function +(a::QQFieldElem, b::Int)
-  z = QQFieldElem()
-  ccall((:fmpq_add_si, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), z, a, b)
-  return z
+for T in (ZZRingElem, Int, UInt)
+  @eval begin
+    +(a::QQFieldElem, b::$T) = add!(QQFieldElem(), a, b)
+    +(a::$T, b::QQFieldElem) = b + a
+  end
 end
 
-function +(a::QQFieldElem, b::ZZRingElem)
-  z = QQFieldElem()
-  ccall((:fmpq_add_fmpz, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
-  return z
-end
-
-+(a::Int, b::QQFieldElem) = b + a
-
-+(a::ZZRingElem, b::QQFieldElem) = b + a
++(a::QQFieldElem, b::Integer) = a + ZZRingElem(b)
++(a::Integer, b::QQFieldElem) = b + a
 
 +(a::QQFieldElem, b::Rational{T}) where {T <: Integer} = a + QQFieldElem(b)
-
 +(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = b + a
 
-function -(a::QQFieldElem, b::Int)
-  z = QQFieldElem()
-  ccall((:fmpq_sub_si, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), z, a, b)
-  return z
+for T in (ZZRingElem, Int, UInt)
+  @eval begin
+    -(a::QQFieldElem, b::$T) = sub!(QQFieldElem(), a, b)
+    -(a::$T, b::QQFieldElem) = neg!(b - a)
+  end
 end
 
-function -(a::QQFieldElem, b::ZZRingElem)
-  z = QQFieldElem()
-  ccall((:fmpq_sub_fmpz, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
-  return z
-end
+-(a::QQFieldElem, b::Integer) = a - ZZRingElem(b)
+-(a::Integer, b::QQFieldElem) = ZZRingElem(a) - b
 
 -(a::QQFieldElem, b::Rational{T}) where {T <: Integer} = a - QQFieldElem(b)
-
 -(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = QQFieldElem(a) - b
 
-function *(a::QQFieldElem, b::ZZRingElem)
-  z = QQFieldElem()
-  ccall((:fmpq_mul_fmpz, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
-  return z
+for T in (ZZRingElem, Int, UInt)
+  @eval begin
+    *(a::QQFieldElem, b::$T) = mul!(QQFieldElem(), a, b)
+    *(a::$T, b::QQFieldElem) = b * a
+  end
 end
 
-*(a::ZZRingElem, b::QQFieldElem) = b*a
-
-function *(a::QQFieldElem, b::Int)
-  z = QQFieldElem()
-  ccall((:fmpq_mul_si, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), z, a, b)
-  return z
-end
-
-*(a::Int, b::QQFieldElem) = b*a
-
-function -(a::ZZRingElem, b::QQFieldElem)
-  n = a*denominator(b) - numerator(b)
-  d = denominator(b)
-  g = gcd(n, d)
-  return parent(b)(divexact(n, g), divexact(d, g))
-end
+*(a::QQFieldElem, b::Integer) = a * ZZRingElem(b)
+*(a::Integer, b::QQFieldElem) = b * a
 
 *(a::QQFieldElem, b::Rational{T}) where {T <: Integer} = a * QQFieldElem(b)
-
 *(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = b * a
 
 *(a::QQFieldElem, b::AbstractFloat) = Rational(a) * b
@@ -390,14 +340,31 @@ end
 #
 ###############################################################################
 
+function cmp(a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+  @ccall libflint.fmpq_cmp(a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Cint
+end
+
+function cmp(a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+  @ccall libflint.fmpq_cmp_fmpz(a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Cint
+end
+
+function cmp(a::QQFieldElemOrPtr, b::Int)
+  @ccall libflint.fmpq_cmp_si(a::Ref{QQFieldElem}, b::Int)::Cint
+end
+
+function cmp(a::QQFieldElemOrPtr, b::UInt)
+  @ccall libflint.fmpq_cmp_ui(a::Ref{QQFieldElem}, b::UInt)::Cint
+end
+
+cmp(a::Union{ZZRingElemOrPtr, Int, UInt}, b::QQFieldElemOrPtr) = -cmp(b, a)
+
 function ==(a::QQFieldElem, b::QQFieldElem)
   return ccall((:fmpq_equal, libflint), Bool,
                (Ref{QQFieldElem}, Ref{QQFieldElem}), a, b)
 end
 
 function isless(a::QQFieldElem, b::QQFieldElem)
-  return ccall((:fmpq_cmp, libflint), Cint,
-               (Ref{QQFieldElem}, Ref{QQFieldElem}), a, b) < 0
+  return cmp(a, b) < 0
 end
 
 ###############################################################################
@@ -423,28 +390,12 @@ end
 
 ==(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = b == a
 
-function isless(a::QQFieldElem, b::Integer)
-  z = QQFieldElem(b)
-  return ccall((:fmpq_cmp, libflint), Cint,
-               (Ref{QQFieldElem}, Ref{QQFieldElem}), a, z) < 0
+function isless(a::QQFieldElem, b::IntegerUnion)
+  return cmp(a, b) < 0
 end
 
-function isless(a::Integer, b::QQFieldElem)
-  z = QQFieldElem(a)
-  return ccall((:fmpq_cmp, libflint), Cint,
-               (Ref{QQFieldElem}, Ref{QQFieldElem}), z, b) < 0
-end
-
-function isless(a::QQFieldElem, b::ZZRingElem)
-  z = QQFieldElem(b)
-  return ccall((:fmpq_cmp, libflint), Cint,
-               (Ref{QQFieldElem}, Ref{QQFieldElem}), a, z) < 0
-end
-
-function isless(a::ZZRingElem, b::QQFieldElem)
-  z = QQFieldElem(a)
-  return ccall((:fmpq_cmp, libflint), Cint,
-               (Ref{QQFieldElem}, Ref{QQFieldElem}), z, b) < 0
+function isless(a::IntegerUnion, b::QQFieldElem)
+  return cmp(a, b) < 0
 end
 
 isless(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = isless(QQFieldElem(a), b)
@@ -470,23 +421,9 @@ function ^(a::QQFieldElem, b::Int)
 end
 
 function ^(a::QQFieldElem, k::ZZRingElem)
-  if a == 0
-    if k == 0
-      return QQFieldElem(1)
-    end
-    return QQFieldElem(0)
-  end
-
-  if a == 1
-    return QQFieldElem(1)
-  end
-  if a == -1
-    if isodd(k)
-      return QQFieldElem(-1)
-    else
-      return QQFieldElem(1)
-    end
-  end
+  is_zero(a) && return QQFieldElem(is_zero(k) ? 1 : 0)
+  is_one(a) && return QQFieldElem(1)
+  a == -1 && return QQFieldElem(isodd(k) ? -1 : 1)
   return a^Int(k)
 end
 
@@ -625,10 +562,7 @@ end
 
 function divexact(a::QQFieldElem, b::QQFieldElem; check::Bool=true)
   iszero(b) && throw(DivideError())
-  z = QQFieldElem()
-  ccall((:fmpq_div, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), z, a, b)
-  return z
+  return divexact!(QQFieldElem(), a, b)
 end
 
 div(a::QQFieldElem, b::QQFieldElem) = divexact(a, b)
@@ -646,10 +580,7 @@ end
 
 function divexact(a::QQFieldElem, b::ZZRingElem; check::Bool=true)
   iszero(b) && throw(DivideError())
-  z = QQFieldElem()
-  ccall((:fmpq_div_fmpz, libflint), Nothing,
-        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
-  return z
+  return divexact!(QQFieldElem(), a, b)
 end
 
 function divexact(a::ZZRingElem, b::QQFieldElem; check::Bool=true)
@@ -1121,12 +1052,12 @@ function set!(c::QQFieldElemOrPtr, a::UInt, b::UInt = UInt(1))
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::ZZRingElem, b::ZZRingElem)
+function set!(c::QQFieldElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
   @ccall libflint.fmpq_set_fmpz_frac(c::Ref{QQFieldElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return c
 end
 
-function set!(c::QQFieldElem, a::ZZRingElem)
+function set!(c::QQFieldElem, a::ZZRingElemOrPtr)
   GC.@preserve c begin
     set!(_num_ptr(c), a)
     one!(_den_ptr(c))
@@ -1134,81 +1065,121 @@ function set!(c::QQFieldElem, a::ZZRingElem)
   return c
 end
 
-function set!(c::Ptr{QQFieldElem}, a::ZZRingElem)
+function set!(c::Ptr{QQFieldElem}, a::ZZRingElemOrPtr)
   set!(_num_ptr(c), a)
   one!(_den_ptr(c))
   return c
 end
 
-function mul!(c::QQFieldElem, a::QQFieldElem, b::QQFieldElem)
+function numerator!(z::ZZRingElem, y::QQFieldElem)
+  ccall((:fmpq_numerator, libflint), Cvoid, (Ref{ZZRingElem}, Ref{QQFieldElem}), z, y)
+  return z
+end
+
+function denominator!(z::ZZRingElem, y::QQFieldElem)
+  ccall((:fmpq_denominator, libflint), Cvoid, (Ref{ZZRingElem}, Ref{QQFieldElem}), z, y)
+  return z
+end
+
+function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
   ccall((:fmpq_mul, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), c, a, b)
   return c
 end
 
-function mul!(c::QQFieldElem, a::QQFieldElem, b::ZZRingElem)
+function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
   ccall((:fmpq_mul_fmpz, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), c, a, b)
   return c
 end
 
-mul!(c::QQFieldElem, a::ZZRingElem, b::QQFieldElem) = mul!(c, b, a)
-
-function mul!(c::QQFieldElem, a::QQFieldElem, b::Int)
+function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
   ccall((:fmpq_mul_si, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), c, a, b)
   return c
 end
 
-mul!(c::QQFieldElem, a::Int, b::QQFieldElem) = mul!(c, b, a)
+function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+  ccall((:fmpq_mul_ui, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), c, a, b)
+  return c
+end
 
+mul!(c::QQFieldElemOrPtr, a::Union{ZZRingElemOrPtr, Int, UInt}, b::QQFieldElemOrPtr) = mul!(c, b, a)
 
-function addmul!(c::QQFieldElem, a::QQFieldElem, b::QQFieldElem)
+function addmul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
   ccall((:fmpq_addmul, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), c, a, b)
   return c
 end
 
-function add!(c::QQFieldElem, a::QQFieldElem, b::QQFieldElem)
+function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
   ccall((:fmpq_add, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), c, a, b)
   return c
 end
 
-function add!(c::QQFieldElem, a::QQFieldElem, b::ZZRingElem)
+function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
   ccall((:fmpq_add_fmpz, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), c, a, b)
   return c
 end
 
-add!(c::QQFieldElem, a::ZZRingElem, b::QQFieldElem) = add!(c, b, a)
-
-function add!(c::QQFieldElem, a::QQFieldElem, b::Int)
+function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
   ccall((:fmpq_add_si, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), c, a, b)
   return c
 end
 
-add!(c::QQFieldElem, a::Int, b::QQFieldElem) = add!(c, b, a)
+function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+  ccall((:fmpq_add_ui, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), c, a, b)
+  return c
+end
 
-@inline function sub!(z::QQFieldElem, a::QQFieldElem, b::QQFieldElem)
+add!(c::QQFieldElemOrPtr, a::Union{ZZRingElemOrPtr, Int, UInt}, b::QQFieldElemOrPtr) = add!(c, b, a)
+
+function submul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+  ccall((:fmpq_submul, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), c, a, b)
+  return c
+end
+
+function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
   ccall((:fmpq_sub, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), z, a, b)
   return z
 end
 
-@inline function sub!(z::QQFieldElem, a::QQFieldElem, b::ZZRingElem)
+function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
   ccall((:fmpq_sub_fmpz, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
   return z
 end
 
-@inline function neg!(z::QQFieldElem, a::QQFieldElem)
+function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
+  ccall((:fmpq_sub_si, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, Int), z, a, b)
+  return z
+end
+
+function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+  ccall((:fmpq_sub_ui, libflint), Nothing,
+        (Ref{QQFieldElem}, Ref{QQFieldElem}, UInt), z, a, b)
+  return z
+end
+
+function neg!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
   ccall((:fmpq_neg, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}), z, a)
   return z
 end
 
-@inline function divexact!(z::QQFieldElem, a::QQFieldElem, b::QQFieldElem)
+function divexact!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
   ccall((:fmpq_div, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{QQFieldElem}), z, a, b)
+  return z
+end
+
+function divexact!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+  ccall((:fmpq_div_fmpz, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}, Ref{ZZRingElem}), z, a, b)
   return z
 end
 
@@ -1246,11 +1217,8 @@ end
 (a::QQField)(b::QQFieldElem) = b
 
 function (a::ZZRing)(b::QQFieldElem)
-  z = ZZRingElem()
-  ccall((:fmpq_denominator, libflint), Nothing, (Ref{ZZRingElem}, Ref{QQFieldElem}), z, b)
-  isone(z) || error("Denominator must be 1")
-  ccall((:fmpq_numerator, libflint), Nothing, (Ref{ZZRingElem}, Ref{QQFieldElem}), z, b)
-  return z
+  is_one(_den_ptr(b)) || error("Denominator must be 1")
+  return numerator(b)
 end
 
 function (::ZZRing)(x::Rational{<:IntegerUnion})

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -505,45 +505,31 @@ end
 #
 ###############################################################################
 
-function +(x::ZZRingElem, c::Int)
-  z = ZZRingElem()
-  add!(z, x, c)
-  return z
-end
++(a::ZZRingElem, b::Int) = add!(ZZRingElem(), a, b)
++(a::Int, b::ZZRingElem) = b + a
 
-+(c::Int, x::ZZRingElem) = x + c
-
-function -(x::ZZRingElem, c::Int)
-  z = ZZRingElem()
-  sub!(z, x, c)
-  return z
-end
-
-function -(c::Int, x::ZZRingElem)
-  z = ZZRingElem()
-  sub!(z, x, c)
-  neg!(z, z)
-  return z
-end
-
-function *(x::ZZRingElem, c::Int)
-  z = ZZRingElem()
-  mul!(z, x, c)
-  return z
-end
-
-*(c::Int, x::ZZRingElem) = x * c
++(a::ZZRingElem, b::UInt) = add!(ZZRingElem(), a, b)
++(a::UInt, b::ZZRingElem) = b + a
 
 +(a::ZZRingElem, b::Integer) = a + ZZRingElem(b)
-
 +(a::Integer, b::ZZRingElem) = ZZRingElem(a) + b
 
--(a::ZZRingElem, b::Integer) = a - ZZRingElem(b)
+-(a::ZZRingElem, b::Int) = sub!(ZZRingElem(), a, b)
+-(a::Int, b::ZZRingElem) = neg!(b - a)
 
+-(a::ZZRingElem, b::UInt) = sub!(ZZRingElem(), a, b)
+-(a::UInt, b::ZZRingElem) = neg!(b - a)
+
+-(a::ZZRingElem, b::Integer) = a - ZZRingElem(b)
 -(a::Integer, b::ZZRingElem) = ZZRingElem(a) - b
 
-*(a::ZZRingElem, b::Integer) = a*ZZRingElem(b)
+*(a::ZZRingElem, b::Int) = mul!(ZZRingElem(), a, b)
+*(a::Int, b::ZZRingElem) = b * a
 
+*(a::ZZRingElem, b::UInt) = mul!(ZZRingElem(), a, b)
+*(a::UInt, b::ZZRingElem) = b * a
+
+*(a::ZZRingElem, b::Integer) = a*ZZRingElem(b)
 *(a::Integer, b::ZZRingElem) = ZZRingElem(a)*b
 
 *(a::ZZRingElem, b::AbstractFloat) = BigInt(a) * b
@@ -856,7 +842,7 @@ end
 #
 ###############################################################################
 
-function cmp(x::ZZRingElem, y::ZZRingElem)
+function cmp(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
   Int(ccall((:fmpz_cmp, libflint), Cint,
             (Ref{ZZRingElem}, Ref{ZZRingElem}), x, y))
 end
@@ -867,7 +853,7 @@ end
 
 <(x::ZZRingElem, y::ZZRingElem) = cmp(x,y) < 0
 
-function cmpabs(x::ZZRingElem, y::ZZRingElem)
+function cmpabs(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
   Int(ccall((:fmpz_cmpabs, libflint), Cint,
             (Ref{ZZRingElem}, Ref{ZZRingElem}), x, y))
 end
@@ -884,7 +870,7 @@ isless(x::Integer, y::ZZRingElem) = ZZRingElem(x) < y
 #
 ###############################################################################
 
-function cmp(x::ZZRingElem, y::Int)
+function cmp(x::ZZRingElemOrPtr, y::Int)
   Int(ccall((:fmpz_cmp_si, libflint), Cint, (Ref{ZZRingElem}, Int), x, y))
 end
 
@@ -900,7 +886,7 @@ end
 
 <(x::Int, y::ZZRingElem) = cmp(y,x) > 0
 
-function cmp(x::ZZRingElem, y::UInt)
+function cmp(x::ZZRingElemOrPtr, y::UInt)
   Int(ccall((:fmpz_cmp_ui, libflint), Cint, (Ref{ZZRingElem}, UInt), x, y))
 end
 
@@ -2718,36 +2704,36 @@ function fmms!(r::ZZRingElem, a::ZZRingElem, b::ZZRingElem, c::ZZRingElem, d::ZZ
 end
 
 
-function divexact!(z::ZZRingElem, a::ZZRingElem, b::UInt)
+function divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::UInt)
   ccall((:fmpz_divexact_ui, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{ZZRingElem}, UInt),
         z, a, b)
   return z
 end
 
-function divexact!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+function divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
   ccall((:fmpz_divexact, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}),
         z, a, b)
   return z
 end
 
-divexact!(z::ZZRingElem, b::ZZRingElem) = divexact!(z, z, b)
+divexact!(z::ZZRingElemOrPtr, b::ZZRingElemOrPtr) = divexact!(z, z, b)
 
-function pow!(z::ZZRingElem, a::ZZRingElem, b::Union{Int, UInt})
+function pow!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Union{Int, UInt})
   ccall((:fmpz_pow_ui, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{ZZRingElem}, UInt),
         z, a, UInt(b))
   return z
 end
 
-function lcm!(z::ZZRingElem, x::ZZRingElem, y::ZZRingElem)
+function lcm!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
   ccall((:fmpz_lcm, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, x, y)
   return z
 end
 
-function gcd!(z::ZZRingElem, x::ZZRingElem, y::ZZRingElem)
+function gcd!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
   ccall((:fmpz_gcd, libflint), Nothing,
         (Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, x, y)
   return z

--- a/src/julia/Rational.jl
+++ b/src/julia/Rational.jl
@@ -1,1 +1,5 @@
-divexact!(z::Rational{Int}, x::Rational{Int}, y::Rational{Int}) = divexact(x, y)
+divexact!(z::T, x::T, y::T) where T <: Rational = divexact(x, y)
+
+numerator!(z::T, x::Rational{T}) where T <: Integer = numerator(x)
+
+denominator!(z::T, x::Rational{T}) where T <: Integer = denominator(x)


### PR DESCRIPTION
- add some missing add!, mul!, etc. methods
- add more efficient +, -, * methods for a ZZRingElem or QQFieldElem as first argument, and an integer as second argument
- optimize is_one and is_zero for QQFieldElem
- drop some pointless uses of `@inline`
- add `cmp` for QQFieldElem and use it
- add numerator! and denominator!
- change a bunch of "unsafe" methods to accept ZZRingElemOrPtr resp. QQFieldElemOrPtr instead of just ZZRingElem and QQFieldElem to make them more flexible


This got a bit out of hand. I have more things lined up, but let's get this in while it passes my local tests, and to see what HeckeCI and OscarCI report.