### PR TITLE
Use `_arb_set`/`_acb_set` instead of ccall

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -112,7 +112,7 @@ mutable struct RealFieldElem <: FieldElem
 
   function RealFieldElem(mid::RealFieldElem, rad::RealFieldElem)
     z = RealFieldElem()
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, mid)
+    _arb_set(z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), z, rad)
     return z
   end
@@ -170,7 +170,7 @@ mutable struct ArbFieldElem <: FieldElem
 
   function ArbFieldElem(mid::ArbFieldElem, rad::ArbFieldElem)
     z = ArbFieldElem()
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, mid)
+    _arb_set(z, mid)
     ccall((:arb_add_error, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), z, rad)
     return z
   end

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -55,7 +55,7 @@ end
 
 function deepcopy_internal(a::ComplexFieldElem, dict::IdDict)
   b = ComplexFieldElem()
-  ccall((:acb_set, libflint), Nothing, (Ref{ComplexFieldElem}, Ref{ComplexFieldElem}), b, a)
+  _acb_set(b, a)
   return b
 end
 

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -1657,11 +1657,19 @@ for (typeofx, passtoc) in ((ComplexFieldElem, Ref{ComplexFieldElem}), (Ptr{Compl
             (($passtoc), ($passtoc), Int), x, x, p)
     end
 
-    function _acb_set(x::($typeofx), y::ComplexFieldElem)
+    function _acb_set(x::($typeofx), y::ComplexFieldElemOrPtr)
       ccall((:acb_set, libflint), Nothing, (($passtoc), Ref{ComplexFieldElem}), x, y)
     end
 
-    function _acb_set(x::($typeofx), y::ComplexFieldElem, p::Int)
+    function _acb_set(x::($typeofx), y::Ptr{acb_struct})
+      ccall((:acb_set, libflint), Nothing, (($passtoc), Ptr{acb_struct}), x, y)
+    end
+
+    function _acb_set(x::Ptr{acb_struct}, y::($typeofx))
+      ccall((:acb_set, libflint), Nothing, (Ptr{acb_struct}, ($passtoc)) , x, y)
+    end
+
+    function _acb_set(x::($typeofx), y::ComplexFieldElemOrPtr, p::Int)
       ccall((:acb_set_round, libflint), Nothing,
             (($passtoc), Ref{ComplexFieldElem}, Int), x, y, p)
     end

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -30,7 +30,7 @@ dense_matrix_type(::Type{ComplexFieldElem}) = ComplexMatrix
 function getindex!(z::ComplexFieldElem, x::ComplexMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:acb_set, libflint), Nothing, (Ref{ComplexFieldElem}, Ptr{ComplexFieldElem}), z, v)
+    _acb_set(z, v)
   end
   return z
 end
@@ -41,7 +41,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:acb_set, libflint), Nothing, (Ref{ComplexFieldElem}, Ptr{ComplexFieldElem}), z, v)
+    _acb_set(z, v)
   end
   return z
 end

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -462,19 +462,17 @@ end
 
 function acb_vec(b::Vector{ComplexFieldElem})
   v = ccall((:_acb_vec_init, libflint), Ptr{acb_struct}, (Int,), length(b))
-  for i=1:length(b)
-    ccall((:acb_set, libflint), Nothing, (Ptr{acb_struct}, Ref{ComplexFieldElem}),
-          v + (i-1)*sizeof(acb_struct), b[i])
+  for i in 1:length(b)
+    _acb_set(v + (i-1)*sizeof(acb_struct), b[i])
   end
   return v
 end
 
 function array(R::ComplexField, v::Ptr{acb_struct}, n::Int)
   r = Vector{ComplexFieldElem}(undef, n)
-  for i=1:n
+  for i in 1:n
     r[i] = R()
-    ccall((:acb_set, libflint), Nothing, (Ref{ComplexFieldElem}, Ptr{acb_struct}),
-          r[i], v + (i-1)*sizeof(acb_struct))
+    _acb_set(r[i], v + (i-1)*sizeof(acb_struct))
   end
   return r
 end

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -1988,11 +1988,19 @@ for (typeofx, passtoc) in ((RealFieldElem, Ref{RealFieldElem}), (Ptr{RealFieldEl
             (($passtoc), Ref{QQFieldElem}, Int), x, y, p)
     end
 
-    function _arb_set(x::($typeofx), y::RealFieldElem)
+    function _arb_set(x::($typeofx), y::RealFieldElemOrPtr)
       ccall((:arb_set, libflint), Nothing, (($passtoc), Ref{RealFieldElem}), x, y)
     end
 
-    function _arb_set(x::($typeofx), y::RealFieldElem, p::Int)
+    function _arb_set(x::($typeofx), y::Ptr{arb_struct})
+      ccall((:arb_set, libflint), Nothing, (($passtoc), Ptr{arb_struct}), x, y)
+    end
+
+    function _arb_set(x::Ptr{arb_struct}, y::($typeofx))
+      ccall((:arb_set, libflint), Nothing, (Ptr{arb_struct}, ($passtoc)) , x, y)
+    end
+
+    function _arb_set(x::($typeofx), y::RealFieldElemOrPtr, p::Int)
       ccall((:arb_set_round, libflint), Nothing,
             (($passtoc), Ref{RealFieldElem}, Int), x, y, p)
     end

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -45,7 +45,7 @@ end
 
 function deepcopy_internal(a::RealFieldElem, dict::IdDict)
   b = parent(a)()
-  ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ref{RealFieldElem}), b, a)
+  _arb_set(b, a)
   return b
 end
 

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -30,7 +30,7 @@ dense_matrix_type(::Type{RealFieldElem}) = RealMatrix
 function getindex!(z::ArbFieldElem, x::RealMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ptr{RealFieldElem}), z, v)
+    _arb_set(z, v)
   end
   return z
 end
@@ -41,7 +41,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ptr{RealFieldElem}), z, v)
+    _arb_set(z, v)
   end
   return z
 end

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -466,19 +466,17 @@ end
 
 function arb_vec(b::Vector{RealFieldElem})
   v = ccall((:_arb_vec_init, libflint), Ptr{arb_struct}, (Int,), length(b))
-  for i=1:length(b)
-    ccall((:arb_set, libflint), Nothing, (Ptr{arb_struct}, Ref{RealFieldElem}),
-          v + (i-1)*sizeof(arb_struct), b[i])
+  for i in 1:length(b)
+    _arb_set(v + (i-1)*sizeof(arb_struct), b[i])
   end
   return v
 end
 
 function array(R::RealField, v::Ptr{arb_struct}, n::Int)
   r = Vector{RealFieldElem}(undef, n)
-  for i=1:n
+  for i in 1:n
     r[i] = R()
-    ccall((:arb_set, libflint), Nothing, (Ref{RealFieldElem}, Ptr{arb_struct}),
-          r[i], v + (i-1)*sizeof(arb_struct))
+    _arb_set(r[i], v + (i-1)*sizeof(arb_struct))
   end
   return r
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1652,11 +1652,19 @@ for (typeofx, passtoc) in ((AcbFieldElem, Ref{AcbFieldElem}), (Ptr{AcbFieldElem}
             (($passtoc), ($passtoc), Int), x, x, p)
     end
 
-    function _acb_set(x::($typeofx), y::AcbFieldElem)
+    function _acb_set(x::($typeofx), y::AcbFieldElemOrPtr)
       ccall((:acb_set, libflint), Nothing, (($passtoc), Ref{AcbFieldElem}), x, y)
     end
 
-    function _acb_set(x::($typeofx), y::AcbFieldElem, p::Int)
+    function _acb_set(x::($typeofx), y::Ptr{acb_struct})
+      ccall((:acb_set, libflint), Nothing, (($passtoc), Ptr{acb_struct}), x, y)
+    end
+
+    function _acb_set(x::Ptr{acb_struct}, y::($typeofx))
+      ccall((:acb_set, libflint), Nothing, (Ptr{acb_struct}, ($passtoc)) , x, y)
+    end
+
+    function _acb_set(x::($typeofx), y::AcbFieldElemOrPtr, p::Int)
       ccall((:acb_set_round, libflint), Nothing,
             (($passtoc), Ref{AcbFieldElem}, Int), x, y, p)
     end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -65,7 +65,7 @@ end
 
 function deepcopy_internal(a::AcbFieldElem, dict::IdDict)
   b = parent(a)()
-  ccall((:acb_set, libflint), Nothing, (Ref{AcbFieldElem}, Ref{AcbFieldElem}), b, a)
+  _acb_set(b, a)
   return b
 end
 

--- a/src/arb/acb_calc.jl
+++ b/src/arb/acb_calc.jl
@@ -2,7 +2,7 @@ function acb_calc_func_wrap(res::Ptr{ComplexFieldElem}, x::Ptr{ComplexFieldElem}
   xx = unsafe_load(x)
   F = unsafe_pointer_to_objref(param)
   w = F(xx)
-  ccall((:acb_set, libflint), Ptr{Nothing}, (Ptr{ComplexFieldElem}, Ref{ComplexFieldElem}), res, w)
+  _acb_set(res, w)
   return zero(Cint)
 end
 

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -33,7 +33,7 @@ precision(x::AcbMatrixSpace) = precision(base_ring(x))
 function getindex!(z::AcbFieldElem, x::AcbMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:acb_set, libflint), Nothing, (Ref{AcbFieldElem}, Ptr{AcbFieldElem}), z, v)
+    _acb_set(z, v)
   end
   return z
 end
@@ -44,7 +44,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:acb_set, libflint), Nothing, (Ref{AcbFieldElem}, Ptr{AcbFieldElem}), z, v)
+    _acb_set(z, v)
   end
   return z
 end

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -461,19 +461,17 @@ end
 
 function acb_vec(b::Vector{AcbFieldElem})
   v = ccall((:_acb_vec_init, libflint), Ptr{acb_struct}, (Int,), length(b))
-  for i=1:length(b)
-    ccall((:acb_set, libflint), Nothing, (Ptr{acb_struct}, Ref{AcbFieldElem}),
-          v + (i-1)*sizeof(acb_struct), b[i])
+  for i in 1:length(b)
+    _acb_set(v + (i-1)*sizeof(acb_struct), b[i])
   end
   return v
 end
 
 function array(R::AcbField, v::Ptr{acb_struct}, n::Int)
   r = Vector{AcbFieldElem}(undef, n)
-  for i=1:n
+  for i in 1:n
     r[i] = R()
-    ccall((:acb_set, libflint), Nothing, (Ref{AcbFieldElem}, Ptr{acb_struct}),
-          r[i], v + (i-1)*sizeof(acb_struct))
+    _acb_set(r[i], v + (i-1)*sizeof(acb_struct))
   end
   return r
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -45,7 +45,7 @@ end
 
 function deepcopy_internal(a::ArbFieldElem, dict::IdDict)
   b = parent(a)()
-  ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ref{ArbFieldElem}), b, a)
+  _arb_set(b, a)
   return b
 end
 

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1996,11 +1996,19 @@ for (typeofx, passtoc) in ((ArbFieldElem, Ref{ArbFieldElem}), (Ptr{ArbFieldElem}
             (($passtoc), Ref{QQFieldElem}, Int), x, y, p)
     end
 
-    function _arb_set(x::($typeofx), y::ArbFieldElem)
+    function _arb_set(x::($typeofx), y::ArbFieldElemOrPtr)
       ccall((:arb_set, libflint), Nothing, (($passtoc), Ref{ArbFieldElem}), x, y)
     end
 
-    function _arb_set(x::($typeofx), y::ArbFieldElem, p::Int)
+    function _arb_set(x::($typeofx), y::Ptr{arb_struct})
+      ccall((:arb_set, libflint), Nothing, (($passtoc), Ptr{arb_struct}), x, y)
+    end
+
+    function _arb_set(x::Ptr{arb_struct}, y::($typeofx))
+      ccall((:arb_set, libflint), Nothing, (Ptr{arb_struct}, ($passtoc)) , x, y)
+    end
+
+    function _arb_set(x::($typeofx), y::ArbFieldElemOrPtr, p::Int)
       ccall((:arb_set_round, libflint), Nothing,
             (($passtoc), Ref{ArbFieldElem}, Int), x, y, p)
     end

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -33,7 +33,7 @@ precision(x::ArbMatrixSpace) = precision(x.base_ring)
 function getindex!(z::ArbFieldElem, x::ArbMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{ArbFieldElem}), z, v)
+    _arb_set(z, v)
   end
   return z
 end
@@ -44,7 +44,7 @@ end
   z = base_ring(x)()
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{ArbFieldElem}), z, v)
+    _arb_set(z, v)
   end
   return z
 end

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -470,19 +470,17 @@ end
 
 function arb_vec(b::Vector{ArbFieldElem})
   v = ccall((:_arb_vec_init, libflint), Ptr{arb_struct}, (Int,), length(b))
-  for i=1:length(b)
-    ccall((:arb_set, libflint), Nothing, (Ptr{arb_struct}, Ref{ArbFieldElem}),
-          v + (i-1)*sizeof(arb_struct), b[i])
+  for i in 1:length(b)
+    _arb_set(v + (i-1)*sizeof(arb_struct), b[i])
   end
   return v
 end
 
 function array(R::ArbField, v::Ptr{arb_struct}, n::Int)
   r = Vector{ArbFieldElem}(undef, n)
-  for i=1:n
+  for i in 1:n
     r[i] = R()
-    ccall((:arb_set, libflint), Nothing, (Ref{ArbFieldElem}, Ptr{arb_struct}),
-          r[i], v + (i-1)*sizeof(arb_struct))
+    _arb_set(r[i], v + (i-1)*sizeof(arb_struct))
   end
   return r
 end


### PR DESCRIPTION
This is somewhat orthogonal to https://github.com/Nemocas/Nemo.jl/pull/1909. Instead of changing `_arb_set`, this PR instead changes all call-sites of the corresponding FLINT-functions to instead call `_arb_set`. 
This is part of the effort to only call FLINT from few dedicated functions.