### PR TITLE
Turn _arb_set and _acb_set into set! methods

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -100,19 +100,19 @@ mutable struct RealFieldElem <: FieldElem
 
   function RealFieldElem(x::Union{Real, ZZRingElem, QQFieldElem, AbstractString, RealFieldElem}, p::Int)
     z = RealFieldElem()
-    _arb_set(z, x, p)
+    set!(z, x, p)
     return z
   end
 
   function RealFieldElem(x::Union{Real, ZZRingElem})
     z = RealFieldElem()
-    _arb_set(z, x)
+    set!(z, x)
     return z
   end
 
   function RealFieldElem(mid::RealFieldElem, rad::RealFieldElem)
     z = RealFieldElem()
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, mid)
+    set!(z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, rad)
     return z
   end
@@ -158,19 +158,19 @@ mutable struct ArbFieldElem <: FieldElem
 
   function ArbFieldElem(x::Union{Real, ZZRingElem, QQFieldElem, AbstractString, ArbFieldElem}, p::Int)
     z = ArbFieldElem()
-    _arb_set(z, x, p)
+    set!(z, x, p)
     return z
   end
 
   function ArbFieldElem(x::Union{Real, ZZRingElem, ArbFieldElem})
     z = ArbFieldElem()
-    _arb_set(z, x)
+    set!(z, x)
     return z
   end
 
   function ArbFieldElem(mid::ArbFieldElem, rad::ArbFieldElem)
     z = ArbFieldElem()
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, mid)
+    set!(z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, rad)
     return z
   end
@@ -219,19 +219,19 @@ mutable struct ComplexFieldElem <: FieldElem
 
   function ComplexFieldElem(x::Union{Number, ZZRingElem, RealFieldElem, ComplexFieldElem})
     z = ComplexFieldElem()
-    _acb_set(z, x)
+    set!(z, x)
     return z
   end
 
   function ComplexFieldElem(x::Union{Number, ZZRingElem, QQFieldElem, RealFieldElem, ComplexFieldElem, AbstractString}, p::Int)
     z = ComplexFieldElem()
-    _acb_set(z, x, p)
+    set!(z, x, p)
     return z
   end
 
   function ComplexFieldElem(x::T, y::T, p::Int) where {T <: Union{Real, ZZRingElem, QQFieldElem, AbstractString, RealFieldElem}}
     z = ComplexFieldElem()
-    _acb_set(z, x, y, p)
+    set!(z, (x, y), p)
     return z
   end
 end
@@ -370,25 +370,25 @@ mutable struct AcbFieldElem <: FieldElem
 
   function AcbFieldElem(x::Union{Number, ZZRingElem, ArbFieldElem, AcbFieldElem})
     z = AcbFieldElem()
-    _acb_set(z, x)
+    set!(z, x)
     return z
   end
 
   function AcbFieldElem(x::Union{Number, ZZRingElem, QQFieldElem, ArbFieldElem, AcbFieldElem, AbstractString}, p::Int)
     z = AcbFieldElem()
-    _acb_set(z, x, p)
+    set!(z, x, p)
     return z
   end
 
   #function AcbFieldElem{T <: Union{Int, UInt, Float64, ZZRingElem, BigFloat, ArbFieldElem}}(x::T, y::T)
   #  z = AcbFieldElem()
-  #  _acb_set(z, x, y)
+  #  set!(z, x, y)
   #  return z
   #end
 
   function AcbFieldElem(x::T, y::T, p::Int) where {T <: Union{Real, ZZRingElem, QQFieldElem, AbstractString, ArbFieldElem}}
     z = AcbFieldElem()
-    _acb_set(z, x, y, p)
+    set!(z, (x, y), p)
     return z
   end
 end
@@ -822,7 +822,7 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -833,7 +833,7 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -844,7 +844,7 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -855,7 +855,7 @@ mutable struct RealMatrix <: MatElem{RealFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -910,7 +910,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -921,7 +921,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -932,7 +932,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -943,7 +943,7 @@ mutable struct ArbMatrix <: MatElem{ArbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _arb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -1016,7 +1016,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -1027,7 +1027,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -1038,7 +1038,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -1049,7 +1049,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -1060,7 +1060,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -1071,7 +1071,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -1082,7 +1082,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -1093,7 +1093,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -1104,7 +1104,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
+        set!(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
     return z
@@ -1115,7 +1115,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
+        set!(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
     return z
@@ -1126,7 +1126,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
+        set!(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
     return z
@@ -1137,7 +1137,7 @@ mutable struct ComplexMatrix <: MatElem{ComplexFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
+        set!(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
     return z
@@ -1206,7 +1206,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -1217,7 +1217,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j])
+        set!(el, arr[i, j])
       end
     end
     return z
@@ -1228,7 +1228,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -1239,7 +1239,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j])
+        set!(el, arr[(i-1)*c+j])
       end
     end
     return z
@@ -1250,7 +1250,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -1261,7 +1261,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j], prec)
+        set!(el, arr[i, j], prec)
       end
     end
     return z
@@ -1272,7 +1272,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -1283,7 +1283,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j], prec)
+        set!(el, arr[(i-1)*c+j], prec)
       end
     end
     return z
@@ -1294,7 +1294,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
+        set!(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
     return z
@@ -1305,7 +1305,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[i, j][1], arr[i,j][2], prec)
+        set!(el, arr[i, j][1], arr[i,j][2], prec)
       end
     end
     return z
@@ -1316,7 +1316,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
+        set!(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
     return z
@@ -1327,7 +1327,7 @@ mutable struct AcbMatrix <: MatElem{AcbFieldElem}
     GC.@preserve z for i = 1:r
       for j = 1:c
         el = mat_entry_ptr(z, i, j)
-        _acb_set(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
+        set!(el, arr[(i-1)*c+j][1], arr[(i-1)*c+j][2], prec)
       end
     end
     return z

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -53,7 +53,7 @@ for T in [Integer, Float64, ZZRingElem, QQFieldElem, RealFieldElem, BigFloat, Co
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _acb_set(z, y, precision(Balls))
+        set!(z, y, precision(Balls))
       end
     end
   end
@@ -70,7 +70,7 @@ for T in [Integer, Float64, ZZRingElem, QQFieldElem, RealFieldElem, BigFloat, Ab
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _acb_set(z, y[1], y[2], precision(Balls))
+        set!(z, y[1], y[2], precision(Balls))
       end
     end
   end

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -1957,89 +1957,74 @@ end
 #
 ################################################################################
 
-for (typeofx, passtoc) in ((RealFieldElem, Ref{RealFieldElem}), (Ptr{RealFieldElem}, Ptr{RealFieldElem}))
-  for (f,t) in (("arb_set_si", Int), ("arb_set_ui", UInt),
-                ("arb_set_d", Float64))
-    @eval begin
-      function _arb_set(x::($typeofx), y::($t))
-        ccall(($f, libflint), Nothing, (($passtoc), ($t)), x, y)
-      end
-
-      function _arb_set(x::($typeofx), y::($t), p::Int)
-        _arb_set(x, y)
-        ccall((:arb_set_round, libflint), Nothing,
-              (($passtoc), ($passtoc), Int), x, x, p)
-      end
-    end
-  end
-
+for (f,t) in (("arb_set_si", Int), ("arb_set_ui", UInt), ("arb_set_d", Float64))
   @eval begin
-    function _arb_set(x::($typeofx), y::ZZRingElem)
-      ccall((:arb_set_fmpz, libflint), Nothing, (($passtoc), Ref{ZZRingElem}), x, y)
+    function set!(x::RealFieldElemOrPtr, y::$t)
+      @ccall libflint.$f(x::Ref{RealFieldElem}, y::$t)::Nothing
     end
 
-    function _arb_set(x::($typeofx), y::ZZRingElem, p::Int)
-      ccall((:arb_set_round_fmpz, libflint), Nothing,
-            (($passtoc), Ref{ZZRingElem}, Int), x, y, p)
-    end
-
-    function _arb_set(x::($typeofx), y::QQFieldElem, p::Int)
-      ccall((:arb_set_fmpq, libflint), Nothing,
-            (($passtoc), Ref{QQFieldElem}, Int), x, y, p)
-    end
-
-    function _arb_set(x::($typeofx), y::RealFieldElem)
-      ccall((:arb_set, libflint), Nothing, (($passtoc), Ref{RealFieldElem}), x, y)
-    end
-
-    function _arb_set(x::($typeofx), y::RealFieldElem, p::Int)
-      ccall((:arb_set_round, libflint), Nothing,
-            (($passtoc), Ref{RealFieldElem}, Int), x, y, p)
-    end
-
-    function _arb_set(x::($typeofx), y::AbstractString, p::Int)
-      s = string(y)
-      err = ccall((:arb_set_str, libflint), Int32,
-                  (($passtoc), Ptr{UInt8}, Int), x, s, p)
-      err == 0 || error("Invalid real string: $(repr(s))")
-    end
-
-    function _arb_set(x::($typeofx), y::BigFloat)
-      m = ccall((:arb_mid_ptr, libflint), Ptr{arf_struct},
-                (($passtoc), ), x)
-      r = ccall((:arb_rad_ptr, libflint), Ptr{mag_struct},
-                (($passtoc), ), x)
-      ccall((:arf_set_mpfr, libflint), Nothing,
-            (Ptr{arf_struct}, Ref{BigFloat}), m, y)
-      ccall((:mag_zero, libflint), Nothing, (Ptr{mag_struct}, ), r)
-    end
-
-    function _arb_set(x::($typeofx), y::BigFloat, p::Int)
-      m = ccall((:arb_mid_ptr, libflint), Ptr{arf_struct}, (($passtoc), ), x)
-      r = ccall((:arb_rad_ptr, libflint), Ptr{mag_struct}, (($passtoc), ), x)
-      ccall((:arf_set_mpfr, libflint), Nothing,
-            (Ptr{arf_struct}, Ref{BigFloat}), m, y)
-      ccall((:mag_zero, libflint), Nothing, (Ptr{mag_struct}, ), r)
-      ccall((:arb_set_round, libflint), Nothing,
-            (($passtoc), ($passtoc), Int), x, x, p)
-    end
-
-    function _arb_set(x::($typeofx), y::Integer)
-      _arb_set(x, ZZRingElem(y))
-    end
-
-    function _arb_set(x::($typeofx), y::Integer, p::Int)
-      _arb_set(x, ZZRingElem(y), p)
-    end
-
-    function _arb_set(x::($typeofx), y::Real)
-      _arb_set(x, BigFloat(y))
-    end
-
-    function _arb_set(x::($typeofx), y::Real, p::Int)
-      _arb_set(x, BigFloat(y), p)
+    function set!(x::RealFieldElemOrPtr, y::$t, p::Int)
+      set!(x, y)
+      @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, x::Ref{RealFieldElem}, p::Int)::Nothing
     end
   end
+end
+
+function set!(x::RealFieldElemOrPtr, y::ZZRingElemOrPtr)
+  @ccall libflint.arb_set_fmpz(x::Ref{RealFieldElem}, y::Ref{ZZRingElem})::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::ZZRingElemOrPtr, p::Int)
+  @ccall libflint.arb_set_round_fmpz(x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, p::Int)::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::QQFieldElemOrPtr, p::Int)
+  @ccall libflint.arb_set_fmpq(x::Ref{RealFieldElem}, y::Ref{QQFieldElem}, p::Int)::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::RealFieldElemOrPtr)
+  @ccall libflint.arb_set(x::Ref{RealFieldElem}, y::Ref{RealFieldElem})::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::RealFieldElemOrPtr, p::Int)
+  @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, p::Int)::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::AbstractString, p::Int)
+  s = string(y)
+  err = @ccall libflint.arb_set_str(x::Ref{RealFieldElem}, s::Ptr{UInt8}, p::Int)::Int32
+  err == 0 || error("Invalid real string: $(repr(s))")
+end
+
+function set!(x::RealFieldElemOrPtr, y::BigFloat)
+  m = @ccall libflint.arb_mid_ptr(x::Ref{RealFieldElem})::Ptr{arf_struct}
+  r = @ccall libflint.arb_rad_ptr(x::Ref{RealFieldElem})::Ptr{mag_struct}
+  @ccall libflint.arf_set_mpfr(m::Ptr{arf_struct}, y::Ref{BigFloat})::Nothing
+  @ccall libflint.mag_zero(r::Ptr{mag_struct})::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::BigFloat, p::Int)
+  m = @ccall libflint.arb_mid_ptr(x::Ref{RealFieldElem})::Ptr{arf_struct}
+  r = @ccall libflint.arb_rad_ptr(x::Ref{RealFieldElem})::Ptr{mag_struct}
+  @ccall libflint.arf_set_mpfr(m::Ptr{arf_struct}, y::Ref{BigFloat})::Nothing
+  @ccall libflint.mag_zero(r::Ptr{mag_struct})::Nothing
+  @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, x::Ref{RealFieldElem}, p::Int)::Nothing
+end
+
+function set!(x::RealFieldElemOrPtr, y::Integer)
+  set!(x, flintify(y))
+end
+
+function set!(x::RealFieldElemOrPtr, y::Integer, p::Int)
+  set!(x, flintify(y), p)
+end
+
+function set!(x::RealFieldElemOrPtr, y::Real)
+  set!(x, BigFloat(y))
+end
+
+function set!(x::RealFieldElemOrPtr, y::Real, p::Int)
+  set!(x, BigFloat(y), p)
 end
 
 ################################################################################

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -30,7 +30,7 @@ dense_matrix_type(::Type{RealFieldElem}) = RealMatrix
 function getindex!(z::ArbFieldElem, x::RealMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ptr{RealFieldElem}), z, v)
+    set!(z, v)
   end
   return z
 end
@@ -41,7 +41,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ptr{RealFieldElem}), z, v)
+    set!(z, v)
   end
   return z
 end
@@ -53,7 +53,7 @@ for T in [Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, RealFieldElem, 
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _arb_set(z, y, precision(Balls))
+        set!(z, y, precision(Balls))
       end
     end
   end

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -56,7 +56,7 @@ for T in [Integer, Float64, ZZRingElem, QQFieldElem, ArbFieldElem, BigFloat, Acb
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _acb_set(z, y, precision(base_ring(x)))
+        set!(z, y, precision(base_ring(x)))
       end
     end
   end
@@ -73,7 +73,7 @@ for T in [Integer, Float64, ZZRingElem, QQFieldElem, ArbFieldElem, BigFloat, Abs
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _acb_set(z, y[1], y[2], precision(base_ring(x)))
+        set!(z, y[1], y[2], precision(base_ring(x)))
       end
     end
   end

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -33,7 +33,7 @@ precision(x::ArbMatrixSpace) = precision(x.base_ring)
 function getindex!(z::ArbFieldElem, x::ArbMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{ArbFieldElem}), z, v)
+    set!(z, v)
   end
   return z
 end
@@ -44,7 +44,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{ArbFieldElem}), z, v)
+    set!(z, v)
   end
   return z
 end
@@ -56,7 +56,7 @@ for T in [Int, UInt, ZZRingElem, QQFieldElem, Float64, BigFloat, ArbFieldElem, A
 
       GC.@preserve x begin
         z = mat_entry_ptr(x, r, c)
-        _arb_set(z, y, precision(base_ring(x)))
+        set!(z, y, precision(base_ring(x)))
       end
     end
   end


### PR DESCRIPTION
Also replace some `for ... @eval begin` macro stuff

Also for the former `_acb_set` methods, we now take a tuple of two integers/reals/etc. coordinates instead of two arguments to avoid ambiguities between them precision argument.

This is just a draft because I later realized that these methods, or at least the ones which set a `ArbFieldElem`/`AcbFieldElem` and take a precision value `p`, should also adjust the parent (even if it is just emptying it). Or perhaps I just rename the methods back for those rings, to not worry about this. Dunno.

Putting this here anyway to avoid duplicated efforts (if someone else would like to continue or supersede this work, be my guest)