### PR TITLE
Introduce low-level analogs for Flint structs

### DIFF
--- a/src/flint/CTypes.jl
+++ b/src/flint/CTypes.jl
@@ -1,0 +1,255 @@
+###############################################################################
+#
+#   Flint C types
+#
+###############################################################################
+
+module Flint
+
+#
+# C types (names provided to ease automatic conversion of struct definitions)
+#
+const int = Cint
+const char = Cchar
+
+#
+# from flint.h
+#
+const ulong = Culong
+const slong = Clong
+
+const flint_bitcnt_t = ulong
+const nn_ptr = Ptr{ulong}
+
+const fmpz = Clong
+
+const fmpz_t = Ptr{fmpz}
+
+struct fmpq
+    num::fmpz
+    den::fmpz
+end
+
+const fmpq_t = Ptr{fmpq}
+
+struct nmod_t
+   n::ulong
+   ninv::ulong
+   norm::flint_bitcnt_t
+end
+
+#
+# from limb_types.h
+#
+
+const FLINT_MAX_FACTORS_IN_LIMB = 15
+
+struct n_factor_t
+  num::int
+  exp::NTuple{FLINT_MAX_FACTORS_IN_LIMB, int}
+  p::NTuple{FLINT_MAX_FACTORS_IN_LIMB, ulong}
+end
+
+struct n_primes_struct
+  small_i::slong
+  small_num::slong
+  small_primes::Ptr{Cuint}
+
+  sieve_a::ulong
+  sieve_b::ulong
+  sieve_i::slong
+  sieve_num::slong
+  sieve::Ptr{char}
+end
+
+#
+# from fmpz_types.h
+#
+
+struct zz_struct
+  alloc::int
+  size::int
+  ptr::nn_ptr
+end
+
+const zz_ptr = Ptr{zz_struct}
+
+struct fmpz_factor_struct
+  sign::int
+  p::Ptr{fmpz}
+  exp::Ptr{ulong}
+  alloc::slong
+  num::slong
+end
+
+struct fmpz_preinvn_struct
+  dinv::nn_ptr
+  n::slong
+  norm::flint_bitcnt_t
+end
+
+struct fmpz_poly_struct
+  coeffs::Ptr{fmpz}
+  alloc::slong
+  length::slong
+end
+
+struct fmpz_poly_factor_struct
+  c::fmpz
+  p::Ptr{fmpz_poly_struct}
+  exp::Ptr{slong}
+  num::slong
+  alloc::slong
+end
+
+struct fmpz_mat_struct
+  entries::Ptr{fmpz}
+  r::slong
+  c::slong
+  rows::Ptr{Ptr{fmpz}}
+end
+
+struct fmpz_poly_mat_struct
+  entries::Ptr{fmpz_poly_struct}
+  r::slong
+  c::slong
+  rows::Ptr{Ptr{fmpz_poly_struct}}
+end
+
+struct fmpz_mpoly_struct
+  coeffs::Ptr{fmpz}
+  exps::Ptr{ulong}
+  alloc::slong
+  length::slong
+  bits::flint_bitcnt_t
+end
+
+struct fmpz_mpoly_factor_struct
+  constant::fmpz_t
+  constant_den::fmpz_t
+  poly::Ptr{fmpz_mpoly_struct}
+  exp::Ptr{fmpz}
+  num::slong
+  alloc::slong
+end
+
+struct fmpz_poly_q_struct
+  num::Ptr{fmpz_poly_struct}
+  den::Ptr{fmpz_poly_struct}
+end
+
+struct fmpz_mpoly_q_struct
+  num::fmpz_mpoly_struct
+  den::fmpz_mpoly_struct
+end
+
+struct fmpzi_struct
+  a::fmpz
+  b::fmpz
+end
+
+
+#
+# from nmod_types.h
+#
+struct nmod_mat_struct
+  entries::Ptr{ulong}
+  r::slong
+  c::slong
+  rows::Ptr{Ptr{ulong}}
+  mod::nmod_t
+end
+
+struct nmod_poly_struct
+  coeffs::nn_ptr
+  alloc::slong
+  length::slong
+  mod::nmod_t
+end
+
+const nmod_poly_t = Ptr{nmod_poly_struct}
+
+struct nmod_poly_factor_struct
+  p::Ptr{nmod_poly_struct}
+  exp::Ptr{slong}
+  num::slong
+  alloc::slong
+end
+
+struct nmod_poly_mat_struct
+  entries::Ptr{nmod_poly_struct}
+  r::slong
+  c::slong
+  rows::Ptr{Ptr{nmod_poly_struct}}
+  modulus::ulong
+end
+
+struct nmod_mpoly_struct
+  coeffs::Ptr{ulong}
+  exps::Ptr{ulong}
+  length::slong
+  bits::flint_bitcnt_t
+  coeffs_alloc::slong
+  exps_alloc::slong
+end
+
+struct nmod_mpoly_factor_struct
+  constant::ulong
+  poly::Ptr{nmod_mpoly_struct}
+  exp::Ptr{fmpz}
+  num::slong
+  alloc::slong
+end
+
+#
+# from fq_nmod_types.h
+#
+
+const fq_nmod_struct = nmod_poly_struct
+
+struct fq_nmod_ctx_struct
+  mod::nmod_t
+
+  sparse_modulus::int
+  is_conway::int
+
+  a::Ptr{ulong}
+  j::Ptr{slong}
+  len::slong
+
+  modulus::nmod_poly_t
+  inv::nmod_poly_t
+
+  var::Ptr{char}
+end
+
+struct fq_nmod_mat_struct
+  entries::Ptr{fq_nmod_struct}
+  r::slong
+  c::slong
+  rows::Ptr{Ptr{fq_nmod_struct}}
+end
+
+struct fq_nmod_poly_struct
+  coeffs::Ptr{fq_nmod_struct}
+  alloc::slong
+  length::slong
+end
+
+struct fq_nmod_poly_factor_struct
+  poly::Ptr{fq_nmod_poly_struct}
+  exp::Ptr{slong}
+  num::slong
+  alloc::slong
+end
+
+struct fq_nmod_mpoly_struct
+  coeffs::Ptr{ulong}
+  exps::Ptr{ulong}
+  length::slong
+  bits::flint_bitcnt_t
+  coeffs_alloc::slong
+  exps_alloc::slong
+end
+
+end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -6,6 +6,8 @@
 
 const _err_dim_negative = ErrorException("Dimensions must be non-negative")
 
+include("CTypes.jl")
+
 ###############################################################################
 #
 #   ZZRing / ZZRingElem
@@ -42,7 +44,7 @@ integer_ring() = ZZRing()
 
 @doc zz_ring_doc
 mutable struct ZZRingElem <: RingElem
-  d::Int
+  d::Flint.fmpz
 
   function ZZRingElem()
     z = new()
@@ -92,11 +94,7 @@ function _fmpz_clear_fn(a::ZZRingElem)
 end
 
 mutable struct fmpz_factor
-  sign::Cint
-  p::Ptr{Nothing} # Array of fmpz_struct's
-  exp::Ptr{UInt}
-  alloc::Int
-  num::Int
+  data::Flint.fmpz_factor_struct
 
   function fmpz_factor()
     z = new()
@@ -241,9 +239,7 @@ end
 const FmpzPolyID = CacheDictType{Symbol, ZZPolyRing}()
 
 mutable struct ZZPolyRingElem <: PolyRingElem{ZZRingElem}
-  coeffs::Ptr{Nothing}
-  alloc::Int
-  length::Int
+  data::Flint.fmpz_poly_struct
   parent::ZZPolyRing
 
   function ZZPolyRingElem()
@@ -291,11 +287,7 @@ function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
 end
 
 mutable struct fmpz_poly_factor
-  d::Int # ZZRingElem
-  p::Ptr{ZZPolyRingElem} # array of flint fmpz_poly_struct's
-  exp::Ptr{Int}
-  num::Int
-  alloc::Int
+  data::Flint.fmpz_poly_factor_struct
 
   function fmpz_poly_factor()
     z = new()
@@ -591,12 +583,7 @@ end
 const NmodPolyRingID = CacheDictType{Tuple{zzModRing, Symbol}, zzModPolyRing}()
 
 mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
-  coeffs::Ptr{Nothing}
-  alloc::Int
-  length::Int
-  mod_n::UInt
-  mod_ninv::UInt
-  mod_norm::UInt
+  data::Flint.nmod_poly_struct
   parent::zzModPolyRing
 
   function zzModPolyRingElem(n::UInt)
@@ -736,6 +723,8 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   mod_n::UInt
   mod_ninv::UInt
   mod_norm::UInt
+  # end of flint struct
+
   parent::fpPolyRing
 
   function fpPolyRingElem(n::UInt)
@@ -3453,6 +3442,8 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
   mod_n::UInt
   mod_ninv::UInt
   mod_norm::UInt
+  # end of flint struct
+
   prec::Int
   val::Int
   parent::fpRelPowerSeriesRing
@@ -3554,6 +3545,8 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
   mod_n::UInt
   mod_ninv::UInt
   mod_norm::UInt
+  # end of flint struct
+
   prec::Int
   val::Int
   parent::zzModRelPowerSeriesRing

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -706,10 +706,10 @@ for (factor_fn, factor_fn_inner, flint_fn) in
            ccall((:fmpz_poly_factor_get_fmpz, libflint), Nothing,
                  (Ref{ZZRingElem}, Ref{fmpz_poly_factor}), z, fac)
            f = ZZPolyRingElem()
-           for i in 1:fac.num
+           for i in 1:fac.data.num
              ccall((:fmpz_poly_factor_get_fmpz_poly, libflint), Nothing,
                    (Ref{ZZPolyRingElem}, Ref{fmpz_poly_factor}, Int), f, fac, i - 1)
-             e = unsafe_load(fac.exp, i)
+             e = unsafe_load(fac.data.exp, i)
              res[parent(x)(f)] = e
            end
            return res, QQFieldElem(z, denominator(x))

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -708,7 +708,7 @@ end
 
 function _factor(x::zzModPolyRingElem)
   !is_prime(modulus(x)) && error("Modulus not prime in factor")
-  fac = nmod_poly_factor(x.mod_n)
+  fac = nmod_poly_factor(x.data.mod.n)
   z = ccall((:nmod_poly_factor, libflint), UInt,
             (Ref{nmod_poly_factor}, Ref{zzModPolyRingElem}), fac, x)
   res = Dict{zzModPolyRingElem,Int}()
@@ -729,7 +729,7 @@ function factor_squarefree(x::zzModPolyRingElem)
 end
 
 function _factor_squarefree(x::zzModPolyRingElem)
-  fac = nmod_poly_factor(x.mod_n)
+  fac = nmod_poly_factor(x.data.mod.n)
   ccall((:nmod_poly_factor_squarefree, libflint), UInt,
         (Ref{nmod_poly_factor}, Ref{zzModPolyRingElem}), fac, x)
   res = Dict{zzModPolyRingElem,Int}()
@@ -753,7 +753,7 @@ function factor_distinct_deg(x::zzModPolyRingElem)
   !is_prime(modulus(x)) && error("Modulus not prime in factor_distinct_deg")
   degs = Vector{Int}(undef, degree(x))
   degss = [ pointer(degs) ]
-  fac = nmod_poly_factor(x.mod_n)
+  fac = nmod_poly_factor(x.data.mod.n)
   ccall((:nmod_poly_factor_distinct_deg, libflint), UInt,
         (Ref{nmod_poly_factor}, Ref{zzModPolyRingElem}, Ptr{Ptr{Int}}),
         fac, x, degss)


### PR DESCRIPTION
This is starting work towards resolving #1875.

I have a few regex with which I can copy&past C struct definitions from flint headers and quickly turn them into Julia structs. However on the long run it might be better to write a little script that you point at the Flint headers in extracts everything for us automatically, that way we can re-run it on Flint updates.

Unfortunately Hecke accesses a few member variables of various of our Flint wrappers directly (e.g. `mod_n`, `ninv`), so we need to coordinate this carefully. Perhaps by adding some getter functions for those first, then changing Hecke to use those, *then* we can merge this (well, once it is ready).


What this does not yet show are:
- extend unsafe funcs like `add!`, `set!` to also accept these C types directly
- conversely e.g. `mat_entry_ptr` should return `Ptr{fmpz_poly_struct}` instead of `Ptr{ZZPolyRingElem}` etc.
- afterward we can probably merge all `BlahAbsPowerSeriesRingElem` into a single parametrized one, and like wise for relative ones (those are basically wrappers around Flint polynomials, and we can re-use the same `set!`, `add!` etc. methods on them)
  - admittedly we probably could so right now as well, at the cost of having some extra overhead in there (i.e. wrap polynomials, which means we carry around an extra pointer to a parent polynomial ring; but that may not be worth it)
- ... more that I forgot for now