### PR TITLE
Remove 'transpose' argument from matrix constructors

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4799,11 +4799,8 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     return z
   end
 
-  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt}, transpose::Bool = false)
+  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt})
     z = zzModMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, mod(arr[i, j], n), i, j)
@@ -4822,11 +4819,8 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     return z
   end
 
-  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
+  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem})
     z = zzModMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
@@ -4851,9 +4845,9 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     return z
   end
 
-  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{T}, transpose::Bool = false) where {T <: Integer}
+  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{T}) where {T <: Integer}
     arr_fmpz = map(ZZRingElem, arr)
-    return zzModMatrix(r, c, n, arr_fmpz, transpose)
+    return zzModMatrix(r, c, n, arr_fmpz)
   end
 
   function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{T}) where {T <: Integer}
@@ -4861,11 +4855,8 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     return zzModMatrix(r, c, n, arr_fmpz)
   end
 
-  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{zzModRingElem}, transpose::Bool = false)
+  function zzModMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{zzModRingElem})
     z = zzModMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[i, j].data, i, j) # no reduction necessary
@@ -4947,11 +4938,8 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
     ZZModMatrix(r, c, R.ninv)
   end
 
-  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
+  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem})
     z = ZZModMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(arr[i, j], ctx), i, j)
@@ -4960,15 +4948,12 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
     return z
   end
 
-  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-    ZZModMatrix(r, c, R.ninv, arr, transpose)
+  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{ZZRingElem})
+    ZZModMatrix(r, c, R.ninv, arr)
   end
 
-  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}, transpose::Bool = false) where T <: Integer
+  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}) where T <: Integer
     z = ZZModMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(ZZRingElem(arr[i, j]), ctx), i, j)
@@ -4977,16 +4962,13 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
     return z
   end
 
-  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{T}, transpose::Bool = false) where T <: Integer
-    ZZModMatrix(r, c, R.ninv, arr, transpose)
+  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{T}) where T <: Integer
+    ZZModMatrix(r, c, R.ninv, arr)
   end
 
-  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZModRingElem}, transpose::Bool = false)
+  function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZModRingElem})
     # FIXME: Check compatibility between ctx and arr?
     z = ZZModMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[i, j].data, i, j)
@@ -4995,8 +4977,8 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
     return z
   end
 
-  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{ZZModRingElem}, transpose::Bool = false)
-    ZZModMatrix(r, c, R, arr, transpose)
+  function ZZModMatrix(r::Int, c::Int, R::ZZModRing, arr::AbstractMatrix{ZZModRingElem})
+    ZZModMatrix(r, c, R, arr)
   end
 
   function ZZModMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractVector{ZZRingElem})
@@ -5101,11 +5083,8 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
     return z
   end
 
-  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
+  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{ZZRingElem})
     z = FpMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(arr[i, j], ctx), i, j)
@@ -5114,11 +5093,8 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
     return z
   end
 
-  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}, transpose::Bool = false) where T <: Integer
+  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{T}) where T <: Integer
     z = FpMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, _reduce(ZZRingElem(arr[i, j]), ctx), i, j)
@@ -5127,12 +5103,9 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
     return z
   end
 
-  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{FpFieldElem}, transpose::Bool = false)
+  function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct, arr::AbstractMatrix{FpFieldElem})
     # FIXME: Check compatibility between ctx and arr?
     z = FpMatrix(r, c, ctx)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[i, j].data, i, j)
@@ -5211,11 +5184,8 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
     return z
   end
 
-  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt}, transpose::Bool = false)
+  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{UInt})
     z = fpMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, mod(arr[i, j], n), i, j)
@@ -5234,11 +5204,8 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
     return z
   end
 
-  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
+  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{ZZRingElem})
     z = fpMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
@@ -5263,9 +5230,9 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
     return z
   end
 
-  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{T}, transpose::Bool = false) where {T <: Integer}
+  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{T}) where {T <: Integer}
     arr_fmpz = map(ZZRingElem, arr)
-    return fpMatrix(r, c, n, arr_fmpz, transpose)
+    return fpMatrix(r, c, n, arr_fmpz)
   end
 
   function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractVector{T}) where {T <: Integer}
@@ -5273,11 +5240,8 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
     return fpMatrix(r, c, n, arr_fmpz)
   end
 
-  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{fpFieldElem}, transpose::Bool = false)
+  function fpMatrix(r::Int, c::Int, n::UInt, arr::AbstractMatrix{fpFieldElem})
     z = fpMatrix(r, c, n)
-    if transpose
-      arr = Base.transpose(arr)
-    end
     for i = 1:r
       for j = 1:c
         setindex_raw!(z, arr[i, j].data, i, j) # no reduction necessary

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -762,9 +762,9 @@ function (a::ZZModMatrixSpace)()
   return z
 end
 
-function (a::ZZModMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::ZZModMatrixSpace)(arr::AbstractMatrix{BigInt})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -776,9 +776,9 @@ function (a::ZZModMatrixSpace)(arr::AbstractVector{BigInt})
   return z
 end
 
-function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -790,9 +790,9 @@ function (a::ZZModMatrixSpace)(arr::AbstractVector{ZZRingElem})
   return z
 end
 
-function (a::ZZModMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::ZZModMatrixSpace)(arr::AbstractMatrix{Int})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -804,10 +804,10 @@ function (a::ZZModMatrixSpace)(arr::AbstractVector{Int})
   return z
 end
 
-function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZModRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
+function (a::ZZModMatrixSpace)(arr::AbstractMatrix{ZZModRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+  z = ZZModMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -241,9 +241,9 @@ function (a::FpMatrixSpace)(b::FpFieldElem)
   return M
 end
 
-function (a::FpMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::FpMatrixSpace)(arr::AbstractMatrix{BigInt})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -255,9 +255,9 @@ function (a::FpMatrixSpace)(arr::AbstractVector{BigInt})
   return z
 end
 
-function (a::FpMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::FpMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -269,9 +269,9 @@ function (a::FpMatrixSpace)(arr::AbstractVector{ZZRingElem})
   return z
 end
 
-function (a::FpMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+function (a::FpMatrixSpace)(arr::AbstractMatrix{Int})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -283,10 +283,10 @@ function (a::FpMatrixSpace)(arr::AbstractVector{Int})
   return z
 end
 
-function (a::FpMatrixSpace)(arr::AbstractMatrix{FpFieldElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
+function (a::FpMatrixSpace)(arr::AbstractMatrix{FpFieldElem})
+  _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr, transpose)
+  z = FpMatrix(nrows(a), ncols(a), base_ring(a).ninv, arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -300,9 +300,9 @@ function (a::fpMatrixSpace)()
   return z
 end
 
-function (a::fpMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::fpMatrixSpace)(arr::AbstractMatrix{BigInt})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -314,9 +314,9 @@ function (a::fpMatrixSpace)(arr::AbstractVector{BigInt})
   return z
 end
 
-function (a::fpMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::fpMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -328,9 +328,9 @@ function (a::fpMatrixSpace)(arr::AbstractVector{ZZRingElem})
   return z
 end
 
-function (a::fpMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::fpMatrixSpace)(arr::AbstractMatrix{Int})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -342,10 +342,10 @@ function (a::fpMatrixSpace)(arr::AbstractVector{Int})
   return z
 end
 
-function (a::fpMatrixSpace)(arr::AbstractMatrix{fpFieldElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
+function (a::fpMatrixSpace)(arr::AbstractMatrix{fpFieldElem})
+  _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+  z = fpMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -760,9 +760,9 @@ function (a::zzModMatrixSpace)()
   return z
 end
 
-function (a::zzModMatrixSpace)(arr::AbstractMatrix{BigInt}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::zzModMatrixSpace)(arr::AbstractMatrix{BigInt})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -774,9 +774,9 @@ function (a::zzModMatrixSpace)(arr::AbstractVector{BigInt})
   return z
 end
 
-function (a::zzModMatrixSpace)(arr::AbstractMatrix{ZZRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::zzModMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -788,9 +788,9 @@ function (a::zzModMatrixSpace)(arr::AbstractVector{ZZRingElem})
   return z
 end
 
-function (a::zzModMatrixSpace)(arr::AbstractMatrix{Int}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
-  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+function (a::zzModMatrixSpace)(arr::AbstractMatrix{Int})
+  _check_dim(nrows(a), ncols(a), arr)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end
@@ -802,10 +802,10 @@ function (a::zzModMatrixSpace)(arr::AbstractVector{Int})
   return z
 end
 
-function (a::zzModMatrixSpace)(arr::AbstractMatrix{zzModRingElem}, transpose::Bool = false)
-  _check_dim(nrows(a), ncols(a), arr, transpose)
+function (a::zzModMatrixSpace)(arr::AbstractMatrix{zzModRingElem})
+  _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr, transpose)
+  z = zzModMatrix(nrows(a), ncols(a), modulus(base_ring(a)), arr)
   z.base_ring = a.base_ring
   return z
 end

--- a/test/flint/gfp_fmpz_mat-test.jl
+++ b/test/flint/gfp_fmpz_mat-test.jl
@@ -247,16 +247,6 @@ end
 
   @test_throws ErrorConstrDimMismatch transpose!(R([ 1 2 ;]))
 
-  R = matrix_space(Z11, 4, 4)
-  m = [1 2 3 4; 2 4 6 2; 6 4 2 4; 2 6 4 0]
-  @test R(m, true) == R(transpose(m))
-  m1 = Matrix{BigInt}(m)
-  @test R(m1, true) == R(transpose(m1))
-  m2 = Matrix{ZZRingElem}(m)
-  @test R(m2, true) == R(transpose(m2))
-  m3 = map(Z11, m)
-  @test R(m3, true) == R(transpose(m3))
-
   C = Z23[1 2 3; 4 5 6; 7 8 9]
   C[3, :] = Z23[7 7 7]
   @test C == Z23[1 2 3; 4 5 6; 7 7 7]


### PR DESCRIPTION
They were not used (at least in Nemo, other than in a test) and are not documented anywhere. There is also no apparent benefit to them compared to requiring the user to transpose the input beforehand. CI will show if Hecke or Oscar use them, maybe?

I have no idea why they were even there. Historical remnant of a more useful feature? Perhaps @fieker or @thofma remember.

In any case, my motivation to remove them is mainly to reduce code complexity (it's one more layer of "wtf" one has to wade through when trying to work out matrix spaces, matrix constructors, matrix-space-as-function methods etc. are interconnected). Moreover, I find code that uses this opaque: 
```
R = matrix_space(Z11, 4, 4)
a = R(m, true)
```
gives no hint what the `true` means and it is difficult to find out by just reading the code (how do you use `?` to find this). Of course interactively one use `@less` or `@edit` (what a blessing those are).
