### PR TITLE
Fix `fpRelPowerSeriesRing` supertype

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3430,7 +3430,7 @@ end
 #
 ###############################################################################
 
-@attributes mutable struct fpRelPowerSeriesRing <: SeriesRing{zzModRingElem}
+@attributes mutable struct fpRelPowerSeriesRing <: SeriesRing{fpFieldElem}
   base_ring::fpField
   prec_max::Int
   S::Symbol


### PR DESCRIPTION
This resolves the issue found by @fingolfin in https://github.com/Nemocas/Nemo.jl/pull/1883#issuecomment-2398992144.