### PR TITLE
Add and use zero!, one!, neg! methods

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -325,13 +325,6 @@ function numerator(a::AbsSimpleNumFieldElem)
   return z
 end
 
-function one!(r::AbsSimpleNumFieldElem)
-  a = parent(r)
-  ccall((:nf_elem_one, libflint), Nothing,
-        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), r, a)
-  return r
-end
-
 function divexact!(z::AbsSimpleNumFieldElem, x::AbsSimpleNumFieldElem, y::ZZRingElem)
   ccall((:nf_elem_scalar_div_fmpz, libflint), Nothing,
         (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{ZZRingElem}, Ref{AbsSimpleNumField}),

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -111,19 +111,9 @@ function gen(a::AbsSimpleNumField)
   return r
 end
 
-function one(a::AbsSimpleNumField)
-  r = AbsSimpleNumFieldElem(a)
-  ccall((:nf_elem_one, libflint), Nothing,
-        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), r, a)
-  return r
-end
+one(a::AbsSimpleNumField) = one!(AbsSimpleNumFieldElem(a))
 
-function zero(a::AbsSimpleNumField)
-  r = AbsSimpleNumFieldElem(a)
-  ccall((:nf_elem_zero, libflint), Nothing,
-        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), r, a)
-  return r
-end
+zero(a::AbsSimpleNumField) = zero!(AbsSimpleNumFieldElem(a))
 
 @doc raw"""
     is_gen(a::AbsSimpleNumFieldElem)
@@ -274,13 +264,7 @@ canonical_unit(x::AbsSimpleNumFieldElem) = x
 #
 ###############################################################################
 
-function -(a::AbsSimpleNumFieldElem)
-  r = a.parent()
-  ccall((:nf_elem_neg, libflint), Nothing,
-        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}),
-        r, a, a.parent)
-  return r
-end
+-(a::AbsSimpleNumFieldElem) = neg!(a.parent(), a)
 
 ###############################################################################
 #
@@ -741,6 +725,18 @@ function zero!(a::AbsSimpleNumFieldElem)
   ccall((:nf_elem_zero, libflint), Nothing,
         (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), a, parent(a))
   return a
+end
+
+function one!(a::AbsSimpleNumFieldElem)
+  ccall((:nf_elem_one, libflint), Nothing,
+        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), a, parent(a))
+  return a
+end
+
+function neg!(z::AbsSimpleNumFieldElem, a::AbsSimpleNumFieldElem)
+  ccall((:nf_elem_neg, libflint), Nothing,
+        (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumField}), z, a, parent(a))
+  return z
 end
 
 function mul!(z::AbsSimpleNumFieldElem, x::AbsSimpleNumFieldElem, y::AbsSimpleNumFieldElem)

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -1586,6 +1586,11 @@ function zero!(z::ComplexFieldElem)
   return z
 end
 
+function one!(z::ComplexFieldElem)
+  ccall((:acb_one, libflint), Nothing, (Ref{ComplexFieldElem},), z)
+  return z
+end
+
 function add!(z::ComplexFieldElem, x::ComplexFieldElem, y::ComplexFieldElem, prec::Int = precision(Balls))
   ccall((:acb_add, libflint), Nothing, (Ref{ComplexFieldElem}, Ref{ComplexFieldElem}, Ref{ComplexFieldElem}, Int),
         z, x, y, prec)

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -707,6 +707,11 @@ function zero!(z::ComplexPolyRingElem)
   return z
 end
 
+function one!(z::ComplexPolyRingElem)
+  ccall((:acb_poly_one, libflint), Nothing, (Ref{ComplexPolyRingElem},), z)
+  return z
+end
+
 function fit!(z::ComplexPolyRingElem, n::Int)
   ccall((:acb_poly_fit_length, libflint), Nothing,
         (Ref{ComplexPolyRingElem}, Int), z, n)

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -1934,6 +1934,11 @@ function zero!(z::RealFieldElem)
   return z
 end
 
+function one!(z::RealFieldElem)
+  ccall((:arb_one, libflint), Nothing, (Ref{RealFieldElem},), z)
+  return z
+end
+
 for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
               ("sub!","arb_sub"))
   @eval begin

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -607,6 +607,12 @@ function zero!(z::RealPolyRingElem)
   return z
 end
 
+function one!(z::RealPolyRingElem)
+  ccall((:arb_poly_one, libflint), Nothing,
+        (Ref{RealPolyRingElem}, ), z)
+  return z
+end
+
 function fit!(z::RealPolyRingElem, n::Int)
   ccall((:arb_poly_fit_length, libflint), Nothing,
         (Ref{RealPolyRingElem}, Int), z, n)

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1574,6 +1574,11 @@ function zero!(z::AcbFieldElem)
   return z
 end
 
+function one!(z::AcbFieldElem)
+  ccall((:acb_one, libflint), Nothing, (Ref{AcbFieldElem},), z)
+  return z
+end
+
 function add!(z::AcbFieldElem, x::AcbFieldElem, y::AcbFieldElem)
   ccall((:acb_add, libflint), Nothing, (Ref{AcbFieldElem}, Ref{AcbFieldElem}, Ref{AcbFieldElem}, Int),
         z, x, y, parent(z).prec)

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -702,6 +702,11 @@ function zero!(z::AcbPolyRingElem)
   return z
 end
 
+function one!(z::AcbPolyRingElem)
+  ccall((:acb_poly_one, libflint), Nothing, (Ref{AcbPolyRingElem},), z)
+  return z
+end
+
 function fit!(z::AcbPolyRingElem, n::Int)
   ccall((:acb_poly_fit_length, libflint), Nothing,
         (Ref{AcbPolyRingElem}, Int), z, n)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1936,6 +1936,11 @@ function zero!(z::ArbFieldElem)
   return z
 end
 
+function one!(z::ArbFieldElem)
+  ccall((:arb_one, libflint), Nothing, (Ref{ArbFieldElem},), z)
+  return z
+end
+
 for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
               ("sub!","arb_sub"))
   @eval begin

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -607,6 +607,12 @@ function zero!(z::ArbPolyRingElem)
   return z
 end
 
+function one!(z::ArbPolyRingElem)
+  ccall((:arb_poly_one, libflint), Nothing,
+        (Ref{ArbPolyRingElem}, ), z)
+  return z
+end
+
 function fit!(z::ArbPolyRingElem, n::Int)
   ccall((:arb_poly_fit_length, libflint), Nothing,
         (Ref{ArbPolyRingElem}, Int), z, n)

--- a/src/calcium/ca.jl
+++ b/src/calcium/ca.jl
@@ -113,11 +113,7 @@ end
 
 zero(C::CalciumField) = C()
 
-function one(C::CalciumField)
-  z = CalciumFieldElem(C)
-  ccall((:ca_one, libflint), Nothing, (Ref{CalciumFieldElem}, Ref{CalciumField}), z, C)
-  return z
-end
+one(C::CalciumField) = one!(CalciumFieldElem(C))
 
 ###############################################################################
 #
@@ -350,10 +346,7 @@ end
 ###############################################################################
 
 function -(a::CalciumFieldElem)
-  C = a.parent
-  r = C()
-  ccall((:ca_neg, libflint), Nothing,
-        (Ref{CalciumFieldElem}, Ref{CalciumFieldElem}, Ref{CalciumField}), r, a, C)
+  r = neg!(a.parent(), a)
   check_special(r)
   return r
 end
@@ -1388,6 +1381,18 @@ end
 function zero!(z::CalciumFieldElem)
   C = z.parent
   ccall((:ca_zero, libflint), Nothing, (Ref{CalciumFieldElem}, Ref{CalciumField}), z, C)
+  return z
+end
+
+function one!(z::CalciumFieldElem)
+  C = z.parent
+  ccall((:ca_one, libflint), Nothing, (Ref{CalciumFieldElem}, Ref{CalciumField}), z, C)
+  return z
+end
+
+function neg!(z::CalciumFieldElem, a::CalciumFieldElem)
+  C = z.parent
+  ccall((:ca_neg, libflint), Nothing, (Ref{CalciumFieldElem}, Ref{CalciumFieldElem}, Ref{CalciumField}), z, a, C)
   return z
 end
 

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -360,11 +360,7 @@ end
 #
 ###############################################################################
 
-function -(a::QQBarFieldElem)
-  z = QQBarFieldElem()
-  ccall((:qqbar_neg, libflint), Nothing, (Ref{QQBarFieldElem}, Ref{QQBarFieldElem}), z, a)
-  return z
-end
+-(a::QQBarFieldElem) = neg!(QQBarFieldElem(), a)
 
 ###############################################################################
 #
@@ -1496,6 +1492,16 @@ end
 
 function zero!(z::QQBarFieldElem)
   ccall((:qqbar_zero, libflint), Nothing, (Ref{QQBarFieldElem},), z)
+  return z
+end
+
+function one!(z::QQBarFieldElem)
+  ccall((:qqbar_one, libflint), Nothing, (Ref{QQBarFieldElem},), z)
+  return z
+end
+
+function neg!(z::QQBarFieldElem, a::QQBarFieldElem)
+  ccall((:qqbar_neg, libflint), Nothing, (Ref{QQBarFieldElem}, Ref{QQBarFieldElem}), z, a)
   return z
 end
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1039,6 +1039,11 @@ function one!(c::QQFieldElemOrPtr)
   set!(c, 1)
 end
 
+function neg!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
+  ccall((:fmpq_neg, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}), z, a)
+  return z
+end
+
 function set!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
   @ccall libflint.fmpq_set(c::Ref{QQFieldElem}, a::Ref{QQFieldElem})::Nothing
   return c
@@ -1167,11 +1172,6 @@ end
 function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
   ccall((:fmpq_sub_ui, libflint), Nothing,
         (Ref{QQFieldElem}, Ref{QQFieldElem}, UInt), z, a, b)
-  return z
-end
-
-function neg!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
-  ccall((:fmpq_neg, libflint), Nothing, (Ref{QQFieldElem}, Ref{QQFieldElem}), z, a)
   return z
 end
 

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -721,6 +721,13 @@ function zero!(z::QQAbsPowerSeriesRingElem)
   return z
 end
 
+function one!(z::QQAbsPowerSeriesRingElem)
+  ccall((:fmpq_poly_one, libflint), Nothing,
+        (Ref{QQAbsPowerSeriesRingElem},), z)
+  z.prec = parent(z).prec_max
+  return z
+end
+
 function fit!(z::QQAbsPowerSeriesRingElem, n::Int)
   ccall((:fmpq_poly_fit_length, libflint), Nothing,
         (Ref{QQAbsPowerSeriesRingElem}, Int), z, n)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -179,12 +179,7 @@ canonical_unit(a::QQMatrix) = canonical_unit(a[1, 1])
 #
 ###############################################################################
 
-function -(x::QQMatrix)
-  z = similar(x)
-  ccall((:fmpq_mat_neg, libflint), Nothing,
-        (Ref{QQMatrix}, Ref{QQMatrix}), z, x)
-  return z
-end
+-(x::QQMatrix) = neg!(similar(x), x)
 
 ###############################################################################
 #
@@ -728,6 +723,24 @@ end
 #
 ###############################################################################
 
+function zero!(z::QQMatrix)
+  ccall((:fmpq_mat_zero, libflint), Nothing,
+        (Ref{QQMatrix},), z)
+  return z
+end
+
+function one!(z::QQMatrix)
+  ccall((:fmpq_mat_one, libflint), Nothing,
+        (Ref{QQMatrix},), z)
+  return z
+end
+
+function neg!(z::QQMatrix, a::QQMatrix)
+  ccall((:fmpq_mat_neg, libflint), Nothing,
+        (Ref{QQMatrix}, Ref{QQMatrix}), z, a)
+  return z
+end
+
 function mul!(z::QQMatrix, x::QQMatrix, y::QQMatrix)
   ccall((:fmpq_mat_mul, libflint), Nothing,
         (Ref{QQMatrix}, Ref{QQMatrix}, Ref{QQMatrix}), z, x, y)
@@ -790,12 +803,6 @@ mul!(z::QQMatrix, y::IntegerUnion, x::QQMatrix) = mul!(z, x, y)
 mul!(x::QQMatrix, y::IntegerUnion) = mul!(x, x, y)
 
 mul!(z::QQMatrix, y::QQMatrix, x::Integer) = mul!(z, y, ZZ(x))
-
-function zero!(z::QQMatrix)
-  ccall((:fmpq_mat_zero, libflint), Nothing,
-        (Ref{QQMatrix},), z)
-  return z
-end
 
 function Generic.add_one!(a::QQMatrix, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -818,8 +818,6 @@ function neg!(a::QQMPolyRingElem, b::QQMPolyRingElem)
   return a
 end
 
-neg!(a::QQMPolyRingElem) = neg!(a, a)
-
 function add!(a::QQMPolyRingElem, b::QQMPolyRingElem, c::QQMPolyRingElem)
   ccall((:fmpq_mpoly_add, libflint), Nothing,
         (Ref{QQMPolyRingElem}, Ref{QQMPolyRingElem},

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -120,12 +120,7 @@ canonical_unit(a::QQPolyRingElem) = canonical_unit(leading_coefficient(a))
 #
 ###############################################################################
 
-function -(x::QQPolyRingElem)
-  z = parent(x)()
-  ccall((:fmpq_poly_neg, libflint), Nothing,
-        (Ref{QQPolyRingElem}, Ref{QQPolyRingElem}), z, x)
-  return z
-end
+-(x::QQPolyRingElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -780,6 +775,18 @@ end
 function zero!(z::QQPolyRingElem)
   ccall((:fmpq_poly_zero, libflint), Nothing,
         (Ref{QQPolyRingElem},), z)
+  return z
+end
+
+function one!(z::QQPolyRingElem)
+  ccall((:fmpq_poly_one, libflint), Nothing,
+        (Ref{QQPolyRingElem},), z)
+  return z
+end
+
+function neg!(z::QQPolyRingElem, a::QQPolyRingElem)
+  ccall((:fmpq_poly_neg, libflint), Nothing,
+        (Ref{QQPolyRingElem}, Ref{QQPolyRingElem}), z, a)
   return z
 end
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -904,7 +904,7 @@ function one!(z::QQRelPowerSeriesRingElem)
   ccall((:fmpq_poly_one, libflint), Nothing,
         (Ref{QQRelPowerSeriesRingElem},), z)
   z.prec = parent(z).prec_max
-  z.val = parent(z).prec_max
+  z.val = 0
   return z
 end
 

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -900,6 +900,14 @@ function zero!(z::QQRelPowerSeriesRingElem)
   return z
 end
 
+function one!(z::QQRelPowerSeriesRingElem)
+  ccall((:fmpq_poly_one, libflint), Nothing,
+        (Ref{QQRelPowerSeriesRingElem},), z)
+  z.prec = parent(z).prec_max
+  z.val = parent(z).prec_max
+  return z
+end
+
 function fit!(z::QQRelPowerSeriesRingElem, n::Int)
   ccall((:fmpq_poly_fit_length, libflint), Nothing,
         (Ref{QQRelPowerSeriesRingElem}, Int), z, n)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2512,6 +2512,13 @@ function one!(z::ZZRingElemOrPtr)
   set!(z, UInt(1))
 end
 
+function neg!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+  ccall((:fmpz_neg, libflint), Nothing,
+        (Ref{ZZRingElem}, Ref{ZZRingElem}),
+        z, a)
+  return z
+end
+
 function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
   @ccall libflint.fmpz_set(z::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
@@ -2558,15 +2565,6 @@ end
 
 add!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Integer) = add!(z, a, flintify(b))
 add!(z::ZZRingElemOrPtr, x::Int, y::ZZRingElemOrPtr) = add!(z, y, x)
-
-function neg!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
-  ccall((:fmpz_neg, libflint), Nothing,
-        (Ref{ZZRingElem}, Ref{ZZRingElem}),
-        z, a)
-  return z
-end
-
-neg!(a::ZZRingElemOrPtr) = neg!(a, a)
 
 function sub!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
   ccall((:fmpz_sub, libflint), Nothing,

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -529,6 +529,13 @@ function zero!(z::ZZAbsPowerSeriesRingElem)
   return z
 end
 
+function one!(z::ZZAbsPowerSeriesRingElem)
+  ccall((:fmpz_poly_one, libflint), Nothing,
+        (Ref{ZZAbsPowerSeriesRingElem},), z)
+  z.prec = parent(z).prec_max
+  return z
+end
+
 function fit!(z::ZZAbsPowerSeriesRingElem, n::Int)
   ccall((:fmpz_poly_fit_length, libflint), Nothing,
         (Ref{ZZAbsPowerSeriesRingElem}, Int), z, n)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1810,6 +1810,23 @@ end
 #
 ###############################################################################
 
+function zero!(z::ZZMatrix)
+  ccall((:fmpz_mat_zero, libflint), Nothing,
+        (Ref{ZZMatrix},), z)
+  return z
+end
+
+function one!(z::ZZMatrix)
+  ccall((:fmpz_mat_one, libflint), Nothing,
+        (Ref{ZZMatrix},), z)
+  return z
+end
+
+function neg!(z::ZZMatrix, w::ZZMatrix)
+  ccall((:fmpz_mat_neg, libflint), Nothing, (Ref{ZZMatrix}, Ref{ZZMatrix}), z, w)
+  return z
+end
+
 function add!(z::ZZMatrix, x::ZZMatrix, y::ZZMatrix)
   ccall((:fmpz_mat_add, libflint), Nothing,
         (Ref{ZZMatrix}, Ref{ZZMatrix}, Ref{ZZMatrix}), z, x, y)
@@ -1859,19 +1876,6 @@ function addmul!(z::ZZMatrix, y::ZZMatrix, x::Int)
         (Ref{ZZMatrix}, Ref{ZZMatrix}, Int), z, y, x)
   return z
 end
-
-function zero!(z::ZZMatrix)
-  ccall((:fmpz_mat_zero, libflint), Nothing,
-        (Ref{ZZMatrix},), z)
-  return z
-end
-
-function neg!(z::ZZMatrix, w::ZZMatrix)
-  ccall((:fmpz_mat_neg, libflint), Nothing, (Ref{ZZMatrix}, Ref{ZZMatrix}), z, w)
-  return z
-end
-
-neg!(z::ZZMatrix) = neg!(z, z)
 
 function mul!(z::Vector{ZZRingElem}, a::ZZMatrix, b::Vector{ZZRingElem})
   ccall((:fmpz_mat_mul_fmpz_vec_ptr, libflint), Nothing,
@@ -2077,9 +2081,7 @@ function identity_matrix(R::ZZRing, n::Int)
   if n < 0
     error("dimension must not be negative")
   end
-  z = ZZMatrix(n, n)
-  ccall((:fmpz_mat_one, libflint), Nothing, (Ref{ZZMatrix}, ), z)
-  return z
+  return one!(ZZMatrix(n, n))
 end
 
 ################################################################################

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -342,6 +342,20 @@ function zero!(z::ZZModRingElem)
   return z
 end
 
+function one!(z::ZZModRingElem)
+  one!(z.data)
+  return z
+end
+
+function neg!(z::ZZModRingElem, a::ZZModRingElem)
+  if iszero(a.data)
+    z.data = zero!(z.data)
+  else
+    z.data = sub!(z.data, R.n, a.data)
+  end
+  return z
+end
+
 function mul!(z::ZZModRingElem, x::ZZModRingElem, y::ZZModRingElem)
   R = parent(z)
   ccall((:fmpz_mod_mul, libflint), Nothing,

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -559,6 +559,14 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       return z
     end
 
+    function one!(z::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($ctype)}),
+            z, z.parent.base_ring.ninv)
+      z.prec = parent(z).prec_max
+      return z
+    end
+
     function fit!(z::($etype), n::Int)
       ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -98,10 +98,7 @@ base_ring(a::T) where T <: Zmod_fmpz_mat = a.base_ring
 
 function one(a::ZZModMatrixSpace)
   (nrows(a) != ncols(a)) && error("Matrices must be square")
-  z = a()
-  ccall((:fmpz_mod_mat_one, libflint), Nothing,
-        (Ref{ZZModMatrix}, Ref{fmpz_mod_ctx_struct}), z, base_ring(a).ninv)
-  return z
+  return one!(a())
 end
 
 function iszero(a::T) where T <: Zmod_fmpz_mat
@@ -198,12 +195,7 @@ reverse_cols(x::T) where T <: Zmod_fmpz_mat = reverse_cols!(deepcopy(x))
 #
 ################################################################################
 
-function -(x::T) where T <: Zmod_fmpz_mat
-  z = similar(x)
-  ccall((:fmpz_mod_mat_neg, libflint), Nothing,
-        (Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}), z, x, base_ring(x).ninv)
-  return z
-end
+-(x::T) where T <: Zmod_fmpz_mat = neg!(similar(x), x)
 
 ################################################################################
 #
@@ -246,6 +238,24 @@ end
 #
 ################################################################################
 
+function zero!(a::T) where T <: Zmod_fmpz_mat
+  ccall((:fmpz_mod_mat_zero, libflint), Nothing,
+        (Ref{T}, Ref{fmpz_mod_ctx_struct}), a, base_ring(a).ninv)
+  return a
+end
+
+function one!(a::T) where T <: Zmod_fmpz_mat
+  ccall((:fmpz_mod_mat_one, libflint), Nothing,
+        (Ref{T}, Ref{fmpz_mod_ctx_struct}), a, base_ring(a).ninv)
+  return a
+end
+
+function neg!(z::T, a::T) where T <: Zmod_fmpz_mat
+  ccall((:fmpz_mod_mat_neg, libflint), Nothing,
+        (Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}), z, a, base_ring(a).ninv)
+  return z
+end
+
 function mul!(a::T, b::T, c::T) where T <: Zmod_fmpz_mat
   ccall((:fmpz_mod_mat_mul, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
@@ -257,12 +267,6 @@ function add!(a::T, b::T, c::T) where T <: Zmod_fmpz_mat
   ccall((:fmpz_mod_mat_add, libflint), Nothing,
         (Ref{T}, Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
         a, b, c, base_ring(b).ninv)
-  return a
-end
-
-function zero!(a::T) where T <: Zmod_fmpz_mat
-  ccall((:fmpz_mod_mat_zero, libflint), Nothing,
-        (Ref{T}, Ref{fmpz_mod_ctx_struct}), a, base_ring(a).ninv)
   return a
 end
 

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -99,21 +99,9 @@ for (etype, rtype, ftype, ctype) in (
       #                a, a.parent)
     end
 
-    function one(R::($rtype))
-      z = R()
-      ccall((:fmpz_mod_mpoly_one, libflint), Nothing,
-            (Ref{($etype)}, Ref{($rtype)}),
-            z, R)
-      return z
-    end
+    one(R::($rtype)) = one!(R())
 
-    function zero(R::($rtype))
-      z = R()
-      ccall((:fmpz_mod_mpoly_zero, libflint), Nothing,
-            (Ref{($etype)}, Ref{($rtype)}),
-            z, R)
-      return z
-    end
+    zero(R::($rtype)) = zero!(R())
 
     function isone(a::($etype))
       return Bool(ccall((:fmpz_mod_mpoly_is_one, libflint), Cint,
@@ -311,13 +299,7 @@ for (etype, rtype, ftype, ctype) in (
     #
     ###############################################################################
 
-    function -(a::($etype))
-      z = parent(a)()
-      ccall((:fmpz_mod_mpoly_neg, libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),
-            z, a, parent(a))
-      return z
-    end
+    -(a::($etype)) = neg!(parent(a)(), a)
 
     function +(a::($etype), b::($etype))
       check_parent(a, b)
@@ -414,13 +396,7 @@ for (etype, rtype, ftype, ctype) in (
 
     -(a::($etype), b::Integer) = a - base_ring(parent(a))(b)
 
-    function -(b::Integer, a::($etype))
-      z = a - b
-      ccall((:fmpz_mod_mpoly_neg, libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),
-            z, z, parent(a))
-      return z
-    end
+    -(b::Integer, a::($etype)) = neg!(a - b)
 
     function *(a::($etype), b::UInt)
       z = parent(a)()
@@ -770,6 +746,20 @@ for (etype, rtype, ftype, ctype) in (
             (Ref{($etype)}, Ref{($rtype)}),
             a, parent(a))
       return a
+    end
+
+    function one!(a::($etype))
+      ccall((:fmpz_mod_mpoly_one, libflint), Nothing,
+            (Ref{($etype)}, Ref{($rtype)}),
+            a, parent(a))
+      return a
+    end
+
+    function neg!(z::($etype), a::($etype))
+      ccall((:fmpz_mod_mpoly_neg, libflint), Nothing,
+            (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),
+            z, a, parent(a))
+      return z
     end
 
     function add!(a::($etype), b::($etype), c::($etype))

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -125,13 +125,7 @@ canonical_unit(a::Zmodn_fmpz_poly) = canonical_unit(leading_coefficient(a))
 #
 ################################################################################
 
-function -(x::T) where {T <: Zmodn_fmpz_poly}
-  z = parent(x)()
-  ccall((:fmpz_mod_poly_neg, libflint), Nothing,
-        (Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
-        z, x, x.parent.base_ring.ninv)
-  return z
-end
+-(x::T) where {T <: Zmodn_fmpz_poly} = neg!(parent(x)(), x)
 
 ################################################################################
 #
@@ -874,6 +868,20 @@ function zero!(x::T) where {T <: Zmodn_fmpz_poly}
         (Ref{T}, Ref{fmpz_mod_ctx_struct}),
         x, x.parent.base_ring.ninv)
   return x
+end
+
+function one!(x::T) where {T <: Zmodn_fmpz_poly}
+  ccall((:fmpz_mod_poly_one, libflint), Nothing,
+        (Ref{T}, Ref{fmpz_mod_ctx_struct}),
+        x, x.parent.base_ring.ninv)
+  return x
+end
+
+function neg!(z::T, x::T) where {T <: Zmodn_fmpz_poly}
+  ccall((:fmpz_mod_poly_neg, libflint), Nothing,
+        (Ref{T}, Ref{T}, Ref{fmpz_mod_ctx_struct}),
+        z, x, x.parent.base_ring.ninv)
+  return z
 end
 
 function fit!(x::T, n::Int) where {T <: Zmodn_fmpz_poly}

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -699,7 +699,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
             (Ref{($etype)}, Ref{($ctype)}),
             x, x.parent.base_ring.ninv)
       x.prec = parent(x).prec_max
-      x.val = parent(x).prec_max
+      x.val = 0
       return x
     end
 

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -694,6 +694,15 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       return x
     end
 
+    function one!(x::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($ctype)}),
+            x, x.parent.base_ring.ninv)
+      x.prec = parent(x).prec_max
+      x.val = parent(x).prec_max
+      return x
+    end
+
     function fit!(x::($etype), n::Int)
       ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -80,19 +80,9 @@ function length(a::ZZMPolyRingElem)
   return n
 end
 
-function one(R::ZZMPolyRing)
-  z = R()
-  ccall((:fmpz_mpoly_one, libflint), Nothing,
-        (Ref{ZZMPolyRingElem}, Ref{ZZMPolyRing}), z, R)
-  return z
-end
+one(R::ZZMPolyRing) = one!(R())
 
-function zero(R::ZZMPolyRing)
-  z = R()
-  ccall((:fmpz_mpoly_zero, libflint), Nothing,
-        (Ref{ZZMPolyRingElem}, Ref{ZZMPolyRing}), z, R)
-  return z
-end
+zero(R::ZZMPolyRing) = zero!(R())
 
 function isone(a::ZZMPolyRingElem)
   b = ccall((:fmpz_mpoly_is_one, libflint), Cint,
@@ -779,6 +769,18 @@ function zero!(a::ZZMPolyRingElem)
   ccall((:fmpz_mpoly_zero, libflint), Nothing,
         (Ref{ZZMPolyRingElem}, Ref{ZZMPolyRing}), a, a.parent)
   return a
+end
+
+function one!(a::ZZMPolyRingElem)
+  ccall((:fmpz_mpoly_one, libflint), Nothing,
+        (Ref{ZZMPolyRingElem}, Ref{ZZMPolyRing}), a, a.parent)
+  return a
+end
+
+function neg!(z::ZZMPolyRingElem, a::ZZMPolyRingElem)
+  ccall((:fmpz_mpoly_neg, libflint), Nothing,
+        (Ref{ZZMPolyRingElem}, Ref{ZZMPolyRingElem}, Ref{ZZMPolyRing}), z, a, a.parent)
+  return z
 end
 
 function add!(a::ZZMPolyRingElem, b::ZZMPolyRingElem, c::ZZMPolyRingElem)

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -115,12 +115,7 @@ canonical_unit(a::ZZPolyRingElem) = canonical_unit(leading_coefficient(a))
 #
 ###############################################################################
 
-function -(x::ZZPolyRingElem)
-  z = parent(x)()
-  ccall((:fmpz_poly_neg, libflint), Nothing,
-        (Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}), z, x)
-  return z
-end
+-(x::ZZPolyRingElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -860,9 +855,21 @@ end
 #
 ###############################################################################
 
-function zero!(z::ZZPolyRingElem)
+function zero!(z::ZZPolyRingElemOrPtr)
   ccall((:fmpz_poly_zero, libflint), Nothing,
         (Ref{ZZPolyRingElem},), z)
+  return z
+end
+
+function one!(z::ZZPolyRingElemOrPtr)
+  ccall((:fmpz_poly_one, libflint), Nothing,
+        (Ref{ZZPolyRingElem},), z)
+  return z
+end
+
+function neg!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr)
+  ccall((:fmpz_poly_neg, libflint), Nothing,
+        (Ref{ZZPolyRingElem}, Ref{ZZPolyRingElem}), z, a)
   return z
 end
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -595,7 +595,7 @@ function one!(x::ZZRelPowerSeriesRingElem)
   ccall((:fmpz_poly_one, libflint), Nothing,
         (Ref{ZZRelPowerSeriesRingElem},), x)
   x.prec = parent(x).prec_max
-  x.val = parent(x).prec_max
+  x.val = 0
   return x
 end
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -591,6 +591,14 @@ function zero!(x::ZZRelPowerSeriesRingElem)
   return x
 end
 
+function one!(x::ZZRelPowerSeriesRingElem)
+  ccall((:fmpz_poly_one, libflint), Nothing,
+        (Ref{ZZRelPowerSeriesRingElem},), x)
+  x.prec = parent(x).prec_max
+  x.val = parent(x).prec_max
+  return x
+end
+
 function fit!(z::ZZRelPowerSeriesRingElem, n::Int)
   ccall((:fmpz_poly_fit_length, libflint), Nothing,
         (Ref{ZZRelPowerSeriesRingElem}, Int), z, n)

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -54,17 +54,9 @@ function coeff(x::FqPolyRepFieldElem, n::Int)
   return z
 end
 
-function zero(a::FqPolyRepField)
-  d = a()
-  ccall((:fq_zero, libflint), Nothing, (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), d, a)
-  return d
-end
+zero(a::FqPolyRepField) = zero!(a())
 
-function one(a::FqPolyRepField)
-  d = a()
-  ccall((:fq_one, libflint), Nothing, (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), d, a)
-  return d
-end
+one(a::FqPolyRepField) = one!(a())
 
 @doc raw"""
     gen(a::FqPolyRepField)
@@ -177,12 +169,7 @@ end
 #
 ###############################################################################
 
-function -(x::FqPolyRepFieldElem)
-  z = parent(x)()
-  ccall((:fq_neg, libflint), Nothing,
-        (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, x, x.parent)
-  return z
-end
+-(x::FqPolyRepFieldElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -476,6 +463,18 @@ end
 function zero!(z::FqPolyRepFieldElem)
   ccall((:fq_zero, libflint), Nothing,
         (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, z.parent)
+  return z
+end
+
+function one!(z::FqPolyRepFieldElem)
+  ccall((:fq_one, libflint), Nothing,
+        (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, z.parent)
+  return z
+end
+
+function neg!(z::FqPolyRepFieldElem, a::FqPolyRepFieldElem)
+  ccall((:fq_neg, libflint), Nothing,
+        (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, a, a.parent)
   return z
 end
 

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -583,6 +583,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return z
     end
 
+    function one!(z::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($ctype)}), z, base_ring(z))
+      z.prec = parent(z).prec_max
+      return z
+    end
+
     function fit!(z::($etype), n::Int)
       ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -46,17 +46,9 @@ function _coeff(x::FqFieldElem, n::Int)
   return z
 end
 
-function zero(a::FqField)
-  d = a()
-  ccall((:fq_default_zero, libflint), Nothing, (Ref{FqFieldElem}, Ref{FqField}), d, a)
-  return d
-end
+zero(a::FqField) = zero!(a())
 
-function one(a::FqField)
-  d = a()
-  ccall((:fq_default_one, libflint), Nothing, (Ref{FqFieldElem}, Ref{FqField}), d, a)
-  return d
-end
+one(a::FqField) = one!(a())
 
 function _gen(a::FqField)
   d = a()
@@ -400,12 +392,7 @@ end
 #
 ###############################################################################
 
-function -(x::FqFieldElem)
-  z = parent(x)()
-  ccall((:fq_default_neg, libflint), Nothing,
-        (Ref{FqFieldElem}, Ref{FqFieldElem}, Ref{FqField}), z, x, x.parent)
-  return z
-end
+-(x::FqFieldElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -672,6 +659,19 @@ function zero!(z::FqFieldElem)
   ccall((:fq_default_zero, libflint), Nothing,
         (Ref{FqFieldElem}, Ref{FqField}), z, z.parent)
   z.poly = nothing
+  return z
+end
+
+function one!(z::FqFieldElem)
+  ccall((:fq_default_one, libflint), Nothing,
+        (Ref{FqFieldElem}, Ref{FqField}), z, z.parent)
+  z.poly = nothing
+  return z
+end
+
+function neg!(z::FqFieldElem, a::FqFieldElem)
+  ccall((:fq_default_neg, libflint), Nothing,
+        (Ref{FqFieldElem}, Ref{FqFieldElem}, Ref{FqField}), z, a, a.parent)
   return z
 end
 

--- a/src/flint/fq_default_abs_series.jl
+++ b/src/flint/fq_default_abs_series.jl
@@ -165,14 +165,7 @@ end
 #
 ###############################################################################
 
-function -(x::FqAbsPowerSeriesRingElem)
-  z = parent(x)()
-  ccall((:fq_default_poly_neg, libflint), Nothing,
-        (Ref{FqAbsPowerSeriesRingElem}, Ref{FqAbsPowerSeriesRingElem}, Ref{FqField}),
-        z, x, base_ring(x))
-  z.prec = x.prec
-  return z
-end
+-(x::FqAbsPowerSeriesRingElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -606,6 +599,21 @@ function zero!(z::FqAbsPowerSeriesRingElem)
   ccall((:fq_default_poly_zero, libflint), Nothing,
         (Ref{FqAbsPowerSeriesRingElem}, Ref{FqField}), z, base_ring(z))
   z.prec = parent(z).prec_max
+  return z
+end
+
+function one!(z::FqAbsPowerSeriesRingElem)
+  ccall((:fq_default_poly_one, libflint), Nothing,
+        (Ref{FqAbsPowerSeriesRingElem}, Ref{FqField}), z, base_ring(z))
+  z.prec = parent(z).prec_max
+  return z
+end
+
+function neg!(z::FqAbsPowerSeriesRingElem, a::FqAbsPowerSeriesRingElem)
+  ccall((:fq_default_poly_neg, libflint), Nothing,
+        (Ref{FqAbsPowerSeriesRingElem}, Ref{FqAbsPowerSeriesRingElem}, Ref{FqField}),
+        z, a, base_ring(a))
+  z.prec = a.prec
   return z
 end
 

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -213,12 +213,7 @@ reverse_cols(x::FqMatrix) = reverse_cols!(deepcopy(x))
 #
 ################################################################################
 
-function -(x::FqMatrix)
-  z = similar(x)
-  ccall((:fq_default_mat_neg, libflint), Nothing,
-        (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqField}), z, x, base_ring(x))
-  return z
-end
+-(x::FqMatrix) = neg!(similar(x), x)
 
 ################################################################################
 #
@@ -261,6 +256,24 @@ end
 #
 ################################################################################
 
+function zero!(a::FqMatrix)
+  ccall((:fq_default_mat_zero, libflint), Nothing,
+        (Ref{FqMatrix}, Ref{FqField}), a, base_ring(a))
+  return a
+end
+
+function one!(a::FqMatrix)
+  ccall((:fq_default_mat_one, libflint), Nothing,
+        (Ref{FqMatrix}, Ref{FqField}), a, base_ring(a))
+  return a
+end
+
+function neg!(z::FqMatrix, a::FqMatrix)
+  ccall((:fq_default_mat_neg, libflint), Nothing,
+        (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqField}), z, a, base_ring(a))
+  return z
+end
+
 function mul!(a::FqMatrix, b::FqMatrix, c::FqMatrix)
   ccall((:fq_default_mat_mul, libflint), Nothing,
         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqField}),
@@ -292,12 +305,6 @@ function add!(a::FqMatrix, b::FqMatrix, c::FqMatrix)
   ccall((:fq_default_mat_add, libflint), Nothing,
         (Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqMatrix}, Ref{FqField}),
         a, b, c, base_ring(a))
-  return a
-end
-
-function zero!(a::FqMatrix)
-  ccall((:fq_default_mat_zero, libflint), Nothing,
-        (Ref{FqMatrix}, Ref{FqField}), a, base_ring(a))
   return a
 end
 

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -441,6 +441,16 @@ function zero!(a::FqMPolyRingElem)
   return a
 end
 
+function one!(a::FqMPolyRingElem)
+  a.data = one!(a.data)
+  return a
+end
+
+function neg!(z::FqMPolyRingElem, a::FqMPolyRingElem)
+  z.data = neg!(z.data, a.data)
+  return z
+end
+
 function add!(a::FqMPolyRingElem, b::FqMPolyRingElem, c::FqMPolyRingElem)
   a.data = add!(a.data, b.data, c.data)
   return a

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -109,13 +109,7 @@ canonical_unit(a::FqPolyRingElem) = canonical_unit(leading_coefficient(a))
 #
 ################################################################################
 
-function -(x::FqPolyRingElem)
-  z = parent(x)()
-  ccall((:fq_default_poly_neg, libflint), Nothing,
-        (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqField}),
-        z, x, base_ring(parent(x)))
-  return z
-end
+-(x::FqPolyRingElem) = neg!(parent(x)(), x)
 
 ################################################################################
 #
@@ -730,6 +724,20 @@ function zero!(z::FqPolyRingElem)
   ccall((:fq_default_poly_zero, libflint), Nothing,
         (Ref{FqPolyRingElem}, Ref{FqField}),
         z, base_ring(parent(z)))
+  return z
+end
+
+function one!(z::FqPolyRingElem)
+  ccall((:fq_default_poly_one, libflint), Nothing,
+        (Ref{FqPolyRingElem}, Ref{FqField}),
+        z, base_ring(parent(z)))
+  return z
+end
+
+function neg!(z::FqPolyRingElem, a::FqPolyRingElem)
+  ccall((:fq_default_poly_neg, libflint), Nothing,
+        (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqField}),
+        z, a, base_ring(parent(a)))
   return z
 end
 

--- a/src/flint/fq_default_rel_series.jl
+++ b/src/flint/fq_default_rel_series.jl
@@ -161,15 +161,7 @@ end
 #
 ###############################################################################
 
-function -(x::FqRelPowerSeriesRingElem)
-  z = parent(x)()
-  ccall((:fq_default_poly_neg, libflint), Nothing,
-        (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Ref{FqField}),
-        z, x, base_ring(x))
-  z.prec = x.prec
-  z.val = x.val
-  return z
-end
+-(x::FqRelPowerSeriesRingElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -243,9 +235,7 @@ function -(a::FqRelPowerSeriesRingElem, b::FqRelPowerSeriesRingElem)
     ccall((:fq_default_poly_shift_left, libflint), Nothing,
           (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
           z, z, b.val - a.val, ctx)
-    ccall((:fq_default_poly_neg, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Ref{FqField}),
-          z, z, ctx)
+    z = neg!(z)
     ccall((:fq_default_poly_add_series, libflint), Nothing,
           (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem},
            Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
@@ -669,6 +659,22 @@ function zero!(x::FqRelPowerSeriesRingElem)
   x.prec = parent(x).prec_max
   x.val = parent(x).prec_max
   return x
+end
+
+function one!(x::FqRelPowerSeriesRingElem)
+  ccall((:fq_default_poly_one, libflint), Nothing,
+        (Ref{FqRelPowerSeriesRingElem}, Ref{FqField}), x, base_ring(x))
+  x.prec = parent(x).prec_max
+  x.val = parent(x).prec_max
+  return x
+end
+
+function neg!(z::FqRelPowerSeriesRingElem, x::FqRelPowerSeriesRingElem)
+  ccall((:fq_default_poly_neg, libflint), Nothing,
+        (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Ref{FqField}), z, x, base_ring(x))
+  z.prec = x.prec
+  z.val = x.val
+  return z
 end
 
 function fit!(z::FqRelPowerSeriesRingElem, n::Int)

--- a/src/flint/fq_default_rel_series.jl
+++ b/src/flint/fq_default_rel_series.jl
@@ -665,7 +665,7 @@ function one!(x::FqRelPowerSeriesRingElem)
   ccall((:fq_default_poly_one, libflint), Nothing,
         (Ref{FqRelPowerSeriesRingElem}, Ref{FqField}), x, base_ring(x))
   x.prec = parent(x).prec_max
-  x.val = parent(x).prec_max
+  x.val = 0
   return x
 end
 

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -208,12 +208,7 @@ reverse_cols(x::FqPolyRepMatrix) = reverse_cols!(deepcopy(x))
 #
 ################################################################################
 
-function -(x::FqPolyRepMatrix)
-  z = similar(x)
-  ccall((:fq_mat_neg, libflint), Nothing,
-        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), z, x, base_ring(x))
-  return z
-end
+-(x::FqPolyRepMatrix) = neg!(similar(x), x)
 
 ################################################################################
 #
@@ -249,6 +244,24 @@ end
 #
 ################################################################################
 
+function zero!(a::FqPolyRepMatrix)
+  ccall((:fq_mat_zero, libflint), Nothing,
+        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), a, base_ring(a))
+  return a
+end
+
+function one!(a::FqPolyRepMatrix)
+  ccall((:fq_mat_one, libflint), Nothing,
+        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), a, base_ring(a))
+  return a
+end
+
+function neg!(z::FqPolyRepMatrix, a::FqPolyRepMatrix)
+  ccall((:fq_mat_neg, libflint), Nothing,
+        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), z, a, base_ring(a))
+  return z
+end
+
 function mul!(a::FqPolyRepMatrix, b::FqPolyRepMatrix, c::FqPolyRepMatrix)
   ccall((:fq_mat_mul, libflint), Nothing,
         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}),
@@ -267,12 +280,6 @@ function sub!(a::FqPolyRepMatrix, b::FqPolyRepMatrix, c::FqPolyRepMatrix)
   ccall((:fq_mat_sub, libflint), Nothing,
         (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}),
         a, b, c, base_ring(a))
-  return a
-end
-
-function zero!(a::FqPolyRepMatrix)
-  ccall((:fq_mat_zero, libflint), Nothing,
-        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), a, base_ring(a))
   return a
 end
 

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -67,19 +67,9 @@ function setindex_raw!(x::fqPolyRepFieldElem, c::UInt, i::Int)
   return x
 end
 
-function zero(a::fqPolyRepField)
-  d = a()
-  ccall((:fq_nmod_zero, libflint), Nothing,
-        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, a)
-  return d
-end
+zero(a::fqPolyRepField) = zero!(a())
 
-function one(a::fqPolyRepField)
-  d = a()
-  ccall((:fq_nmod_one, libflint), Nothing,
-        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), d, a)
-  return d
-end
+one(a::fqPolyRepField) = one!(a())
 
 function gen(a::fqPolyRepField)
   d = a()
@@ -172,12 +162,7 @@ end
 #
 ###############################################################################
 
-function -(x::fqPolyRepFieldElem)
-  z = parent(x)()
-  ccall((:fq_nmod_neg, libflint), Nothing,
-        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, x, x.parent)
-  return z
-end
+-(x::fqPolyRepFieldElem) = neg!(parent(x)(), x)
 
 ###############################################################################
 #
@@ -459,6 +444,24 @@ end
 #
 ###############################################################################
 
+function zero!(z::fqPolyRepFieldElem)
+  ccall((:fq_nmod_zero, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, z.parent)
+  return z
+end
+
+function one!(z::fqPolyRepFieldElem)
+  ccall((:fq_nmod_one, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, z.parent)
+  return z
+end
+
+function neg!(z::fqPolyRepFieldElem, a::fqPolyRepFieldElem)
+  ccall((:fq_nmod_neg, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, a, a.parent)
+  return z
+end
+
 function set!(z::fqPolyRepFieldElem, x::fqPolyRepFieldElemOrPtr)
   ccall((:fq_nmod_set, libflint), Nothing,
         (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
@@ -487,12 +490,6 @@ function set!(z::fqPolyRepFieldElem, x::fpPolyRingElemOrPtr)
   ccall((:fq_nmod_set_nmod_poly, libflint), Nothing,
         (Ref{fqPolyRepFieldElem}, Ref{fpPolyRingElem}, Ref{fqPolyRepField}),
         z, x, parent(z))
-end
-
-function zero!(z::fqPolyRepFieldElem)
-  ccall((:fq_nmod_zero, libflint), Nothing,
-        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, z.parent)
-  return z
 end
 
 function mul!(z::fqPolyRepFieldElem, x::fqPolyRepFieldElem, y::fqPolyRepFieldElem)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -194,12 +194,7 @@ reverse_cols(x::fqPolyRepMatrix) = reverse_cols!(deepcopy(x))
 #
 ################################################################################
 
-function -(x::fqPolyRepMatrix)
-  z = similar(x)
-  ccall((:fq_nmod_mat_neg, libflint), Nothing,
-        (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), z, x, base_ring(x))
-  return z
-end
+-(x::fqPolyRepMatrix) = neg!(similar(x), x)
 
 ################################################################################
 #
@@ -236,6 +231,24 @@ end
 #
 ################################################################################
 
+function zero!(a::fqPolyRepMatrix)
+  ccall((:fq_nmod_mat_zero, libflint), Nothing,
+        (Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), a, base_ring(a))
+  return a
+end
+
+function one!(a::fqPolyRepMatrix)
+  ccall((:fq_nmod_mat_one, libflint), Nothing,
+        (Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), a, base_ring(a))
+  return a
+end
+
+function neg!(z::fqPolyRepMatrix, a::fqPolyRepMatrix)
+  ccall((:fq_nmod_mat_neg, libflint), Nothing,
+        (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), z, a, base_ring(a))
+  return z
+end
+
 function mul!(a::fqPolyRepMatrix, b::fqPolyRepMatrix, c::fqPolyRepMatrix)
   ccall((:fq_nmod_mat_mul, libflint), Nothing,
         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}),
@@ -254,12 +267,6 @@ function sub!(a::fqPolyRepMatrix, b::fqPolyRepMatrix, c::fqPolyRepMatrix)
   ccall((:fq_nmod_mat_sub, libflint), Nothing,
         (Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}),
         a, b, c, base_ring(a))
-  return a
-end
-
-function zero!(a::fqPolyRepMatrix)
-  ccall((:fq_nmod_mat_zero, libflint), Nothing,
-        (Ref{fqPolyRepMatrix}, Ref{fqPolyRepField}), a, base_ring(a))
   return a
 end
 

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -81,21 +81,9 @@ function length(a::fqPolyRepMPolyRingElem)
   return n
 end
 
-function one(R::fqPolyRepMPolyRing)
-  z = R()
-  ccall((:fq_nmod_mpoly_one, libflint), Nothing,
-        (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
-        z, R)
-  return z
-end
+one(R::fqPolyRepMPolyRing) = one!(R())
 
-function zero(R::fqPolyRepMPolyRing)
-  z = R()
-  ccall((:fq_nmod_mpoly_zero, libflint), Nothing,
-        (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
-        z, R)
-  return z
-end
+zero(R::fqPolyRepMPolyRing) = zero!(R())
 
 function isone(a::fqPolyRepMPolyRingElem)
   b = ccall((:fq_nmod_mpoly_is_one, libflint), Cint,
@@ -295,13 +283,7 @@ end
 #
 ###############################################################################
 
-function -(a::fqPolyRepMPolyRingElem)
-  z = parent(a)()
-  ccall((:fq_nmod_mpoly_neg, libflint), Nothing,
-        (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
-        z, a, a.parent)
-  return z
-end
+-(a::fqPolyRepMPolyRingElem) = neg!(parent(a)(), a)
 
 function +(a::fqPolyRepMPolyRingElem, b::fqPolyRepMPolyRingElem)
   check_parent(a, b)
@@ -763,6 +745,20 @@ function zero!(a::fqPolyRepMPolyRingElem)
         (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
         a, a.parent)
   return a
+end
+
+function one!(a::fqPolyRepMPolyRingElem)
+  ccall((:fq_nmod_mpoly_one, libflint), Nothing,
+        (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
+        a, a.parent)
+  return a
+end
+
+function neg!(z::fqPolyRepMPolyRingElem, a::fqPolyRepMPolyRingElem)
+  ccall((:fq_nmod_mpoly_neg, libflint), Nothing,
+        (Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRingElem}, Ref{fqPolyRepMPolyRing}),
+        z, a, a.parent)
+  return z
 end
 
 function add!(a::fqPolyRepMPolyRingElem, b::fqPolyRepMPolyRingElem, c::fqPolyRepMPolyRingElem)

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -117,13 +117,7 @@ canonical_unit(a::fqPolyRepPolyRingElem) = canonical_unit(leading_coefficient(a)
 #
 ################################################################################
 
-function -(x::fqPolyRepPolyRingElem)
-  z = parent(x)()
-  ccall((:fq_nmod_poly_neg, libflint), Nothing,
-        (Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepField}),
-        z, x, base_ring(parent(x)))
-  return z
-end
+-(x::fqPolyRepPolyRingElem) = neg!(parent(x)(), x)
 
 ################################################################################
 #
@@ -725,6 +719,20 @@ function zero!(z::fqPolyRepPolyRingElem)
   ccall((:fq_nmod_poly_zero, libflint), Nothing,
         (Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepField}),
         z, base_ring(parent(z)))
+  return z
+end
+
+function one!(z::fqPolyRepPolyRingElem)
+  ccall((:fq_nmod_poly_one, libflint), Nothing,
+        (Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepField}),
+        z, base_ring(parent(z)))
+  return z
+end
+
+function neg!(z::fqPolyRepPolyRingElem, a::fqPolyRepPolyRingElem)
+  ccall((:fq_nmod_poly_neg, libflint), Nothing,
+        (Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepPolyRingElem}, Ref{fqPolyRepField}),
+        z, a, base_ring(parent(a)))
   return z
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -117,13 +117,7 @@ canonical_unit(a::FqPolyRepPolyRingElem) = canonical_unit(leading_coefficient(a)
 #
 ################################################################################
 
-function -(x::FqPolyRepPolyRingElem)
-  z = parent(x)()
-  ccall((:fq_poly_neg, libflint), Nothing,
-        (Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepField}),
-        z, x, base_ring(parent(x)))
-  return z
-end
+-(x::FqPolyRepPolyRingElem) = neg!(parent(x)(), x)
 
 ################################################################################
 #
@@ -724,6 +718,20 @@ function zero!(z::FqPolyRepPolyRingElem)
   ccall((:fq_poly_zero, libflint), Nothing,
         (Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepField}),
         z, base_ring(parent(z)))
+  return z
+end
+
+function one!(z::FqPolyRepPolyRingElem)
+  ccall((:fq_poly_one, libflint), Nothing,
+        (Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepField}),
+        z, base_ring(parent(z)))
+  return z
+end
+
+function neg!(z::FqPolyRepPolyRingElem, a::FqPolyRepPolyRingElem)
+  ccall((:fq_poly_neg, libflint), Nothing,
+        (Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepPolyRingElem}, Ref{FqPolyRepField}),
+        z, a, base_ring(parent(a)))
   return z
 end
 

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -166,15 +166,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function -(x::($etype))
-      z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
-            z, x, base_ring(x))
-      z.prec = x.prec
-      z.val = x.val
-      return z
-    end
+    -(x::($etype)) = neg!(parent(x)(), x)
 
     ###############################################################################
     #
@@ -641,6 +633,22 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       x.prec = parent(x).prec_max
       x.val = parent(x).prec_max
       return x
+    end
+
+    function one!(x::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+      x.prec = parent(x).prec_max
+      x.val = parent(x).prec_max
+      return x
+    end
+
+    function neg!(z::($etype), x::($etype))
+      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}), z, x, base_ring(x))
+      z.prec = x.prec
+      z.val = x.val
+      return z
     end
 
     function fit!(z::($etype), n::Int)

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -639,7 +639,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       ccall(($(flint_fn*"_one"), libflint), Nothing,
             (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
       x.prec = parent(x).prec_max
-      x.val = parent(x).prec_max
+      x.val = 0
       return x
     end
 

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -346,7 +346,7 @@ end
 
 function one!(z::fpFieldElem)
   R = parent(z)
-  return fpFieldElem(UInt(0), R)
+  return fpFieldElem(UInt(1), R)
 end
 
 function neg!(z::fpFieldElem, x::fpFieldElem)

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -344,6 +344,15 @@ function zero!(z::fpFieldElem)
   return fpFieldElem(UInt(0), R)
 end
 
+function one!(z::fpFieldElem)
+  R = parent(z)
+  return fpFieldElem(UInt(0), R)
+end
+
+function neg!(z::fpFieldElem, x::fpFieldElem)
+  return -x
+end
+
 function mul!(z::fpFieldElem, x::fpFieldElem, y::ZZRingElem)
   R = parent(x)
   d = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), y, R.n)

--- a/src/flint/gfp_elem.jl
+++ b/src/flint/gfp_elem.jl
@@ -339,27 +339,8 @@ end
 #
 ###############################################################################
 
-function zero!(z::fpFieldElem)
-  R = parent(z)
-  return fpFieldElem(UInt(0), R)
-end
-
-function one!(z::fpFieldElem)
-  R = parent(z)
-  return fpFieldElem(UInt(1), R)
-end
-
-function neg!(z::fpFieldElem, x::fpFieldElem)
-  return -x
-end
-
-function mul!(z::fpFieldElem, x::fpFieldElem, y::ZZRingElem)
-  R = parent(x)
-  d = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), y, R.n)
-  r = mulmod(x.data, d, R.n, R.ninv)
-  z.data = r
-  return z
-end
+# Since this data type is immutable, we can not do better for the unsafe ops
+# than their default implementations.
 
 ###############################################################################
 #

--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -354,6 +354,16 @@ function zero!(z::FpFieldElem)
   return z
 end
 
+function one!(z::FpFieldElem)
+  one!(z.data)
+  return z
+end
+
+function neg!(z::FpFieldElem, x::FpFieldElem)
+  z.data = R.n - x.data
+  return z
+end
+
 function mul!(z::FpFieldElem, x::FpFieldElem, y::FpFieldElem)
   R = parent(z)
   ccall((:fmpz_mod_mul, libflint), Nothing,

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -355,6 +355,15 @@ function zero!(z::zzModRingElem)
   return zzModRingElem(UInt(0), R)
 end
 
+function one!(z::zzModRingElem)
+  R = parent(z)
+  return zzModRingElem(UInt(1), R)
+end
+
+function neg!(z::zzModRingElem, x::zzModRingElem)
+  return -x
+end
+
 function mul!(z::zzModRingElem, x::zzModRingElem, y::zzModRingElem)
   return x*y
 end

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -350,31 +350,9 @@ end
 #
 ###############################################################################
 
-function zero!(z::zzModRingElem)
-  R = parent(z)
-  return zzModRingElem(UInt(0), R)
-end
+# Since this data type is immutable, we can not do better for the unsafe ops
+# than their default implementations.
 
-function one!(z::zzModRingElem)
-  R = parent(z)
-  return zzModRingElem(UInt(1), R)
-end
-
-function neg!(z::zzModRingElem, x::zzModRingElem)
-  return -x
-end
-
-function mul!(z::zzModRingElem, x::zzModRingElem, y::zzModRingElem)
-  return x*y
-end
-
-function add!(z::zzModRingElem, x::zzModRingElem)
-  return z + x
-end
-
-function add!(z::zzModRingElem, x::zzModRingElem, y::zzModRingElem)
-  return x + y
-end
 ###############################################################################
 #
 #   Random functions

--- a/src/flint/nmod_abs_series.jl
+++ b/src/flint/nmod_abs_series.jl
@@ -167,13 +167,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     #
     ###############################################################################
 
-    function -(x::($etype))
-      z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}), z, x)
-      z.prec = x.prec
-      return z
-    end
+    -(x::($etype)) = neg!(parent(x)(), x)
 
     ###############################################################################
     #
@@ -507,6 +501,20 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       ccall(($(flint_fn*"_zero"), libflint), Nothing,
             (Ref{($etype)},), z)
       z.prec = parent(z).prec_max
+      return z
+    end
+
+    function one!(z::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)},), z)
+      z.prec = parent(z).prec_max
+      return z
+    end
+
+    function neg!(z::($etype), x::($etype))
+      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($etype)}), z, x)
+      z.prec = x.prec
       return z
     end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -104,9 +104,7 @@ base_ring(a::T) where T <: Zmodn_mat = a.base_ring
 
 function one(a::zzModMatrixSpace)
   (nrows(a) != ncols(a)) && error("Matrices must be square")
-  z = a()
-  ccall((:nmod_mat_one, libflint), Nothing, (Ref{zzModMatrix}, ), z)
-  return z
+  return one!(a())
 end
 
 function iszero(a::T) where T <: Zmodn_mat
@@ -202,12 +200,7 @@ reverse_cols(x::T) where T <: Zmodn_mat = reverse_cols!(deepcopy(x))
 #
 ################################################################################
 
-function -(x::T) where T <: Zmodn_mat
-  z = similar(x)
-  ccall((:nmod_mat_neg, libflint), Nothing,
-        (Ref{T}, Ref{T}), z, x)
-  return z
-end
+-(x::T) where T <: Zmodn_mat = neg!(similar(x), x)
 
 ################################################################################
 #
@@ -247,6 +240,21 @@ end
 #
 ################################################################################
 
+function zero!(a::T) where T <: Zmodn_mat
+  ccall((:nmod_mat_zero, libflint), Nothing, (Ref{T}, ), a)
+  return a
+end
+
+function one!(a::T) where T <: Zmodn_mat
+  ccall((:nmod_mat_one, libflint), Nothing, (Ref{T}, ), a)
+  return a
+end
+
+function neg!(z::T, a::T) where T <: Zmodn_mat
+  ccall((:nmod_mat_neg, libflint), Nothing, (Ref{T}, Ref{T}), z, a)
+  return z
+end
+
 function mul!(a::T, b::T, c::T) where T <: Zmodn_mat
   ccall((:nmod_mat_mul, libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
   return a
@@ -259,11 +267,6 @@ end
 
 function sub!(a::T, b::T, c::T) where T <: Zmodn_mat
   ccall((:nmod_mat_sub, libflint), Nothing, (Ref{T}, Ref{T}, Ref{T}), a, b, c)
-  return a
-end
-
-function zero!(a::T) where T <: Zmodn_mat
-  ccall((:nmod_mat_zero, libflint), Nothing, (Ref{T}, ), a)
   return a
 end
 

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -93,21 +93,9 @@ for (etype, rtype, ftype, ctype, utype) in (
       #                a, a.parent)
     end
 
-    function one(R::($rtype))
-      z = R()
-      ccall((:nmod_mpoly_one, libflint), Nothing,
-            (Ref{($etype)}, Ref{($rtype)}),
-            z, R)
-      return z
-    end
+    one(R::($rtype)) = one!(R())
 
-    function zero(R::($rtype))
-      z = R()
-      ccall((:nmod_mpoly_zero, libflint), Nothing,
-            (Ref{($etype)}, Ref{($rtype)}),
-            z, R)
-      return z
-    end
+    zero(R::($rtype)) = zero!(R())
 
     function isone(a::($etype))
       return Bool(ccall((:nmod_mpoly_is_one, libflint), Cint,
@@ -297,13 +285,7 @@ for (etype, rtype, ftype, ctype, utype) in (
     #
     ###############################################################################
 
-    function -(a::($etype))
-      z = parent(a)()
-      ccall((:nmod_mpoly_neg, libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),
-            z, a, parent(a))
-      return z
-    end
+    -(a::($etype)) = neg!(parent(a)(), a)
 
     function +(a::($etype), b::($etype))
       check_parent(a, b)
@@ -806,6 +788,20 @@ for (etype, rtype, ftype, ctype, utype) in (
             (Ref{($etype)}, Ref{($rtype)}),
             a, parent(a))
       return a
+    end
+
+    function one!(a::($etype))
+      ccall((:nmod_mpoly_one, libflint), Nothing,
+            (Ref{($etype)}, Ref{($rtype)}),
+            a, parent(a))
+      return a
+    end
+
+    function neg!(z::($etype), a::($etype))
+      ccall((:nmod_mpoly_neg, libflint), Nothing,
+            (Ref{($etype)}, Ref{($etype)}, Ref{($rtype)}),
+            z, a, parent(a))
+      return z
     end
 
     function add!(a::($etype), b::($etype), c::($etype))

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -140,12 +140,7 @@ end
 #
 ################################################################################
 
-function -(x::T) where T <: Zmodn_poly
-  z = parent(x)()
-  ccall((:nmod_poly_neg, libflint), Nothing,
-        (Ref{T}, Ref{T}), z, x)
-  return z
-end
+-(x::T) where T <: Zmodn_poly = neg!(parent(x)(), x)
 
 ################################################################################
 #
@@ -893,6 +888,11 @@ end
 function one!(a::T) where T <: Zmodn_poly
   ccall((:nmod_poly_one, libflint), Nothing, (Ref{T}, ), a)
   return a
+end
+
+function neg!(z::T, a::T) where T <: Zmodn_poly
+  ccall((:nmod_poly_neg, libflint), Nothing, (Ref{T}, Ref{T}), z, a)
+  return z
 end
 
 function fit!(x::T, n::Int) where T <: Zmodn_poly

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -691,7 +691,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       ccall(($(flint_fn*"_one"), libflint), Nothing,
             (Ref{($etype)},), x)
       x.prec = parent(x).prec_max
-      x.val = parent(x).prec_max
+      x.val = 0
       return x
     end
 

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -161,15 +161,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     #
     ###############################################################################
 
-    function -(x::($etype))
-      z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}),
-            z, x)
-      z.prec = x.prec
-      z.val = x.val
-      return z
-    end
+    -(x::($etype)) = neg!(parent(x)(), x)
 
     ###############################################################################
     #
@@ -693,6 +685,23 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       x.prec = parent(x).prec_max
       x.val = parent(x).prec_max
       return x
+    end
+
+    function one!(x::($etype))
+      ccall(($(flint_fn*"_one"), libflint), Nothing,
+            (Ref{($etype)},), x)
+      x.prec = parent(x).prec_max
+      x.val = parent(x).prec_max
+      return x
+    end
+
+    function neg!(z::($etype), x::($etype))
+      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+            (Ref{($etype)}, Ref{($etype)}),
+            z, x)
+      z.prec = x.prec
+      z.val = x.val
+      return z
     end
 
     function fit!(x::($etype), n::Int)


### PR DESCRIPTION
Add a bunch of `one!` and `neg!` methods. Also used `zero!`, `one!`, `neg!` in a few more spots. And placed these function in a uniform way into the code based (i.e. these are now always the first three unsafe operations).

This is incomplete in so far as there are still types missing a "native" `neg!` (and in some very few cases also `one!`).

Unfortunately this function is not covered by the ring conformance test suite -- we should change that (in AA). 