### PR TITLE
Clean up `*_mat_entry_set` calls

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5827,72 +5827,54 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{fqPolyRepFieldElem}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-              (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-              z, i - 1, j - 1, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{fqPolyRepFieldElem}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-              (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-              z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        el = mat_entry_ptr(z, i, j)
-        ccall((:fq_nmod_set_fmpz, libflint), Nothing,
-              (Ptr{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}), el, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        el = mat_entry_ptr(z, i, j)
-        ccall((:fq_nmod_set_fmpz, libflint), Nothing,
-              (Ptr{fqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{fqPolyRepField}), el, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::fqPolyRepField) where {T <: Integer}
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-              (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-              z, i - 1, j - 1, ctx(arr[i, j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[i, j])
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::fqPolyRepField) where {T <: Integer}
     z = fqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-              (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-              z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[(i - 1) * c + j])
+      @inbounds z[i, j] = el
     end
     return z
   end
@@ -5901,8 +5883,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
     ctx = parent(d)
     z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:min(r, c)
-      ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-            (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}), z, i - 1, i- 1, d, ctx)
+      @inbounds z[i, i] = d
     end
     return z
   end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5573,8 +5573,7 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
   end
 
   function FqMatrix(arr::AbstractMatrix{<:Union{FqFieldElem,ZZRingElem,Integer}}, ctx::FqField)
-    r = nrows(arr)
-    c = ncols(arr)
+    (r, c) = size(arr)
     z = FqMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       @inbounds z[i, j] = arr[i, j]
@@ -5677,8 +5676,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
   end
 
   function FqPolyRepMatrix(arr::AbstractMatrix{<:Union{FqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::FqPolyRepField)
-    r = nrows(arr)
-    c = ncols(arr)
+    (r, c) = size(arr)
     z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       @inbounds z[i, j] = arr[i, j]
@@ -5756,8 +5754,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   end
 
   function fqPolyRepMatrix(arr::AbstractMatrix{<:Union{fqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::fqPolyRepField)
-    r = nrows(arr)
-    c = ncols(arr)
+    (r, c) = size(arr)
     z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       @inbounds z[i, j] = arr[i, j]

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5572,7 +5572,7 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
     return z
   end
 
-  function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{FqFieldElem}, ctx::FqField)
+  function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{FqFieldElem,ZZRingElem,Integer}}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[i, j]
@@ -5581,46 +5581,10 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
     return z
   end
 
-  function FqMatrix(r::Int, c::Int, arr::AbstractVector{FqFieldElem}, ctx::FqField)
+  function FqMatrix(r::Int, c::Int, arr::AbstractVector{<:Union{FqFieldElem,ZZRingElem,Integer}}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqField)
-    z = FqMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqField)
-    z = FqMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqField) where {T <: Integer}
-    z = FqMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[i, j])
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqField) where {T <: Integer}
-    z = FqMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[(i - 1) * c + j])
       @inbounds z[i, j] = el
     end
     return z
@@ -5711,7 +5675,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
     return z
   end
 
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{FqPolyRepFieldElem}, ctx::FqPolyRepField)
+  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{FqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[i, j]
@@ -5720,46 +5684,10 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
     return z
   end
 
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{FqPolyRepFieldElem}, ctx::FqPolyRepField)
+  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{<:Union{FqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqPolyRepField)
-    z = FqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqPolyRepField)
-    z = FqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqPolyRepField) where {T <: Integer}
-    z = FqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[i, j])
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqPolyRepField) where {T <: Integer}
-    z = FqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[(i - 1) * c + j])
       @inbounds z[i, j] = el
     end
     return z
@@ -5825,7 +5753,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
     return z
   end
 
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{fqPolyRepFieldElem}, ctx::fqPolyRepField)
+  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{fqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[i, j]
@@ -5834,46 +5762,10 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
     return z
   end
 
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{fqPolyRepFieldElem}, ctx::fqPolyRepField)
+  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{<:Union{fqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::fqPolyRepField)
     z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
       el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::fqPolyRepField)
-    z = fqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::fqPolyRepField)
-    z = fqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = arr[(i - 1) * c + j]
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::fqPolyRepField) where {T <: Integer}
-    z = fqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[i, j])
-      @inbounds z[i, j] = el
-    end
-    return z
-  end
-
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::fqPolyRepField) where {T <: Integer}
-    z = fqPolyRepMatrix(r, c, ctx)
-    for i = 1:r, j = 1:c
-      el = ctx(arr[(i - 1) * c + j])
       @inbounds z[i, j] = el
     end
     return z

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5572,11 +5572,12 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
     return z
   end
 
-  function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{FqFieldElem,ZZRingElem,Integer}}, ctx::FqField)
+  function FqMatrix(arr::AbstractMatrix{<:Union{FqFieldElem,ZZRingElem,Integer}}, ctx::FqField)
+    r = nrows(arr)
+    c = ncols(arr)
     z = FqMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
+      @inbounds z[i, j] = arr[i, j]
     end
     return z
   end
@@ -5675,11 +5676,12 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
     return z
   end
 
-  function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{FqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::FqPolyRepField)
+  function FqPolyRepMatrix(arr::AbstractMatrix{<:Union{FqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::FqPolyRepField)
+    r = nrows(arr)
+    c = ncols(arr)
     z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
+      @inbounds z[i, j] = arr[i, j]
     end
     return z
   end
@@ -5753,11 +5755,12 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
     return z
   end
 
-  function fqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{<:Union{fqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::fqPolyRepField)
+  function fqPolyRepMatrix(arr::AbstractMatrix{<:Union{fqPolyRepFieldElem,ZZRingElem,Integer}}, ctx::fqPolyRepField)
+    r = nrows(arr)
+    c = ncols(arr)
     z = fqPolyRepMatrix(r, c, ctx)
     for i = 1:r, j = 1:c
-      el = arr[i, j]
-      @inbounds z[i, j] = el
+      @inbounds z[i, j] = arr[i, j]
     end
     return z
   end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5574,78 +5574,54 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{FqFieldElem}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{FqFieldElem}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set_fmpz, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{ZZRingElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqField)
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set_fmpz, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{ZZRingElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqField) where {T <: Integer}
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, ctx(arr[i, j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[i, j])
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqField) where {T <: Integer}
     z = FqMatrix(r, c, ctx)
-    for i = 1:r
-      for j = 1:c
-        ccall((:fq_default_mat_entry_set, libflint), Nothing,
-              (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
-               Ref{FqField}),
-              z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[(i - 1) * c + j])
+      @inbounds z[i, j] = el
     end
     return z
   end
@@ -5654,9 +5630,7 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
     ctx = parent(d)
     z = FqMatrix(r, c, ctx)
     for i = 1:min(r, c)
-      ccall((:fq_default_mat_entry_set, libflint), Nothing,
-            (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem},
-             Ref{FqField}), z, i - 1, i - 1, d, ctx)
+      @inbounds z[i, i] = d
     end
     return z
   end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5739,72 +5739,54 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{FqPolyRepFieldElem}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_mat_entry_set, libflint), Nothing,
-              (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-              z, i - 1, j - 1, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{FqPolyRepFieldElem}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_mat_entry_set, libflint), Nothing,
-              (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-              z, i - 1, j - 1, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{ZZRingElem}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        el = mat_entry_ptr(z, i, j)
-        ccall((:fq_set_fmpz, libflint), Nothing,
-              (Ptr{FqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{FqPolyRepField}), el, arr[i, j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[i, j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{ZZRingElem}, ctx::FqPolyRepField)
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        el = mat_entry_ptr(z, i, j)
-        ccall((:fq_set_fmpz, libflint), Nothing,
-              (Ptr{FqPolyRepFieldElem}, Ref{ZZRingElem}, Ref{FqPolyRepField}), el, arr[(i - 1) * c + j], ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = arr[(i - 1) * c + j]
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractMatrix{T}, ctx::FqPolyRepField) where {T <: Integer}
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_mat_entry_set, libflint), Nothing,
-              (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-              z, i - 1, j - 1, ctx(arr[i, j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[i, j])
+      @inbounds z[i, j] = el
     end
     return z
   end
 
   function FqPolyRepMatrix(r::Int, c::Int, arr::AbstractVector{T}, ctx::FqPolyRepField) where {T <: Integer}
     z = FqPolyRepMatrix(r, c, ctx)
-    GC.@preserve z for i = 1:r
-      for j = 1:c
-        ccall((:fq_mat_entry_set, libflint), Nothing,
-              (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-              z, i - 1, j - 1, ctx(arr[(i - 1) * c + j]), ctx)
-      end
+    for i = 1:r, j = 1:c
+      el = ctx(arr[(i - 1) * c + j])
+      @inbounds z[i, j] = el
     end
     return z
   end
@@ -5813,8 +5795,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
     ctx = parent(d)
     z = FqPolyRepMatrix(r, c, ctx)
     for i = 1:min(r, c)
-      ccall((:fq_mat_entry_set, libflint), Nothing,
-            (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}), z, i - 1, i- 1, d, ctx)
+      @inbounds z[i, i] = d
     end
     return z
   end

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -62,8 +62,7 @@ end
   nothing
 end
 
-setindex!(a::FqMatrix, u::Integer, i::Int, j::Int) =
-setindex!(a, base_ring(a)(u), i, j)
+setindex!(a::FqMatrix, u::Integer, i::Int, j::Int) = setindex!(a, base_ring(a)(u), i, j)
 
 function setindex!(a::FqMatrix, b::FqMatrix, r::UnitRange{Int64}, c::UnitRange{Int64})
   _checkbounds(a, r, c)

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -45,14 +45,11 @@ end
   return z
 end
 
-@inline function setindex!(a::FqMatrix, u::FqFieldElem, i::Int, j::Int)
+@inline function setindex!(a::FqMatrix, u::FqFieldElemOrPtr, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
-  K = base_ring(a)
-  uu = K(u)
-  ccall((:fq_default_mat_entry_set, libflint), Nothing,
-        (Ref{FqMatrix}, Int, Int, Ref{FqFieldElem}, Ref{FqField}),
-        a, i - 1, j - 1, uu, base_ring(a))
-  nothing
+  @ccall libflint.fq_default_mat_entry_set(
+    a::Ref{FqMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{FqFieldElem}, base_ring(a)::Ref{FqField}
+  )::Nothing
 end
 
 @inline function setindex!(a::FqMatrix, u::ZZRingElem, i::Int, j::Int)

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -674,22 +674,12 @@ function (a::FqMatrixSpace)(b::FqFieldElem)
   return FqMatrix(nrows(a), ncols(a), b)
 end
 
-function (a::FqMatrixSpace)(arr::AbstractMatrix{T}) where {T <: Integer}
+function (a::FqMatrixSpace)(arr::AbstractMatrix{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
-  return FqMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return FqMatrix(arr, base_ring(a))
 end
 
-function (a::FqMatrixSpace)(arr::AbstractVector{T}) where {T <: Integer}
-  _check_dim(nrows(a), ncols(a), arr)
-  return FqMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::FqMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
-  _check_dim(nrows(a), ncols(a), arr)
-  return FqMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::FqMatrixSpace)(arr::AbstractVector{ZZRingElem})
+function (a::FqMatrixSpace)(arr::AbstractVector{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
   return FqMatrix(nrows(a), ncols(a), arr, base_ring(a))
 end
@@ -697,7 +687,7 @@ end
 function (a::FqMatrixSpace)(arr::AbstractMatrix{FqFieldElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  return FqMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return FqMatrix(arr, base_ring(a))
 end
 
 function (a::FqMatrixSpace)(arr::AbstractVector{FqFieldElem})
@@ -732,7 +722,8 @@ end
 ###############################################################################
 
 function matrix(R::FqField, arr::AbstractMatrix{<: Union{FqFieldElem, ZZRingElem, Integer}})
-  z = FqMatrix(size(arr, 1), size(arr, 2), arr, R)
+  Base.require_one_based_indexing(arr)
+  z = FqMatrix(arr, R)
   return z
 end
 

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -47,8 +47,9 @@ end
 
 @inline function setindex!(a::FqMatrix, u::FqFieldElemOrPtr, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
+  uu = base_ring(a)(u)
   @ccall libflint.fq_default_mat_entry_set(
-    a::Ref{FqMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{FqFieldElem}, base_ring(a)::Ref{FqField}
+    a::Ref{FqMatrix}, (i-1)::Int, (j-1)::Int, uu::Ref{FqFieldElem}, base_ring(a)::Ref{FqField}
   )::Nothing
 end
 

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -47,11 +47,11 @@ end
   return z
 end
 
-@inline function setindex!(a::FqPolyRepMatrix, u::FqPolyRepFieldElem, i::Int, j::Int)
+@inline function setindex!(a::FqPolyRepMatrix, u::FqPolyRepFieldElemOrPtr, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
-  ccall((:fq_mat_entry_set, libflint), Nothing,
-        (Ref{FqPolyRepMatrix}, Int, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-        a, i - 1, j - 1, u, base_ring(a))
+  @ccall libflint.fq_mat_entry_set(
+    a::Ref{FqPolyRepMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{FqPolyRepFieldElem}, base_ring(a)::Ref{FqPolyRepField}
+  )::Nothing
 end
 
 @inline function setindex!(a::FqPolyRepMatrix, u::ZZRingElem, i::Int, j::Int)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -667,22 +667,12 @@ function (a::FqPolyRepMatrixSpace)(b::FqPolyRepFieldElem)
   return FqPolyRepMatrix(nrows(a), ncols(a), b)
 end
 
-function (a::FqPolyRepMatrixSpace)(arr::AbstractMatrix{T}) where {T <: Integer}
+function (a::FqPolyRepMatrixSpace)(arr::AbstractMatrix{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
-  return FqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return FqPolyRepMatrix(arr, base_ring(a))
 end
 
-function (a::FqPolyRepMatrixSpace)(arr::AbstractVector{T}) where {T <: Integer}
-  _check_dim(nrows(a), ncols(a), arr)
-  return FqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::FqPolyRepMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
-  _check_dim(nrows(a), ncols(a), arr)
-  return FqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::FqPolyRepMatrixSpace)(arr::AbstractVector{ZZRingElem})
+function (a::FqPolyRepMatrixSpace)(arr::AbstractVector{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
   return FqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
 end
@@ -690,7 +680,7 @@ end
 function (a::FqPolyRepMatrixSpace)(arr::AbstractMatrix{FqPolyRepFieldElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  return FqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return FqPolyRepMatrix(arr, base_ring(a))
 end
 
 function (a::FqPolyRepMatrixSpace)(arr::AbstractVector{FqPolyRepFieldElem})
@@ -711,7 +701,8 @@ end
 ###############################################################################
 
 function matrix(R::FqPolyRepField, arr::AbstractMatrix{<: Union{FqPolyRepFieldElem, ZZRingElem, Integer}})
-  z = FqPolyRepMatrix(size(arr, 1), size(arr, 2), arr, R)
+  Base.require_one_based_indexing(arr)
+  z = FqPolyRepMatrix(arr, R)
   return z
 end
 

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -63,8 +63,7 @@ end
   end
 end
 
-setindex!(a::FqPolyRepMatrix, u::Integer, i::Int, j::Int) =
-setindex!(a, base_ring(a)(u), i, j)
+setindex!(a::FqPolyRepMatrix, u::Integer, i::Int, j::Int) = setindex!(a, base_ring(a)(u), i, j)
 
 function setindex!(a::FqPolyRepMatrix, b::FqPolyRepMatrix, r::UnitRange{Int64}, c::UnitRange{Int64})
   _checkbounds(a, r, c)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -63,8 +63,7 @@ end
   end
 end
 
-setindex!(a::fqPolyRepMatrix, u::Integer, i::Int, j::Int) =
-setindex!(a, base_ring(a)(u), i, j)
+setindex!(a::fqPolyRepMatrix, u::Integer, i::Int, j::Int) = setindex!(a, base_ring(a)(u), i, j)
 
 function setindex!(a::fqPolyRepMatrix, b::fqPolyRepMatrix, r::UnitRange{Int64}, c::UnitRange{Int64})
   _checkbounds(a, r, c)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -47,11 +47,11 @@ end
   return z
 end
 
-@inline function setindex!(a::fqPolyRepMatrix, u::fqPolyRepFieldElem, i::Int, j::Int)
+@inline function setindex!(a::fqPolyRepMatrix, u::fqPolyRepFieldElemOrPtr, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
-  ccall((:fq_nmod_mat_entry_set, libflint), Nothing,
-        (Ref{fqPolyRepMatrix}, Int, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-        a, i - 1, j - 1, u, base_ring(a))
+  @ccall libflint.fq_nmod_mat_entry_set(
+    a::Ref{fqPolyRepMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{fqPolyRepFieldElem}, base_ring(a)::Ref{fqPolyRepField}
+  )::Nothing
 end
 
 @inline function setindex!(a::fqPolyRepMatrix, u::ZZRingElem, i::Int, j::Int)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -656,22 +656,12 @@ function (a::fqPolyRepMatrixSpace)(b::fqPolyRepFieldElem)
   return fqPolyRepMatrix(nrows(a), ncols(a), b)
 end
 
-function (a::fqPolyRepMatrixSpace)(arr::AbstractMatrix{T}) where {T <: Integer}
+function (a::fqPolyRepMatrixSpace)(arr::AbstractMatrix{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
-  return fqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return fqPolyRepMatrix(arr, base_ring(a))
 end
 
-function (a::fqPolyRepMatrixSpace)(arr::AbstractVector{T}) where {T <: Integer}
-  _check_dim(nrows(a), ncols(a), arr)
-  return fqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::fqPolyRepMatrixSpace)(arr::AbstractMatrix{ZZRingElem})
-  _check_dim(nrows(a), ncols(a), arr)
-  return fqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
-end
-
-function (a::fqPolyRepMatrixSpace)(arr::AbstractVector{ZZRingElem})
+function (a::fqPolyRepMatrixSpace)(arr::AbstractVector{<:IntegerUnion})
   _check_dim(nrows(a), ncols(a), arr)
   return fqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
 end
@@ -679,7 +669,7 @@ end
 function (a::fqPolyRepMatrixSpace)(arr::AbstractMatrix{fqPolyRepFieldElem})
   _check_dim(nrows(a), ncols(a), arr)
   (length(arr) > 0 && (base_ring(a) != parent(arr[1]))) && error("Elements must have same base ring")
-  return fqPolyRepMatrix(nrows(a), ncols(a), arr, base_ring(a))
+  return fqPolyRepMatrix(arr, base_ring(a))
 end
 
 function (a::fqPolyRepMatrixSpace)(arr::AbstractVector{fqPolyRepFieldElem})
@@ -700,7 +690,8 @@ end
 ###############################################################################
 
 function matrix(R::fqPolyRepField, arr::AbstractMatrix{<: Union{fqPolyRepFieldElem, ZZRingElem, Integer}})
-  z = fqPolyRepMatrix(size(arr, 1), size(arr, 2), arr, R)
+  Base.require_one_based_indexing(arr)
+  z = fqPolyRepMatrix(arr, R)
   return z
 end
 


### PR DESCRIPTION
Use the already installed `setindex!` methods with `@inbounds` instead of ccalls everywhere