### PR TITLE
Add exhaustive divrem tests for ZZ

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -491,10 +491,6 @@ function rem(x::ZZRingElem, c::ZZRingElem)
   return r
 end
 
-function rem(a::ZZRingElem, b::UInt)
-  return ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), a, b)
-end
-
 ###############################################################################
 #
 #   Ad hoc binary operators

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -1657,3 +1657,90 @@ end
   @test @inferred collect(bits(ZZ(5))) == Bool[true, false, true]
   @test @inferred collect(bits(ZZ(2)^64)) == append!([true], falses(64))
 end
+
+@testset "ZZRingElem.divrem (both versions)" begin
+  for i in 1:5
+    x = rand(100:1000)
+    y = rand(5:100)
+
+    for (x, y) in ((x, y), (-x, y), (x, -y), (-x, -y))
+      Bdr = Base.divrem(x, y)
+      @test Bdr == (Base.div(x, y), Base.rem(x, y))
+      @test Bdr == Base.divrem(BigInt(x), y)
+      @test Bdr == (Base.div(BigInt(x), y), Base.rem(BigInt(x), y))
+      @test Bdr == Base.divrem(x, BigInt(y))
+      @test Bdr == (Base.div(x, BigInt(y)), Base.rem(x, BigInt(y)))
+      @test Bdr == Base.divrem(BigInt(x), BigInt(y))
+      @test Bdr == (Base.div(BigInt(x), BigInt(y)), Base.rem(BigInt(x), BigInt(y)))
+      @test Bdr == Base.divrem(ZZ(x), y)
+      @test Bdr == (Base.div(ZZ(x), y), Base.rem(ZZ(x), y))
+      @test Bdr == Base.divrem(x, ZZ(y))
+      @test Bdr == (Base.div(x, ZZ(y)), Base.rem(x, ZZ(y)))
+      @test Bdr == Base.divrem(ZZ(x), ZZ(y))
+      @test Bdr == (Base.div(ZZ(x), ZZ(y)), Base.rem(ZZ(x), ZZ(y)))
+      @test Bdr == Base.divrem(BigInt(x), ZZ(y))
+      @test Bdr == (Base.div(BigInt(x), ZZ(y)), Base.rem(BigInt(x), ZZ(y)))
+      @test Bdr == Base.divrem(ZZ(x), BigInt(y))
+      @test Bdr == (Base.div(ZZ(x), BigInt(y)), Base.rem(ZZ(x), BigInt(y)))
+      if x > 0
+        #@test Bdr == Base.divrem(UInt(x), y)
+        #@test Bdr == (Base.div(UInt(x), y), Base.rem(UInt(x), y))
+        @test Bdr == Base.divrem(UInt(x), BigInt(y))
+        @test Bdr == (Base.div(UInt(x), BigInt(y)), Base.rem(UInt(x), BigInt(y)))
+        @test Bdr == Base.divrem(UInt(x), ZZ(y))
+        @test Bdr == (Base.div(UInt(x), ZZ(y)), Base.rem(UInt(x), ZZ(y)))
+      end
+      if y > 0
+        @test Bdr == Base.divrem(x, UInt(y))
+        @test Bdr == (Base.div(x, UInt(y)), Base.rem(x, UInt(y)))
+        @test Bdr == Base.divrem(BigInt(x), UInt(y))
+        @test Bdr == (Base.div(BigInt(x), UInt(y)), Base.rem(BigInt(x), UInt(y)))
+        @test Bdr == Base.divrem(ZZ(x), UInt(y))
+        @test Bdr == (Base.div(ZZ(x), UInt(y)), Base.rem(ZZ(x), UInt(y)))
+        if x > 0
+          @test unsigned.(Bdr) == Base.divrem(UInt(x), UInt(y))
+          @test unsigned.(Bdr) == (Base.div(UInt(x), UInt(y)), Base.rem(UInt(x), UInt(y)))
+        end
+      end
+
+      Ndr = Nemo.divrem(x, y)
+      @test Ndr == (Nemo.div(x, y), mod(x, y))
+      @test Ndr == Nemo.divrem(BigInt(x), y)
+      @test Ndr == (Nemo.div(BigInt(x), y), mod(BigInt(x), y))
+      @test Ndr == Nemo.divrem(x, BigInt(y))
+      @test Ndr == (Nemo.div(x, BigInt(y)), mod(x, BigInt(y)))
+      @test Ndr == Nemo.divrem(BigInt(x), BigInt(y))
+      @test Ndr == (Nemo.div(BigInt(x), BigInt(y)), mod(BigInt(x), BigInt(y)))
+      @test Ndr == Nemo.divrem(ZZ(x), y)
+      @test Ndr == (Nemo.div(ZZ(x), y), mod(ZZ(x), y))
+      @test Ndr == Nemo.divrem(x, ZZ(y))
+      @test Ndr == (Nemo.div(x, ZZ(y)), mod(x, ZZ(y)))
+      @test Ndr == Nemo.divrem(ZZ(x), ZZ(y))
+      @test Ndr == (Nemo.div(ZZ(x), ZZ(y)), mod(ZZ(x), ZZ(y)))
+      @test Ndr == Nemo.divrem(BigInt(x), ZZ(y))
+      @test Ndr == (Nemo.div(BigInt(x), ZZ(y)), mod(BigInt(x), ZZ(y)))
+      @test Ndr == Nemo.divrem(ZZ(x), BigInt(y))
+      @test Ndr == (Nemo.div(ZZ(x), BigInt(y)), mod(ZZ(x), BigInt(y)))
+      if x > 0
+        #@test Ndr == Nemo.divrem(UInt(x), y)
+        #@test Ndr == (Nemo.div(UInt(x), y), mod(UInt(x), y))
+        @test Ndr == Nemo.divrem(UInt(x), BigInt(y))
+        @test Ndr == (Nemo.div(UInt(x), BigInt(y)), mod(UInt(x), BigInt(y)))
+        @test Ndr == Nemo.divrem(UInt(x), ZZ(y))
+        @test Ndr == (Nemo.div(UInt(x), ZZ(y)), mod(UInt(x), ZZ(y)))
+      end
+      if y > 0
+        #@test Ndr == Nemo.divrem(x, UInt(y))
+        #@test Ndr == (Nemo.div(x, UInt(y)), mod(x, UInt(y)))
+        @test Ndr == Nemo.divrem(BigInt(x), UInt(y))
+        @test Ndr == (Nemo.div(BigInt(x), UInt(y)), mod(BigInt(x), UInt(y)))
+        @test Ndr == Nemo.divrem(ZZ(x), UInt(y))
+        @test Ndr == (Nemo.div(ZZ(x), UInt(y)), mod(ZZ(x), UInt(y)))
+        if x > 0
+          @test unsigned.(Ndr) == Nemo.divrem(UInt(x), UInt(y))
+          @test unsigned.(Ndr) == (Nemo.div(UInt(x), UInt(y)), mod(UInt(x), UInt(y)))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before I touch the implementations, I wanted to make sure to capture the current behavior.

Assumption: `Base.divrem(x,y) == (Base.div(x,y), Base.rem(x,y)` and `Nemo.divrem(x,y) == (Nemo.div(x,y), Base.mod(x,y))`

The few commented out tests are due to some weirdness with finite precision Ints together with unsiged Ints. All of the offending methods are in AA, and even in julia base are some discussions about what the return type of these should be.

One method I had to remove (there is a fallback via `UInt -> ZZRingElem`), because it did not satisfy the above assumption.

Does this look sensible?