### PR TITLE
Reduce allocations in `QQFieldElem` construction

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -20,7 +20,7 @@ end
 
 QQFieldElem(a::Rational{T}) where {T <: Integer} = QQFieldElem(numerator(a), denominator(a))
 
-QQFieldElem(a::Integer) = QQFieldElem(ZZRingElem(a), ZZRingElem(1))
+QQFieldElem(a::Integer) = QQFieldElem(flintify(a))
 
 QQFieldElem(a::Integer, b::Integer) = QQFieldElem(ZZRingElem(a), ZZRingElem(b))
 
@@ -1191,7 +1191,7 @@ end
 #
 ###############################################################################
 
-(a::QQField)() = QQFieldElem(ZZRingElem(0), ZZRingElem(1))
+(a::QQField)() = zero(a)
 
 function (a::QQField)(b::Rational)
   # work around Julia bug, https://github.com/JuliaLang/julia/issues/32569


### PR DESCRIPTION
master:
```julia
julia> @btime QQ()
  80.455 ns (3 allocations: 64 bytes)
0

julia> @btime QQ(Int8(42))
  161.457 ns (5 allocations: 104 bytes)
42
```

this PR:
```julia
julia> @btime QQ()
  35.276 ns (1 allocation: 32 bytes)
0

julia> @btime QQ(Int8(42))
  33.706 ns (1 allocation: 32 bytes)
42
```