### PR TITLE
test: get rid of ring_to_mat

### DIFF
--- a/test/Rings-test.jl
+++ b/test/Rings-test.jl
@@ -1,15 +1,3 @@
-const ring_to_mat = Dict(ZZ                         => ZZMatrix,
-                         QQ                         => QQMatrix,
-                         residue_ring(ZZ, 9)[1]          => zzModMatrix,
-                         GF(5)                           => fpMatrix,
-                         finite_field(3, 2, "b")[1]      => fqPolyRepMatrix,
-                         finite_field(ZZRingElem(3), 2, "b")[1] => FqPolyRepMatrix,
-                         ArbField()                      => ArbMatrix,
-                         AcbField()                      => AcbMatrix,
-                         RealField()                     => RealMatrix,
-                         ComplexField()                  => ComplexMatrix,
-                        )
-
 include("flint/fmpz-test.jl")
 include("flint/fmpz_poly-test.jl")
 include("flint/fmpz_mod_poly-test.jl")

--- a/test/arb/ComplexMat-test.jl
+++ b/test/arb/ComplexMat-test.jl
@@ -113,14 +113,6 @@ end
   @test t isa ComplexMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{ComplexFieldElem}(CC, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/arb/RealMat-test.jl
+++ b/test/arb/RealMat-test.jl
@@ -112,14 +112,6 @@ end
   @test t isa RealMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{RealFieldElem}(RR, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/arb/acb_mat-test.jl
+++ b/test/arb/acb_mat-test.jl
@@ -113,14 +113,6 @@ end
   @test t isa AcbMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{AcbFieldElem}(CC, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/arb/arb_mat-test.jl
+++ b/test/arb/arb_mat-test.jl
@@ -112,14 +112,6 @@ end
   @test t isa ArbMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{ArbFieldElem}(RR, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -138,14 +138,6 @@ end
   @test t isa QQMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{QQFieldElem}(QQ, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -96,20 +96,6 @@ end
   @test size(t) == (2, 3)
   @test iszero(t)
 
-  for (R, M) in ring_to_mat
-    t = sim_zero(s, R)
-    @test size(t) == size(s)
-    if sim_zero == zero
-      @test iszero(t)
-    end
-
-    t = sim_zero(s, R, 2, 3)
-    @test size(t) == (2, 3)
-    if sim_zero == zero
-      @test iszero(t)
-    end
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{ZZRingElem}(ZZ, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -155,14 +155,6 @@ end
   t = similar(s, 2, 3)
   @test t isa ZZModMatrix
   @test size(t) == (2, 3)
-
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
 end
 
 @testset "ZZModMatrix.printing" begin

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -198,14 +198,6 @@ end
   @test t isa FqMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{FqFieldElem}(F9, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -182,14 +182,6 @@ end
   @test t isa FqPolyRepMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{FqPolyRepFieldElem}(F9, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -182,14 +182,6 @@ end
   @test t isa fqPolyRepMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{fqPolyRepFieldElem}(F9, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/gfp_fmpz_mat-test.jl
+++ b/test/flint/gfp_fmpz_mat-test.jl
@@ -156,14 +156,6 @@ end
   t = similar(s, 2, 3)
   @test t isa FpMatrix
   @test size(t) == (2, 3)
-
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
 end
 
 @testset "FpMatrix.printing" begin

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -186,14 +186,6 @@ end
   @test t isa fpMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{Nemo.fpFieldElem}(Z13, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -182,14 +182,6 @@ end
   @test t isa zzModMatrix
   @test size(t) == (2, 3)
 
-  for (R, M) in ring_to_mat
-    t = similar(s, R)
-    @test size(t) == size(s)
-
-    t = similar(s, R, 2, 3)
-    @test size(t) == (2, 3)
-  end
-
   # issue #651
   m = one(Generic.MatSpaceElem{Nemo.zzModRingElem}(Z13, 2, 2))
   for n = (m, -m, m*m, m+m, 2m)


### PR DESCRIPTION
The 'similar' methods being tested are generic and defined &
tested in AA.

Getting rid of this makes it somewhat less annoying to run the
affect test files interactively.
