### PR TITLE
Remove redundant one/zero methods for ring elements

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -340,15 +340,6 @@ function one!(r::AbsSimpleNumFieldElem)
   return r
 end
 
-function one(r::AbsSimpleNumFieldElem)
-  a = parent(r)
-  return one(a)
-end
-
-function zero(r::AbsSimpleNumFieldElem)
-  return zero(parent(r))
-end
-
 function divexact!(z::AbsSimpleNumFieldElem, x::AbsSimpleNumFieldElem, y::ZZRingElem)
   ccall((:nf_elem_scalar_div_fmpz, libflint), Nothing,
         (Ref{AbsSimpleNumFieldElem}, Ref{AbsSimpleNumFieldElem}, Ref{ZZRingElem}, Ref{AbsSimpleNumField}),

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -210,10 +210,6 @@ one(::Type{ZZRingElem}) = ZZRingElem(1)
 
 zero(::Type{ZZRingElem}) = ZZRingElem(0)
 
-one(::ZZRingElem) = ZZRingElem(1)
-
-zero(::ZZRingElem) = ZZRingElem(0)
-
 @doc raw"""
     sign(a::ZZRingElem)
 


### PR DESCRIPTION
They are redundant as we have generic ones in AA
