### PR TITLE
Add isapprox methods for ZZRingElem & QQFieldElem

### DIFF
--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -369,6 +369,13 @@ function isless(a::QQFieldElem, b::QQFieldElem)
   return cmp(a, b) < 0
 end
 
+function Base.isapprox(x::QQFieldElem, y::QQFieldElem;
+                       atol::Real=0, rtol::Real=0,
+                       nans::Bool=false, norm::Function=abs)
+    return x == y ||
+        (norm(x - y) <= max(atol, rtol*max(norm(x), norm(y))))
+end
+
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -860,6 +860,16 @@ isless(x::ZZRingElem, y::Integer) = x < ZZRingElem(y)
 
 isless(x::Integer, y::ZZRingElem) = ZZRingElem(x) < y
 
+function Base.isapprox(x::ZZRingElem, y::ZZRingElem;
+                       atol::Real=0, rtol::Real=0,
+                       nans::Bool=false, norm::Function=abs)
+  if norm === abs && atol < 1 && rtol == 0
+    return x == y
+  else
+    return norm(x - y) <= max(atol, rtol*max(norm(x), norm(y)))
+  end
+end
+
 ###############################################################################
 #
 #   Ad hoc comparison


### PR DESCRIPTION
... to allow testing relative and absolute series

This does not included dedicated test cases. The plan is that in PR #1880 we enable conformance tests for power series rings over ZZ and QQ and these will then test these methods.

As such we could also just wait till #1880 is ready, which however requires at least one more AA release.