### PR TITLE
Remove unnecessary loop variable from series meta-programming

### DIFF
--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -6,9 +6,9 @@
 #
 ###############################################################################
 
-for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
-                                                       (ZZModAbsPowerSeriesRingElem, ZZModAbsPowerSeriesRing, fmpz_mod_ctx_struct, ZZModRingElem, ZZModRing, "fmpz_mod_poly"),
-                                                       (FpAbsPowerSeriesRingElem, FpAbsPowerSeriesRing, fmpz_mod_ctx_struct, FpFieldElem, FpField, "fmpz_mod_poly"))
+for (etype, rtype, ctype, mtype, brtype) in (
+                                            (ZZModAbsPowerSeriesRingElem, ZZModAbsPowerSeriesRing, fmpz_mod_ctx_struct, ZZModRingElem, ZZModRing),
+                                            (FpAbsPowerSeriesRingElem, FpAbsPowerSeriesRing, fmpz_mod_ctx_struct, FpFieldElem, FpField))
   @eval begin
 
     ###############################################################################
@@ -50,7 +50,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       p = a.parent.base_ring.ninv
       if len > 0
         c = ZZRingElem()
-        ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
               (Ref{ZZRingElem}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               c, a, len - 1, p)
@@ -58,7 +58,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       while len > 0 && iszero(c)
         len -= 1
         if len > 0
-          ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+          ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                 (Ref{ZZRingElem}, Ref{($etype)}, Int,
                  Ref{($ctype)}),
                 c, a, len - 1, p)
@@ -69,7 +69,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function length(x::($etype))
       return x.length
-      #   return ccall(($(flint_fn*"_length"), libflint), Int,
+      #   return ccall((:fmpz_mod_poly_length, libflint), Int,
       #                (Ref{($etype)}, Ref{($ctype)}),
       #                x, x.parent.base_ring.ninv)
     end
@@ -82,7 +82,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         return R(0)
       end
       z = ZZRingElem()
-      ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{ZZRingElem}, Ref{($etype)}, Int, Ref{($ctype)}),
             z, x, n, x.parent.base_ring.ninv)
       return R(z)
@@ -107,7 +107,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function is_gen(a::($etype))
       return precision(a) == 0 ||
-      Bool(ccall(($(flint_fn*"_is_gen"), libflint), Cint,
+      Bool(ccall((:fmpz_mod_poly_is_gen, libflint), Cint,
                  (Ref{($etype)}, Ref{($ctype)}),
                  a, a.parent.base_ring.ninv))
     end
@@ -118,7 +118,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function isone(a::($etype))
       return precision(a) == 0 ||
-      Bool(ccall(($(flint_fn*"_is_one"), libflint), Cint,
+      Bool(ccall((:fmpz_mod_poly_is_one, libflint), Cint,
                  (Ref{($etype)}, Ref{($ctype)}),
                  a, a.parent.base_ring.ninv))
     end
@@ -182,7 +182,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function -(x::($etype))
       z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_neg, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($ctype)}),
             z, x, x.parent.base_ring.ninv)
@@ -209,7 +209,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, a.parent.base_ring.ninv)
@@ -229,7 +229,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, a.parent.base_ring.ninv)
@@ -259,7 +259,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
       lenz = min(lena + lenb - 1, prec)
 
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, a.parent.base_ring.ninv)
@@ -275,7 +275,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     function *(x::$(mtype), y::($etype))
       z = parent(y)()
       z.prec = y.prec
-      ccall(($(flint_fn*"_scalar_mul_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, y, x.data, y.parent.base_ring.ninv)
@@ -287,7 +287,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     function *(x::ZZRingElem, y::($etype))
       z = parent(y)()
       z.prec = y.prec
-      ccall(($(flint_fn*"_scalar_mul_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, y, x, y.parent.base_ring.ninv)
@@ -312,11 +312,11 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z.prec = min(z.prec, max_precision(parent(x)))
       zlen = min(z.prec, xlen + len)
       p = x.parent.base_ring.ninv
-      ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Int,
              Ref{($ctype)}),
             z, x, len, p)
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Int,
              Ref{($ctype)}),
             z, z, zlen, p)
@@ -331,7 +331,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z.prec = max(0, x.prec - len)
       else
         z.prec = x.prec - len
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, x, len, x.parent.base_ring.ninv)
@@ -354,7 +354,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if precision(x) <= k
         return x
       end
-      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),
             x, k, x.parent.base_ring.ninv)
       x.prec = k
@@ -381,7 +381,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z = parent(a)()
         z.prec = a.prec + (b - 1)*valuation(a)
         z.prec = min(z.prec, max_precision(parent(a)))
-        ccall(($(flint_fn*"_pow_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_pow_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, UInt, Int,
                Ref{($ctype)}),
               z, a, b, z.prec, a.parent.base_ring.ninv)
@@ -402,7 +402,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       n = max(length(x), length(y))
       n = min(n, prec)
 
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
+      return Bool(ccall((:fmpz_mod_poly_equal_trunc, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}, Int,
                          Ref{($ctype)}),
                         x, y, n, x.parent.base_ring.ninv))
@@ -415,7 +415,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if x.prec != y.prec || length(x) != length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
+      return Bool(ccall((:fmpz_mod_poly_equal, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
                         x, y, x.parent.base_ring.ninv))
     end
@@ -431,7 +431,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         return false
       elseif length(x) == 1
         z = ZZRingElem()
-        ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
               (Ref{ZZRingElem}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, x, 0, x.parent.base_ring.ninv)
@@ -450,7 +450,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       elseif length(x) == 1
         z = ZZRingElem()
         r = mod(y, modulus(x))
-        ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
               (Ref{ZZRingElem}, Ref{($etype)}, Int, Ref{($ctype)}),
               z, x, 0, x.parent.base_ring.ninv)
         return Bool(ccall((:fmpz_equal, libflint), Cint,
@@ -489,7 +489,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       prec = min(x.prec, y.prec - v2 + v1)
       z = parent(x)()
       z.prec = prec
-      ccall(($(flint_fn*"_div_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_div_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, x, y, prec, x.parent.base_ring.ninv)
@@ -506,7 +506,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       iszero(y) && throw(DivideError())
       z = parent(x)()
       z.prec = x.prec
-      ccall(($(flint_fn*"_scalar_div_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, x, data(y), x.parent.base_ring.ninv)
@@ -518,7 +518,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z = parent(x)()
       z.prec = x.prec
       r = mod(y, modulus(x))
-      ccall(($(flint_fn*"_scalar_div_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, x, y, x.parent.base_ring.ninv)
@@ -538,7 +538,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       !is_unit(a) && error("Unable to invert power series")
       ainv = parent(a)()
       ainv.prec = a.prec
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_inv_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Int,
              Ref{($ctype)}),
             ainv, a, a.prec, a.parent.base_ring.ninv)
@@ -552,7 +552,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     ###############################################################################
 
     function zero!(z::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_zero, libflint), Nothing,
             (Ref{($etype)}, Ref{($ctype)}),
             z, z.parent.base_ring.ninv)
       z.prec = parent(z).prec_max
@@ -560,7 +560,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function one!(z::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_one, libflint), Nothing,
             (Ref{($etype)}, Ref{($ctype)}),
             z, z.parent.base_ring.ninv)
       z.prec = parent(z).prec_max
@@ -568,14 +568,14 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function fit!(z::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_fit_length, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),
             z, n, z.parent.base_ring.ninv)
       return nothing
     end
 
     function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      ccall(($(flint_fn*"_set_coeff_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{ZZRingElem}, Ref{($ctype)}),
             z, n, x, z.parent.base_ring.ninv)
       return z
@@ -604,7 +604,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       end
 
       z.prec = prec
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, a.parent.base_ring.ninv)
@@ -622,7 +622,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
       lenc = max(lena, lenb)
       c.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             c, a, b, lenc, a.parent.base_ring.ninv)
@@ -630,7 +630,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
+      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{$(ctype)}),
             a, n, a.parent.base_ring.ninv)
       return a

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -6,9 +6,9 @@
 #
 ###############################################################################
 
-for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
-                                                       (ZZModRelPowerSeriesRingElem, ZZModRelPowerSeriesRing, fmpz_mod_ctx_struct, ZZModRingElem, ZZModRing, "fmpz_mod_poly"),
-                                                       (FpRelPowerSeriesRingElem, FpRelPowerSeriesRing, fmpz_mod_ctx_struct, FpFieldElem, FpField, "fmpz_mod_poly"))
+for (etype, rtype, ctype, mtype, brtype) in (
+                                            (ZZModRelPowerSeriesRingElem, ZZModRelPowerSeriesRing, fmpz_mod_ctx_struct, ZZModRingElem, ZZModRing),
+                                            (FpRelPowerSeriesRingElem, FpRelPowerSeriesRing, fmpz_mod_ctx_struct, FpFieldElem, FpField))
   @eval begin
 
     ###############################################################################
@@ -47,7 +47,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if len > 0
         c = ZZRingElem()
         while len > 0
-          ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+          ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                 (Ref{ZZRingElem}, Ref{($etype)}, Int,
                  Ref{($ctype)}),
                 c, a, len - 1, a.parent.base_ring.ninv)
@@ -62,7 +62,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function pol_length(x::($etype))
       return x.length
-      #   return ccall(($(flint_fn*"_length"), libflint), Int,
+      #   return ccall((:fmpz_mod_poly_length, libflint), Int,
       #                (Ref{($etype)}, Ref{($ctype)}),
       #                x, x.parent.base_ring.ninv)
     end
@@ -75,7 +75,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         return R(0)
       end
       z = ZZRingElem()
-      ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
             (Ref{ZZRingElem}, Ref{($etype)}, Int, Ref{($ctype)}),
             z, x, n, x.parent.base_ring.ninv)
       return R(z)
@@ -114,7 +114,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z.val = zprec
       else
         z.val = zval + i
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, i, z.parent.base_ring.ninv)
@@ -172,7 +172,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
 
     function -(x::($etype))
       z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_neg, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($ctype)}),
             z, x, x.parent.base_ring.ninv)
@@ -199,35 +199,35 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, b, max(0, lenz - b.val + a.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, b.val - a.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, z, a, lenz, p)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, a, max(0, lenz - a.val + b.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, a.val - b.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, z, b, lenz, p)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, a, b, lenz, p)
@@ -251,39 +251,39 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, b, max(0, lenz - b.val + a.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, b.val - a.val, p)
-        ccall(($(flint_fn*"_neg"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_neg, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($ctype)}),
               z, z, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, z, a, lenz, p)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, a, max(0, lenz - a.val + b.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, a.val - b.val, p)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, z, b, lenz, p)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_sub_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, a, b, lenz, p)
@@ -310,7 +310,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         return z
       end
       lenz = min(lena + lenb - 1, prec)
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, a.parent.base_ring.ninv)
@@ -328,7 +328,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall(($(flint_fn*"_scalar_mul_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, y, x.data, y.parent.base_ring.ninv)
@@ -342,7 +342,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall(($(flint_fn*"_scalar_mul_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_mul_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, y, x, y.parent.base_ring.ninv)
@@ -384,7 +384,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z.prec = max(0, x.prec - len)
         z.val = max(0, xval - len)
         zlen = min(xlen + xval - len, xlen)
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_right, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, x, xlen - zlen, x.parent.base_ring.ninv)
@@ -412,7 +412,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         x = zero!(x)
         x.val = k
       else
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
               (Ref{($etype)}, Int, Ref{$(ctype)}),
               x, k - valuation(x), x.parent.base_ring.ninv)
       end
@@ -448,7 +448,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z = parent(a)()
         z.prec = a.prec + (b - 1)*valuation(a)
         z.val = b*valuation(a)
-        ccall(($(flint_fn*"_pow_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_pow_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, UInt, Int,
                Ref{($ctype)}),
               z, a, b, z.prec - z.val, a.parent.base_ring.ninv)
@@ -477,7 +477,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if xlen != ylen
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
+      return Bool(ccall((:fmpz_mod_poly_equal_trunc, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}, Int,
                          Ref{($ctype)}),
                         x, y, xlen, y.parent.base_ring.ninv))
@@ -490,7 +490,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
+      return Bool(ccall((:fmpz_mod_poly_equal, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
                         x, y, x.parent.base_ring.ninv))
     end
@@ -509,7 +509,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       elseif pol_length(x) == 1
         if x.val == 0
           z = ZZRingElem()
-          ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+          ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                 (Ref{ZZRingElem}, Ref{($etype)}, Int,
                  Ref{($ctype)}),
                 z, x, 0, x.parent.base_ring.ninv)
@@ -534,7 +534,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       elseif pol_length(x) == 1
         if x.val == 0
           z = ZZRingElem()
-          ccall(($(flint_fn*"_get_coeff_fmpz"), libflint), Nothing,
+          ccall((:fmpz_mod_poly_get_coeff_fmpz, libflint), Nothing,
                 (Ref{ZZRingElem}, Ref{($etype)}, Int,
                  Ref{($ctype)}),
                 z, x, 0, x.parent.base_ring.ninv)
@@ -580,7 +580,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z.val = xval - yval
       z.prec = prec + z.val
       if prec != 0
-        ccall(($(flint_fn*"_div_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_div_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               z, x, y, prec, x.parent.base_ring.ninv)
@@ -599,7 +599,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z = parent(x)()
       z.prec = x.prec
       z.val = x.val
-      ccall(($(flint_fn*"_scalar_div_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, x, y.data, x.parent.base_ring.ninv)
@@ -613,7 +613,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       z.prec = x.prec
       z.val = x.val
       r = mod(y, modulus(x))
-      ccall(($(flint_fn*"_scalar_div_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_scalar_div_fmpz, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{ZZRingElem},
              Ref{($ctype)}),
             z, x, r, x.parent.base_ring.ninv)
@@ -634,7 +634,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       ainv = parent(a)()
       ainv.prec = a.prec
       ainv.val = 0
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_inv_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Int,
              Ref{($ctype)}),
             ainv, a, a.prec, a.parent.base_ring.ninv)
@@ -673,7 +673,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         d[k + 1] = divexact(base_ring(a)(s), k).data
       end
       z = parent(a)(d, preca, preca, 0)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
+      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),
             z, normalise(z, preca), a.parent.base_ring.ninv)
       return z
@@ -686,7 +686,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     ###############################################################################
 
     function zero!(x::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_zero, libflint), Nothing,
             (Ref{($etype)}, Ref{($ctype)}),
             x, x.parent.base_ring.ninv)
       x.prec = parent(x).prec_max
@@ -695,7 +695,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function one!(x::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_one, libflint), Nothing,
             (Ref{($etype)}, Ref{($ctype)}),
             x, x.parent.base_ring.ninv)
       x.prec = parent(x).prec_max
@@ -704,21 +704,21 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function fit!(x::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_fit_length, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{($ctype)}),
             x, n, x.parent.base_ring.ninv)
       return nothing
     end
 
     function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      ccall(($(flint_fn*"_set_coeff_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{ZZRingElem}, Ref{($ctype)}),
             z, n, x, z.parent.base_ring.ninv)
       return z
     end
 
     function setcoeff!(z::($etype), n::Int, x::($mtype))
-      ccall(($(flint_fn*"_set_coeff_fmpz"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_set_coeff_fmpz, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{ZZRingElem}, Ref{($ctype)}),
             z, n, x.data, z.parent.base_ring.ninv)
       return z
@@ -738,7 +738,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       if lena <= 0 || lenb <= 0
         lenz = 0
       end
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:fmpz_mod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)},
              Ref{($etype)}, Int, Ref{($ctype)}),
             z, a, b, lenz, z.parent.base_ring.ninv)
@@ -758,34 +758,34 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
         z = ($etype)(p)
         z.parent = parent(a)
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, b, max(0, lenz - b.val + a.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               z, z, b.val - a.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               a, a, z, lenz, p)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
               (Ref{($etype)}, Int, Ref{($ctype)}),
               a, max(0, lenz - a.val + b.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               a, a, a.val - b.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               a, a, b, lenz, p)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               a, a, b, lenz, p)
@@ -811,35 +811,35 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenc = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               c, b, max(0, lenc - b.val + a.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               c, c, b.val - a.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               c, c, a, lenc, p)
       elseif b.val < a.val
         lenc = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               c, a, max(0, lenc - a.val + b.val), p)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int,
                Ref{($ctype)}),
               c, c, a.val - b.val, p)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               c, c, b, lenc, p)
       else
         lenc = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:fmpz_mod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)},
                Ref{($etype)}, Int, Ref{($ctype)}),
               c, a, b, lenc, p)
@@ -851,7 +851,7 @@ for (etype, rtype, ctype, mtype, brtype, flint_fn) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
+      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
             (Ref{($etype)}, Int, Ref{$(ctype)}),
             a, n, a.parent.base_ring.ninv)
       return a

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -6,9 +6,9 @@
 #
 ###############################################################################
 
-for (etype, rtype, mtype, brtype, flint_fn) in (
-                                                (zzModRelPowerSeriesRingElem, zzModRelPowerSeriesRing, zzModRingElem, zzModRing, "nmod_poly"),
-                                                (fpRelPowerSeriesRingElem, fpRelPowerSeriesRing, fpFieldElem, fpField, "nmod_poly"))
+for (etype, rtype, mtype, brtype) in (
+                                      (zzModRelPowerSeriesRingElem, zzModRelPowerSeriesRing, zzModRingElem, zzModRing),
+                                      (fpRelPowerSeriesRingElem, fpRelPowerSeriesRing, fpFieldElem, fpField))
   @eval begin
 
     ###############################################################################
@@ -45,13 +45,13 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
 
     function normalise(a::($etype), len::Int)
       if len > 0
-        c = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+        c = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                   (Ref{($etype)}, Int), a, len - 1)
       end
       while len > 0 && iszero(c)
         len -= 1
         if len > 0
-          c = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+          c = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                     (Ref{($etype)}, Int), a, len - 1)
         end
       end
@@ -59,7 +59,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     end
 
     function pol_length(x::($etype))
-      return ccall(($(flint_fn*"_length"), libflint), Int, (Ref{($etype)},), x)
+      return ccall((:nmod_poly_length, libflint), Int, (Ref{($etype)},), x)
     end
 
     precision(x::($etype)) = x.prec
@@ -69,7 +69,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       if n < 0
         return R(0)
       end
-      z = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+      z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                 (Ref{($etype)}, Int), x, n)
       return R(z)
     end
@@ -107,7 +107,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         z.val = zprec
       else
         z.val = zval + i
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
+        ccall((:nmod_poly_shift_right, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int), z, z, i)
       end
       return nothing
@@ -180,29 +180,29 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z = parent(a)()
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, b, max(0, lenz - b.val + a.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, z, b.val - a.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, z, a, lenz)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, a, max(0, lenz - a.val + b.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, z, a.val - b.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, z, b, lenz)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, a, b, lenz)
       end
@@ -224,31 +224,31 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z = parent(a)()
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, b, max(0, lenz - b.val + a.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, z, b.val - a.val)
-        ccall(($(flint_fn*"_neg"), libflint), Nothing,
+        ccall((:nmod_poly_neg, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}), z, z)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, z, a, lenz)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, a, max(0, lenz - a.val + b.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, z, a.val - b.val)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
+        ccall((:nmod_poly_sub_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, z, b, lenz)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
+        ccall((:nmod_poly_sub_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, a, b, lenz)
       end
@@ -274,7 +274,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         return z
       end
       lenz = min(lena + lenb - 1, prec)
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:nmod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
             z, a, b, lenz)
       renormalize!(z)
@@ -291,7 +291,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, y, data(x))
       renormalize!(z)
@@ -305,7 +305,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z.prec = y.prec
       z.val = y.val
       r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(y))
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, y, r)
       renormalize!(z)
@@ -316,7 +316,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, y, mod(x, modulus(y)))
       renormalize!(z)
@@ -359,7 +359,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         z.prec = max(0, x.prec - len)
         z.val = max(0, xval - len)
         zlen = min(xlen + xval - len, xlen)
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
+        ccall((:nmod_poly_shift_right, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, x, xlen - zlen)
         renormalize!(z)
@@ -386,7 +386,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         x = zero!(x)
         x.val = k
       else
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+        ccall((:nmod_poly_truncate, libflint), Nothing,
               (Ref{($etype)}, Int),
               x, k - valuation(x))
       end
@@ -422,7 +422,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         z = parent(a)()
         z.prec = a.prec + (b - 1)*valuation(a)
         z.val = b*valuation(a)
-        ccall(($(flint_fn*"_pow_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_pow_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int, Int),
               z, a, b, z.prec - z.val)
       end
@@ -450,7 +450,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       if xlen != ylen
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
+      return Bool(ccall((:nmod_poly_equal_trunc, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}, Int),
                         x, y, xlen))
     end
@@ -462,7 +462,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
+      return Bool(ccall((:nmod_poly_equal, libflint), Cint,
                         (Ref{($etype)}, Ref{($etype)}), x, y))
     end
 
@@ -479,7 +479,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         return false
       elseif pol_length(x) == 1
         if x.val == 0
-          z = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+          z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                     (Ref{($etype)}, Int), x, 0)
           return data(y) == z
         else
@@ -500,7 +500,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       elseif pol_length(x) == 1
         if x.val == 0
           r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), y, modulus(x))
-          z = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+          z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                     (Ref{($etype)}, Int), x, 0)
           return r == z
         else
@@ -522,7 +522,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       elseif pol_length(x) == 1
         if x.val == 0
           r = mod(y, modulus(x))
-          z = ccall(($(flint_fn*"_get_coeff_ui"), libflint), UInt,
+          z = ccall((:nmod_poly_get_coeff_ui, libflint), UInt,
                     (Ref{($etype)}, Int), x, 0)
           return r == z
         else
@@ -563,7 +563,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z.val = xval - yval
       z.prec = prec + z.val
       if prec != 0
-        ccall(($(flint_fn*"_div_series"), libflint), Nothing,
+        ccall((:nmod_poly_div_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               z, x, y, prec)
       end
@@ -582,7 +582,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z.prec = x.prec
       z.val = x.val
       r = inv(y)
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, x, data(r))
       return z
@@ -596,7 +596,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z.val = x.val
       r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), y, modulus(x))
       rinv = inv(base_ring(x)(r))
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, x, data(rinv))
       return z
@@ -610,7 +610,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       z.val = x.val
       r = mod(y, modulus(x))
       rinv = inv(base_ring(x)(r))
-      ccall(($(flint_fn*"_scalar_mul_nmod"), libflint), Nothing,
+      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, UInt),
             z, x, data(rinv))
       return z
@@ -630,7 +630,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       ainv = parent(a)()
       ainv.prec = a.prec
       ainv.val = 0
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
+      ccall((:nmod_poly_inv_series, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Int),
             ainv, a, a.prec)
       return ainv
@@ -668,7 +668,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         d[k + 1] = divexact(base_ring(a)(s), k)
       end
       z = parent(a)(d, preca, preca, 0)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
+      ccall((:_nmod_poly_set_length, libflint), Nothing,
             (Ref{($etype)}, Int), z, normalise(z, preca))
       return z
     end
@@ -680,7 +680,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     ###############################################################################
 
     function zero!(x::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
+      ccall((:nmod_poly_zero, libflint), Nothing,
             (Ref{($etype)},), x)
       x.prec = parent(x).prec_max
       x.val = parent(x).prec_max
@@ -688,7 +688,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     end
 
     function one!(x::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
+      ccall((:nmod_poly_one, libflint), Nothing,
             (Ref{($etype)},), x)
       x.prec = parent(x).prec_max
       x.val = 0
@@ -696,7 +696,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     end
 
     function neg!(z::($etype), x::($etype))
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
+      ccall((:nmod_poly_neg, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}),
             z, x)
       z.prec = x.prec
@@ -705,14 +705,14 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     end
 
     function fit!(x::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
+      ccall((:nmod_poly_fit_length, libflint), Nothing,
             (Ref{($etype)}, Int), x, n)
       return nothing
     end
 
     function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
       r = ccall((:fmpz_fdiv_ui, libflint), UInt, (Ref{ZZRingElem}, UInt), x, modulus(z))
-      ccall(($(flint_fn*"_set_coeff_ui"), libflint), Nothing,
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
             (Ref{($etype)}, Int, UInt),
             z, n, r)
       return z
@@ -720,14 +720,14 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
 
     function setcoeff!(z::($etype), n::Int, x::UInt)
       r = mod(x, modulus(z))
-      ccall(($(flint_fn*"_set_coeff_ui"), libflint), Nothing,
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
             (Ref{($etype)}, Int, UInt),
             z, n, r)
       return z
     end
 
     function setcoeff!(z::($etype), n::Int, x::($mtype))
-      ccall(($(flint_fn*"_set_coeff_ui"), libflint), Nothing,
+      ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
             (Ref{($etype)}, Int, UInt),
             z, n, data(x))
       return z
@@ -747,7 +747,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       if lena <= 0 || lenb <= 0
         lenz = 0
       end
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
+      ccall((:nmod_poly_mullow, libflint), Nothing,
             (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
             z, a, b, lenz)
       renormalize!(z)
@@ -766,29 +766,29 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
         z = ($etype)(n)
         z.parent = parent(a)
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, b, max(0, lenz - b.val + a.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               z, z, b.val - a.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               a, a, z, lenz)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
+        ccall((:nmod_poly_truncate, libflint), Nothing,
               (Ref{($etype)}, Int),
               a, max(0, lenz - a.val + b.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               a, a, a.val - b.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               a, a, b, lenz)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               a, a, b, lenz)
       end
@@ -812,29 +812,29 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
       lenb = min(lenb, prec - b.val)
       if a.val < b.val
         lenc = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               c, b, max(0, lenc - b.val + a.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               c, c, b.val - a.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               c, c, a, lenc)
       elseif b.val < a.val
         lenc = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
+        ccall((:nmod_poly_set_trunc, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               c, a, max(0, lenc - a.val + b.val))
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
+        ccall((:nmod_poly_shift_left, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Int),
               c, c, a.val - b.val)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               c, c, b, lenc)
       else
         lenc = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
+        ccall((:nmod_poly_add_series, libflint), Nothing,
               (Ref{($etype)}, Ref{($etype)}, Ref{($etype)}, Int),
               c, a, b, lenc)
       end
@@ -845,7 +845,7 @@ for (etype, rtype, mtype, brtype, flint_fn) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
+      ccall((:_nmod_poly_set_length, libflint), Nothing,
             (Ref{$(etype)}, Int), a, n::Int)
       return a
     end


### PR DESCRIPTION
The loop variables in question are the same for all iterations, making it possible to instead inline them.
Inlining makes everything a lot more readable (at least for me). Furthermore, it enables us to `grep` for some flint function and find all places where it is called (of course if all similar places are inlined/unrolled as well). 