### PR TITLE
Add more `setcoeff!` methods and use them to deduplicate PolyRingElem constructors

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -567,32 +567,12 @@ mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
     return zzModPolyRingElem(n, mod(a, n) % UInt)
   end
 
-  function zzModPolyRingElem(n::UInt, arr::Vector{ZZRingElem})
+  function zzModPolyRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,zzModRingElem}})
     z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
+    @ccall libflint.nmod_poly_init2(z::Ref{zzModPolyRingElem}, n::UInt, length(a)::Int)::Nothing
     finalizer(_nmod_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i - 1, arr[i])
-    end
-    return z
-  end
-
-  function zzModPolyRingElem(n::UInt, arr::Vector{UInt})
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_nmod_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i - 1, arr[i])
-    end
-    return z
-  end
-
-  function zzModPolyRingElem(n::UInt, arr::Vector{zzModRingElem})
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_nmod_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i-1, arr[i].data)
+    for i in 1:length(a)
+      setcoeff!(z, i - 1, a[i])
     end
     return z
   end
@@ -685,32 +665,12 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
     return fpPolyRingElem(n, mod(a, n) % UInt)
   end
 
-  function fpPolyRingElem(n::UInt, arr::Vector{ZZRingElem})
+  function fpPolyRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,fpFieldElem}})
     z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
+    @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(a)::Int)::Nothing
     finalizer(_gfp_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i - 1, arr[i])
-    end
-    return z
-  end
-
-  function fpPolyRingElem(n::UInt, arr::Vector{UInt})
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i - 1, arr[i])
-    end
-    return z
-  end
-
-  function fpPolyRingElem(n::UInt, arr::Vector{fpFieldElem})
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
-    for i in 1:length(arr)
-      setcoeff!(z, i-1, arr[i].data)
+    for i in 1:length(a)
+      setcoeff!(z, i - 1, a[i])
     end
     return z
   end
@@ -2957,36 +2917,11 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
     return z
   end
 
-  function fpRelPowerSeriesRingElem(p::UInt, a::Vector{ZZRingElem}, len::Int, prec::Int, val::Int)
+  function fpRelPowerSeriesRingElem(p::UInt, a::Vector{<:Union{Integer,ZZRingElem,fpFieldElem}}, len::Int, prec::Int, val::Int)
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      tt = @ccall libflint.fmpz_fdiv_ui(a[i]::Ref{ZZRingElem}, p::UInt)::UInt
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpRelPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_gfp_rel_series_clear_fn, z)
-    return z
-  end
-
-  function fpRelPowerSeriesRingElem(p::UInt, a::Vector{UInt}, len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpRelPowerSeriesRingElem}, (i - 1)::Int, a[i]::UInt)::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_gfp_rel_series_clear_fn, z)
-    return z
-  end
-
-  function fpRelPowerSeriesRingElem(p::UInt, a::Vector{fpFieldElem}, len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpRelPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::UInt)::Nothing
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     z.val = val
@@ -3049,36 +2984,11 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     return z
   end
 
-  function zzModRelPowerSeriesRingElem(p::UInt, a::Vector{ZZRingElem}, len::Int, prec::Int, val::Int)
+  function zzModRelPowerSeriesRingElem(p::UInt, a::Vector{<:Union{Integer,ZZRingElem,zzModRingElem}}, len::Int, prec::Int, val::Int)
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{zzModRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      tt = @ccall libflint.fmpz_fdiv_ui(a[i]::Ref{ZZRingElem}, p::UInt)::UInt
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModRelPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_nmod_rel_series_clear_fn, z)
-    return z
-  end
-
-  function zzModRelPowerSeriesRingElem(p::UInt, a::Vector{UInt}, len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModRelPowerSeriesRingElem}, (i - 1)::Int, a[i]::UInt)::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_nmod_rel_series_clear_fn, z)
-    return z
-  end
-
-  function zzModRelPowerSeriesRingElem(p::UInt, a::Vector{zzModRingElem}, len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
-    for i = 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModRelPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::UInt)::Nothing
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     z.val = val
@@ -3426,34 +3336,11 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
     return z
   end
 
-  function zzModAbsPowerSeriesRingElem(n::UInt, arr::Vector{ZZRingElem}, len::Int, prec::Int)
+  function zzModAbsPowerSeriesRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,zzModRingElem}}, len::Int, prec::Int)
     z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
+    @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt, length(a)::Int)::Nothing
     for i in 1:len
-      tt = @ccall libflint.fmpz_fdiv_ui(arr[i]::Ref{ZZRingElem}, n::UInt)::UInt
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
-    end
-    z.prec = prec
-    finalizer(_nmod_abs_series_clear_fn, z)
-    return z
-  end
-
-  function zzModAbsPowerSeriesRingElem(n::UInt, arr::Vector{UInt}, len::Int, prec::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
-    for i in 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i - 1)::Int, arr[i]::UInt)::Nothing
-    end
-    z.prec = prec
-    finalizer(_nmod_abs_series_clear_fn, z)
-    return z
-  end
-
-  function zzModAbsPowerSeriesRingElem(n::UInt, arr::Vector{zzModRingElem}, len::Int, prec::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
-    for i in 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i-1)::Int, arr[i].data::UInt)::Nothing
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     finalizer(_nmod_abs_series_clear_fn, z)
@@ -3518,34 +3405,11 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
     return z
   end
 
-  function fpAbsPowerSeriesRingElem(n::UInt, arr::Vector{ZZRingElem}, len::Int, prec::Int)
+  function fpAbsPowerSeriesRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,fpFieldElem}}, len::Int, prec::Int)
     z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
+    @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt, length(a)::Int)::Nothing
     for i in 1:len
-      tt = @ccall libflint.fmpz_fdiv_ui(arr[i]::Ref{ZZRingElem}, n::UInt)::UInt
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
-    end
-    z.prec = prec
-    finalizer(_gfp_abs_series_clear_fn, z)
-    return z
-  end
-
-  function fpAbsPowerSeriesRingElem(n::UInt, arr::Vector{UInt}, len::Int, prec::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
-    for i in 1:len
-      @ccall libflint.nmod_poly_series_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i - 1)::Int, arr[i]::UInt)::Nothing
-    end
-    z.prec = prec
-    finalizer(_gfp_abs_series_clear_fn, z)
-    return z
-  end
-
-  function fpAbsPowerSeriesRingElem(n::UInt, arr::Vector{fpFieldElem}, len::Int, prec::Int)
-    z = new()
-    @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt, length(arr)::Int)::Nothing
-    for i in 1:len
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i-1)::Int, arr[i].data::UInt)::Nothing
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     finalizer(_gfp_abs_series_clear_fn, z)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -557,14 +557,10 @@ mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
     return z
   end
 
-  function zzModPolyRingElem(n::UInt, a::UInt)
+  function zzModPolyRingElem(n::UInt, a::Union{Integer,ZZRingElem,zzModRingElem})
     z = zzModPolyRingElem(n)
     setcoeff!(z, 0, a)
     return z
-  end
-
-  function zzModPolyRingElem(n::UInt, a::Integer)
-    return zzModPolyRingElem(n, mod(a, n) % UInt)
   end
 
   function zzModPolyRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,zzModRingElem}})
@@ -655,14 +651,10 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
     return z
   end
 
-  function fpPolyRingElem(n::UInt, a::UInt)
+  function fpPolyRingElem(n::UInt, a::Union{Integer,ZZRingElem,fpFieldElem})
     z = fpPolyRingElem(n)
     setcoeff!(z, 0, a)
     return z
-  end
-
-  function fpPolyRingElem(n::UInt, a::Integer)
-    return fpPolyRingElem(n, mod(a, n) % UInt)
   end
 
   function fpPolyRingElem(n::UInt, a::Vector{<:Union{Integer,ZZRingElem,fpFieldElem}})
@@ -756,23 +748,13 @@ mutable struct ZZModPolyRingElem <: PolyRingElem{ZZModRingElem}
     return ZZModPolyRingElem(R.ninv)
   end
 
-  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::ZZRingElem)
+  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::Union{Integer,ZZRingElem,ZZModRingElem})
     z = ZZModPolyRingElem(n)
-    @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModPolyRingElem}, 0::Int, a::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    setcoeff!(z, 0, a)
     return z
   end
 
-  function ZZModPolyRingElem(R::ZZModRing, a::ZZRingElem)
-    return ZZModPolyRingElem(R.ninv, a)
-  end
-
-  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::UInt)
-    z = ZZModPolyRingElem(n)
-    @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{ZZModPolyRingElem}, 0::Int, a::UInt, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    return z
-  end
-
-  function ZZModPolyRingElem(R::ZZModRing, a::UInt)
+  function ZZModPolyRingElem(R::ZZModRing, a::Union{Integer,ZZRingElem,ZZModRingElem})
     return ZZModPolyRingElem(R.ninv, a)
   end
 
@@ -886,20 +868,14 @@ mutable struct FpPolyRingElem <: PolyRingElem{FpFieldElem}
     return FpPolyRingElem(R.ninv)
   end
 
-  function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::ZZRingElem)
+  function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::Union{Integer,ZZRingElem,FpFieldElem})
     z = FpPolyRingElem(n)
-    @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpPolyRingElem}, 0::Int, a::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    setcoeff!(z, 0, a)
     return z
   end
 
-  function FpPolyRingElem(R::FpField, a::ZZRingElem)
+  function FpPolyRingElem(R::FpField, a::Union{Integer,ZZRingElem,FpFieldElem})
     return FpPolyRingElem(R.ninv, a)
-  end
-
-  function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::UInt)
-    z = FpPolyRingElem(n)
-    @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{FpPolyRingElem}, 0::Int, a::UInt, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    return z
   end
 
   function FpPolyRingElem(R::FpField, a::UInt)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -559,7 +559,7 @@ mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
 
   function zzModPolyRingElem(n::UInt, a::Union{Integer,ZZRingElem,zzModRingElem})
     z = zzModPolyRingElem(n)
-    setcoeff!(z, 0, a)
+    setcoeff!(z, 0, a, n)
     return z
   end
 
@@ -568,7 +568,7 @@ mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
     @ccall libflint.nmod_poly_init2(z::Ref{zzModPolyRingElem}, n::UInt, length(a)::Int)::Nothing
     finalizer(_nmod_poly_clear_fn, z)
     for i in 1:length(a)
-      setcoeff!(z, i - 1, a[i])
+      setcoeff!(z, i - 1, a[i], n)
     end
     return z
   end
@@ -653,7 +653,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
 
   function fpPolyRingElem(n::UInt, a::Union{Integer,ZZRingElem,fpFieldElem})
     z = fpPolyRingElem(n)
-    setcoeff!(z, 0, a)
+    setcoeff!(z, 0, a, n)
     return z
   end
 
@@ -662,7 +662,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(a)::Int)::Nothing
     finalizer(_gfp_poly_clear_fn, z)
     for i in 1:length(a)
-      setcoeff!(z, i - 1, a[i])
+      setcoeff!(z, i - 1, a[i], n)
     end
     return z
   end
@@ -750,7 +750,7 @@ mutable struct ZZModPolyRingElem <: PolyRingElem{ZZModRingElem}
 
   function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::Union{Integer,ZZRingElem,ZZModRingElem})
     z = ZZModPolyRingElem(n)
-    setcoeff!(z, 0, a)
+    setcoeff!(z, 0, a, n)
     return z
   end
 
@@ -759,11 +759,10 @@ mutable struct ZZModPolyRingElem <: PolyRingElem{ZZModRingElem}
   end
 
   function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}})
-    length(a) == 0 && error("Array must have length > 0")
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModPolyRingElem}, length(a)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
     for i in 1:length(a)
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], n)
     end
     finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
@@ -870,7 +869,7 @@ mutable struct FpPolyRingElem <: PolyRingElem{FpFieldElem}
 
   function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::Union{Integer,ZZRingElem,FpFieldElem})
     z = FpPolyRingElem(n)
-    setcoeff!(z, 0, a)
+    setcoeff!(z, 0, a, n)
     return z
   end
 
@@ -883,11 +882,10 @@ mutable struct FpPolyRingElem <: PolyRingElem{FpFieldElem}
   end
 
   function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}})
-    length(a) == 0 && error("Array must have length > 0")
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpPolyRingElem}, length(a)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
     for i in 1:length(a)
-      setcoeff!(z, i - 1, a[i])
+      setcoeff!(z, i - 1, a[i], n)
     end
     finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
@@ -2869,7 +2867,7 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     z.val = val
@@ -2936,7 +2934,7 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{zzModRelPowerSeriesRingElem}, p::UInt, len::Int)::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     z.val = val
@@ -3007,7 +3005,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing   
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     z.val = val
@@ -3085,7 +3083,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     z.val = val
@@ -3162,7 +3160,7 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     finalizer(_gfp_fmpz_abs_series_clear_fn, z)
@@ -3235,7 +3233,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt, length(a)::Int)::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], n)
     end
     z.prec = prec
     finalizer(_nmod_abs_series_clear_fn, z)
@@ -3304,7 +3302,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt, length(a)::Int)::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], n)
     end
     z.prec = prec
     finalizer(_gfp_abs_series_clear_fn, z)
@@ -3373,7 +3371,7 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
     for i in 1:len
-      setcoeff!(z, i-1, a[i])
+      setcoeff!(z, i-1, a[i], p)
     end
     z.prec = prec
     finalizer(_fmpz_mod_abs_series_clear_fn, z)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -776,33 +776,19 @@ mutable struct ZZModPolyRingElem <: PolyRingElem{ZZModRingElem}
     return ZZModPolyRingElem(R.ninv, a)
   end
 
-  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, arr::Vector{ZZRingElem})
-    length(arr) == 0 && error("Array must have length > 0")
+  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}})
+    length(a) == 0 && error("Array must have length > 0")
     z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModPolyRingElem}, length(arr)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i in 1:length(arr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModPolyRingElem}, (i - 1)::Int, arr[i]::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModPolyRingElem}, length(a)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    for i in 1:length(a)
+      setcoeff!(z, i-1, a[i])
     end
     finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
-  function ZZModPolyRingElem(R::ZZModRing, arr::Vector{ZZRingElem})
-    return ZZModPolyRingElem(R.ninv, arr)
-  end
-
-  function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, arr::Vector{ZZModRingElem})
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModPolyRingElem}, length(arr)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i in 1:length(arr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModPolyRingElem}, (i - 1)::Int, arr[i].data::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    finalizer(_fmpz_mod_poly_clear_fn, z)
-    return z
-  end
-
-  function ZZModPolyRingElem(R::ZZModRing, arr::Vector{ZZModRingElem})
-    return ZZModPolyRingElem(R.ninv, arr)
+  function ZZModPolyRingElem(R::ZZModRing, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}})
+    return ZZModPolyRingElem(R.ninv, a)
   end
 
   function ZZModPolyRingElem(n::fmpz_mod_ctx_struct, f::ZZPolyRingElem)
@@ -920,33 +906,19 @@ mutable struct FpPolyRingElem <: PolyRingElem{FpFieldElem}
     return FpPolyRingElem(R.ninv, a)
   end
 
-  function FpPolyRingElem(n::fmpz_mod_ctx_struct, arr::Vector{ZZRingElem})
-    length(arr) == 0 && error("Array must have length > 0")
+  function FpPolyRingElem(n::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}})
+    length(a) == 0 && error("Array must have length > 0")
     z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpPolyRingElem}, length(arr)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i in 1:length(arr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpPolyRingElem}, (i - 1)::Int, arr[i]::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpPolyRingElem}, length(a)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
+    for i in 1:length(a)
+      setcoeff!(z, i - 1, a[i])
     end
     finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
-  function FpPolyRingElem(R::FpField, arr::Vector{ZZRingElem})
-    FpPolyRingElem(R.ninv, arr)
-  end
-
-  function FpPolyRingElem(n::fmpz_mod_ctx_struct, arr::Vector{FpFieldElem})
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpPolyRingElem}, length(arr)::Int, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i in 1:length(arr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpPolyRingElem}, (i - 1)::Int, arr[i].data::Ref{ZZRingElem}, n::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    finalizer(_fmpz_mod_poly_clear_fn, z)
-    return z
-  end
-
-  function FpPolyRingElem(R::FpField, arr::Vector{FpFieldElem})
-    return FpPolyRingElem(R.ninv, arr)
+  function FpPolyRingElem(R::FpField, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}})
+    return FpPolyRingElem(R.ninv, a)
   end
 
   function FpPolyRingElem(n::fmpz_mod_ctx_struct, f::ZZPolyRingElem)
@@ -3054,12 +3026,12 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     return FpRelPowerSeriesRingElem(R.ninv)
   end
 
-  function FpRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZRingElem},
+  function FpRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}},
       len::Int, prec::Int, val::Int)
     z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpRelPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
+    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing   
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     z.val = val
@@ -3067,25 +3039,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     return z
   end
 
-  function FpRelPowerSeriesRingElem(R::FpField, a::Vector{ZZRingElem},
-      len::Int, prec::Int, val::Int)
-    return FpRelPowerSeriesRingElem(R.ninv, a, len, prec, val)
-  end
-
-  function FpRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{FpFieldElem},
-      len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpRelPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_gfp_fmpz_rel_series_clear_fn, z)
-    return z
-  end
-
-  function FpRelPowerSeriesRingElem(R::FpField, a::Vector{FpFieldElem},
+  function FpRelPowerSeriesRingElem(R::FpField, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}},
       len::Int, prec::Int, val::Int)
     return FpRelPowerSeriesRingElem(R.ninv, a, len, prec, val)
   end
@@ -3150,12 +3104,12 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     return ZZModRelPowerSeriesRingElem(R.ninv)
   end
 
-  function ZZModRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZRingElem},
+  function ZZModRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}},
       len::Int, prec::Int, val::Int)
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModRelPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     z.val = val
@@ -3163,25 +3117,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     return z
   end
 
-  function ZZModRelPowerSeriesRingElem(R::ZZModRing, a::Vector{ZZRingElem},
-      len::Int, prec::Int, val::Int)
-    return ZZModRelPowerSeriesRingElem(R.ninv, a, len, prec, val)
-  end
-
-  function ZZModRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZModRingElem},
-      len::Int, prec::Int, val::Int)
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModRelPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModRelPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    z.prec = prec
-    z.val = val
-    finalizer(_fmpz_mod_rel_series_clear_fn, z)
-    return z
-  end
-
-  function ZZModRelPowerSeriesRingElem(R::ZZModRing, a::Vector{ZZModRingElem},
+  function ZZModRelPowerSeriesRingElem(R::ZZModRing, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}},
       len::Int, prec::Int, val::Int)
     return ZZModRelPowerSeriesRingElem(R.ninv, a, len, prec, val)
   end
@@ -3245,36 +3181,19 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
     return FpAbsPowerSeriesRingElem(R.ninv)
   end
 
-  function FpAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZRingElem},
+  function FpAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}},
       len::Int, prec::Int)
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     finalizer(_gfp_fmpz_abs_series_clear_fn, z)
     return z
   end
 
-  function FpAbsPowerSeriesRingElem(R::FpField, a::Vector{ZZRingElem}, len::Int, prec::Int)
-    return FpAbsPowerSeriesRingElem(R.ninv, a, len, prec)
-  end
-
-  function FpAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{FpFieldElem},
-      len::Int, prec::Int)
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{FpAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpAbsPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    z.prec = prec
-    finalizer(_gfp_fmpz_abs_series_clear_fn, z)
-    return z
-  end
-
-  function FpAbsPowerSeriesRingElem(R::FpField, a::Vector{FpFieldElem},
-      len::Int, prec::Int)
+  function FpAbsPowerSeriesRingElem(R::FpField, a::Vector{<:Union{Integer,ZZRingElem,FpFieldElem}}, len::Int, prec::Int)
     return FpAbsPowerSeriesRingElem(R.ninv, a, len, prec)
   end
 
@@ -3473,36 +3392,19 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
     return ZZModAbsPowerSeriesRingElem(R.ninv)
   end
 
-  function ZZModAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZRingElem},
+  function ZZModAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}},
       len::Int, prec::Int)
     z = new()
     @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
+    for i in 1:len
+      setcoeff!(z, i-1, a[i])
     end
     z.prec = prec
     finalizer(_fmpz_mod_abs_series_clear_fn, z)
     return z
   end
 
-  function ZZModAbsPowerSeriesRingElem(R::ZZModRing, a::Vector{ZZRingElem}, len::Int, prec::Int)
-    return ZZModAbsPowerSeriesRingElem(R.ninv, a, len, prec)
-  end
-
-  function ZZModAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct, a::Vector{ZZModRingElem},
-      len::Int, prec::Int)
-    z = new()
-    @ccall libflint.fmpz_mod_poly_init2(z::Ref{ZZModAbsPowerSeriesRingElem}, len::Int, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    for i = 1:len
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModAbsPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    end
-    z.prec = prec
-    finalizer(_fmpz_mod_abs_series_clear_fn, z)
-    return z
-  end
-
-  function ZZModAbsPowerSeriesRingElem(R::ZZModRing, a::Vector{ZZModRingElem},
-      len::Int, prec::Int)
+  function ZZModAbsPowerSeriesRingElem(R::ZZModRing, a::Vector{<:Union{Integer,ZZRingElem,ZZModRingElem}}, len::Int, prec::Int)
     return ZZModAbsPowerSeriesRingElem(R.ninv, a, len, prec)
   end
 

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -496,23 +496,23 @@ for (etype, rtype, ctype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElemOrPtr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::ZZRingElemOrPtr, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, i::Int, x::Ref{ZZRingElem}, ctx::Ref{($ctype)})::Nothing
       return z
     end
     
-    function setcoeff!(z::($etype), n::Int, x::UInt)
-      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::UInt, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, i::Int, x::UInt, ctx::Ref{($ctype)})::Nothing
       return z
     end
     
-    function setcoeff!(z::($etype), n::Int, x::Int)
-      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::Int, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, i::Int, x::UInt, ctx::Ref{($ctype)})::Nothing
     end
     
-    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    setcoeff!(z::($etype), i::Int, x::Integer, ctx::($ctype)=base_ring(z).ninv) = setcoeff!(z, i, flintify(x), ctx)
     
-    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
+    setcoeff!(z::($etype), i::Int, x::($mtype), ctx::($ctype)=base_ring(z).ninv) = setcoeff!(z, i, data(x), ctx)
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = length(a)

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -496,14 +496,23 @@ for (etype, rtype, ctype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, z.parent.base_ring.ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), n::Int, x::ZZRingElemOrPtr)
+      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{($ctype)})::Nothing
       return z
     end
-
-    function setcoeff!(z::($etype), n::Int, x::$(mtype))
-      return setcoeff!(z, n, data(x))
+    
+    function setcoeff!(z::($etype), n::Int, x::UInt)
+      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+      return z
     end
+    
+    function setcoeff!(z::($etype), n::Int, x::Int)
+      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    end
+    
+    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    
+    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = length(a)

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -779,23 +779,23 @@ end
 
 #
 
-function setcoeff!(z::T, n::Int, x::ZZRingElemOrPtr) where T <: Zmodn_fmpz_poly
-  @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{T}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function setcoeff!(z::T, i::Int, x::ZZRingElemOrPtr, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{T}, i::Int, x::Ref{ZZRingElem}, ctx::Ref{fmpz_mod_ctx_struct})::Nothing
   return z
 end
 
-function setcoeff!(z::T, n::Int, x::UInt) where T <: Zmodn_fmpz_poly
-  @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{T}, n::Int, x::UInt, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function setcoeff!(z::T, i::Int, x::UInt, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{T}, i::Int, x::UInt, ctx::Ref{fmpz_mod_ctx_struct})::Nothing
   return z
 end
 
-function setcoeff!(z::T, n::Int, x::Int) where T <: Zmodn_fmpz_poly
-  @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{T}, n::Int, x::UInt, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function setcoeff!(z::T, i::Int, x::Int, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{T}, i::Int, x::UInt, ctx::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-setcoeff!(z::T, n::Int, x::Integer) where T <: Zmodn_fmpz_poly = setcoeff!(z, n, flintify(x))
+setcoeff!(z::T, i::Int, x::Integer, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) where T <: Zmodn_fmpz_poly = setcoeff!(z, i, flintify(x), ctx)
 
-setcoeff!(z::ZZModPolyRingElem, n::Int, x::ZZModRingElem) = setcoeff!(z, n, data(x))
+setcoeff!(z::ZZModPolyRingElem, i::Int, x::ZZModRingElem, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) = setcoeff!(z, i, data(x), ctx)
 
 #
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -777,24 +777,27 @@ function fit!(x::T, n::Int) where {T <: Zmodn_fmpz_poly}
   return nothing
 end
 
-function setcoeff!(x::T, n::Int, y::UInt) where {T <: Zmodn_fmpz_poly}
-  @ccall libflint.fmpz_mod_poly_set_coeff_ui(x::Ref{T}, n::Int, y::UInt, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return x
+#
+
+function setcoeff!(z::T, n::Int, x::ZZRingElemOrPtr) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{T}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+  return z
 end
 
-function setcoeff!(x::T, n::Int, y::Int) where {T <: Zmodn_fmpz_poly}
-  @ccall libflint.fmpz_mod_poly_set_coeff_si(x::Ref{T}, n::Int, y::UInt, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return x
+function setcoeff!(z::T, n::Int, x::UInt) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{T}, n::Int, x::UInt, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+  return z
 end
 
-function setcoeff!(x::T, n::Int, y::ZZRingElem) where {T <: Zmodn_fmpz_poly}
-  @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(x::Ref{T}, n::Int, y::Ref{ZZRingElem}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return x
+function setcoeff!(z::T, n::Int, x::Int) where T <: Zmodn_fmpz_poly
+  @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{T}, n::Int, x::UInt, base_ring(z).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-setcoeff!(x::T, n::Int, y::Integer) where {T <: Zmodn_fmpz_poly} = setcoeff!(x, n, ZZRingElem(y))
+setcoeff!(z::T, n::Int, x::Integer) where T <: Zmodn_fmpz_poly = setcoeff!(z, n, flintify(x))
 
-setcoeff!(x::ZZModPolyRingElem, n::Int, y::ZZModRingElem) = setcoeff!(x, n, y.data)
+setcoeff!(z::ZZModPolyRingElem, n::Int, x::ZZModRingElem) = setcoeff!(z, n, data(x))
+
+#
 
 function add!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
   @ccall libflint.fmpz_mod_poly_add(z::Ref{T}, x::Ref{T}, y::Ref{T}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -599,15 +599,23 @@ for (etype, rtype, ctype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, z.parent.base_ring.ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), n::Int, x::ZZRingElemOrPtr)
+      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{($ctype)})::Nothing
       return z
     end
-
-    function setcoeff!(z::($etype), n::Int, x::($mtype))
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x.data::Ref{ZZRingElem}, z.parent.base_ring.ninv::Ref{($ctype)})::Nothing
+    
+    function setcoeff!(z::($etype), n::Int, x::UInt)
+      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
       return z
     end
+    
+    function setcoeff!(z::($etype), n::Int, x::Int)
+      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    end
+    
+    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    
+    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = pol_length(a)

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -599,23 +599,23 @@ for (etype, rtype, ctype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElemOrPtr)
-      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, n::Int, x::Ref{ZZRingElem}, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::ZZRingElemOrPtr, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{($etype)}, i::Int, x::Ref{ZZRingElem}, ctx::Ref{($ctype)})::Nothing
       return z
     end
     
-    function setcoeff!(z::($etype), n::Int, x::UInt)
-      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::UInt, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_ui(z::Ref{($etype)}, i::Int, x::UInt, ctx::Ref{($ctype)})::Nothing
       return z
     end
     
-    function setcoeff!(z::($etype), n::Int, x::Int)
-      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, n::Int, x::UInt, base_ring(z).ninv::Ref{($ctype)})::Nothing
+    function setcoeff!(z::($etype), i::Int, x::Int, ctx::($ctype)=base_ring(z).ninv)
+      @ccall libflint.fmpz_mod_poly_set_coeff_si(z::Ref{($etype)}, i::Int, x::UInt, ctx::Ref{($ctype)})::Nothing
     end
     
-    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    setcoeff!(z::($etype), i::Int, x::Integer, ctx::($ctype)=base_ring(z).ninv) = setcoeff!(z, i, flintify(x), ctx)
     
-    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
+    setcoeff!(z::($etype), i::Int, x::($mtype), ctx::($ctype)=base_ring(z).ninv) = setcoeff!(z, i, data(x), ctx)
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = pol_length(a)

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -384,7 +384,7 @@ end
 #
 ################################################################################
 
-setcoeff!(x::FpPolyRingElem, n::Int, y::FpFieldElem) = setcoeff!(x, n, y.data)
+setcoeff!(z::FpPolyRingElem, n::Int, x::FpFieldElem) = setcoeff!(z, n, data(x))
 
 ################################################################################
 #

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -384,7 +384,7 @@ end
 #
 ################################################################################
 
-setcoeff!(z::FpPolyRingElem, n::Int, x::FpFieldElem) = setcoeff!(z, n, data(x))
+setcoeff!(z::FpPolyRingElem, i::Int, x::FpFieldElem, ctx::fmpz_mod_ctx_struct=base_ring(z).ninv) = setcoeff!(z, i, data(x), ctx)
 
 ################################################################################
 #

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -465,7 +465,7 @@ end
 #
 ################################################################################
 
-setcoeff!(z::fpPolyRingElem, n::Int, x::fpFieldElem) = setcoeff!(z, n, data(x))
+setcoeff!(z::fpPolyRingElem, i::Int, x::fpFieldElem, n::UInt=modulus(z)) = setcoeff!(z, i, data(x), n)
 
 ################################################################################
 #

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -465,7 +465,7 @@ end
 #
 ################################################################################
 
-setcoeff!(x::fpPolyRingElem, n::Int, y::fpFieldElem) = setcoeff!(x, n, y.data)
+setcoeff!(z::fpPolyRingElem, n::Int, x::fpFieldElem) = setcoeff!(z, n, data(x))
 
 ################################################################################
 #

--- a/src/flint/nmod_abs_series.jl
+++ b/src/flint/nmod_abs_series.jl
@@ -484,15 +484,23 @@ for (etype, rtype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::($mtype))
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x.data::UInt)::Nothing
+    function setcoeff!(z::($etype), n::Int, x::UInt)
+      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt)::Nothing
       return z
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      R = base_ring(z)
-      return setcoeff!(z, n, R(x))
+    function setcoeff!(z::($etype), n::Int, x::Int)
+      return setcoeff!(z, n, mod(x, modulus(z)))
     end
+
+    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
+      xx = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(z))
+      return setcoeff!(z, n, xx)
+    end
+
+    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+
+    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = length(a)

--- a/src/flint/nmod_abs_series.jl
+++ b/src/flint/nmod_abs_series.jl
@@ -484,23 +484,23 @@ for (etype, rtype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::UInt)
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt)::Nothing
+    function setcoeff!(z::($etype), i::Int, x::UInt, n::UInt=modulus(z))
+      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, i::Int, x::UInt)::Nothing
       return z
     end
 
-    function setcoeff!(z::($etype), n::Int, x::Int)
-      return setcoeff!(z, n, mod(x, modulus(z)))
+    function setcoeff!(z::($etype), i::Int, x::Int, n::UInt=modulus(z))
+      return setcoeff!(z, i, mod(x, n), n)
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      xx = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(z))
-      return setcoeff!(z, n, xx)
+    function setcoeff!(z::($etype), i::Int, x::ZZRingElem, n::UInt=modulus(z))
+      xx = @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, n::UInt)::UInt
+      return setcoeff!(z, i, xx, n)
     end
 
-    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    setcoeff!(z::($etype), i::Int, x::Integer, n::UInt=modulus(z)) = setcoeff!(z, i, flintify(x), n)
 
-    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
+    setcoeff!(z::($etype), i::Int, x::($mtype), n::UInt=modulus(z)) = setcoeff!(z, i, data(x), n)
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = length(a)

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -844,25 +844,27 @@ function fit!(x::T, n::Int) where T <: Zmodn_poly
   return nothing
 end
 
-function setcoeff!(x::T, n::Int, y::UInt) where T <: Zmodn_poly
-  @ccall libflint.nmod_poly_set_coeff_ui(x::Ref{T}, n::Int, y::UInt)::Nothing
-  return x
+#
+
+function setcoeff!(z::T, n::Int, x::UInt) where T <: Zmodn_poly
+  @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{T}, n::Int, x::UInt)::Nothing
+  return z
 end
 
-function setcoeff!(x::T, n::Int, y::Int) where T <: Zmodn_poly
-  @ccall libflint.nmod_poly_set_coeff_ui(x::Ref{T}, n::Int, mod(y, x.mod_n)::UInt)::Nothing
-  return x
+function setcoeff!(z::T, n::Int, x::Int) where T <: Zmodn_poly
+  return setcoeff!(z, n, mod(x, modulus(z)))
 end
 
-function setcoeff!(x::T, n::Int, y::ZZRingElem) where T <: Zmodn_poly
-  r = @ccall libflint.fmpz_fdiv_ui(y::Ref{ZZRingElem}, x.mod_n::UInt)::UInt
-  setcoeff!(x, n, r)
-  return x
+function setcoeff!(z::T, n::Int, x::ZZRingElem) where T <: Zmodn_poly
+  xx = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(z))
+  return setcoeff!(z, n, xx)
 end
 
-setcoeff!(x::T, n::Int, y::Integer) where T <: Zmodn_poly = setcoeff!(x, n, ZZRingElem(y))
+setcoeff!(z::T, n::Int, x::Integer) where T <: Zmodn_poly = setcoeff!(z, n, flintify(x))
 
-setcoeff!(x::zzModPolyRingElem, n::Int, y::zzModRingElem) = setcoeff!(x, n, y.data)
+setcoeff!(z::zzModPolyRingElem, n::Int, x::zzModRingElem) = setcoeff!(z, n, data(x))
+
+#
 
 function add!(z::T, x::T, y::T) where T <: Zmodn_poly
   @ccall libflint.nmod_poly_add(z::Ref{T}, x::Ref{T}, y::Ref{T})::Nothing

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -846,23 +846,23 @@ end
 
 #
 
-function setcoeff!(z::T, n::Int, x::UInt) where T <: Zmodn_poly
-  @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{T}, n::Int, x::UInt)::Nothing
+function setcoeff!(z::T, i::Int, x::UInt, n::UInt=modulus(z)) where T <: Zmodn_poly
+  @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{T}, i::Int, x::UInt)::Nothing
   return z
 end
 
-function setcoeff!(z::T, n::Int, x::Int) where T <: Zmodn_poly
-  return setcoeff!(z, n, mod(x, modulus(z)))
+function setcoeff!(z::T, i::Int, x::Int, n::UInt=modulus(z)) where T <: Zmodn_poly
+  return setcoeff!(z, i, mod(x, n), n)
 end
 
-function setcoeff!(z::T, n::Int, x::ZZRingElem) where T <: Zmodn_poly
-  xx = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(z))
-  return setcoeff!(z, n, xx)
+function setcoeff!(z::T, i::Int, x::ZZRingElem, n::UInt=modulus(z)) where T <: Zmodn_poly
+  xx = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, n)
+  return setcoeff!(z, i, xx, n)
 end
 
-setcoeff!(z::T, n::Int, x::Integer) where T <: Zmodn_poly = setcoeff!(z, n, flintify(x))
+setcoeff!(z::T, i::Int, x::Integer, n::UInt=modulus(z)) where T <: Zmodn_poly = setcoeff!(z, i, flintify(x), n)
 
-setcoeff!(z::zzModPolyRingElem, n::Int, x::zzModRingElem) = setcoeff!(z, n, data(x))
+setcoeff!(z::zzModPolyRingElem, i::Int, x::zzModRingElem, n::UInt=modulus(z)) = setcoeff!(z, i, data(x), n)
 
 #
 

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -641,23 +641,23 @@ for (etype, rtype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::UInt)
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt)::Nothing
+    function setcoeff!(z::($etype), i::Int, x::UInt, n::UInt=modulus(z))
+      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, i::Int, x::UInt)::Nothing
       return z
     end
 
-    function setcoeff!(z::($etype), n::Int, x::Int)
-      return setcoeff!(z, n, mod(x, modulus(z)))
+    function setcoeff!(z::($etype), i::Int, x::Int, n::UInt=modulus(z))
+      return setcoeff!(z, i, mod(x, n), n)
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      xx = @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, modulus(z)::UInt)::UInt
-      return setcoeff!(z, n, xx)
+    function setcoeff!(z::($etype), i::Int, x::ZZRingElem, n::UInt=modulus(z))
+      xx = @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, n::UInt)::UInt
+      return setcoeff!(z, i, xx, n)
     end
 
-    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+    setcoeff!(z::($etype), i::Int, x::Integer, n::UInt=modulus(z)) = setcoeff!(z, i, flintify(x), n)
 
-    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
+    setcoeff!(z::($etype), i::Int, x::($mtype), n::UInt=modulus(z)) = setcoeff!(z, i, data(x), n)
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = pol_length(a)

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -641,22 +641,23 @@ for (etype, rtype, mtype, brtype) in (
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      r = @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, modulus(z)::UInt)::UInt
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, r::UInt)::Nothing
-      return z
-    end
-
     function setcoeff!(z::($etype), n::Int, x::UInt)
-      r = mod(x, modulus(z))
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, r::UInt)::Nothing
+      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, x::UInt)::Nothing
       return z
     end
 
-    function setcoeff!(z::($etype), n::Int, x::($mtype))
-      @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{($etype)}, n::Int, data(x)::UInt)::Nothing
-      return z
+    function setcoeff!(z::($etype), n::Int, x::Int)
+      return setcoeff!(z, n, mod(x, modulus(z)))
     end
+
+    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
+      xx = @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, modulus(z)::UInt)::UInt
+      return setcoeff!(z, n, xx)
+    end
+
+    setcoeff!(z::($etype), n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+
+    setcoeff!(z::($etype), n::Int, x::($mtype)) = setcoeff!(z, n, data(x))
 
     function mul!(z::($etype), a::($etype), b::($etype))
       lena = pol_length(a)


### PR DESCRIPTION
Unfortunately this won't work as I try to access attributes/parents of elements in `setcoeff!` before they are set.
I see two ways to resolve this issue:
1. All element constructors should get a parent. This will be a bigger change, in particular if we want to have this consistent for all poly types.
2. `setcoeff!` gets an optional fourth argument, that is a `UInt` for `nmod_poly`-based types and a `fmpz_mod_ctx_struct` for `fmpz_mod_poly`-based types. If this fourth argument is not passed, we can reconstruct it (in many cases, but not inside of the constructors as parents are not available).

I would tend to 2 for now, and maybe remove this fourth argument again once 1 has made enough progress. What do you think @fingolfin ?