### PR TITLE
Add `set!` for finite field elements

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2427,39 +2427,17 @@ mutable struct FqPolyRepFieldElem <: FinFieldElem
     return d
   end
 
-  function FqPolyRepFieldElem(ctx::FqPolyRepField, x::Int)
+  function FqPolyRepFieldElem(
+    ctx::FqPolyRepField,
+    x::Union{
+      FqPolyRepFieldElem,
+      Integer,ZZRingElem,
+      ZZPolyRingElem,
+      ZZModPolyRingElem,FpPolyRingElem
+    },
+  )
     d = FqPolyRepFieldElem(ctx)
-    ccall((:fq_set_si, libflint), Nothing,
-          (Ref{FqPolyRepFieldElem}, Int, Ref{FqPolyRepField}), d, x, ctx)
-    return d
-  end
-
-  function FqPolyRepFieldElem(ctx::FqPolyRepField, x::ZZRingElem)
-    d = FqPolyRepFieldElem(ctx)
-    ccall((:fq_set_fmpz, libflint), Nothing,
-          (Ref{FqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{FqPolyRepField}), d, x, ctx)
-    return d
-  end
-
-  function FqPolyRepFieldElem(ctx::FqPolyRepField, x::FpPolyRingElem)
-    d = FqPolyRepFieldElem(ctx)
-    ccall((:fq_set_fmpz_mod_poly, libflint), Nothing,
-          (Ref{FqPolyRepFieldElem}, Ref{FpPolyRingElem}, Ref{FqPolyRepField}),
-          d, x, ctx)
-    return d
-  end
-
-  function FqPolyRepFieldElem(ctx::FqPolyRepField, x::FqPolyRepFieldElem)
-    d = FqPolyRepFieldElem(ctx)
-    ccall((:fq_set, libflint), Nothing,
-          (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), d, x, ctx)
-    return d
-  end
-
-  function FqPolyRepFieldElem(ctx::FqPolyRepField, x::ZZPolyRingElem)
-    d = FqPolyRepFieldElem(ctx)
-    ccall((:fq_set_fmpz_poly, libflint), Nothing,
-          (Ref{FqPolyRepFieldElem}, Ref{ZZPolyRingElem}, Ref{FqPolyRepField}), d, x, ctx)
+    set!(d, x)
     return d
   end
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2294,59 +2294,18 @@ mutable struct FqFieldElem <: FinFieldElem
     return d
   end
 
-  function FqFieldElem(ctx::FqField, x::Int)
+  function FqFieldElem(
+    ctx::FqField,
+    x::Union{
+      FqFieldElem,
+      Integer, ZZRingElem,
+      ZZPolyRingElem,
+      zzModPolyRingElem, fpPolyRingElem,
+      ZZModPolyRingElem, FpPolyRingElem,
+    },
+  )
     d = FqFieldElem(ctx)
-    ccall((:fq_default_set_si, libflint), Nothing,
-          (Ref{FqFieldElem}, Int, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::ZZRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_fmpz, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{ZZRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::ZZPolyRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_fmpz_poly, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{ZZPolyRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::zzModPolyRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_nmod_poly, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{zzModPolyRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::fpPolyRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_nmod_poly, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{fpPolyRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::ZZModPolyRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_fmpz_mod_poly, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{ZZModPolyRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::FpPolyRingElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set_fmpz_mod_poly, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{FpPolyRingElem}, Ref{FqField}), d, x, ctx)
-    return d
-  end
-
-  function FqFieldElem(ctx::FqField, x::FqFieldElem)
-    d = FqFieldElem(ctx)
-    ccall((:fq_default_set, libflint), Nothing,
-          (Ref{FqFieldElem}, Ref{FqFieldElem}, Ref{FqField}), d, x, ctx)
+    set!(d, x)
     return d
   end
 end

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -478,6 +478,40 @@ function neg!(z::FqPolyRepFieldElem, a::FqPolyRepFieldElem)
   return z
 end
 
+#
+
+function set!(z::FqPolyRepFieldElem, a::FqPolyRepFieldElemOrPtr)
+  @ccall libflint.fq_set(z::Ref{FqPolyRepFieldElem}, a::Ref{FqPolyRepFieldElem}, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+function set!(z::FqPolyRepFieldElem, a::Int)
+  @ccall libflint.fq_set_si(z::Ref{FqPolyRepFieldElem}, a::Int, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+function set!(z::FqPolyRepFieldElem, a::UInt)
+  @ccall libflint.fq_set_ui(z::Ref{FqPolyRepFieldElem}, a::UInt, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+function set!(z::FqPolyRepFieldElem, a::ZZRingElemOrPtr)
+  @ccall libflint.fq_set_fmpz(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+set!(z::FqPolyRepFieldElem, a::Integer) = set!(z, flintify(a))
+
+function set!(z::FqPolyRepFieldElem, a::ZZPolyRingElemOrPtr)
+  @ccall libflint.fq_set_fmpz_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+function set!(z::FqPolyRepFieldElem, a::ZZModPolyRingElemOrPtr)
+  @ccall libflint.fq_set_fmpz_mod_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZModPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+function set!(z::FqPolyRepFieldElem, a::FpPolyRingElemOrPtr)
+  @ccall libflint.fq_set_fmpz_mod_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{FpPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
+end
+
+#
+
 function mul!(z::FqPolyRepFieldElem, x::FqPolyRepFieldElem, y::FqPolyRepFieldElem)
   ccall((:fq_mul, libflint), Nothing,
         (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, x, y, y.parent)

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -648,6 +648,55 @@ end
 
 #
 
+function set!(z::FqFieldElem, a::FqFieldElemOrPtr)
+  @ccall libflint.fq_default_set(z::Ref{FqFieldElem}, a::Ref{FqFieldElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::Int)
+  @ccall libflint.fq_default_set_si(z::Ref{FqFieldElem}, a::Int, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::UInt)
+  @ccall libflint.fq_default_set_ui(z::Ref{FqFieldElem}, a::UInt, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::ZZRingElemOrPtr)
+  @ccall libflint.fq_default_set_fmpz(z::Ref{FqFieldElem}, a::Ref{ZZRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+set!(z::FqFieldElem, a::Integer) = set!(z, flintify(a))
+
+function set!(z::FqFieldElem, a::ZZPolyRingElemOrPtr)
+  @ccall libflint.fq_default_set_fmpz_poly(z::Ref{FqFieldElem}, a::Ref{ZZPolyRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::zzModPolyRingElemOrPtr)
+  @ccall libflint.fq_default_set_nmod_poly(z::Ref{FqFieldElem}, a::Ref{zzModPolyRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::fpPolyRingElemOrPtr)
+  @ccall libflint.fq_default_set_nmod_poly(z::Ref{FqFieldElem}, a::Ref{fpPolyRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::ZZModPolyRingElemOrPtr)
+  @ccall libflint.fq_default_set_fmpz_mod_poly(z::Ref{FqFieldElem}, a::Ref{ZZModPolyRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+function set!(z::FqFieldElem, a::FpPolyRingElemOrPtr)
+  @ccall libflint.fq_default_set_fmpz_mod_poly(z::Ref{FqFieldElem}, a::Ref{FpPolyRingElem}, parent(z)::Ref{FqField})::Nothing
+  z.poly = nothing
+end
+
+#
+
 function add!(z::FqFieldElem, x::FqFieldElem, y::FqFieldElem)
   @ccall libflint.fq_default_add(z::Ref{FqFieldElem}, x::Ref{FqFieldElem}, y::Ref{FqFieldElem}, x.parent::Ref{FqField})::Nothing
   z.poly = nothing


### PR DESCRIPTION
ping @fingolfin to not work on the same thing

- ~`fpField`~ (skipping here due to other code structure)
- ~`FpField`~ (skipping here due to other code structure)
- ~`fqPolyRepField`~ (already done in #1810)
- [x] `FqPolyRepField` / `fq`
- [x] `FqField` / `fq_default`
