### PR TITLE
Explicitly test show_banner and whatever it calls

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -331,6 +331,13 @@ end
 #
 ################################################################################
 
+function show_banner()
+  println("")
+  println("Welcome to Nemo version $(version())")
+  println("")
+  println("Nemo comes with absolutely no warranty whatsoever")
+end
+
 const __isthreaded = Ref(false)
 
 function __init__()
@@ -348,10 +355,7 @@ function __init__()
         (Ptr{Nothing},), @cfunction(flint_abort, Nothing, ()))
 
   if AbstractAlgebra.should_show_banner() && get(ENV, "NEMO_PRINT_BANNER", "true") != "false"
-    println("")
-    println("Welcome to Nemo version $(version())")
-    println("")
-    println("Nemo comes with absolutely no warranty whatsoever")
+    show_banner()
   end
 
   # Initialize the thread local random state

--- a/test/Nemo-test.jl
+++ b/test/Nemo-test.jl
@@ -1,3 +1,4 @@
+Nemo.show_banner()
 include("Fields-test.jl")
 include("Rings-test.jl")
 include("Generic-test.jl")


### PR DESCRIPTION
By default, banner is not showed when running `]test Nemo`, hence `Nemo.version` may be untested.