### PR TITLE
Split series over fq_nmod and fq into different files

### DIFF
--- a/src/Rings.jl
+++ b/src/Rings.jl
@@ -52,8 +52,6 @@ include("flint/fmpz_mod_rel_series.jl")
 
 include("flint/fmpz_mod_abs_series.jl")
 
-include("flint/nmod_abs_series.jl")
-
 include("flint/fmpz_mat.jl")
 
 include("flint/fmpq_mat.jl")
@@ -92,7 +90,13 @@ include("flint/fq_rel_series.jl")
 
 include("flint/fq_abs_series.jl")
 
+include("flint/fq_nmod_rel_series.jl")
+
+include("flint/fq_nmod_abs_series.jl")
+
 include("flint/nmod_rel_series.jl")
+
+include("flint/nmod_abs_series.jl")
 
 include("flint/fq_default_rel_series.jl")
 

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -4,699 +4,699 @@
 #
 ###############################################################################
 
-    ###############################################################################
-    #
-    #   Data type and parent object methods
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
 
-    function O(a::FqPolyRepAbsPowerSeriesRingElem)
-      if iszero(a)
-        return deepcopy(a)    # 0 + O(x^n)
-      end
-      prec = length(a) - 1
-      prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
-      z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{FqPolyRepFieldElem}(undef, 0), 0, prec)
-      z.parent = parent(a)
-      return z
-    end
+function O(a::FqPolyRepAbsPowerSeriesRingElem)
+  if iszero(a)
+    return deepcopy(a)    # 0 + O(x^n)
+  end
+  prec = length(a) - 1
+  prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
+  z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{FqPolyRepFieldElem}(undef, 0), 0, prec)
+  z.parent = parent(a)
+  return z
+end
 
-    elem_type(::Type{FqPolyRepAbsPowerSeriesRing}) = FqPolyRepAbsPowerSeriesRingElem
+elem_type(::Type{FqPolyRepAbsPowerSeriesRing}) = FqPolyRepAbsPowerSeriesRingElem
 
-    parent_type(::Type{FqPolyRepAbsPowerSeriesRingElem}) = FqPolyRepAbsPowerSeriesRing
+parent_type(::Type{FqPolyRepAbsPowerSeriesRingElem}) = FqPolyRepAbsPowerSeriesRing
 
-    base_ring(R::FqPolyRepAbsPowerSeriesRing) = R.base_ring
+base_ring(R::FqPolyRepAbsPowerSeriesRing) = R.base_ring
 
-    abs_series_type(::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
+abs_series_type(::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
 
-    var(a::FqPolyRepAbsPowerSeriesRing) = a.S
+var(a::FqPolyRepAbsPowerSeriesRing) = a.S
 
-    ###############################################################################
-    #
-    #   Basic manipulation
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
 
-    max_precision(R::FqPolyRepAbsPowerSeriesRing) = R.prec_max
+max_precision(R::FqPolyRepAbsPowerSeriesRing) = R.prec_max
 
-    function normalise(a::FqPolyRepAbsPowerSeriesRingElem, len::Int)
-      ctx = base_ring(a)
-      if len > 0
-        c = base_ring(a)()
-        ccall((:fq_poly_get_coeff, libflint), Nothing,
-              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, a, len - 1, ctx)
-      end
-      while len > 0 && iszero(c)
-        len -= 1
-        if len > 0
-          ccall((:fq_poly_get_coeff, libflint), Nothing,
-                (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-                c, a, len - 1, ctx)
-        end
-      end
-
-      return len
-    end
-
-    function length(x::FqPolyRepAbsPowerSeriesRingElem)
-      return ccall((:fq_poly_length, libflint), Int,
-                   (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
-    end
-
-    precision(x::FqPolyRepAbsPowerSeriesRingElem) = x.prec
-
-    function coeff(x::FqPolyRepAbsPowerSeriesRingElem, n::Int)
-      if n < 0
-        return base_ring(x)()
-      end
-      z = base_ring(x)()
+function normalise(a::FqPolyRepAbsPowerSeriesRingElem, len::Int)
+  ctx = base_ring(a)
+  if len > 0
+    c = base_ring(a)()
+    ccall((:fq_poly_get_coeff, libflint), Nothing,
+          (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, a, len - 1, ctx)
+  end
+  while len > 0 && iszero(c)
+    len -= 1
+    if len > 0
       ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, x, n, base_ring(x))
-      return z
+            c, a, len - 1, ctx)
     end
+  end
 
-    zero(R::FqPolyRepAbsPowerSeriesRing) = R(0)
+  return len
+end
 
-    one(R::FqPolyRepAbsPowerSeriesRing) = R(1)
+function length(x::FqPolyRepAbsPowerSeriesRingElem)
+  return ccall((:fq_poly_length, libflint), Int,
+                (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
+end
 
-    function gen(R::FqPolyRepAbsPowerSeriesRing)
-      S = base_ring(R)
-      z = FqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
-      z.parent = R
-      return z
+precision(x::FqPolyRepAbsPowerSeriesRingElem) = x.prec
+
+function coeff(x::FqPolyRepAbsPowerSeriesRingElem, n::Int)
+  if n < 0
+    return base_ring(x)()
+  end
+  z = base_ring(x)()
+  ccall((:fq_poly_get_coeff, libflint), Nothing,
+        (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, x, n, base_ring(x))
+  return z
+end
+
+zero(R::FqPolyRepAbsPowerSeriesRing) = R(0)
+
+one(R::FqPolyRepAbsPowerSeriesRing) = R(1)
+
+function gen(R::FqPolyRepAbsPowerSeriesRing)
+  S = base_ring(R)
+  z = FqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
+  z.parent = R
+  return z
+end
+
+function deepcopy_internal(a::FqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
+  z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
+  z.prec = a.prec
+  z.parent = parent(a)
+  return z
+end
+
+function is_gen(a::FqPolyRepAbsPowerSeriesRingElem)
+  return precision(a) == 0 || ccall((:fq_poly_is_gen, libflint), Bool,
+                                    (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
+end
+
+iszero(a::FqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
+
+is_unit(a::FqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
+
+function isone(a::FqPolyRepAbsPowerSeriesRingElem)
+  return precision(a) == 0 || ccall((:fq_poly_is_one, libflint), Bool,
+                                    (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
+end
+
+# todo: write an fq_poly_valuation
+function valuation(a::FqPolyRepAbsPowerSeriesRingElem)
+  for i = 1:length(a)
+    if !iszero(coeff(a, i - 1))
+      return i - 1
     end
+  end
+  return precision(a)
+end
 
-    function deepcopy_internal(a::FqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
-      z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
-      z.prec = a.prec
-      z.parent = parent(a)
-      return z
+characteristic(R::FqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
+
+###############################################################################
+#
+#   Similar
+#
+###############################################################################
+
+function similar(f::AbsPowerSeriesRingElem, R::FqPolyRepField, max_prec::Int,
+    s::Symbol=var(parent(f)); cached::Bool=true)
+  par = FqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
+  z = FqPolyRepAbsPowerSeriesRingElem(R)
+  if base_ring(f) === R && s == var(parent(f)) &&
+    f isa FqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
+    # steal parent in case it is not cached
+    z.parent = parent(f)
+  else
+    z.parent = par
+  end
+  z.prec = max_prec
+  return z
+end
+
+###############################################################################
+#
+#   abs_series constructor
+#
+###############################################################################
+
+function abs_series(R::FqPolyRepField, arr::Vector{T},
+    len::Int, prec::Int, var::VarName=:x;
+    max_precision::Int=prec, cached::Bool=true) where T
+  prec < len && error("Precision too small for given data")
+  coeffs = T == FqPolyRepFieldElem ? arr : map(R, arr)
+  coeffs = length(coeffs) == 0 ? FqPolyRepFieldElem[] : coeffs
+  par = FqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
+  z = FqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
+  z.parent = par
+  return z
+end
+
+###############################################################################
+#
+#   Unary operators
+#
+###############################################################################
+
+function -(x::FqPolyRepAbsPowerSeriesRingElem)
+  z = parent(x)()
+  ccall((:fq_poly_neg, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
+        z, x, base_ring(x))
+  z.prec = x.prec
+  return z
+end
+
+###############################################################################
+#
+#   Binary operators
+#
+###############################################################################
+
+function +(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  z.prec = prec
+  ccall((:fq_poly_add_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+function -(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  z.prec = prec
+  ccall((:fq_poly_sub_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+function *(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec + bval, b.prec + aval)
+  prec = min(prec, max_precision(parent(a)))
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z = parent(a)()
+  z.prec = prec
+  if lena == 0 || lenb == 0
+    return z
+  end
+  lenz = min(lena + lenb - 1, prec)
+  ccall((:fq_poly_mullow, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem)
+  z = parent(y)()
+  z.prec = y.prec
+  ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, y, x, base_ring(y))
+  return z
+end
+
+*(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem) = y * x
+
+###############################################################################
+#
+#   Shifting
+#
+###############################################################################
+
+function shift_left(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = length(x)
+  z = parent(x)()
+  z.prec = x.prec + len
+  z.prec = min(z.prec, max_precision(parent(x)))
+  zlen = min(z.prec, xlen + len)
+  ccall((:fq_poly_shift_left, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, x, len, base_ring(x))
+  ccall((:fq_poly_set_trunc, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, z, zlen, base_ring(x))
+  return z
+end
+
+function shift_right(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = length(x)
+  z = parent(x)()
+  if len >= xlen
+    z.prec = max(0, x.prec - len)
+  else
+    z.prec = x.prec - len
+    ccall((:fq_poly_shift_right, libflint), Nothing,
+          (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, x, len, base_ring(x))
+  end
+  return z
+end
+
+###############################################################################
+#
+#   Truncation
+#
+###############################################################################
+
+function truncate(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
+    return x
+  end
+  ccall((:fq_poly_truncate, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        x, k, base_ring(x))
+  x.prec = k
+  return x
+end
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(a::FqPolyRepAbsPowerSeriesRingElem, b::Int)
+  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
+  if precision(a) > 0 && is_gen(a) && b > 0
+    return shift_left(a, b - 1)
+  elseif length(a) == 1
+    return parent(a)([coeff(a, 0)^b], 1, a.prec)
+  elseif b == 0
+    z = one(parent(a))
+    z = set_precision!(z, precision(a))
+  else
+    bit = ~((~UInt(0)) >> 1)
+    while (UInt(bit) & b) == 0
+      bit >>= 1
     end
-
-    function is_gen(a::FqPolyRepAbsPowerSeriesRingElem)
-      return precision(a) == 0 || ccall((:fq_poly_is_gen, libflint), Bool,
-                                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
-    end
-
-    iszero(a::FqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
-
-    is_unit(a::FqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
-
-    function isone(a::FqPolyRepAbsPowerSeriesRingElem)
-      return precision(a) == 0 || ccall((:fq_poly_is_one, libflint), Bool,
-                                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
-    end
-
-    # todo: write an fq_poly_valuation
-    function valuation(a::FqPolyRepAbsPowerSeriesRingElem)
-      for i = 1:length(a)
-        if !iszero(coeff(a, i - 1))
-          return i - 1
-        end
+    z = a
+    bit >>= 1
+    while bit !=0
+      z = z*z
+      if (UInt(bit) & b) != 0
+        z *= a
       end
-      return precision(a)
+      bit >>= 1
     end
+  end
+  return z
+end
 
-    characteristic(R::FqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
 
-    ###############################################################################
-    #
-    #   Similar
-    #
-    ###############################################################################
+function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
+  check_parent(x, y)
+  prec = min(x.prec, y.prec)
+  n = max(length(x), length(y))
+  n = min(n, prec)
+  return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
+                    (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+                    x, y, n, base_ring(x)))
+end
 
-    function similar(f::AbsPowerSeriesRingElem, R::FqPolyRepField, max_prec::Int,
-        s::Symbol=var(parent(f)); cached::Bool=true)
-      par = FqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
-      z = FqPolyRepAbsPowerSeriesRingElem(R)
-      if base_ring(f) === R && s == var(parent(f)) &&
-        f isa FqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
-        # steal parent in case it is not cached
-        z.parent = parent(f)
-      else
-        z.parent = par
-      end
-      z.prec = max_prec
-      return z
+function isequal(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
+  if parent(x) != parent(y)
+    return false
+  end
+  if x.prec != y.prec || length(x) != length(y)
+    return false
+  end
+  return Bool(ccall((:fq_poly_equal, libflint), Cint,
+                    (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
+                    x, y, base_ring(x)))
+end
+
+###############################################################################
+#
+#   Ad hoc comparisons
+#
+###############################################################################
+
+function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem)
+  if length(x) > 1
+    return false
+  elseif length(x) == 1
+    z = base_ring(x)()
+    ccall((:fq_poly_get_coeff, libflint), Nothing,
+          (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, x, 0, base_ring(x))
+    return z == y
+  else
+    return precision(x) == 0 || iszero(y)
+  end
+end
+
+==(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
+
+function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
+  if length(x) > 1
+    return false
+  elseif length(x) == 1
+    z = base_ring(x)()
+    ccall((:fq_poly_get_coeff, libflint), Nothing,
+          (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, x, 0, base_ring(x))
+    return z == y
+  else
+    return precision(x) == 0 || iszero(y)
+  end
+end
+
+==(x::ZZRingElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
+
+==(x::FqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
+
+==(x::Integer, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  check_parent(x, y)
+  iszero(y) && throw(DivideError())
+  v2 = valuation(y)
+  v1 = valuation(x)
+  if v2 != 0
+    if v1 >= v2
+      x = shift_right(x, v2)
+      y = shift_right(y, v2)
     end
+  end
+  check && !is_unit(y) && error("Unable to invert power series")
+  prec = min(x.prec, y.prec - v2 + v1)
+  z = parent(x)()
+  z.prec = prec
+  ccall((:fq_poly_div_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, x, y, prec, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   abs_series constructor
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Ad hoc exact division
+#
+###############################################################################
 
-    function abs_series(R::FqPolyRepField, arr::Vector{T},
-        len::Int, prec::Int, var::VarName=:x;
-        max_precision::Int=prec, cached::Bool=true) where T
-      prec < len && error("Precision too small for given data")
-      coeffs = T == FqPolyRepFieldElem ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? FqPolyRepFieldElem[] : coeffs
-      par = FqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
-      z = FqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
-      z.parent = par
-      return z
-    end
+function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
+  iszero(y) && throw(DivideError())
+  z = parent(x)()
+  z.prec = x.prec
+  ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, x, y, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Unary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
 
-    function -(x::FqPolyRepAbsPowerSeriesRingElem)
-      z = parent(x)()
-      ccall((:fq_poly_neg, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
-            z, x, base_ring(x))
-      z.prec = x.prec
-      return z
-    end
+function inv(a::FqPolyRepAbsPowerSeriesRingElem)
+  iszero(a) && throw(DivideError())
+  !is_unit(a) && error("Unable to invert power series")
+  ainv = parent(a)()
+  ainv.prec = a.prec
+  ccall((:fq_poly_inv_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        ainv, a, a.prec, base_ring(a))
+  return ainv
+end
 
-    ###############################################################################
-    #
-    #   Binary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Square root
+#
+###############################################################################
 
-    function +(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      z.prec = prec
-      ccall((:fq_poly_add_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    function -(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      z.prec = prec
-      ccall((:fq_poly_sub_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    function *(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec + bval, b.prec + aval)
-      prec = min(prec, max_precision(parent(a)))
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z = parent(a)()
-      z.prec = prec
-      if lena == 0 || lenb == 0
-        return z
-      end
-      lenz = min(lena + lenb - 1, prec)
-      ccall((:fq_poly_mullow, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc binary operators
-    #
-    ###############################################################################
-
-    function *(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem)
-      z = parent(y)()
-      z.prec = y.prec
-      ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, y, x, base_ring(y))
-      return z
-    end
-
-    *(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem) = y * x
-
-    ###############################################################################
-    #
-    #   Shifting
-    #
-    ###############################################################################
-
-    function shift_left(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = length(x)
-      z = parent(x)()
-      z.prec = x.prec + len
-      z.prec = min(z.prec, max_precision(parent(x)))
-      zlen = min(z.prec, xlen + len)
-      ccall((:fq_poly_shift_left, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, x, len, base_ring(x))
-      ccall((:fq_poly_set_trunc, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, z, zlen, base_ring(x))
-      return z
-    end
-
-    function shift_right(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = length(x)
-      z = parent(x)()
-      if len >= xlen
-        z.prec = max(0, x.prec - len)
-      else
-        z.prec = x.prec - len
-        ccall((:fq_poly_shift_right, libflint), Nothing,
-              (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, x, len, base_ring(x))
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Truncation
-    #
-    ###############################################################################
-
-    function truncate(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
-      return truncate!(deepcopy(x), k)
-    end
-
-    function truncate!(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
-      k < 0 && throw(DomainError(k, "Index must be non-negative"))
-      if precision(x) <= k
-        return x
-      end
-      ccall((:fq_poly_truncate, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            x, k, base_ring(x))
-      x.prec = k
-      return x
-    end
-
-    ###############################################################################
-    #
-    #   Powering
-    #
-    ###############################################################################
-
-    function ^(a::FqPolyRepAbsPowerSeriesRingElem, b::Int)
-      b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-      if precision(a) > 0 && is_gen(a) && b > 0
-        return shift_left(a, b - 1)
-      elseif length(a) == 1
-        return parent(a)([coeff(a, 0)^b], 1, a.prec)
-      elseif b == 0
-        z = one(parent(a))
-        z = set_precision!(z, precision(a))
-      else
-        bit = ~((~UInt(0)) >> 1)
-        while (UInt(bit) & b) == 0
-          bit >>= 1
-        end
-        z = a
-        bit >>= 1
-        while bit !=0
-          z = z*z
-          if (UInt(bit) & b) != 0
-            z *= a
-          end
-          bit >>= 1
-        end
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Comparison
-    #
-    ###############################################################################
-
-    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
-      check_parent(x, y)
-      prec = min(x.prec, y.prec)
-      n = max(length(x), length(y))
-      n = min(n, prec)
-      return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
-                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-                        x, y, n, base_ring(x)))
-    end
-
-    function isequal(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
-      if parent(x) != parent(y)
-        return false
-      end
-      if x.prec != y.prec || length(x) != length(y)
-        return false
-      end
-      return Bool(ccall((:fq_poly_equal, libflint), Cint,
-                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
-                        x, y, base_ring(x)))
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc comparisons
-    #
-    ###############################################################################
-
-    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem)
-      if length(x) > 1
-        return false
-      elseif length(x) == 1
-        z = base_ring(x)()
-        ccall((:fq_poly_get_coeff, libflint), Nothing,
-              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, x, 0, base_ring(x))
-        return z == y
-      else
-        return precision(x) == 0 || iszero(y)
-      end
-    end
-
-    ==(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
-      if length(x) > 1
-        return false
-      elseif length(x) == 1
-        z = base_ring(x)()
-        ccall((:fq_poly_get_coeff, libflint), Nothing,
-              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, x, 0, base_ring(x))
-        return z == y
-      else
-        return precision(x) == 0 || iszero(y)
-      end
-    end
-
-    ==(x::ZZRingElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    ==(x::FqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
-
-    ==(x::Integer, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    ###############################################################################
-    #
-    #   Exact division
-    #
-    ###############################################################################
-
-    function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      check_parent(x, y)
-      iszero(y) && throw(DivideError())
-      v2 = valuation(y)
-      v1 = valuation(x)
-      if v2 != 0
-        if v1 >= v2
-          x = shift_right(x, v2)
-          y = shift_right(y, v2)
-        end
-      end
-      check && !is_unit(y) && error("Unable to invert power series")
-      prec = min(x.prec, y.prec - v2 + v1)
-      z = parent(x)()
-      z.prec = prec
-      ccall((:fq_poly_div_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, x, y, prec, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc exact division
-    #
-    ###############################################################################
-
-    function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
-      iszero(y) && throw(DivideError())
-      z = parent(x)()
-      z.prec = x.prec
-      ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, x, y, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Inversion
-    #
-    ###############################################################################
-
-    function inv(a::FqPolyRepAbsPowerSeriesRingElem)
-      iszero(a) && throw(DivideError())
-      !is_unit(a) && error("Unable to invert power series")
-      ainv = parent(a)()
-      ainv.prec = a.prec
-      ccall((:fq_poly_inv_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            ainv, a, a.prec, base_ring(a))
-      return ainv
-    end
-
-    ###############################################################################
-    #
-    #   Square root
-    #
-    ###############################################################################
-
-    function sqrt_classical_char2(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      asqrt = S()
-      prec = div(precision(a) + 1, 2)
-      asqrt = set_precision!(asqrt, prec)
-      if check
-        for i = 1:2:precision(a) - 1 # series must have even exponents
-          if !iszero(coeff(a, i))
-            return false, S()
-          end
-        end
-      end
-      for i = 0:prec - 1
-        if check
-          flag, c = is_square_with_sqrt(coeff(a, 2*i))
-          !flag && error("Not a square")
-        else
-          # degree of finite field could be > 1 so sqrt necessary here
-          c = sqrt(coeff(a, 2*i); check=check)
-        end
-        asqrt = setcoeff!(asqrt, i, c)
-      end
-      return true, asqrt
-    end
-
-    function sqrt_classical(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      R = base_ring(a)
-      S = parent(a)
-      if characteristic(R) == 2
-        return sqrt_classical_char2(a; check=check)
-      end
-      v = valuation(a)
-      z = S()
-      z.prec = a.prec - div(v, 2)
-      if iszero(a)
-        return true, z
-      end
-      if check && !iseven(v)
+function sqrt_classical_char2(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  asqrt = S()
+  prec = div(precision(a) + 1, 2)
+  asqrt = set_precision!(asqrt, prec)
+  if check
+    for i = 1:2:precision(a) - 1 # series must have even exponents
+      if !iszero(coeff(a, i))
         return false, S()
       end
-      a = shift_right(a, v)
-      c = coeff(a, 0)
-      if check
-        flag, s = is_square_with_sqrt(c)
-        if !flag
-          return false, S()
-        end
-      else
-        s = sqrt(c; check=check)
-      end
-      a = divexact(a, c)
-      z.prec = a.prec - div(v, 2)
-      ccall((:fq_poly_sqrt_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, a.prec, base_ring(a))
-      if !isone(s)
-        z *= s
-      end
-      if !iszero(v)
-        z = shift_left(z, div(v, 2))
-      end
-      return true, z
     end
-
-    function Base.sqrt(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      flag, s = sqrt_classical(a; check=check)
-      check && !flag && error("Not a square")
-      return s
+  end
+  for i = 0:prec - 1
+    if check
+      flag, c = is_square_with_sqrt(coeff(a, 2*i))
+      !flag && error("Not a square")
+    else
+      # degree of finite field could be > 1 so sqrt necessary here
+      c = sqrt(coeff(a, 2*i); check=check)
     end
+    asqrt = setcoeff!(asqrt, i, c)
+  end
+  return true, asqrt
+end
 
-    function is_square(a::FqPolyRepAbsPowerSeriesRingElem)
-      flag, s = sqrt_classical(a; check=true)
-      return flag
+function sqrt_classical(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  R = base_ring(a)
+  S = parent(a)
+  if characteristic(R) == 2
+    return sqrt_classical_char2(a; check=check)
+  end
+  v = valuation(a)
+  z = S()
+  z.prec = a.prec - div(v, 2)
+  if iszero(a)
+    return true, z
+  end
+  if check && !iseven(v)
+    return false, S()
+  end
+  a = shift_right(a, v)
+  c = coeff(a, 0)
+  if check
+    flag, s = is_square_with_sqrt(c)
+    if !flag
+      return false, S()
     end
+  else
+    s = sqrt(c; check=check)
+  end
+  a = divexact(a, c)
+  z.prec = a.prec - div(v, 2)
+  ccall((:fq_poly_sqrt_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, a.prec, base_ring(a))
+  if !isone(s)
+    z *= s
+  end
+  if !iszero(v)
+    z = shift_left(z, div(v, 2))
+  end
+  return true, z
+end
 
-    function is_square_with_sqrt(a::FqPolyRepAbsPowerSeriesRingElem)
-      return sqrt_classical(a; check=true)
-    end
+function Base.sqrt(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  flag, s = sqrt_classical(a; check=check)
+  check && !flag && error("Not a square")
+  return s
+end
 
-    ###############################################################################
-    #
-    #   Unsafe functions
-    #
-    ###############################################################################
+function is_square(a::FqPolyRepAbsPowerSeriesRingElem)
+  flag, s = sqrt_classical(a; check=true)
+  return flag
+end
 
-    function zero!(z::FqPolyRepAbsPowerSeriesRingElem)
-      ccall((:fq_poly_zero, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
-      z.prec = parent(z).prec_max
-      return z
-    end
+function is_square_with_sqrt(a::FqPolyRepAbsPowerSeriesRingElem)
+  return sqrt_classical(a; check=true)
+end
 
-    function one!(z::FqPolyRepAbsPowerSeriesRingElem)
-      ccall((:fq_poly_one, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
-      z.prec = parent(z).prec_max
-      return z
-    end
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
 
-    function fit!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int)
-      ccall((:fq_poly_fit_length, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, n, base_ring(z))
-      return nothing
-    end
+function zero!(z::FqPolyRepAbsPowerSeriesRingElem)
+  ccall((:fq_poly_zero, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
+  z.prec = parent(z).prec_max
+  return z
+end
 
-    function setcoeff!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int, x::FqPolyRepFieldElem)
-      ccall((:fq_poly_set_coeff, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function one!(z::FqPolyRepAbsPowerSeriesRingElem)
+  ccall((:fq_poly_one, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
+  z.prec = parent(z).prec_max
+  return z
+end
 
-    function mul!(z::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
-      lena = length(a)
-      lenb = length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec + bval, b.prec + aval)
-      prec = min(prec, max_precision(parent(z)))
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = min(lena + lenb - 1, prec)
-      if lenz < 0
-        lenz = 0
-      end
-      z.prec = prec
-      ccall((:fq_poly_mullow, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(z))
-      return z
-    end
+function fit!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int)
+  ccall((:fq_poly_fit_length, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, n, base_ring(z))
+  return nothing
+end
 
-    function add!(c::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenc = max(lena, lenb)
-      c.prec = prec
-      ccall((:fq_poly_add_series, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
-             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            c, a, b, lenc, base_ring(a))
-      return c
-    end
+function setcoeff!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int, x::FqPolyRepFieldElem)
+  ccall((:fq_poly_set_coeff, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function set_length!(a::FqPolyRepAbsPowerSeriesRingElem, n::Int)
-      ccall((:_fq_poly_set_length, libflint), Nothing,
-            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            a, n, base_ring(a))
-      return a
-    end
+function mul!(z::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
+  lena = length(a)
+  lenb = length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec + bval, b.prec + aval)
+  prec = min(prec, max_precision(parent(z)))
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = min(lena + lenb - 1, prec)
+  if lenz < 0
+    lenz = 0
+  end
+  z.prec = prec
+  ccall((:fq_poly_mullow, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(z))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Promotion rules
-    #
-    ###############################################################################
+function add!(c::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenc = max(lena, lenb)
+  c.prec = prec
+  ccall((:fq_poly_add_series, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+          Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        c, a, b, lenc, base_ring(a))
+  return c
+end
 
-    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = FqPolyRepAbsPowerSeriesRingElem
+function set_length!(a::FqPolyRepAbsPowerSeriesRingElem, n::Int)
+  ccall((:_fq_poly_set_length, libflint), Nothing,
+        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        a, n, base_ring(a))
+  return a
+end
 
-    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
+###############################################################################
+#
+#   Promotion rules
+#
+###############################################################################
 
-    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = FqPolyRepAbsPowerSeriesRingElem
+promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = FqPolyRepAbsPowerSeriesRingElem
 
-    ###############################################################################
-    #
-    #   Parent object call overload
-    #
-    ###############################################################################
+promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
 
-    function (a::FqPolyRepAbsPowerSeriesRing)()
-      ctx = base_ring(a)
-      z = FqPolyRepAbsPowerSeriesRingElem(ctx)
-      z.prec = a.prec_max
-      z.parent = a
-      return z
-    end
+promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = FqPolyRepAbsPowerSeriesRingElem
 
-    function (a::FqPolyRepAbsPowerSeriesRing)(b::Integer)
-      return a(base_ring(a)(b))
-    end
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
 
-    function (a::FqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
-      return a(base_ring(a)(b))
-    end
+function (a::FqPolyRepAbsPowerSeriesRing)()
+  ctx = base_ring(a)
+  z = FqPolyRepAbsPowerSeriesRingElem(ctx)
+  z.prec = a.prec_max
+  z.parent = a
+  return z
+end
 
-    function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepFieldElem)
-      ctx = base_ring(a)
-      if iszero(b)
-        z = FqPolyRepAbsPowerSeriesRingElem(ctx)
-        z.prec = a.prec_max
-      else
-        z = FqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
-      end
-      z.parent = a
-      return z
-    end
+function (a::FqPolyRepAbsPowerSeriesRing)(b::Integer)
+  return a(base_ring(a)(b))
+end
 
-    function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepAbsPowerSeriesRingElem)
-      parent(b) != a && error("Unable to coerce power series")
-      return b
-    end
+function (a::FqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
+  return a(base_ring(a)(b))
+end
 
-    function (a::FqPolyRepAbsPowerSeriesRing)(b::Vector{FqPolyRepFieldElem}, len::Int, prec::Int)
-      ctx = base_ring(a)
-      z = FqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
-      z.parent = a
-      return z
-    end
+function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepFieldElem)
+  ctx = base_ring(a)
+  if iszero(b)
+    z = FqPolyRepAbsPowerSeriesRingElem(ctx)
+    z.prec = a.prec_max
+  else
+    z = FqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
+  end
+  z.parent = a
+  return z
+end
+
+function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepAbsPowerSeriesRingElem)
+  parent(b) != a && error("Unable to coerce power series")
+  return b
+end
+
+function (a::FqPolyRepAbsPowerSeriesRing)(b::Vector{FqPolyRepFieldElem}, len::Int, prec::Int)
+  ctx = base_ring(a)
+  z = FqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
+  z.parent = a
+  return z
+end
 
 
 ###############################################################################

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -4,36 +4,32 @@
 #
 ###############################################################################
 
-for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
-                                                           (FqPolyRepAbsPowerSeriesRingElem, FqPolyRepAbsPowerSeriesRing, FqPolyRepField, FqPolyRepFieldElem, "fq_poly", "fq"))
-  @eval begin
-
     ###############################################################################
     #
     #   Data type and parent object methods
     #
     ###############################################################################
 
-    function O(a::($etype))
+    function O(a::FqPolyRepAbsPowerSeriesRingElem)
       if iszero(a)
         return deepcopy(a)    # 0 + O(x^n)
       end
       prec = length(a) - 1
       prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
-      z = ($etype)(base_ring(a), Vector{$(btype)}(undef, 0), 0, prec)
+      z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{FqPolyRepFieldElem}(undef, 0), 0, prec)
       z.parent = parent(a)
       return z
     end
 
-    elem_type(::Type{($rtype)}) = ($etype)
+    elem_type(::Type{FqPolyRepAbsPowerSeriesRing}) = FqPolyRepAbsPowerSeriesRingElem
 
-    parent_type(::Type{($etype)}) = ($rtype)
+    parent_type(::Type{FqPolyRepAbsPowerSeriesRingElem}) = FqPolyRepAbsPowerSeriesRing
 
-    base_ring(R::($rtype)) = R.base_ring
+    base_ring(R::FqPolyRepAbsPowerSeriesRing) = R.base_ring
 
-    abs_series_type(::Type{($btype)}) = ($etype)
+    abs_series_type(::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
 
-    var(a::($rtype)) = a.S
+    var(a::FqPolyRepAbsPowerSeriesRing) = a.S
 
     ###############################################################################
     #
@@ -41,21 +37,21 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    max_precision(R::($rtype)) = R.prec_max
+    max_precision(R::FqPolyRepAbsPowerSeriesRing) = R.prec_max
 
-    function normalise(a::($etype), len::Int)
+    function normalise(a::FqPolyRepAbsPowerSeriesRingElem, len::Int)
       ctx = base_ring(a)
       if len > 0
         c = base_ring(a)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_poly_get_coeff, libflint), Nothing,
+              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
               c, a, len - 1, ctx)
       end
       while len > 0 && iszero(c)
         len -= 1
         if len > 0
-          ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-                (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+          ccall((:fq_poly_get_coeff, libflint), Nothing,
+                (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
                 c, a, len - 1, ctx)
         end
       end
@@ -63,58 +59,58 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return len
     end
 
-    function length(x::($etype))
-      return ccall(($(flint_fn*"_length"), libflint), Int,
-                   (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+    function length(x::FqPolyRepAbsPowerSeriesRingElem)
+      return ccall((:fq_poly_length, libflint), Int,
+                   (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
     end
 
-    precision(x::($etype)) = x.prec
+    precision(x::FqPolyRepAbsPowerSeriesRingElem) = x.prec
 
-    function coeff(x::($etype), n::Int)
+    function coeff(x::FqPolyRepAbsPowerSeriesRingElem, n::Int)
       if n < 0
         return base_ring(x)()
       end
       z = base_ring(x)()
-      ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-            (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_get_coeff, libflint), Nothing,
+            (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, x, n, base_ring(x))
       return z
     end
 
-    zero(R::($rtype)) = R(0)
+    zero(R::FqPolyRepAbsPowerSeriesRing) = R(0)
 
-    one(R::($rtype)) = R(1)
+    one(R::FqPolyRepAbsPowerSeriesRing) = R(1)
 
-    function gen(R::($rtype))
+    function gen(R::FqPolyRepAbsPowerSeriesRing)
       S = base_ring(R)
-      z = ($etype)(S, [S(0), S(1)], 2, max_precision(R))
+      z = FqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
       z.parent = R
       return z
     end
 
-    function deepcopy_internal(a::($etype), dict::IdDict)
-      z = ($etype)(base_ring(a), a)
+    function deepcopy_internal(a::FqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
+      z = FqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
       z.prec = a.prec
       z.parent = parent(a)
       return z
     end
 
-    function is_gen(a::($etype))
-      return precision(a) == 0 || ccall(($(flint_fn*"_is_gen"), libflint), Bool,
-                                        (Ref{($etype)}, Ref{($ctype)}), a, base_ring(a))
+    function is_gen(a::FqPolyRepAbsPowerSeriesRingElem)
+      return precision(a) == 0 || ccall((:fq_poly_is_gen, libflint), Bool,
+                                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
     end
 
-    iszero(a::($etype)) = length(a) == 0
+    iszero(a::FqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
 
-    is_unit(a::($etype)) = valuation(a) == 0 && is_unit(coeff(a, 0))
+    is_unit(a::FqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
 
-    function isone(a::($etype))
-      return precision(a) == 0 || ccall(($(flint_fn*"_is_one"), libflint), Bool,
-                                        (Ref{($etype)}, Ref{($ctype)}), a, base_ring(a))
+    function isone(a::FqPolyRepAbsPowerSeriesRingElem)
+      return precision(a) == 0 || ccall((:fq_poly_is_one, libflint), Bool,
+                                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), a, base_ring(a))
     end
 
     # todo: write an fq_poly_valuation
-    function valuation(a::($etype))
+    function valuation(a::FqPolyRepAbsPowerSeriesRingElem)
       for i = 1:length(a)
         if !iszero(coeff(a, i - 1))
           return i - 1
@@ -123,7 +119,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return precision(a)
     end
 
-    characteristic(R::($rtype)) = characteristic(base_ring(R))
+    characteristic(R::FqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
 
     ###############################################################################
     #
@@ -131,12 +127,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function similar(f::AbsPowerSeriesRingElem, R::($ctype), max_prec::Int,
+    function similar(f::AbsPowerSeriesRingElem, R::FqPolyRepField, max_prec::Int,
         s::Symbol=var(parent(f)); cached::Bool=true)
-      par = ($rtype)(R, max_prec, s, cached)
-      z = ($etype)(R)
+      par = FqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
+      z = FqPolyRepAbsPowerSeriesRingElem(R)
       if base_ring(f) === R && s == var(parent(f)) &&
-        f isa ($etype) && max_precision(parent(f)) == max_prec
+        f isa FqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
         # steal parent in case it is not cached
         z.parent = parent(f)
       else
@@ -152,14 +148,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function abs_series(R::($ctype), arr::Vector{T},
+    function abs_series(R::FqPolyRepField, arr::Vector{T},
         len::Int, prec::Int, var::VarName=:x;
         max_precision::Int=prec, cached::Bool=true) where T
       prec < len && error("Precision too small for given data")
-      coeffs = T == ($btype) ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? ($btype)[] : coeffs
-      par = ($rtype)(R, max_precision, Symbol(var), cached)
-      z = ($etype)(R, coeffs, len, prec)
+      coeffs = T == FqPolyRepFieldElem ? arr : map(R, arr)
+      coeffs = length(coeffs) == 0 ? FqPolyRepFieldElem[] : coeffs
+      par = FqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
+      z = FqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
       z.parent = par
       return z
     end
@@ -170,10 +166,10 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function -(x::($etype))
+    function -(x::FqPolyRepAbsPowerSeriesRingElem)
       z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+      ccall((:fq_poly_neg, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
             z, x, base_ring(x))
       z.prec = x.prec
       return z
@@ -185,7 +181,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function +(a::($etype), b::($etype))
+    function +(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -195,14 +191,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_add_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
 
-    function -(a::($etype), b::($etype))
+    function -(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -212,14 +208,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_sub_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
 
-    function *(a::($etype), b::($etype))
+    function *(a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -235,9 +231,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         return z
       end
       lenz = min(lena + lenb - 1, prec)
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_mullow, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
@@ -248,16 +244,16 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function *(x::($btype), y::($etype))
+    function *(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem)
       z = parent(y)()
       z.prec = y.prec
-      ccall(($(flint_fn*"_scalar_mul_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
             z, y, x, base_ring(y))
       return z
     end
 
-    *(x::($etype), y::($btype)) = y * x
+    *(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem) = y * x
 
     ###############################################################################
     #
@@ -265,23 +261,23 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function shift_left(x::($etype), len::Int)
+    function shift_left(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = length(x)
       z = parent(x)()
       z.prec = x.prec + len
       z.prec = min(z.prec, max_precision(parent(x)))
       zlen = min(z.prec, xlen + len)
-      ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_shift_left, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, x, len, base_ring(x))
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_set_trunc, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, z, zlen, base_ring(x))
       return z
     end
 
-    function shift_right(x::($etype), len::Int)
+    function shift_right(x::FqPolyRepAbsPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = length(x)
       z = parent(x)()
@@ -289,8 +285,8 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         z.prec = max(0, x.prec - len)
       else
         z.prec = x.prec - len
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_poly_shift_right, libflint), Nothing,
+              (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
               z, x, len, base_ring(x))
       end
       return z
@@ -302,17 +298,17 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), k::Int)
+    function truncate(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
       return truncate!(deepcopy(x), k)
     end
 
-    function truncate!(x::($etype), k::Int)
+    function truncate!(x::FqPolyRepAbsPowerSeriesRingElem, k::Int)
       k < 0 && throw(DomainError(k, "Index must be non-negative"))
       if precision(x) <= k
         return x
       end
-      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_truncate, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             x, k, base_ring(x))
       x.prec = k
       return x
@@ -324,7 +320,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ^(a::($etype), b::Int)
+    function ^(a::FqPolyRepAbsPowerSeriesRingElem, b::Int)
       b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
       if precision(a) > 0 && is_gen(a) && b > 0
         return shift_left(a, b - 1)
@@ -357,25 +353,25 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ==(x::($etype), y::($etype))
+    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
       check_parent(x, y)
       prec = min(x.prec, y.prec)
       n = max(length(x), length(y))
       n = min(n, prec)
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
+                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
                         x, y, n, base_ring(x)))
     end
 
-    function isequal(x::($etype), y::($etype))
+    function isequal(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem)
       if parent(x) != parent(y)
         return false
       end
       if x.prec != y.prec || length(x) != length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+      return Bool(ccall((:fq_poly_equal, libflint), Cint,
+                        (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}),
                         x, y, base_ring(x)))
     end
 
@@ -385,13 +381,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ==(x::($etype), y::($btype))
+    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem)
       if length(x) > 1
         return false
       elseif length(x) == 1
         z = base_ring(x)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_poly_get_coeff, libflint), Nothing,
+              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
               z, x, 0, base_ring(x))
         return z == y
       else
@@ -399,15 +395,15 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
     end
 
-    ==(x::($btype), y::($etype)) = y == x
+    ==(x::FqPolyRepFieldElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
 
-    function ==(x::($etype), y::ZZRingElem)
+    function ==(x::FqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
       if length(x) > 1
         return false
       elseif length(x) == 1
         z = base_ring(x)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_poly_get_coeff, libflint), Nothing,
+              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
               z, x, 0, base_ring(x))
         return z == y
       else
@@ -415,11 +411,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
     end
 
-    ==(x::ZZRingElem, y::($etype)) = y == x
+    ==(x::ZZRingElem, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
 
-    ==(x::($etype), y::Integer) = x == ZZRingElem(y)
+    ==(x::FqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
 
-    ==(x::Integer, y::($etype)) = y == x
+    ==(x::Integer, y::FqPolyRepAbsPowerSeriesRingElem) = y == x
 
     ###############################################################################
     #
@@ -427,7 +423,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::($etype); check::Bool=true)
+    function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       check_parent(x, y)
       iszero(y) && throw(DivideError())
       v2 = valuation(y)
@@ -442,9 +438,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       prec = min(x.prec, y.prec - v2 + v1)
       z = parent(x)()
       z.prec = prec
-      ccall(($(flint_fn*"_div_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_div_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, x, y, prec, base_ring(x))
       return z
     end
@@ -455,12 +451,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::($btype); check::Bool=true)
+    function divexact(x::FqPolyRepAbsPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
       iszero(y) && throw(DivideError())
       z = parent(x)()
       z.prec = x.prec
-      ccall(($(flint_fn*"_scalar_div_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
             z, x, y, base_ring(x))
       return z
     end
@@ -471,13 +467,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function inv(a::($etype))
+    function inv(a::FqPolyRepAbsPowerSeriesRingElem)
       iszero(a) && throw(DivideError())
       !is_unit(a) && error("Unable to invert power series")
       ainv = parent(a)()
       ainv.prec = a.prec
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_inv_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             ainv, a, a.prec, base_ring(a))
       return ainv
     end
@@ -488,7 +484,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function sqrt_classical_char2(a::($etype); check::Bool=true)
+    function sqrt_classical_char2(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       S = parent(a)
       asqrt = S()
       prec = div(precision(a) + 1, 2)
@@ -513,7 +509,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, asqrt
     end
 
-    function sqrt_classical(a::($etype); check::Bool=true)
+    function sqrt_classical(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       R = base_ring(a)
       S = parent(a)
       if characteristic(R) == 2
@@ -540,8 +536,8 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
       a = divexact(a, c)
       z.prec = a.prec - div(v, 2)
-      ccall(($(flint_fn*"_sqrt_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_sqrt_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, a, a.prec, base_ring(a))
       if !isone(s)
         z *= s
@@ -552,18 +548,18 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, z
     end
 
-    function Base.sqrt(a::($etype); check::Bool=true)
+    function Base.sqrt(a::FqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       flag, s = sqrt_classical(a; check=check)
       check && !flag && error("Not a square")
       return s
     end
 
-    function is_square(a::($etype))
+    function is_square(a::FqPolyRepAbsPowerSeriesRingElem)
       flag, s = sqrt_classical(a; check=true)
       return flag
     end
 
-    function is_square_with_sqrt(a::($etype))
+    function is_square_with_sqrt(a::FqPolyRepAbsPowerSeriesRingElem)
       return sqrt_classical(a; check=true)
     end
 
@@ -573,35 +569,35 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function zero!(z::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), z, base_ring(z))
+    function zero!(z::FqPolyRepAbsPowerSeriesRingElem)
+      ccall((:fq_poly_zero, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
       z.prec = parent(z).prec_max
       return z
     end
 
-    function one!(z::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), z, base_ring(z))
+    function one!(z::FqPolyRepAbsPowerSeriesRingElem)
+      ccall((:fq_poly_one, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepField}), z, base_ring(z))
       z.prec = parent(z).prec_max
       return z
     end
 
-    function fit!(z::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function fit!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int)
+      ccall((:fq_poly_fit_length, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, n, base_ring(z))
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::($btype))
-      ccall(($(flint_fn*"_set_coeff"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($btype)}, Ref{($ctype)}),
+    function setcoeff!(z::FqPolyRepAbsPowerSeriesRingElem, n::Int, x::FqPolyRepFieldElem)
+      ccall((:fq_poly_set_coeff, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
             z, n, x, base_ring(z))
       return z
     end
 
-    function mul!(z::($etype), a::($etype), b::($etype))
+    function mul!(z::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
       lena = length(a)
       lenb = length(b)
       aval = valuation(a)
@@ -615,14 +611,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         lenz = 0
       end
       z.prec = prec
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_mullow, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             z, a, b, lenz, base_ring(z))
       return z
     end
 
-    function add!(c::($etype), a::($etype), b::($etype))
+    function add!(c::FqPolyRepAbsPowerSeriesRingElem, a::FqPolyRepAbsPowerSeriesRingElem, b::FqPolyRepAbsPowerSeriesRingElem)
       lena = length(a)
       lenb = length(b)
       prec = min(a.prec, b.prec)
@@ -630,16 +626,16 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenb = min(lenb, prec)
       lenc = max(lena, lenb)
       c.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_poly_add_series, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Ref{FqPolyRepAbsPowerSeriesRingElem},
+             Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             c, a, b, lenc, base_ring(a))
       return c
     end
 
-    function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function set_length!(a::FqPolyRepAbsPowerSeriesRingElem, n::Int)
+      ccall((:_fq_poly_set_length, libflint), Nothing,
+            (Ref{FqPolyRepAbsPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
             a, n, base_ring(a))
       return a
     end
@@ -650,11 +646,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    promote_rule(::Type{($etype)}, ::Type{T}) where {T <: Integer} = ($etype)
+    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = FqPolyRepAbsPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{$(btype)}) = ($etype)
+    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{FqPolyRepFieldElem}) = FqPolyRepAbsPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{ZZRingElem}) = ($etype)
+    promote_rule(::Type{FqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = FqPolyRepAbsPowerSeriesRingElem
 
     ###############################################################################
     #
@@ -662,48 +658,46 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function (a::($rtype))()
+    function (a::FqPolyRepAbsPowerSeriesRing)()
       ctx = base_ring(a)
-      z = ($etype)(ctx)
+      z = FqPolyRepAbsPowerSeriesRingElem(ctx)
       z.prec = a.prec_max
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::Integer)
+    function (a::FqPolyRepAbsPowerSeriesRing)(b::Integer)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::ZZRingElem)
+    function (a::FqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::($btype))
+    function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepFieldElem)
       ctx = base_ring(a)
       if iszero(b)
-        z = ($etype)(ctx)
+        z = FqPolyRepAbsPowerSeriesRingElem(ctx)
         z.prec = a.prec_max
       else
-        z = ($etype)(ctx, [b], 1, a.prec_max)
+        z = FqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
       end
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::($etype))
+    function (a::FqPolyRepAbsPowerSeriesRing)(b::FqPolyRepAbsPowerSeriesRingElem)
       parent(b) != a && error("Unable to coerce power series")
       return b
     end
 
-    function (a::($rtype))(b::Vector{$(btype)}, len::Int, prec::Int)
+    function (a::FqPolyRepAbsPowerSeriesRing)(b::Vector{FqPolyRepFieldElem}, len::Int, prec::Int)
       ctx = base_ring(a)
-      z = ($etype)(ctx, b, len, prec)
+      z = FqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
       z.parent = a
       return z
     end
 
-  end # eval
-end # for
 
 ###############################################################################
 #

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -1,11 +1,11 @@
 ###############################################################################
 #
-#   fq_abs_series.jl: Absolute series over finite fields
+#   fq_nmod_abs_series.jl: Absolute series over finite fields
 #
 ###############################################################################
 
 for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
-                                                           (FqPolyRepAbsPowerSeriesRingElem, FqPolyRepAbsPowerSeriesRing, FqPolyRepField, FqPolyRepFieldElem, "fq_poly", "fq"))
+                                                           (fqPolyRepAbsPowerSeriesRingElem, fqPolyRepAbsPowerSeriesRing, fqPolyRepField, fqPolyRepFieldElem, "fq_nmod_poly", "fq_nmod"))
   @eval begin
 
     ###############################################################################
@@ -711,11 +711,11 @@ end # for
 #
 ###############################################################################
 
-function power_series_ring(R::FqPolyRepField, prec::Int, s::VarName; model::Symbol=:capped_relative, cached::Bool = true)
+function power_series_ring(R::fqPolyRepField, prec::Int, s::VarName; model::Symbol=:capped_relative, cached::Bool = true)
   if model == :capped_relative
-    parent_obj = FqPolyRepRelPowerSeriesRing(R, prec, Symbol(s), cached)
+    parent_obj = fqPolyRepRelPowerSeriesRing(R, prec, Symbol(s), cached)
   elseif model == :capped_absolute
-    parent_obj = FqPolyRepAbsPowerSeriesRing(R, prec, Symbol(s), cached)
+    parent_obj = fqPolyRepAbsPowerSeriesRing(R, prec, Symbol(s), cached)
   else
     error("Unknown model")
   end
@@ -723,10 +723,10 @@ function power_series_ring(R::FqPolyRepField, prec::Int, s::VarName; model::Symb
   return parent_obj, gen(parent_obj)
 end
 
-function AbsPowerSeriesRing(R::FqPolyRepField, prec::Int)
-  return FqPolyRepAbsPowerSeriesRing(R, prec, :x, false)
+function AbsPowerSeriesRing(R::fqPolyRepField, prec::Int)
+  return fqPolyRepAbsPowerSeriesRing(R, prec, :x, false)
 end
 
-function RelPowerSeriesRing(R::FqPolyRepField, prec::Int)
-  return FqPolyRepRelPowerSeriesRing(R, prec, :x, false)
+function RelPowerSeriesRing(R::fqPolyRepField, prec::Int)
+  return fqPolyRepRelPowerSeriesRing(R, prec, :x, false)
 end

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -4,699 +4,699 @@
 #
 ###############################################################################
 
-    ###############################################################################
-    #
-    #   Data type and parent object methods
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
 
-    function O(a::fqPolyRepAbsPowerSeriesRingElem)
-      if iszero(a)
-        return deepcopy(a)    # 0 + O(x^n)
-      end
-      prec = length(a) - 1
-      prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
-      z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, prec)
-      z.parent = parent(a)
-      return z
-    end
+function O(a::fqPolyRepAbsPowerSeriesRingElem)
+  if iszero(a)
+    return deepcopy(a)    # 0 + O(x^n)
+  end
+  prec = length(a) - 1
+  prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
+  z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, prec)
+  z.parent = parent(a)
+  return z
+end
 
-    elem_type(::Type{fqPolyRepAbsPowerSeriesRing}) = fqPolyRepAbsPowerSeriesRingElem
+elem_type(::Type{fqPolyRepAbsPowerSeriesRing}) = fqPolyRepAbsPowerSeriesRingElem
 
-    parent_type(::Type{fqPolyRepAbsPowerSeriesRingElem}) = fqPolyRepAbsPowerSeriesRing
+parent_type(::Type{fqPolyRepAbsPowerSeriesRingElem}) = fqPolyRepAbsPowerSeriesRing
 
-    base_ring(R::fqPolyRepAbsPowerSeriesRing) = R.base_ring
+base_ring(R::fqPolyRepAbsPowerSeriesRing) = R.base_ring
 
-    abs_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
+abs_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
 
-    var(a::fqPolyRepAbsPowerSeriesRing) = a.S
+var(a::fqPolyRepAbsPowerSeriesRing) = a.S
 
-    ###############################################################################
-    #
-    #   Basic manipulation
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
 
-    max_precision(R::fqPolyRepAbsPowerSeriesRing) = R.prec_max
+max_precision(R::fqPolyRepAbsPowerSeriesRing) = R.prec_max
 
-    function normalise(a::fqPolyRepAbsPowerSeriesRingElem, len::Int)
-      ctx = base_ring(a)
-      if len > 0
-        c = base_ring(a)()
-        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, a, len - 1, ctx)
-      end
-      while len > 0 && iszero(c)
-        len -= 1
-        if len > 0
-          ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-                (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-                c, a, len - 1, ctx)
-        end
-      end
-
-      return len
-    end
-
-    function length(x::fqPolyRepAbsPowerSeriesRingElem)
-      return ccall((:fq_nmod_poly_length, libflint), Int,
-                   (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
-    end
-
-    precision(x::fqPolyRepAbsPowerSeriesRingElem) = x.prec
-
-    function coeff(x::fqPolyRepAbsPowerSeriesRingElem, n::Int)
-      if n < 0
-        return base_ring(x)()
-      end
-      z = base_ring(x)()
+function normalise(a::fqPolyRepAbsPowerSeriesRingElem, len::Int)
+  ctx = base_ring(a)
+  if len > 0
+    c = base_ring(a)()
+    ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+          (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, a, len - 1, ctx)
+  end
+  while len > 0 && iszero(c)
+    len -= 1
+    if len > 0
       ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, x, n, base_ring(x))
-      return z
+            c, a, len - 1, ctx)
     end
+  end
 
-    zero(R::fqPolyRepAbsPowerSeriesRing) = R(0)
+  return len
+end
 
-    one(R::fqPolyRepAbsPowerSeriesRing) = R(1)
+function length(x::fqPolyRepAbsPowerSeriesRingElem)
+  return ccall((:fq_nmod_poly_length, libflint), Int,
+                (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
+end
 
-    function gen(R::fqPolyRepAbsPowerSeriesRing)
-      S = base_ring(R)
-      z = fqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
-      z.parent = R
-      return z
+precision(x::fqPolyRepAbsPowerSeriesRingElem) = x.prec
+
+function coeff(x::fqPolyRepAbsPowerSeriesRingElem, n::Int)
+  if n < 0
+    return base_ring(x)()
+  end
+  z = base_ring(x)()
+  ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, x, n, base_ring(x))
+  return z
+end
+
+zero(R::fqPolyRepAbsPowerSeriesRing) = R(0)
+
+one(R::fqPolyRepAbsPowerSeriesRing) = R(1)
+
+function gen(R::fqPolyRepAbsPowerSeriesRing)
+  S = base_ring(R)
+  z = fqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
+  z.parent = R
+  return z
+end
+
+function deepcopy_internal(a::fqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
+  z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
+  z.prec = a.prec
+  z.parent = parent(a)
+  return z
+end
+
+function is_gen(a::fqPolyRepAbsPowerSeriesRingElem)
+  return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, libflint), Bool,
+                                    (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
+end
+
+iszero(a::fqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
+
+is_unit(a::fqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
+
+function isone(a::fqPolyRepAbsPowerSeriesRingElem)
+  return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, libflint), Bool,
+                                    (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
+end
+
+# todo: write an fq_poly_valuation
+function valuation(a::fqPolyRepAbsPowerSeriesRingElem)
+  for i = 1:length(a)
+    if !iszero(coeff(a, i - 1))
+      return i - 1
     end
+  end
+  return precision(a)
+end
 
-    function deepcopy_internal(a::fqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
-      z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
-      z.prec = a.prec
-      z.parent = parent(a)
-      return z
+characteristic(R::fqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
+
+###############################################################################
+#
+#   Similar
+#
+###############################################################################
+
+function similar(f::AbsPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
+    s::Symbol=var(parent(f)); cached::Bool=true)
+  par = fqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
+  z = fqPolyRepAbsPowerSeriesRingElem(R)
+  if base_ring(f) === R && s == var(parent(f)) &&
+    f isa fqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
+    # steal parent in case it is not cached
+    z.parent = parent(f)
+  else
+    z.parent = par
+  end
+  z.prec = max_prec
+  return z
+end
+
+###############################################################################
+#
+#   abs_series constructor
+#
+###############################################################################
+
+function abs_series(R::fqPolyRepField, arr::Vector{T},
+    len::Int, prec::Int, var::VarName=:x;
+    max_precision::Int=prec, cached::Bool=true) where T
+  prec < len && error("Precision too small for given data")
+  coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
+  coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
+  par = fqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
+  z = fqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
+  z.parent = par
+  return z
+end
+
+###############################################################################
+#
+#   Unary operators
+#
+###############################################################################
+
+function -(x::fqPolyRepAbsPowerSeriesRingElem)
+  z = parent(x)()
+  ccall((:fq_nmod_poly_neg, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
+        z, x, base_ring(x))
+  z.prec = x.prec
+  return z
+end
+
+###############################################################################
+#
+#   Binary operators
+#
+###############################################################################
+
+function +(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  z.prec = prec
+  ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+function -(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  z.prec = prec
+  ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+function *(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = length(a)
+  lenb = length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec + bval, b.prec + aval)
+  prec = min(prec, max_precision(parent(a)))
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z = parent(a)()
+  z.prec = prec
+  if lena == 0 || lenb == 0
+    return z
+  end
+  lenz = min(lena + lenb - 1, prec)
+  ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem)
+  z = parent(y)()
+  z.prec = y.prec
+  ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, y, x, base_ring(y))
+  return z
+end
+
+*(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
+
+###############################################################################
+#
+#   Shifting
+#
+###############################################################################
+
+function shift_left(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = length(x)
+  z = parent(x)()
+  z.prec = x.prec + len
+  z.prec = min(z.prec, max_precision(parent(x)))
+  zlen = min(z.prec, xlen + len)
+  ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, x, len, base_ring(x))
+  ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, z, zlen, base_ring(x))
+  return z
+end
+
+function shift_right(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = length(x)
+  z = parent(x)()
+  if len >= xlen
+    z.prec = max(0, x.prec - len)
+  else
+    z.prec = x.prec - len
+    ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+          (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, x, len, base_ring(x))
+  end
+  return z
+end
+
+###############################################################################
+#
+#   Truncation
+#
+###############################################################################
+
+function truncate(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
+    return x
+  end
+  ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        x, k, base_ring(x))
+  x.prec = k
+  return x
+end
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(a::fqPolyRepAbsPowerSeriesRingElem, b::Int)
+  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
+  if precision(a) > 0 && is_gen(a) && b > 0
+    return shift_left(a, b - 1)
+  elseif length(a) == 1
+    return parent(a)([coeff(a, 0)^b], 1, a.prec)
+  elseif b == 0
+    z = one(parent(a))
+    z = set_precision!(z, precision(a))
+  else
+    bit = ~((~UInt(0)) >> 1)
+    while (UInt(bit) & b) == 0
+      bit >>= 1
     end
-
-    function is_gen(a::fqPolyRepAbsPowerSeriesRingElem)
-      return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, libflint), Bool,
-                                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
-    end
-
-    iszero(a::fqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
-
-    is_unit(a::fqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
-
-    function isone(a::fqPolyRepAbsPowerSeriesRingElem)
-      return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, libflint), Bool,
-                                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
-    end
-
-    # todo: write an fq_poly_valuation
-    function valuation(a::fqPolyRepAbsPowerSeriesRingElem)
-      for i = 1:length(a)
-        if !iszero(coeff(a, i - 1))
-          return i - 1
-        end
+    z = a
+    bit >>= 1
+    while bit !=0
+      z = z*z
+      if (UInt(bit) & b) != 0
+        z *= a
       end
-      return precision(a)
+      bit >>= 1
     end
+  end
+  return z
+end
 
-    characteristic(R::fqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
 
-    ###############################################################################
-    #
-    #   Similar
-    #
-    ###############################################################################
+function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
+  check_parent(x, y)
+  prec = min(x.prec, y.prec)
+  n = max(length(x), length(y))
+  n = min(n, prec)
+  return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
+                    (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+                    x, y, n, base_ring(x)))
+end
 
-    function similar(f::AbsPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
-        s::Symbol=var(parent(f)); cached::Bool=true)
-      par = fqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
-      z = fqPolyRepAbsPowerSeriesRingElem(R)
-      if base_ring(f) === R && s == var(parent(f)) &&
-        f isa fqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
-        # steal parent in case it is not cached
-        z.parent = parent(f)
-      else
-        z.parent = par
-      end
-      z.prec = max_prec
-      return z
+function isequal(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
+  if parent(x) != parent(y)
+    return false
+  end
+  if x.prec != y.prec || length(x) != length(y)
+    return false
+  end
+  return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
+                    (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
+                    x, y, base_ring(x)))
+end
+
+###############################################################################
+#
+#   Ad hoc comparisons
+#
+###############################################################################
+
+function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem)
+  if length(x) > 1
+    return false
+  elseif length(x) == 1
+    z = base_ring(x)()
+    ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+          (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, x, 0, base_ring(x))
+    return z == y
+  else
+    return precision(x) == 0 || iszero(y)
+  end
+end
+
+==(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
+
+function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
+  if length(x) > 1
+    return false
+  elseif length(x) == 1
+    z = base_ring(x)()
+    ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+          (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, x, 0, base_ring(x))
+    return z == y
+  else
+    return precision(x) == 0 || iszero(y)
+  end
+end
+
+==(x::ZZRingElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
+
+==(x::fqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
+
+==(x::Integer, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  check_parent(x, y)
+  iszero(y) && throw(DivideError())
+  v2 = valuation(y)
+  v1 = valuation(x)
+  if v2 != 0
+    if v1 >= v2
+      x = shift_right(x, v2)
+      y = shift_right(y, v2)
     end
+  end
+  check && !is_unit(y) && error("Unable to invert power series")
+  prec = min(x.prec, y.prec - v2 + v1)
+  z = parent(x)()
+  z.prec = prec
+  ccall((:fq_nmod_poly_div_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, x, y, prec, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   abs_series constructor
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Ad hoc exact division
+#
+###############################################################################
 
-    function abs_series(R::fqPolyRepField, arr::Vector{T},
-        len::Int, prec::Int, var::VarName=:x;
-        max_precision::Int=prec, cached::Bool=true) where T
-      prec < len && error("Precision too small for given data")
-      coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
-      par = fqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
-      z = fqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
-      z.parent = par
-      return z
-    end
+function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem; check::Bool=true)
+  iszero(y) && throw(DivideError())
+  z = parent(x)()
+  z.prec = x.prec
+  ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, x, y, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Unary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
 
-    function -(x::fqPolyRepAbsPowerSeriesRingElem)
-      z = parent(x)()
-      ccall((:fq_nmod_poly_neg, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
-            z, x, base_ring(x))
-      z.prec = x.prec
-      return z
-    end
+function inv(a::fqPolyRepAbsPowerSeriesRingElem)
+  iszero(a) && throw(DivideError())
+  !is_unit(a) && error("Unable to invert power series")
+  ainv = parent(a)()
+  ainv.prec = a.prec
+  ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        ainv, a, a.prec, base_ring(a))
+  return ainv
+end
 
-    ###############################################################################
-    #
-    #   Binary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Square root
+#
+###############################################################################
 
-    function +(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      z.prec = prec
-      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    function -(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      z.prec = prec
-      ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    function *(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = length(a)
-      lenb = length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec + bval, b.prec + aval)
-      prec = min(prec, max_precision(parent(a)))
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z = parent(a)()
-      z.prec = prec
-      if lena == 0 || lenb == 0
-        return z
-      end
-      lenz = min(lena + lenb - 1, prec)
-      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc binary operators
-    #
-    ###############################################################################
-
-    function *(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem)
-      z = parent(y)()
-      z.prec = y.prec
-      ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, y, x, base_ring(y))
-      return z
-    end
-
-    *(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
-
-    ###############################################################################
-    #
-    #   Shifting
-    #
-    ###############################################################################
-
-    function shift_left(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = length(x)
-      z = parent(x)()
-      z.prec = x.prec + len
-      z.prec = min(z.prec, max_precision(parent(x)))
-      zlen = min(z.prec, xlen + len)
-      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, x, len, base_ring(x))
-      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, z, zlen, base_ring(x))
-      return z
-    end
-
-    function shift_right(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = length(x)
-      z = parent(x)()
-      if len >= xlen
-        z.prec = max(0, x.prec - len)
-      else
-        z.prec = x.prec - len
-        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
-              (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, x, len, base_ring(x))
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Truncation
-    #
-    ###############################################################################
-
-    function truncate(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
-      return truncate!(deepcopy(x), k)
-    end
-
-    function truncate!(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
-      k < 0 && throw(DomainError(k, "Index must be non-negative"))
-      if precision(x) <= k
-        return x
-      end
-      ccall((:fq_nmod_poly_truncate, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            x, k, base_ring(x))
-      x.prec = k
-      return x
-    end
-
-    ###############################################################################
-    #
-    #   Powering
-    #
-    ###############################################################################
-
-    function ^(a::fqPolyRepAbsPowerSeriesRingElem, b::Int)
-      b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-      if precision(a) > 0 && is_gen(a) && b > 0
-        return shift_left(a, b - 1)
-      elseif length(a) == 1
-        return parent(a)([coeff(a, 0)^b], 1, a.prec)
-      elseif b == 0
-        z = one(parent(a))
-        z = set_precision!(z, precision(a))
-      else
-        bit = ~((~UInt(0)) >> 1)
-        while (UInt(bit) & b) == 0
-          bit >>= 1
-        end
-        z = a
-        bit >>= 1
-        while bit !=0
-          z = z*z
-          if (UInt(bit) & b) != 0
-            z *= a
-          end
-          bit >>= 1
-        end
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Comparison
-    #
-    ###############################################################################
-
-    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
-      check_parent(x, y)
-      prec = min(x.prec, y.prec)
-      n = max(length(x), length(y))
-      n = min(n, prec)
-      return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
-                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-                        x, y, n, base_ring(x)))
-    end
-
-    function isequal(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
-      if parent(x) != parent(y)
-        return false
-      end
-      if x.prec != y.prec || length(x) != length(y)
-        return false
-      end
-      return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
-                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
-                        x, y, base_ring(x)))
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc comparisons
-    #
-    ###############################################################################
-
-    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem)
-      if length(x) > 1
-        return false
-      elseif length(x) == 1
-        z = base_ring(x)()
-        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, x, 0, base_ring(x))
-        return z == y
-      else
-        return precision(x) == 0 || iszero(y)
-      end
-    end
-
-    ==(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
-      if length(x) > 1
-        return false
-      elseif length(x) == 1
-        z = base_ring(x)()
-        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, x, 0, base_ring(x))
-        return z == y
-      else
-        return precision(x) == 0 || iszero(y)
-      end
-    end
-
-    ==(x::ZZRingElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    ==(x::fqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
-
-    ==(x::Integer, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
-
-    ###############################################################################
-    #
-    #   Exact division
-    #
-    ###############################################################################
-
-    function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      check_parent(x, y)
-      iszero(y) && throw(DivideError())
-      v2 = valuation(y)
-      v1 = valuation(x)
-      if v2 != 0
-        if v1 >= v2
-          x = shift_right(x, v2)
-          y = shift_right(y, v2)
-        end
-      end
-      check && !is_unit(y) && error("Unable to invert power series")
-      prec = min(x.prec, y.prec - v2 + v1)
-      z = parent(x)()
-      z.prec = prec
-      ccall((:fq_nmod_poly_div_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, x, y, prec, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc exact division
-    #
-    ###############################################################################
-
-    function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem; check::Bool=true)
-      iszero(y) && throw(DivideError())
-      z = parent(x)()
-      z.prec = x.prec
-      ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, x, y, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Inversion
-    #
-    ###############################################################################
-
-    function inv(a::fqPolyRepAbsPowerSeriesRingElem)
-      iszero(a) && throw(DivideError())
-      !is_unit(a) && error("Unable to invert power series")
-      ainv = parent(a)()
-      ainv.prec = a.prec
-      ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            ainv, a, a.prec, base_ring(a))
-      return ainv
-    end
-
-    ###############################################################################
-    #
-    #   Square root
-    #
-    ###############################################################################
-
-    function sqrt_classical_char2(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      asqrt = S()
-      prec = div(precision(a) + 1, 2)
-      asqrt = set_precision!(asqrt, prec)
-      if check
-        for i = 1:2:precision(a) - 1 # series must have even exponents
-          if !iszero(coeff(a, i))
-            return false, S()
-          end
-        end
-      end
-      for i = 0:prec - 1
-        if check
-          flag, c = is_square_with_sqrt(coeff(a, 2*i))
-          !flag && error("Not a square")
-        else
-          # degree of finite field could be > 1 so sqrt necessary here
-          c = sqrt(coeff(a, 2*i); check=check)
-        end
-        asqrt = setcoeff!(asqrt, i, c)
-      end
-      return true, asqrt
-    end
-
-    function sqrt_classical(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      R = base_ring(a)
-      S = parent(a)
-      if characteristic(R) == 2
-        return sqrt_classical_char2(a; check=check)
-      end
-      v = valuation(a)
-      z = S()
-      z.prec = a.prec - div(v, 2)
-      if iszero(a)
-        return true, z
-      end
-      if check && !iseven(v)
+function sqrt_classical_char2(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  asqrt = S()
+  prec = div(precision(a) + 1, 2)
+  asqrt = set_precision!(asqrt, prec)
+  if check
+    for i = 1:2:precision(a) - 1 # series must have even exponents
+      if !iszero(coeff(a, i))
         return false, S()
       end
-      a = shift_right(a, v)
-      c = coeff(a, 0)
-      if check
-        flag, s = is_square_with_sqrt(c)
-        if !flag
-          return false, S()
-        end
-      else
-        s = sqrt(c; check=check)
-      end
-      a = divexact(a, c)
-      z.prec = a.prec - div(v, 2)
-      ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, a.prec, base_ring(a))
-      if !isone(s)
-        z *= s
-      end
-      if !iszero(v)
-        z = shift_left(z, div(v, 2))
-      end
-      return true, z
     end
-
-    function Base.sqrt(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
-      flag, s = sqrt_classical(a; check=check)
-      check && !flag && error("Not a square")
-      return s
+  end
+  for i = 0:prec - 1
+    if check
+      flag, c = is_square_with_sqrt(coeff(a, 2*i))
+      !flag && error("Not a square")
+    else
+      # degree of finite field could be > 1 so sqrt necessary here
+      c = sqrt(coeff(a, 2*i); check=check)
     end
+    asqrt = setcoeff!(asqrt, i, c)
+  end
+  return true, asqrt
+end
 
-    function is_square(a::fqPolyRepAbsPowerSeriesRingElem)
-      flag, s = sqrt_classical(a; check=true)
-      return flag
+function sqrt_classical(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  R = base_ring(a)
+  S = parent(a)
+  if characteristic(R) == 2
+    return sqrt_classical_char2(a; check=check)
+  end
+  v = valuation(a)
+  z = S()
+  z.prec = a.prec - div(v, 2)
+  if iszero(a)
+    return true, z
+  end
+  if check && !iseven(v)
+    return false, S()
+  end
+  a = shift_right(a, v)
+  c = coeff(a, 0)
+  if check
+    flag, s = is_square_with_sqrt(c)
+    if !flag
+      return false, S()
     end
+  else
+    s = sqrt(c; check=check)
+  end
+  a = divexact(a, c)
+  z.prec = a.prec - div(v, 2)
+  ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, a.prec, base_ring(a))
+  if !isone(s)
+    z *= s
+  end
+  if !iszero(v)
+    z = shift_left(z, div(v, 2))
+  end
+  return true, z
+end
 
-    function is_square_with_sqrt(a::fqPolyRepAbsPowerSeriesRingElem)
-      return sqrt_classical(a; check=true)
-    end
+function Base.sqrt(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
+  flag, s = sqrt_classical(a; check=check)
+  check && !flag && error("Not a square")
+  return s
+end
 
-    ###############################################################################
-    #
-    #   Unsafe functions
-    #
-    ###############################################################################
+function is_square(a::fqPolyRepAbsPowerSeriesRingElem)
+  flag, s = sqrt_classical(a; check=true)
+  return flag
+end
 
-    function zero!(z::fqPolyRepAbsPowerSeriesRingElem)
-      ccall((:fq_nmod_poly_zero, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
-      z.prec = parent(z).prec_max
-      return z
-    end
+function is_square_with_sqrt(a::fqPolyRepAbsPowerSeriesRingElem)
+  return sqrt_classical(a; check=true)
+end
 
-    function one!(z::fqPolyRepAbsPowerSeriesRingElem)
-      ccall((:fq_nmod_poly_one, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
-      z.prec = parent(z).prec_max
-      return z
-    end
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
 
-    function fit!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int)
-      ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, n, base_ring(z))
-      return nothing
-    end
+function zero!(z::fqPolyRepAbsPowerSeriesRingElem)
+  ccall((:fq_nmod_poly_zero, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
+  z.prec = parent(z).prec_max
+  return z
+end
 
-    function setcoeff!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
-      ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function one!(z::fqPolyRepAbsPowerSeriesRingElem)
+  ccall((:fq_nmod_poly_one, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
+  z.prec = parent(z).prec_max
+  return z
+end
 
-    function mul!(z::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
-      lena = length(a)
-      lenb = length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec + bval, b.prec + aval)
-      prec = min(prec, max_precision(parent(z)))
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenz = min(lena + lenb - 1, prec)
-      if lenz < 0
-        lenz = 0
-      end
-      z.prec = prec
-      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(z))
-      return z
-    end
+function fit!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int)
+  ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, n, base_ring(z))
+  return nothing
+end
 
-    function add!(c::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
-      lena = length(a)
-      lenb = length(b)
-      prec = min(a.prec, b.prec)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      lenc = max(lena, lenb)
-      c.prec = prec
-      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
-             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            c, a, b, lenc, base_ring(a))
-      return c
-    end
+function setcoeff!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
+  ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function set_length!(a::fqPolyRepAbsPowerSeriesRingElem, n::Int)
-      ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
-            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            a, n, base_ring(a))
-      return a
-    end
+function mul!(z::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
+  lena = length(a)
+  lenb = length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec + bval, b.prec + aval)
+  prec = min(prec, max_precision(parent(z)))
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenz = min(lena + lenb - 1, prec)
+  if lenz < 0
+    lenz = 0
+  end
+  z.prec = prec
+  ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(z))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Promotion rules
-    #
-    ###############################################################################
+function add!(c::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
+  lena = length(a)
+  lenb = length(b)
+  prec = min(a.prec, b.prec)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  lenc = max(lena, lenb)
+  c.prec = prec
+  ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+          Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        c, a, b, lenc, base_ring(a))
+  return c
+end
 
-    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepAbsPowerSeriesRingElem
+function set_length!(a::fqPolyRepAbsPowerSeriesRingElem, n::Int)
+  ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
+        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        a, n, base_ring(a))
+  return a
+end
 
-    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
+###############################################################################
+#
+#   Promotion rules
+#
+###############################################################################
 
-    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepAbsPowerSeriesRingElem
+promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepAbsPowerSeriesRingElem
 
-    ###############################################################################
-    #
-    #   Parent object call overload
-    #
-    ###############################################################################
+promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
 
-    function (a::fqPolyRepAbsPowerSeriesRing)()
-      ctx = base_ring(a)
-      z = fqPolyRepAbsPowerSeriesRingElem(ctx)
-      z.prec = a.prec_max
-      z.parent = a
-      return z
-    end
+promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepAbsPowerSeriesRingElem
 
-    function (a::fqPolyRepAbsPowerSeriesRing)(b::Integer)
-      return a(base_ring(a)(b))
-    end
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
 
-    function (a::fqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
-      return a(base_ring(a)(b))
-    end
+function (a::fqPolyRepAbsPowerSeriesRing)()
+  ctx = base_ring(a)
+  z = fqPolyRepAbsPowerSeriesRingElem(ctx)
+  z.prec = a.prec_max
+  z.parent = a
+  return z
+end
 
-    function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepFieldElem)
-      ctx = base_ring(a)
-      if iszero(b)
-        z = fqPolyRepAbsPowerSeriesRingElem(ctx)
-        z.prec = a.prec_max
-      else
-        z = fqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
-      end
-      z.parent = a
-      return z
-    end
+function (a::fqPolyRepAbsPowerSeriesRing)(b::Integer)
+  return a(base_ring(a)(b))
+end
 
-    function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepAbsPowerSeriesRingElem)
-      parent(b) != a && error("Unable to coerce power series")
-      return b
-    end
+function (a::fqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
+  return a(base_ring(a)(b))
+end
 
-    function (a::fqPolyRepAbsPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int)
-      ctx = base_ring(a)
-      z = fqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
-      z.parent = a
-      return z
-    end
+function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepFieldElem)
+  ctx = base_ring(a)
+  if iszero(b)
+    z = fqPolyRepAbsPowerSeriesRingElem(ctx)
+    z.prec = a.prec_max
+  else
+    z = fqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
+  end
+  z.parent = a
+  return z
+end
+
+function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepAbsPowerSeriesRingElem)
+  parent(b) != a && error("Unable to coerce power series")
+  return b
+end
+
+function (a::fqPolyRepAbsPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int)
+  ctx = base_ring(a)
+  z = fqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
+  z.parent = a
+  return z
+end
 
 
 ###############################################################################

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -4,36 +4,32 @@
 #
 ###############################################################################
 
-for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
-                                                           (fqPolyRepAbsPowerSeriesRingElem, fqPolyRepAbsPowerSeriesRing, fqPolyRepField, fqPolyRepFieldElem, "fq_nmod_poly", "fq_nmod"))
-  @eval begin
-
     ###############################################################################
     #
     #   Data type and parent object methods
     #
     ###############################################################################
 
-    function O(a::($etype))
+    function O(a::fqPolyRepAbsPowerSeriesRingElem)
       if iszero(a)
         return deepcopy(a)    # 0 + O(x^n)
       end
       prec = length(a) - 1
       prec < 0 && throw(DomainError(prec, "Valuation must be non-negative"))
-      z = ($etype)(base_ring(a), Vector{$(btype)}(undef, 0), 0, prec)
+      z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, prec)
       z.parent = parent(a)
       return z
     end
 
-    elem_type(::Type{($rtype)}) = ($etype)
+    elem_type(::Type{fqPolyRepAbsPowerSeriesRing}) = fqPolyRepAbsPowerSeriesRingElem
 
-    parent_type(::Type{($etype)}) = ($rtype)
+    parent_type(::Type{fqPolyRepAbsPowerSeriesRingElem}) = fqPolyRepAbsPowerSeriesRing
 
-    base_ring(R::($rtype)) = R.base_ring
+    base_ring(R::fqPolyRepAbsPowerSeriesRing) = R.base_ring
 
-    abs_series_type(::Type{($btype)}) = ($etype)
+    abs_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
 
-    var(a::($rtype)) = a.S
+    var(a::fqPolyRepAbsPowerSeriesRing) = a.S
 
     ###############################################################################
     #
@@ -41,21 +37,21 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    max_precision(R::($rtype)) = R.prec_max
+    max_precision(R::fqPolyRepAbsPowerSeriesRing) = R.prec_max
 
-    function normalise(a::($etype), len::Int)
+    function normalise(a::fqPolyRepAbsPowerSeriesRingElem, len::Int)
       ctx = base_ring(a)
       if len > 0
         c = base_ring(a)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, a, len - 1, ctx)
       end
       while len > 0 && iszero(c)
         len -= 1
         if len > 0
-          ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-                (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+          ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+                (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
                 c, a, len - 1, ctx)
         end
       end
@@ -63,58 +59,58 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return len
     end
 
-    function length(x::($etype))
-      return ccall(($(flint_fn*"_length"), libflint), Int,
-                   (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+    function length(x::fqPolyRepAbsPowerSeriesRingElem)
+      return ccall((:fq_nmod_poly_length, libflint), Int,
+                   (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
     end
 
-    precision(x::($etype)) = x.prec
+    precision(x::fqPolyRepAbsPowerSeriesRingElem) = x.prec
 
-    function coeff(x::($etype), n::Int)
+    function coeff(x::fqPolyRepAbsPowerSeriesRingElem, n::Int)
       if n < 0
         return base_ring(x)()
       end
       z = base_ring(x)()
-      ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-            (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+            (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, x, n, base_ring(x))
       return z
     end
 
-    zero(R::($rtype)) = R(0)
+    zero(R::fqPolyRepAbsPowerSeriesRing) = R(0)
 
-    one(R::($rtype)) = R(1)
+    one(R::fqPolyRepAbsPowerSeriesRing) = R(1)
 
-    function gen(R::($rtype))
+    function gen(R::fqPolyRepAbsPowerSeriesRing)
       S = base_ring(R)
-      z = ($etype)(S, [S(0), S(1)], 2, max_precision(R))
+      z = fqPolyRepAbsPowerSeriesRingElem(S, [S(0), S(1)], 2, max_precision(R))
       z.parent = R
       return z
     end
 
-    function deepcopy_internal(a::($etype), dict::IdDict)
-      z = ($etype)(base_ring(a), a)
+    function deepcopy_internal(a::fqPolyRepAbsPowerSeriesRingElem, dict::IdDict)
+      z = fqPolyRepAbsPowerSeriesRingElem(base_ring(a), a)
       z.prec = a.prec
       z.parent = parent(a)
       return z
     end
 
-    function is_gen(a::($etype))
-      return precision(a) == 0 || ccall(($(flint_fn*"_is_gen"), libflint), Bool,
-                                        (Ref{($etype)}, Ref{($ctype)}), a, base_ring(a))
+    function is_gen(a::fqPolyRepAbsPowerSeriesRingElem)
+      return precision(a) == 0 || ccall((:fq_nmod_poly_is_gen, libflint), Bool,
+                                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
     end
 
-    iszero(a::($etype)) = length(a) == 0
+    iszero(a::fqPolyRepAbsPowerSeriesRingElem) = length(a) == 0
 
-    is_unit(a::($etype)) = valuation(a) == 0 && is_unit(coeff(a, 0))
+    is_unit(a::fqPolyRepAbsPowerSeriesRingElem) = valuation(a) == 0 && is_unit(coeff(a, 0))
 
-    function isone(a::($etype))
-      return precision(a) == 0 || ccall(($(flint_fn*"_is_one"), libflint), Bool,
-                                        (Ref{($etype)}, Ref{($ctype)}), a, base_ring(a))
+    function isone(a::fqPolyRepAbsPowerSeriesRingElem)
+      return precision(a) == 0 || ccall((:fq_nmod_poly_is_one, libflint), Bool,
+                                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), a, base_ring(a))
     end
 
     # todo: write an fq_poly_valuation
-    function valuation(a::($etype))
+    function valuation(a::fqPolyRepAbsPowerSeriesRingElem)
       for i = 1:length(a)
         if !iszero(coeff(a, i - 1))
           return i - 1
@@ -123,7 +119,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return precision(a)
     end
 
-    characteristic(R::($rtype)) = characteristic(base_ring(R))
+    characteristic(R::fqPolyRepAbsPowerSeriesRing) = characteristic(base_ring(R))
 
     ###############################################################################
     #
@@ -131,12 +127,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function similar(f::AbsPowerSeriesRingElem, R::($ctype), max_prec::Int,
+    function similar(f::AbsPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
         s::Symbol=var(parent(f)); cached::Bool=true)
-      par = ($rtype)(R, max_prec, s, cached)
-      z = ($etype)(R)
+      par = fqPolyRepAbsPowerSeriesRing(R, max_prec, s, cached)
+      z = fqPolyRepAbsPowerSeriesRingElem(R)
       if base_ring(f) === R && s == var(parent(f)) &&
-        f isa ($etype) && max_precision(parent(f)) == max_prec
+        f isa fqPolyRepAbsPowerSeriesRingElem && max_precision(parent(f)) == max_prec
         # steal parent in case it is not cached
         z.parent = parent(f)
       else
@@ -152,14 +148,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function abs_series(R::($ctype), arr::Vector{T},
+    function abs_series(R::fqPolyRepField, arr::Vector{T},
         len::Int, prec::Int, var::VarName=:x;
         max_precision::Int=prec, cached::Bool=true) where T
       prec < len && error("Precision too small for given data")
-      coeffs = T == ($btype) ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? ($btype)[] : coeffs
-      par = ($rtype)(R, max_precision, Symbol(var), cached)
-      z = ($etype)(R, coeffs, len, prec)
+      coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
+      coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
+      par = fqPolyRepAbsPowerSeriesRing(R, max_precision, Symbol(var), cached)
+      z = fqPolyRepAbsPowerSeriesRingElem(R, coeffs, len, prec)
       z.parent = par
       return z
     end
@@ -170,10 +166,10 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function -(x::($etype))
+    function -(x::fqPolyRepAbsPowerSeriesRingElem)
       z = parent(x)()
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_neg, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
             z, x, base_ring(x))
       z.prec = x.prec
       return z
@@ -185,7 +181,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function +(a::($etype), b::($etype))
+    function +(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -195,14 +191,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
 
-    function -(a::($etype), b::($etype))
+    function -(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -212,14 +208,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenz = max(lena, lenb)
       z = parent(a)()
       z.prec = prec
-      ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
 
-    function *(a::($etype), b::($etype))
+    function *(a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
       check_parent(a, b)
       lena = length(a)
       lenb = length(b)
@@ -235,9 +231,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         return z
       end
       lenz = min(lena + lenb - 1, prec)
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
@@ -248,16 +244,16 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function *(x::($btype), y::($etype))
+    function *(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem)
       z = parent(y)()
       z.prec = y.prec
-      ccall(($(flint_fn*"_scalar_mul_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, y, x, base_ring(y))
       return z
     end
 
-    *(x::($etype), y::($btype)) = y * x
+    *(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
 
     ###############################################################################
     #
@@ -265,23 +261,23 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function shift_left(x::($etype), len::Int)
+    function shift_left(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = length(x)
       z = parent(x)()
       z.prec = x.prec + len
       z.prec = min(z.prec, max_precision(parent(x)))
       zlen = min(z.prec, xlen + len)
-      ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, x, len, base_ring(x))
-      ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, z, zlen, base_ring(x))
       return z
     end
 
-    function shift_right(x::($etype), len::Int)
+    function shift_right(x::fqPolyRepAbsPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = length(x)
       z = parent(x)()
@@ -289,8 +285,8 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         z.prec = max(0, x.prec - len)
       else
         z.prec = x.prec - len
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+              (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, x, len, base_ring(x))
       end
       return z
@@ -302,17 +298,17 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), k::Int)
+    function truncate(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
       return truncate!(deepcopy(x), k)
     end
 
-    function truncate!(x::($etype), k::Int)
+    function truncate!(x::fqPolyRepAbsPowerSeriesRingElem, k::Int)
       k < 0 && throw(DomainError(k, "Index must be non-negative"))
       if precision(x) <= k
         return x
       end
-      ccall(($(flint_fn*"_truncate"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             x, k, base_ring(x))
       x.prec = k
       return x
@@ -324,7 +320,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ^(a::($etype), b::Int)
+    function ^(a::fqPolyRepAbsPowerSeriesRingElem, b::Int)
       b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
       if precision(a) > 0 && is_gen(a) && b > 0
         return shift_left(a, b - 1)
@@ -357,25 +353,25 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ==(x::($etype), y::($etype))
+    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
       check_parent(x, y)
       prec = min(x.prec, y.prec)
       n = max(length(x), length(y))
       n = min(n, prec)
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
+                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
                         x, y, n, base_ring(x)))
     end
 
-    function isequal(x::($etype), y::($etype))
+    function isequal(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem)
       if parent(x) != parent(y)
         return false
       end
       if x.prec != y.prec || length(x) != length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+      return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
+                        (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}),
                         x, y, base_ring(x)))
     end
 
@@ -385,13 +381,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ==(x::($etype), y::($btype))
+    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem)
       if length(x) > 1
         return false
       elseif length(x) == 1
         z = base_ring(x)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, x, 0, base_ring(x))
         return z == y
       else
@@ -399,15 +395,15 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
     end
 
-    ==(x::($btype), y::($etype)) = y == x
+    ==(x::fqPolyRepFieldElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
 
-    function ==(x::($etype), y::ZZRingElem)
+    function ==(x::fqPolyRepAbsPowerSeriesRingElem, y::ZZRingElem)
       if length(x) > 1
         return false
       elseif length(x) == 1
         z = base_ring(x)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, x, 0, base_ring(x))
         return z == y
       else
@@ -415,11 +411,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
     end
 
-    ==(x::ZZRingElem, y::($etype)) = y == x
+    ==(x::ZZRingElem, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
 
-    ==(x::($etype), y::Integer) = x == ZZRingElem(y)
+    ==(x::fqPolyRepAbsPowerSeriesRingElem, y::Integer) = x == ZZRingElem(y)
 
-    ==(x::Integer, y::($etype)) = y == x
+    ==(x::Integer, y::fqPolyRepAbsPowerSeriesRingElem) = y == x
 
     ###############################################################################
     #
@@ -427,7 +423,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::($etype); check::Bool=true)
+    function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       check_parent(x, y)
       iszero(y) && throw(DivideError())
       v2 = valuation(y)
@@ -442,9 +438,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       prec = min(x.prec, y.prec - v2 + v1)
       z = parent(x)()
       z.prec = prec
-      ccall(($(flint_fn*"_div_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_div_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, x, y, prec, base_ring(x))
       return z
     end
@@ -455,12 +451,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::($btype); check::Bool=true)
+    function divexact(x::fqPolyRepAbsPowerSeriesRingElem, y::fqPolyRepFieldElem; check::Bool=true)
       iszero(y) && throw(DivideError())
       z = parent(x)()
       z.prec = x.prec
-      ccall(($(flint_fn*"_scalar_div_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, x, y, base_ring(x))
       return z
     end
@@ -471,13 +467,13 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function inv(a::($etype))
+    function inv(a::fqPolyRepAbsPowerSeriesRingElem)
       iszero(a) && throw(DivideError())
       !is_unit(a) && error("Unable to invert power series")
       ainv = parent(a)()
       ainv.prec = a.prec
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             ainv, a, a.prec, base_ring(a))
       return ainv
     end
@@ -488,7 +484,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function sqrt_classical_char2(a::($etype); check::Bool=true)
+    function sqrt_classical_char2(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       S = parent(a)
       asqrt = S()
       prec = div(precision(a) + 1, 2)
@@ -513,7 +509,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, asqrt
     end
 
-    function sqrt_classical(a::($etype); check::Bool=true)
+    function sqrt_classical(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       R = base_ring(a)
       S = parent(a)
       if characteristic(R) == 2
@@ -540,8 +536,8 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       end
       a = divexact(a, c)
       z.prec = a.prec - div(v, 2)
-      ccall(($(flint_fn*"_sqrt_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, a.prec, base_ring(a))
       if !isone(s)
         z *= s
@@ -552,18 +548,18 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, z
     end
 
-    function Base.sqrt(a::($etype); check::Bool=true)
+    function Base.sqrt(a::fqPolyRepAbsPowerSeriesRingElem; check::Bool=true)
       flag, s = sqrt_classical(a; check=check)
       check && !flag && error("Not a square")
       return s
     end
 
-    function is_square(a::($etype))
+    function is_square(a::fqPolyRepAbsPowerSeriesRingElem)
       flag, s = sqrt_classical(a; check=true)
       return flag
     end
 
-    function is_square_with_sqrt(a::($etype))
+    function is_square_with_sqrt(a::fqPolyRepAbsPowerSeriesRingElem)
       return sqrt_classical(a; check=true)
     end
 
@@ -573,35 +569,35 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function zero!(z::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), z, base_ring(z))
+    function zero!(z::fqPolyRepAbsPowerSeriesRingElem)
+      ccall((:fq_nmod_poly_zero, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
       z.prec = parent(z).prec_max
       return z
     end
 
-    function one!(z::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), z, base_ring(z))
+    function one!(z::fqPolyRepAbsPowerSeriesRingElem)
+      ccall((:fq_nmod_poly_one, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepField}), z, base_ring(z))
       z.prec = parent(z).prec_max
       return z
     end
 
-    function fit!(z::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function fit!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int)
+      ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, n, base_ring(z))
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::($btype))
-      ccall(($(flint_fn*"_set_coeff"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($btype)}, Ref{($ctype)}),
+    function setcoeff!(z::fqPolyRepAbsPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
+      ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, n, x, base_ring(z))
       return z
     end
 
-    function mul!(z::($etype), a::($etype), b::($etype))
+    function mul!(z::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
       lena = length(a)
       lenb = length(b)
       aval = valuation(a)
@@ -615,14 +611,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         lenz = 0
       end
       z.prec = prec
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(z))
       return z
     end
 
-    function add!(c::($etype), a::($etype), b::($etype))
+    function add!(c::fqPolyRepAbsPowerSeriesRingElem, a::fqPolyRepAbsPowerSeriesRingElem, b::fqPolyRepAbsPowerSeriesRingElem)
       lena = length(a)
       lenb = length(b)
       prec = min(a.prec, b.prec)
@@ -630,16 +626,16 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenb = min(lenb, prec)
       lenc = max(lena, lenb)
       c.prec = prec
-      ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Ref{fqPolyRepAbsPowerSeriesRingElem},
+             Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             c, a, b, lenc, base_ring(a))
       return c
     end
 
-    function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function set_length!(a::fqPolyRepAbsPowerSeriesRingElem, n::Int)
+      ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
+            (Ref{fqPolyRepAbsPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             a, n, base_ring(a))
       return a
     end
@@ -650,11 +646,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    promote_rule(::Type{($etype)}, ::Type{T}) where {T <: Integer} = ($etype)
+    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepAbsPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{$(btype)}) = ($etype)
+    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepAbsPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{ZZRingElem}) = ($etype)
+    promote_rule(::Type{fqPolyRepAbsPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepAbsPowerSeriesRingElem
 
     ###############################################################################
     #
@@ -662,48 +658,46 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function (a::($rtype))()
+    function (a::fqPolyRepAbsPowerSeriesRing)()
       ctx = base_ring(a)
-      z = ($etype)(ctx)
+      z = fqPolyRepAbsPowerSeriesRingElem(ctx)
       z.prec = a.prec_max
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::Integer)
+    function (a::fqPolyRepAbsPowerSeriesRing)(b::Integer)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::ZZRingElem)
+    function (a::fqPolyRepAbsPowerSeriesRing)(b::ZZRingElem)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::($btype))
+    function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepFieldElem)
       ctx = base_ring(a)
       if iszero(b)
-        z = ($etype)(ctx)
+        z = fqPolyRepAbsPowerSeriesRingElem(ctx)
         z.prec = a.prec_max
       else
-        z = ($etype)(ctx, [b], 1, a.prec_max)
+        z = fqPolyRepAbsPowerSeriesRingElem(ctx, [b], 1, a.prec_max)
       end
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::($etype))
+    function (a::fqPolyRepAbsPowerSeriesRing)(b::fqPolyRepAbsPowerSeriesRingElem)
       parent(b) != a && error("Unable to coerce power series")
       return b
     end
 
-    function (a::($rtype))(b::Vector{$(btype)}, len::Int, prec::Int)
+    function (a::fqPolyRepAbsPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int)
       ctx = base_ring(a)
-      z = ($etype)(ctx, b, len, prec)
+      z = fqPolyRepAbsPowerSeriesRingElem(ctx, b, len, prec)
       z.parent = a
       return z
     end
 
-  end # eval
-end # for
 
 ###############################################################################
 #

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -1,11 +1,11 @@
 ###############################################################################
 #
-#   fq_rel_series.jl: Relative series over finite fields
+#   fq_nmod_rel_series.jl: Relative series over finite fields
 #
 ###############################################################################
 
 for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
-                                                           (FqPolyRepRelPowerSeriesRingElem, FqPolyRepRelPowerSeriesRing, FqPolyRepField, FqPolyRepFieldElem, "fq_poly", "fq"))
+                                                           (fqPolyRepRelPowerSeriesRingElem, fqPolyRepRelPowerSeriesRing, fqPolyRepField, fqPolyRepFieldElem, "fq_nmod_poly", "fq_nmod"))
   @eval begin
 
     ###############################################################################

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -4,848 +4,848 @@
 #
 ###############################################################################
 
-    ###############################################################################
-    #
-    #   Data type and parent object methods
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
 
-    function O(a::fqPolyRepRelPowerSeriesRingElem)
-      val = pol_length(a) + valuation(a) - 1
-      val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
-      z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, val, val)
-      z.parent = parent(a)
-      return z
-    end
+function O(a::fqPolyRepRelPowerSeriesRingElem)
+  val = pol_length(a) + valuation(a) - 1
+  val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
+  z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, val, val)
+  z.parent = parent(a)
+  return z
+end
 
-    elem_type(::Type{fqPolyRepRelPowerSeriesRing}) = fqPolyRepRelPowerSeriesRingElem
+elem_type(::Type{fqPolyRepRelPowerSeriesRing}) = fqPolyRepRelPowerSeriesRingElem
 
-    parent_type(::Type{fqPolyRepRelPowerSeriesRingElem}) = fqPolyRepRelPowerSeriesRing
+parent_type(::Type{fqPolyRepRelPowerSeriesRingElem}) = fqPolyRepRelPowerSeriesRing
 
-    base_ring(R::fqPolyRepRelPowerSeriesRing) = R.base_ring
+base_ring(R::fqPolyRepRelPowerSeriesRing) = R.base_ring
 
-    rel_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
+rel_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
 
-    var(a::fqPolyRepRelPowerSeriesRing) = a.S
+var(a::fqPolyRepRelPowerSeriesRing) = a.S
 
-    ###############################################################################
-    #
-    #   Basic manipulation
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
 
-    max_precision(R::fqPolyRepRelPowerSeriesRing) = R.prec_max
+max_precision(R::fqPolyRepRelPowerSeriesRing) = R.prec_max
 
-    function normalise(a::fqPolyRepRelPowerSeriesRingElem, len::Int)
-      ctx = base_ring(a)
-      if len > 0
-        c = base_ring(a)()
-        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, a, len - 1, ctx)
-      end
-      while len > 0 && iszero(c)
-        len -= 1
-        if len > 0
-          ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
-                (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-                c, a, len - 1, ctx)
-        end
-      end
-      return len
-    end
-
-    function pol_length(x::fqPolyRepRelPowerSeriesRingElem)
-      return ccall((:fq_nmod_poly_length, libflint), Int,
-                   (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
-    end
-
-    precision(x::fqPolyRepRelPowerSeriesRingElem) = x.prec
-
-    function polcoeff(x::fqPolyRepRelPowerSeriesRingElem, n::Int)
-      z = base_ring(x)()
-      if n < 0
-        return z
-      end
+function normalise(a::fqPolyRepRelPowerSeriesRingElem, len::Int)
+  ctx = base_ring(a)
+  if len > 0
+    c = base_ring(a)()
+    ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+          (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, a, len - 1, ctx)
+  end
+  while len > 0 && iszero(c)
+    len -= 1
+    if len > 0
       ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
             (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, x, n, base_ring(x))
-      return z
+            c, a, len - 1, ctx)
     end
+  end
+  return len
+end
 
-    zero(R::fqPolyRepRelPowerSeriesRing) = R(0)
+function pol_length(x::fqPolyRepRelPowerSeriesRingElem)
+  return ccall((:fq_nmod_poly_length, libflint), Int,
+                (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
+end
 
-    one(R::fqPolyRepRelPowerSeriesRing) = R(1)
+precision(x::fqPolyRepRelPowerSeriesRingElem) = x.prec
 
-    function gen(R::fqPolyRepRelPowerSeriesRing)
-      z = fqPolyRepRelPowerSeriesRingElem(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
-      z.parent = R
-      return z
+function polcoeff(x::fqPolyRepRelPowerSeriesRingElem, n::Int)
+  z = base_ring(x)()
+  if n < 0
+    return z
+  end
+  ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+        (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, x, n, base_ring(x))
+  return z
+end
+
+zero(R::fqPolyRepRelPowerSeriesRing) = R(0)
+
+one(R::fqPolyRepRelPowerSeriesRing) = R(1)
+
+function gen(R::fqPolyRepRelPowerSeriesRing)
+  z = fqPolyRepRelPowerSeriesRingElem(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
+  z.parent = R
+  return z
+end
+
+function deepcopy_internal(a::fqPolyRepRelPowerSeriesRingElem, dict::IdDict)
+  z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), a)
+  z.prec = a.prec
+  z.val = a.val
+  z.parent = parent(a)
+  return z
+end
+
+function renormalize!(z::fqPolyRepRelPowerSeriesRingElem)
+  i = 0
+  zlen = pol_length(z)
+  zval = valuation(z)
+  zprec = precision(z)
+  while i < zlen && iszero(polcoeff(z, i))
+    i += 1
+  end
+  z.prec = zprec
+  if i == zlen
+    z.val = zprec
+  else
+    z.val = zval + i
+    ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, i, base_ring(z))
+  end
+  return nothing
+end
+
+characteristic(R::fqPolyRepRelPowerSeriesRing) = characteristic(base_ring(R))
+
+###############################################################################
+#
+#   Similar
+#
+###############################################################################
+
+function similar(f::RelPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
+    s::Symbol=var(parent(f)); cached::Bool=true)
+  par = fqPolyRepRelPowerSeriesRing(R, max_prec, s, cached)
+  z = fqPolyRepRelPowerSeriesRingElem(R)
+  if base_ring(f) === R && s == var(parent(f)) &&
+    f isa fqPolyRepRelPowerSeriesRingElem && max_precision(parent(f)) == max_prec
+    # steal parent in case it is not cached
+    z.parent = parent(f)
+  else
+    z.parent = par
+  end
+  z.prec = max_prec
+  z.val = max_prec
+  return z
+end
+
+###############################################################################
+#
+#   rel_series constructor
+#
+###############################################################################
+
+function rel_series(R::fqPolyRepField, arr::Vector{T},
+    len::Int, prec::Int, val::Int, var::VarName=:x;
+    max_precision::Int=prec, cached::Bool=true) where T
+  prec < len + val && error("Precision too small for given data")
+  coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
+  coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
+  par = fqPolyRepRelPowerSeriesRing(R, max_precision, Symbol(var), cached)
+  z = fqPolyRepRelPowerSeriesRingElem(R, coeffs, len, prec, val)
+  z.parent = par
+  return z
+end
+
+###############################################################################
+#
+#   Unary operators
+#
+###############################################################################
+
+-(x::fqPolyRepRelPowerSeriesRingElem) = neg!(parent(x)(), x)
+
+###############################################################################
+#
+#   Binary operators
+#
+###############################################################################
+
+function +(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  z = parent(a)()
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, a, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, a.val - b.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, a, b, lenz, ctx)
+  end
+  z.prec = prec
+  z.val = val
+  renormalize!(z)
+  return z
+end
+
+function -(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_nmod_poly_neg, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
+          z, z, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, a, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, a.val - b.val, ctx)
+    ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, a, b, lenz, ctx)
+  end
+  z.prec = prec
+  z.val = val
+  renormalize!(z)
+  return z
+end
+
+function *(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec - aval, b.prec - bval)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z = parent(a)()
+  z.val = a.val + b.val
+  z.prec = prec + z.val
+  if lena == 0 || lenb == 0
+    return z
+  end
+  lenz = min(lena + lenb - 1, prec)
+  ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+          Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::fqPolyRepFieldElem, y::fqPolyRepRelPowerSeriesRingElem)
+  z = parent(y)()
+  z.prec = y.prec
+  z.val = y.val
+  ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+          Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, y, x, base_ring(y))
+  return z
+end
+
+*(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
+
+###############################################################################
+#
+#   Shifting
+#
+###############################################################################
+
+function shift_left(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = pol_length(x)
+  z = fqPolyRepRelPowerSeriesRingElem(base_ring(x), x)
+  z.prec = x.prec + len
+  z.val = x.val + len
+  z.parent = parent(x)
+  return z
+end
+
+function shift_right(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = pol_length(x)
+  xval = valuation(x)
+  z = parent(x)()
+  if len >= xlen + xval
+    z.prec = max(0, x.prec - len)
+    z.val = max(0, x.prec - len)
+  else
+    z.prec = max(0, x.prec - len)
+    z.val = max(0, xval - len)
+    zlen = min(xlen + xval - len, xlen)
+    ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Int, Ref{fqPolyRepField}),
+          z, x, xlen - zlen, base_ring(x))
+    renormalize!(z)
+  end
+  return z
+end
+
+###############################################################################
+#
+#   Truncation
+#
+###############################################################################
+
+function truncate(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
+    return x
+  end
+  if k <= valuation(x)
+    x = zero!(x)
+    x.val = k
+  else
+    ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          x, k - valuation(x), base_ring(x))
+  end
+  x.prec = k
+  return x
+end
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(a::fqPolyRepRelPowerSeriesRingElem, b::Int)
+  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
+  if is_gen(a)
+    z = parent(a)()
+    z = setcoeff!(z, 0, base_ring(a)(1))
+    z.prec = a.prec + b - 1
+    z.val = b
+  elseif pol_length(a) == 0
+    z = parent(a)()
+    z.prec = b*valuation(a)
+    z.val = b*valuation(a)
+  elseif pol_length(a) == 1
+    return parent(a)([polcoeff(a, 0)^b], 1,
+                      (b - 1)*valuation(a) + precision(a), b*valuation(a))
+  elseif b == 0
+    return one(parent(a))
+  else
+    bit = ~((~UInt(0)) >> 1)
+    while (UInt(bit) & b) == 0
+      bit >>= 1
     end
-
-    function deepcopy_internal(a::fqPolyRepRelPowerSeriesRingElem, dict::IdDict)
-      z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), a)
-      z.prec = a.prec
-      z.val = a.val
-      z.parent = parent(a)
-      return z
-    end
-
-    function renormalize!(z::fqPolyRepRelPowerSeriesRingElem)
-      i = 0
-      zlen = pol_length(z)
-      zval = valuation(z)
-      zprec = precision(z)
-      while i < zlen && iszero(polcoeff(z, i))
-        i += 1
+    z = a
+    bit >>= 1
+    while bit != 0
+      z = z*z
+      if (UInt(bit) & b) != 0
+        z *= a
       end
-      z.prec = zprec
-      if i == zlen
-        z.val = zprec
-      else
-        z.val = zval + i
-        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, i, base_ring(z))
-      end
-      return nothing
+      bit >>= 1
     end
+  end
+  return z
+end
 
-    characteristic(R::fqPolyRepRelPowerSeriesRing) = characteristic(base_ring(R))
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
 
-    ###############################################################################
-    #
-    #   Similar
-    #
-    ###############################################################################
+function ==(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
+  check_parent(x, y)
+  prec = min(x.prec, y.prec)
+  if prec <= x.val && prec <= y.val
+    return true
+  end
+  if x.val != y.val
+    return false
+  end
+  xlen = normalise(x, min(pol_length(x), prec - x.val))
+  ylen = normalise(y, min(pol_length(y), prec - y.val))
+  if xlen != ylen
+    return false
+  end
+  return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
+                    (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+                      Int, Ref{fqPolyRepField}),
+                    x, y, xlen, base_ring(x)))
+end
 
-    function similar(f::RelPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
-        s::Symbol=var(parent(f)); cached::Bool=true)
-      par = fqPolyRepRelPowerSeriesRing(R, max_prec, s, cached)
-      z = fqPolyRepRelPowerSeriesRingElem(R)
-      if base_ring(f) === R && s == var(parent(f)) &&
-        f isa fqPolyRepRelPowerSeriesRingElem && max_precision(parent(f)) == max_prec
-        # steal parent in case it is not cached
-        z.parent = parent(f)
-      else
-        z.parent = par
-      end
-      z.prec = max_prec
-      z.val = max_prec
-      return z
+function isequal(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
+  if parent(x) != parent(y)
+    return false
+  end
+  if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
+    return false
+  end
+  return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
+                    (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
+                    x, y, base_ring(x)))
+end
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  check_parent(x, y)
+  iszero(y) && throw(DivideError())
+  yval = valuation(y)
+  xval = valuation(x)
+  if yval != 0
+    if xval >= yval
+      x = shift_right(x, yval)
+      y = shift_right(y, yval)
     end
+  end
+  check && !is_unit(y) && error("Unable to invert power series")
+  prec = min(x.prec - x.val, y.prec - y.val)
+  z = parent(x)()
+  z.val = xval - yval
+  z.prec = prec + z.val
+  if prec != 0
+    ccall((:fq_nmod_poly_div_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, x, y, prec, base_ring(x))
+  end
+  return z
+end
 
-    ###############################################################################
-    #
-    #   rel_series constructor
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Ad hoc exact division
+#
+###############################################################################
 
-    function rel_series(R::fqPolyRepField, arr::Vector{T},
-        len::Int, prec::Int, val::Int, var::VarName=:x;
-        max_precision::Int=prec, cached::Bool=true) where T
-      prec < len + val && error("Precision too small for given data")
-      coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
-      par = fqPolyRepRelPowerSeriesRing(R, max_precision, Symbol(var), cached)
-      z = fqPolyRepRelPowerSeriesRingElem(R, coeffs, len, prec, val)
-      z.parent = par
-      return z
-    end
+function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
+  iszero(y) && throw(DivideError())
+  z = parent(x)()
+  z.prec = x.prec
+  z.prec = x.prec
+  z.val = x.val
+  ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+          Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, x, y, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Unary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
 
-    -(x::fqPolyRepRelPowerSeriesRingElem) = neg!(parent(x)(), x)
+function inv(a::fqPolyRepRelPowerSeriesRingElem)
+  iszero(a) && throw(DivideError())
+  !is_unit(a) && error("Unable to invert power series")
+  ainv = parent(a)()
+  ainv.prec = a.prec
+  ainv.val = 0
+  ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        ainv, a, a.prec, base_ring(a))
+  return ainv
+end
 
-    ###############################################################################
-    #
-    #   Binary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Square root
+#
+###############################################################################
 
-    function +(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      z = parent(a)()
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, a, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, a.val - b.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, a, b, lenz, ctx)
-      end
-      z.prec = prec
-      z.val = val
-      renormalize!(z)
-      return z
-    end
-
-    function -(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_nmod_poly_neg, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
-              z, z, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, a, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, a.val - b.val, ctx)
-        ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, a, b, lenz, ctx)
-      end
-      z.prec = prec
-      z.val = val
-      renormalize!(z)
-      return z
-    end
-
-    function *(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec - aval, b.prec - bval)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z = parent(a)()
-      z.val = a.val + b.val
-      z.prec = prec + z.val
-      if lena == 0 || lenb == 0
-        return z
-      end
-      lenz = min(lena + lenb - 1, prec)
-      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-             Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc binary operators
-    #
-    ###############################################################################
-
-    function *(x::fqPolyRepFieldElem, y::fqPolyRepRelPowerSeriesRingElem)
-      z = parent(y)()
-      z.prec = y.prec
-      z.val = y.val
-      ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-             Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, y, x, base_ring(y))
-      return z
-    end
-
-    *(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
-
-    ###############################################################################
-    #
-    #   Shifting
-    #
-    ###############################################################################
-
-    function shift_left(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = pol_length(x)
-      z = fqPolyRepRelPowerSeriesRingElem(base_ring(x), x)
-      z.prec = x.prec + len
-      z.val = x.val + len
-      z.parent = parent(x)
-      return z
-    end
-
-    function shift_right(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = pol_length(x)
-      xval = valuation(x)
-      z = parent(x)()
-      if len >= xlen + xval
-        z.prec = max(0, x.prec - len)
-        z.val = max(0, x.prec - len)
-      else
-        z.prec = max(0, x.prec - len)
-        z.val = max(0, xval - len)
-        zlen = min(xlen + xval - len, xlen)
-        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Int, Ref{fqPolyRepField}),
-              z, x, xlen - zlen, base_ring(x))
-        renormalize!(z)
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Truncation
-    #
-    ###############################################################################
-
-    function truncate(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
-      return truncate!(deepcopy(x), k)
-    end
-
-    function truncate!(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
-      k < 0 && throw(DomainError(k, "Index must be non-negative"))
-      if precision(x) <= k
-        return x
-      end
-      if k <= valuation(x)
-        x = zero!(x)
-        x.val = k
-      else
-        ccall((:fq_nmod_poly_truncate, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              x, k - valuation(x), base_ring(x))
-      end
-      x.prec = k
-      return x
-    end
-
-    ###############################################################################
-    #
-    #   Powering
-    #
-    ###############################################################################
-
-    function ^(a::fqPolyRepRelPowerSeriesRingElem, b::Int)
-      b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-      if is_gen(a)
-        z = parent(a)()
-        z = setcoeff!(z, 0, base_ring(a)(1))
-        z.prec = a.prec + b - 1
-        z.val = b
-      elseif pol_length(a) == 0
-        z = parent(a)()
-        z.prec = b*valuation(a)
-        z.val = b*valuation(a)
-      elseif pol_length(a) == 1
-        return parent(a)([polcoeff(a, 0)^b], 1,
-                         (b - 1)*valuation(a) + precision(a), b*valuation(a))
-      elseif b == 0
-        return one(parent(a))
-      else
-        bit = ~((~UInt(0)) >> 1)
-        while (UInt(bit) & b) == 0
-          bit >>= 1
-        end
-        z = a
-        bit >>= 1
-        while bit != 0
-          z = z*z
-          if (UInt(bit) & b) != 0
-            z *= a
-          end
-          bit >>= 1
-        end
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Comparison
-    #
-    ###############################################################################
-
-    function ==(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
-      check_parent(x, y)
-      prec = min(x.prec, y.prec)
-      if prec <= x.val && prec <= y.val
-        return true
-      end
-      if x.val != y.val
-        return false
-      end
-      xlen = normalise(x, min(pol_length(x), prec - x.val))
-      ylen = normalise(y, min(pol_length(y), prec - y.val))
-      if xlen != ylen
-        return false
-      end
-      return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
-                        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-                         Int, Ref{fqPolyRepField}),
-                        x, y, xlen, base_ring(x)))
-    end
-
-    function isequal(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
-      if parent(x) != parent(y)
-        return false
-      end
-      if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
-        return false
-      end
-      return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
-                        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
-                        x, y, base_ring(x)))
-    end
-
-    ###############################################################################
-    #
-    #   Exact division
-    #
-    ###############################################################################
-
-    function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      check_parent(x, y)
-      iszero(y) && throw(DivideError())
-      yval = valuation(y)
-      xval = valuation(x)
-      if yval != 0
-        if xval >= yval
-          x = shift_right(x, yval)
-          y = shift_right(y, yval)
-        end
-      end
-      check && !is_unit(y) && error("Unable to invert power series")
-      prec = min(x.prec - x.val, y.prec - y.val)
-      z = parent(x)()
-      z.val = xval - yval
-      z.prec = prec + z.val
-      if prec != 0
-        ccall((:fq_nmod_poly_div_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, x, y, prec, base_ring(x))
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc exact division
-    #
-    ###############################################################################
-
-    function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
-      iszero(y) && throw(DivideError())
-      z = parent(x)()
-      z.prec = x.prec
-      z.prec = x.prec
-      z.val = x.val
-      ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-             Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, x, y, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Inversion
-    #
-    ###############################################################################
-
-    function inv(a::fqPolyRepRelPowerSeriesRingElem)
-      iszero(a) && throw(DivideError())
-      !is_unit(a) && error("Unable to invert power series")
-      ainv = parent(a)()
-      ainv.prec = a.prec
-      ainv.val = 0
-      ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            ainv, a, a.prec, base_ring(a))
-      return ainv
-    end
-
-    ###############################################################################
-    #
-    #   Square root
-    #
-    ###############################################################################
-
-    function sqrt_classical_char2(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      R = base_ring(a)
-      prec = div(precision(a) + 1, 2)
-      if iszero(a)
-        asqrt = parent(a)()
-        asqrt = set_precision!(asqrt, prec)
-        asqrt = set_valuation!(asqrt, prec)
-        return true, asqrt
-      end
-      aval = valuation(a)
-      if check && !iseven(aval)
+function sqrt_classical_char2(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  R = base_ring(a)
+  prec = div(precision(a) + 1, 2)
+  if iszero(a)
+    asqrt = parent(a)()
+    asqrt = set_precision!(asqrt, prec)
+    asqrt = set_valuation!(asqrt, prec)
+    return true, asqrt
+  end
+  aval = valuation(a)
+  if check && !iseven(aval)
+    return false, S()
+  end
+  aval2 = div(aval, 2)
+  asqrt = parent(a)()
+  asqrt = set_precision!(asqrt, prec)
+  asqrt = set_valuation!(asqrt, aval2)
+  if check
+    for i = 1:2:precision(a) - aval - 1 # series must have even exponents
+      if !iszero(polcoeff(a, i))
         return false, S()
       end
-      aval2 = div(aval, 2)
-      asqrt = parent(a)()
-      asqrt = set_precision!(asqrt, prec)
-      asqrt = set_valuation!(asqrt, aval2)
-      if check
-        for i = 1:2:precision(a) - aval - 1 # series must have even exponents
-          if !iszero(polcoeff(a, i))
-            return false, S()
-          end
-        end
-      end
-      for i = 0:prec - aval2 - 1
-        c = polcoeff(a, 2*i)
-        if check && !is_square(c)
-          return false, S()
-        end
-        asqrt = setcoeff!(asqrt, i, sqrt(c; check=false))
-      end
-      return true, asqrt
     end
-
-    function sqrt_classical(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      R = base_ring(a)
-      v = valuation(a)
-      z = S()
-      v2 = div(v, 2)
-      if iszero(a)
-        z.prec = v2
-        z.val = v2
-        return true, z
-      end
-      if check && !iseven(v)
-        return false, S()
-      end
-      if characteristic(R) == 2
-        return sqrt_classical_char2(a; check=check)
-      end
-      z.prec = a.prec - v2
-      z.val = v2
-      c = coeff(a, v)
-      if check
-        flag, s = is_square_with_sqrt(c)
-        if !flag
-          return false, S()
-        end
-      else
-        s = sqrt(c; check=check)
-      end
-      a = divexact(a, c)
-      ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-             Int, Ref{fqPolyRepField}),
-            z, a, a.prec, base_ring(a))
-      if !isone(s)
-        z *= s
-      end
-      return true, z
+  end
+  for i = 0:prec - aval2 - 1
+    c = polcoeff(a, 2*i)
+    if check && !is_square(c)
+      return false, S()
     end
+    asqrt = setcoeff!(asqrt, i, sqrt(c; check=false))
+  end
+  return true, asqrt
+end
 
-    function Base.sqrt(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      flag, q = sqrt_classical(a; check=check)
-      if check && !flag
-        error("Not a square in sqrt")
-      end
-      return q
+function sqrt_classical(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  R = base_ring(a)
+  v = valuation(a)
+  z = S()
+  v2 = div(v, 2)
+  if iszero(a)
+    z.prec = v2
+    z.val = v2
+    return true, z
+  end
+  if check && !iseven(v)
+    return false, S()
+  end
+  if characteristic(R) == 2
+    return sqrt_classical_char2(a; check=check)
+  end
+  z.prec = a.prec - v2
+  z.val = v2
+  c = coeff(a, v)
+  if check
+    flag, s = is_square_with_sqrt(c)
+    if !flag
+      return false, S()
     end
+  else
+    s = sqrt(c; check=check)
+  end
+  a = divexact(a, c)
+  ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+          Int, Ref{fqPolyRepField}),
+        z, a, a.prec, base_ring(a))
+  if !isone(s)
+    z *= s
+  end
+  return true, z
+end
 
-    function is_square(a::fqPolyRepRelPowerSeriesRingElem)
-      flag, q = sqrt_classical(a; check=true)
-      return flag
-    end
+function Base.sqrt(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  flag, q = sqrt_classical(a; check=check)
+  if check && !flag
+    error("Not a square in sqrt")
+  end
+  return q
+end
 
-    function is_square_with_sqrt(a::fqPolyRepRelPowerSeriesRingElem)
-      return sqrt_classical(a; check=true)
-    end
+function is_square(a::fqPolyRepRelPowerSeriesRingElem)
+  flag, q = sqrt_classical(a; check=true)
+  return flag
+end
 
-    ###############################################################################
-    #
-    #   Unsafe functions
-    #
-    ###############################################################################
+function is_square_with_sqrt(a::fqPolyRepRelPowerSeriesRingElem)
+  return sqrt_classical(a; check=true)
+end
 
-    function zero!(x::fqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_nmod_poly_zero, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
-      x.prec = parent(x).prec_max
-      x.val = parent(x).prec_max
-      return x
-    end
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
 
-    function one!(x::fqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_nmod_poly_one, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
-      x.prec = parent(x).prec_max
-      x.val = 0
-      return x
-    end
+function zero!(x::fqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_nmod_poly_zero, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
+  x.prec = parent(x).prec_max
+  x.val = parent(x).prec_max
+  return x
+end
 
-    function neg!(z::fqPolyRepRelPowerSeriesRingElem, x::fqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_nmod_poly_neg, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), z, x, base_ring(x))
-      z.prec = x.prec
-      z.val = x.val
-      return z
-    end
+function one!(x::fqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_nmod_poly_one, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
+  x.prec = parent(x).prec_max
+  x.val = 0
+  return x
+end
 
-    function fit!(z::fqPolyRepRelPowerSeriesRingElem, n::Int)
-      ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, n, base_ring(z))
-      return nothing
-    end
+function neg!(z::fqPolyRepRelPowerSeriesRingElem, x::fqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_nmod_poly_neg, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), z, x, base_ring(x))
+  z.prec = x.prec
+  z.val = x.val
+  return z
+end
 
-    function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::ZZRingElem)
-      ccall((:fq_nmod_poly_set_coeff_fmpz, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{ZZRingElem}, Ref{fqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function fit!(z::fqPolyRepRelPowerSeriesRingElem, n::Int)
+  ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, n, base_ring(z))
+  return nothing
+end
 
-    function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
-      ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::ZZRingElem)
+  ccall((:fq_nmod_poly_set_coeff_fmpz, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{ZZRingElem}, Ref{fqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function mul!(z::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec - aval, b.prec - bval)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z.val = a.val + b.val
-      z.prec = prec + z.val
-      lenz = min(lena + lenb - 1, prec)
-      if lena <= 0 || lenb <= 0
-        lenz = 0
-      end
-      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-             Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            z, a, b, lenz, base_ring(z))
-      return z
-    end
+function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
+  ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function add!(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      ctx = base_ring(a)
-      if a.val < b.val
-        z = fqPolyRepRelPowerSeriesRingElem(base_ring(a))
-        z.parent = parent(a)
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              a, a, z, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_nmod_poly_truncate, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              a, a, a.val - b.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              a, a, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              a, a, b, lenz, ctx)
-      end
-      a.prec = prec
-      a.val = val
-      renormalize!(a)
-      return a
-    end
+function mul!(z::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec - aval, b.prec - bval)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z.val = a.val + b.val
+  z.prec = prec + z.val
+  lenz = min(lena + lenb - 1, prec)
+  if lena <= 0 || lenb <= 0
+    lenz = 0
+  end
+  ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+          Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        z, a, b, lenz, base_ring(z))
+  return z
+end
 
-    function add!(c::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
-      if c === a
-        return add!(c, b)
-      elseif c === b
-        return add!(c, a)
-      end
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenc = max(lena, lenb + b.val - a.val)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, b, max(0, lenc - b.val + a.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, c, b.val - a.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, c, a, lenc, ctx)
-      elseif b.val < a.val
-        lenc = max(lena + a.val - b.val, lenb)
-        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, a, max(0, lenc - a.val + b.val), ctx)
-        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, c, a.val - b.val, ctx)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, c, b, lenc, ctx)
-      else
-        lenc = max(lena, lenb)
-        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
-              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
-               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-              c, a, b, lenc, ctx)
-      end
-      c.prec = prec
-      c.val = val
-      renormalize!(c)
-      return c
-    end
+function add!(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  ctx = base_ring(a)
+  if a.val < b.val
+    z = fqPolyRepRelPowerSeriesRingElem(base_ring(a))
+    z.parent = parent(a)
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          a, a, z, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          a, a, a.val - b.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          a, a, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          a, a, b, lenz, ctx)
+  end
+  a.prec = prec
+  a.val = val
+  renormalize!(a)
+  return a
+end
 
-    function set_length!(a::fqPolyRepRelPowerSeriesRingElem, n::Int)
-      ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
-            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
-            a, n, base_ring(a))
-      return a
-    end
+function add!(c::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
+  if c === a
+    return add!(c, b)
+  elseif c === b
+    return add!(c, a)
+  end
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenc = max(lena, lenb + b.val - a.val)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, b, max(0, lenc - b.val + a.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, c, b.val - a.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, c, a, lenc, ctx)
+  elseif b.val < a.val
+    lenc = max(lena + a.val - b.val, lenb)
+    ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, a, max(0, lenc - a.val + b.val), ctx)
+    ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, c, a.val - b.val, ctx)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, c, b, lenc, ctx)
+  else
+    lenc = max(lena, lenb)
+    ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+          (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+            Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+          c, a, b, lenc, ctx)
+  end
+  c.prec = prec
+  c.val = val
+  renormalize!(c)
+  return c
+end
 
-    ###############################################################################
-    #
-    #   Promotion rules
-    #
-    ###############################################################################
+function set_length!(a::fqPolyRepRelPowerSeriesRingElem, n::Int)
+  ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
+        (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
+        a, n, base_ring(a))
+  return a
+end
 
-    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepRelPowerSeriesRingElem
+###############################################################################
+#
+#   Promotion rules
+#
+###############################################################################
 
-    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepRelPowerSeriesRingElem
+promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepRelPowerSeriesRingElem
 
-    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
+promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepRelPowerSeriesRingElem
 
-    ###############################################################################
-    #
-    #   Parent object call overload
-    #
-    ###############################################################################
+promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
 
-    function (a::fqPolyRepRelPowerSeriesRing)()
-      ctx = base_ring(a)
-      z = fqPolyRepRelPowerSeriesRingElem(ctx)
-      z.prec = a.prec_max
-      z.val = a.prec_max
-      z.parent = a
-      return z
-    end
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
 
-    function (a::fqPolyRepRelPowerSeriesRing)(b::Integer)
-      return a(base_ring(a)(b))
-    end
+function (a::fqPolyRepRelPowerSeriesRing)()
+  ctx = base_ring(a)
+  z = fqPolyRepRelPowerSeriesRingElem(ctx)
+  z.prec = a.prec_max
+  z.val = a.prec_max
+  z.parent = a
+  return z
+end
 
-    function (a::fqPolyRepRelPowerSeriesRing)(b::ZZRingElem)
-      return a(base_ring(a)(b))
-    end
+function (a::fqPolyRepRelPowerSeriesRing)(b::Integer)
+  return a(base_ring(a)(b))
+end
 
-    function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepFieldElem)
-      ctx = base_ring(a)
-      if iszero(b)
-        z = fqPolyRepRelPowerSeriesRingElem(ctx)
-        z.prec = a.prec_max
-        z.val = a.prec_max
-      else
-        z = fqPolyRepRelPowerSeriesRingElem(ctx, [b], 1, a.prec_max, 0)
-      end
-      z.parent = a
-      return z
-    end
+function (a::fqPolyRepRelPowerSeriesRing)(b::ZZRingElem)
+  return a(base_ring(a)(b))
+end
 
-    function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepRelPowerSeriesRingElem)
-      parent(b) != a && error("Unable to coerce power series")
-      return b
-    end
+function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepFieldElem)
+  ctx = base_ring(a)
+  if iszero(b)
+    z = fqPolyRepRelPowerSeriesRingElem(ctx)
+    z.prec = a.prec_max
+    z.val = a.prec_max
+  else
+    z = fqPolyRepRelPowerSeriesRingElem(ctx, [b], 1, a.prec_max, 0)
+  end
+  z.parent = a
+  return z
+end
 
-    function (a::fqPolyRepRelPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int, val::Int)
-      ctx = base_ring(a)
-      z = fqPolyRepRelPowerSeriesRingElem(ctx, b, len, prec, val)
-      z.parent = a
-      return z
-    end
+function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepRelPowerSeriesRingElem)
+  parent(b) != a && error("Unable to coerce power series")
+  return b
+end
+
+function (a::fqPolyRepRelPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int, val::Int)
+  ctx = base_ring(a)
+  z = fqPolyRepRelPowerSeriesRingElem(ctx, b, len, prec, val)
+  z.parent = a
+  return z
+end

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -4,33 +4,29 @@
 #
 ###############################################################################
 
-for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
-                                                           (fqPolyRepRelPowerSeriesRingElem, fqPolyRepRelPowerSeriesRing, fqPolyRepField, fqPolyRepFieldElem, "fq_nmod_poly", "fq_nmod"))
-  @eval begin
-
     ###############################################################################
     #
     #   Data type and parent object methods
     #
     ###############################################################################
 
-    function O(a::($etype))
+    function O(a::fqPolyRepRelPowerSeriesRingElem)
       val = pol_length(a) + valuation(a) - 1
       val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
-      z = ($etype)(base_ring(a), Vector{($btype)}(undef, 0), 0, val, val)
+      z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), Vector{fqPolyRepFieldElem}(undef, 0), 0, val, val)
       z.parent = parent(a)
       return z
     end
 
-    elem_type(::Type{($rtype)}) = ($etype)
+    elem_type(::Type{fqPolyRepRelPowerSeriesRing}) = fqPolyRepRelPowerSeriesRingElem
 
-    parent_type(::Type{($etype)}) = ($rtype)
+    parent_type(::Type{fqPolyRepRelPowerSeriesRingElem}) = fqPolyRepRelPowerSeriesRing
 
-    base_ring(R::($rtype)) = R.base_ring
+    base_ring(R::fqPolyRepRelPowerSeriesRing) = R.base_ring
 
-    rel_series_type(::Type{($btype)}) = ($etype)
+    rel_series_type(::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
 
-    var(a::($rtype)) = a.S
+    var(a::fqPolyRepRelPowerSeriesRing) = a.S
 
     ###############################################################################
     #
@@ -38,64 +34,64 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    max_precision(R::($rtype)) = R.prec_max
+    max_precision(R::fqPolyRepRelPowerSeriesRing) = R.prec_max
 
-    function normalise(a::($etype), len::Int)
+    function normalise(a::fqPolyRepRelPowerSeriesRingElem, len::Int)
       ctx = base_ring(a)
       if len > 0
         c = base_ring(a)()
-        ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-              (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+              (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, a, len - 1, ctx)
       end
       while len > 0 && iszero(c)
         len -= 1
         if len > 0
-          ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-                (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+          ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+                (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
                 c, a, len - 1, ctx)
         end
       end
       return len
     end
 
-    function pol_length(x::($etype))
-      return ccall(($(flint_fn*"_length"), libflint), Int,
-                   (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+    function pol_length(x::fqPolyRepRelPowerSeriesRingElem)
+      return ccall((:fq_nmod_poly_length, libflint), Int,
+                   (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
     end
 
-    precision(x::($etype)) = x.prec
+    precision(x::fqPolyRepRelPowerSeriesRingElem) = x.prec
 
-    function polcoeff(x::($etype), n::Int)
+    function polcoeff(x::fqPolyRepRelPowerSeriesRingElem, n::Int)
       z = base_ring(x)()
       if n < 0
         return z
       end
-      ccall(($(flint_fn*"_get_coeff"), libflint), Nothing,
-            (Ref{($btype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_get_coeff, libflint), Nothing,
+            (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, x, n, base_ring(x))
       return z
     end
 
-    zero(R::($rtype)) = R(0)
+    zero(R::fqPolyRepRelPowerSeriesRing) = R(0)
 
-    one(R::($rtype)) = R(1)
+    one(R::fqPolyRepRelPowerSeriesRing) = R(1)
 
-    function gen(R::($rtype))
-      z = ($etype)(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
+    function gen(R::fqPolyRepRelPowerSeriesRing)
+      z = fqPolyRepRelPowerSeriesRingElem(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
       z.parent = R
       return z
     end
 
-    function deepcopy_internal(a::($etype), dict::IdDict)
-      z = ($etype)(base_ring(a), a)
+    function deepcopy_internal(a::fqPolyRepRelPowerSeriesRingElem, dict::IdDict)
+      z = fqPolyRepRelPowerSeriesRingElem(base_ring(a), a)
       z.prec = a.prec
       z.val = a.val
       z.parent = parent(a)
       return z
     end
 
-    function renormalize!(z::($etype))
+    function renormalize!(z::fqPolyRepRelPowerSeriesRingElem)
       i = 0
       zlen = pol_length(z)
       zval = valuation(z)
@@ -108,14 +104,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         z.val = zprec
       else
         z.val = zval + i
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, i, base_ring(z))
       end
       return nothing
     end
 
-    characteristic(R::($rtype)) = characteristic(base_ring(R))
+    characteristic(R::fqPolyRepRelPowerSeriesRing) = characteristic(base_ring(R))
 
     ###############################################################################
     #
@@ -123,12 +119,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function similar(f::RelPowerSeriesRingElem, R::($ctype), max_prec::Int,
+    function similar(f::RelPowerSeriesRingElem, R::fqPolyRepField, max_prec::Int,
         s::Symbol=var(parent(f)); cached::Bool=true)
-      par = ($rtype)(R, max_prec, s, cached)
-      z = ($etype)(R)
+      par = fqPolyRepRelPowerSeriesRing(R, max_prec, s, cached)
+      z = fqPolyRepRelPowerSeriesRingElem(R)
       if base_ring(f) === R && s == var(parent(f)) &&
-        f isa ($etype) && max_precision(parent(f)) == max_prec
+        f isa fqPolyRepRelPowerSeriesRingElem && max_precision(parent(f)) == max_prec
         # steal parent in case it is not cached
         z.parent = parent(f)
       else
@@ -145,14 +141,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function rel_series(R::($ctype), arr::Vector{T},
+    function rel_series(R::fqPolyRepField, arr::Vector{T},
         len::Int, prec::Int, val::Int, var::VarName=:x;
         max_precision::Int=prec, cached::Bool=true) where T
       prec < len + val && error("Precision too small for given data")
-      coeffs = T == ($btype) ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? ($btype)[] : coeffs
-      par = ($rtype)(R, max_precision, Symbol(var), cached)
-      z = ($etype)(R, coeffs, len, prec, val)
+      coeffs = T == fqPolyRepFieldElem ? arr : map(R, arr)
+      coeffs = length(coeffs) == 0 ? fqPolyRepFieldElem[] : coeffs
+      par = fqPolyRepRelPowerSeriesRing(R, max_precision, Symbol(var), cached)
+      z = fqPolyRepRelPowerSeriesRingElem(R, coeffs, len, prec, val)
       z.parent = par
       return z
     end
@@ -163,7 +159,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    -(x::($etype)) = neg!(parent(x)(), x)
+    -(x::fqPolyRepRelPowerSeriesRingElem) = neg!(parent(x)(), x)
 
     ###############################################################################
     #
@@ -171,7 +167,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function +(a::($etype), b::($etype))
+    function +(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       check_parent(a, b)
       lena = pol_length(a)
       lenb = pol_length(b)
@@ -183,33 +179,33 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       ctx = base_ring(a)
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, b.val - a.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, a, lenz, ctx)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, a.val - b.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, b, lenz, ctx)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, a, b, lenz, ctx)
       end
       z.prec = prec
@@ -218,7 +214,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return z
     end
 
-    function -(a::($etype), b::($etype))
+    function -(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       check_parent(a, b)
       lena = pol_length(a)
       lenb = pol_length(b)
@@ -231,36 +227,36 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       ctx = base_ring(a)
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, b.val - a.val, ctx)
-        ccall(($(flint_fn*"_neg"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_neg, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
               z, z, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, a, lenz, ctx)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, a.val - b.val, ctx)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, b, lenz, ctx)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_sub_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_sub_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, a, b, lenz, ctx)
       end
       z.prec = prec
@@ -269,7 +265,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return z
     end
 
-    function *(a::($etype), b::($etype))
+    function *(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       check_parent(a, b)
       lena = pol_length(a)
       lenb = pol_length(b)
@@ -285,9 +281,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         return z
       end
       lenz = min(lena + lenb - 1, prec)
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+             Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(a))
       return z
     end
@@ -298,18 +294,18 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function *(x::($btype), y::($etype))
+    function *(x::fqPolyRepFieldElem, y::fqPolyRepRelPowerSeriesRingElem)
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall(($(flint_fn*"_scalar_mul_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_scalar_mul_fq_nmod, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+             Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, y, x, base_ring(y))
       return z
     end
 
-    *(x::($etype), y::($btype)) = y * x
+    *(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepFieldElem) = y * x
 
     ###############################################################################
     #
@@ -317,17 +313,17 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function shift_left(x::($etype), len::Int)
+    function shift_left(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = pol_length(x)
-      z = ($etype)(base_ring(x), x)
+      z = fqPolyRepRelPowerSeriesRingElem(base_ring(x), x)
       z.prec = x.prec + len
       z.val = x.val + len
       z.parent = parent(x)
       return z
     end
 
-    function shift_right(x::($etype), len::Int)
+    function shift_right(x::fqPolyRepRelPowerSeriesRingElem, len::Int)
       len < 0 && throw(DomainError(len, "Shift must be non-negative"))
       xlen = pol_length(x)
       xval = valuation(x)
@@ -339,9 +335,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         z.prec = max(0, x.prec - len)
         z.val = max(0, xval - len)
         zlen = min(xlen + xval - len, xlen)
-        ccall(($(flint_fn*"_shift_right"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_right, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Int, Ref{fqPolyRepField}),
               z, x, xlen - zlen, base_ring(x))
         renormalize!(z)
       end
@@ -354,11 +350,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function truncate(x::($etype), k::Int)
+    function truncate(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
       return truncate!(deepcopy(x), k)
     end
 
-    function truncate!(x::($etype), k::Int)
+    function truncate!(x::fqPolyRepRelPowerSeriesRingElem, k::Int)
       k < 0 && throw(DomainError(k, "Index must be non-negative"))
       if precision(x) <= k
         return x
@@ -367,8 +363,8 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         x = zero!(x)
         x.val = k
       else
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
-              (Ref{($etype)}, Int, Ref{$(ctype)}),
+        ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               x, k - valuation(x), base_ring(x))
       end
       x.prec = k
@@ -381,7 +377,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ^(a::($etype), b::Int)
+    function ^(a::fqPolyRepRelPowerSeriesRingElem, b::Int)
       b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
       if is_gen(a)
         z = parent(a)()
@@ -421,7 +417,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function ==(x::($etype), y::($etype))
+    function ==(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
       check_parent(x, y)
       prec = min(x.prec, y.prec)
       if prec <= x.val && prec <= y.val
@@ -435,21 +431,21 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       if xlen != ylen
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal_trunc"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)},
-                         Int, Ref{($ctype)}),
+      return Bool(ccall((:fq_nmod_poly_equal_trunc, libflint), Cint,
+                        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+                         Int, Ref{fqPolyRepField}),
                         x, y, xlen, base_ring(x)))
     end
 
-    function isequal(x::($etype), y::($etype))
+    function isequal(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem)
       if parent(x) != parent(y)
         return false
       end
       if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
         return false
       end
-      return Bool(ccall(($(flint_fn*"_equal"), libflint), Cint,
-                        (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}),
+      return Bool(ccall((:fq_nmod_poly_equal, libflint), Cint,
+                        (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}),
                         x, y, base_ring(x)))
     end
 
@@ -459,7 +455,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::($etype); check::Bool=true)
+    function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
       check_parent(x, y)
       iszero(y) && throw(DivideError())
       yval = valuation(y)
@@ -476,9 +472,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       z.val = xval - yval
       z.prec = prec + z.val
       if prec != 0
-        ccall(($(flint_fn*"_div_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_div_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, x, y, prec, base_ring(x))
       end
       return z
@@ -490,15 +486,15 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function divexact(x::($etype), y::FqPolyRepFieldElem; check::Bool=true)
+    function divexact(x::fqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
       iszero(y) && throw(DivideError())
       z = parent(x)()
       z.prec = x.prec
       z.prec = x.prec
       z.val = x.val
-      ccall(($(flint_fn*"_scalar_div_"*flint_tail), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($btype)}, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_scalar_div_fq_nmod, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+             Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, x, y, base_ring(x))
       return z
     end
@@ -509,14 +505,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function inv(a::($etype))
+    function inv(a::fqPolyRepRelPowerSeriesRingElem)
       iszero(a) && throw(DivideError())
       !is_unit(a) && error("Unable to invert power series")
       ainv = parent(a)()
       ainv.prec = a.prec
       ainv.val = 0
-      ccall(($(flint_fn*"_inv_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_inv_series, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             ainv, a, a.prec, base_ring(a))
       return ainv
     end
@@ -527,7 +523,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function sqrt_classical_char2(a::($etype); check::Bool=true)
+    function sqrt_classical_char2(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
       S = parent(a)
       R = base_ring(a)
       prec = div(precision(a) + 1, 2)
@@ -562,7 +558,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, asqrt
     end
 
-    function sqrt_classical(a::($etype); check::Bool=true)
+    function sqrt_classical(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
       S = parent(a)
       R = base_ring(a)
       v = valuation(a)
@@ -591,9 +587,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
         s = sqrt(c; check=check)
       end
       a = divexact(a, c)
-      ccall(($(flint_fn*"_sqrt_series"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_sqrt_series, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+             Int, Ref{fqPolyRepField}),
             z, a, a.prec, base_ring(a))
       if !isone(s)
         z *= s
@@ -601,7 +597,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return true, z
     end
 
-    function Base.sqrt(a::($etype); check::Bool=true)
+    function Base.sqrt(a::fqPolyRepRelPowerSeriesRingElem; check::Bool=true)
       flag, q = sqrt_classical(a; check=check)
       if check && !flag
         error("Not a square in sqrt")
@@ -609,12 +605,12 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return q
     end
 
-    function is_square(a::($etype))
+    function is_square(a::fqPolyRepRelPowerSeriesRingElem)
       flag, q = sqrt_classical(a; check=true)
       return flag
     end
 
-    function is_square_with_sqrt(a::($etype))
+    function is_square_with_sqrt(a::fqPolyRepRelPowerSeriesRingElem)
       return sqrt_classical(a; check=true)
     end
 
@@ -624,52 +620,52 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function zero!(x::($etype))
-      ccall(($(flint_fn*"_zero"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+    function zero!(x::fqPolyRepRelPowerSeriesRingElem)
+      ccall((:fq_nmod_poly_zero, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
       x.prec = parent(x).prec_max
       x.val = parent(x).prec_max
       return x
     end
 
-    function one!(x::($etype))
-      ccall(($(flint_fn*"_one"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($ctype)}), x, base_ring(x))
+    function one!(x::fqPolyRepRelPowerSeriesRingElem)
+      ccall((:fq_nmod_poly_one, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), x, base_ring(x))
       x.prec = parent(x).prec_max
       x.val = 0
       return x
     end
 
-    function neg!(z::($etype), x::($etype))
-      ccall(($(flint_fn*"_neg"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, Ref{($ctype)}), z, x, base_ring(x))
+    function neg!(z::fqPolyRepRelPowerSeriesRingElem, x::fqPolyRepRelPowerSeriesRingElem)
+      ccall((:fq_nmod_poly_neg, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepField}), z, x, base_ring(x))
       z.prec = x.prec
       z.val = x.val
       return z
     end
 
-    function fit!(z::($etype), n::Int)
-      ccall(($(flint_fn*"_fit_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function fit!(z::fqPolyRepRelPowerSeriesRingElem, n::Int)
+      ccall((:fq_nmod_poly_fit_length, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, n, base_ring(z))
       return nothing
     end
 
-    function setcoeff!(z::($etype), n::Int, x::ZZRingElem)
-      ccall(($(flint_fn*"_set_coeff_fmpz"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{ZZRingElem}, Ref{($ctype)}),
+    function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::ZZRingElem)
+      ccall((:fq_nmod_poly_set_coeff_fmpz, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{ZZRingElem}, Ref{fqPolyRepField}),
             z, n, x, base_ring(z))
       return z
     end
 
-    function setcoeff!(z::($etype), n::Int, x::($btype))
-      ccall(($(flint_fn*"_set_coeff"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($btype)}, Ref{($ctype)}),
+    function setcoeff!(z::fqPolyRepRelPowerSeriesRingElem, n::Int, x::fqPolyRepFieldElem)
+      ccall((:fq_nmod_poly_set_coeff, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepFieldElem}, Ref{fqPolyRepField}),
             z, n, x, base_ring(z))
       return z
     end
 
-    function mul!(z::($etype), a::($etype), b::($etype))
+    function mul!(z::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       lena = pol_length(a)
       lenb = pol_length(b)
       aval = valuation(a)
@@ -683,14 +679,14 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       if lena <= 0 || lenb <= 0
         lenz = 0
       end
-      ccall(($(flint_fn*"_mullow"), libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)},
-             Ref{($etype)}, Int, Ref{($ctype)}),
+      ccall((:fq_nmod_poly_mullow, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+             Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             z, a, b, lenz, base_ring(z))
       return z
     end
 
-    function add!(a::($etype), b::($etype))
+    function add!(a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       lena = pol_length(a)
       lenb = pol_length(b)
       prec = min(a.prec, b.prec)
@@ -699,36 +695,36 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       lenb = min(lenb, prec - b.val)
       ctx = base_ring(a)
       if a.val < b.val
-        z = ($etype)(base_ring(a))
+        z = fqPolyRepRelPowerSeriesRingElem(base_ring(a))
         z.parent = parent(a)
         lenz = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               z, z, b.val - a.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               a, a, z, lenz, ctx)
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_truncate"), libflint), Nothing,
-              (Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_truncate, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               a, max(0, lenz - a.val + b.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               a, a, a.val - b.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               a, a, b, lenz, ctx)
       else
         lenz = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               a, a, b, lenz, ctx)
       end
       a.prec = prec
@@ -737,7 +733,7 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return a
     end
 
-    function add!(c::($etype), a::($etype), b::($etype))
+    function add!(c::fqPolyRepRelPowerSeriesRingElem, a::fqPolyRepRelPowerSeriesRingElem, b::fqPolyRepRelPowerSeriesRingElem)
       if c === a
         return add!(c, b)
       elseif c === b
@@ -752,33 +748,33 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       ctx = base_ring(a)
       if a.val < b.val
         lenc = max(lena, lenb + b.val - a.val)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, b, max(0, lenc - b.val + a.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, c, b.val - a.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, c, a, lenc, ctx)
       elseif b.val < a.val
         lenc = max(lena + a.val - b.val, lenb)
-        ccall(($(flint_fn*"_set_trunc"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_set_trunc, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, a, max(0, lenc - a.val + b.val), ctx)
-        ccall(($(flint_fn*"_shift_left"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_shift_left, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, c, a.val - b.val, ctx)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, c, b, lenc, ctx)
       else
         lenc = max(lena, lenb)
-        ccall(($(flint_fn*"_add_series"), libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)},
-               Ref{($etype)}, Int, Ref{($ctype)}),
+        ccall((:fq_nmod_poly_add_series, libflint), Nothing,
+              (Ref{fqPolyRepRelPowerSeriesRingElem}, Ref{fqPolyRepRelPowerSeriesRingElem},
+               Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
               c, a, b, lenc, ctx)
       end
       c.prec = prec
@@ -787,9 +783,9 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
       return c
     end
 
-    function set_length!(a::($etype), n::Int)
-      ccall(($("_"*flint_fn*"_set_length"), libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
+    function set_length!(a::fqPolyRepRelPowerSeriesRingElem, n::Int)
+      ccall((:_fq_nmod_poly_set_length, libflint), Nothing,
+            (Ref{fqPolyRepRelPowerSeriesRingElem}, Int, Ref{fqPolyRepField}),
             a, n, base_ring(a))
       return a
     end
@@ -800,11 +796,11 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    promote_rule(::Type{($etype)}, ::Type{T}) where {T <: Integer} = ($etype)
+    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = fqPolyRepRelPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{ZZRingElem}) = ($etype)
+    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{ZZRingElem}) = fqPolyRepRelPowerSeriesRingElem
 
-    promote_rule(::Type{($etype)}, ::Type{($btype)}) = ($etype)
+    promote_rule(::Type{fqPolyRepRelPowerSeriesRingElem}, ::Type{fqPolyRepFieldElem}) = fqPolyRepRelPowerSeriesRingElem
 
     ###############################################################################
     #
@@ -812,47 +808,44 @@ for (etype, rtype, ctype, btype, flint_fn, flint_tail) in (
     #
     ###############################################################################
 
-    function (a::($rtype))()
+    function (a::fqPolyRepRelPowerSeriesRing)()
       ctx = base_ring(a)
-      z = ($etype)(ctx)
+      z = fqPolyRepRelPowerSeriesRingElem(ctx)
       z.prec = a.prec_max
       z.val = a.prec_max
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::Integer)
+    function (a::fqPolyRepRelPowerSeriesRing)(b::Integer)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::ZZRingElem)
+    function (a::fqPolyRepRelPowerSeriesRing)(b::ZZRingElem)
       return a(base_ring(a)(b))
     end
 
-    function (a::($rtype))(b::($btype))
+    function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepFieldElem)
       ctx = base_ring(a)
       if iszero(b)
-        z = ($etype)(ctx)
+        z = fqPolyRepRelPowerSeriesRingElem(ctx)
         z.prec = a.prec_max
         z.val = a.prec_max
       else
-        z = ($etype)(ctx, [b], 1, a.prec_max, 0)
+        z = fqPolyRepRelPowerSeriesRingElem(ctx, [b], 1, a.prec_max, 0)
       end
       z.parent = a
       return z
     end
 
-    function (a::($rtype))(b::($etype))
+    function (a::fqPolyRepRelPowerSeriesRing)(b::fqPolyRepRelPowerSeriesRingElem)
       parent(b) != a && error("Unable to coerce power series")
       return b
     end
 
-    function (a::($rtype))(b::Vector{($btype)}, len::Int, prec::Int, val::Int)
+    function (a::fqPolyRepRelPowerSeriesRing)(b::Vector{fqPolyRepFieldElem}, len::Int, prec::Int, val::Int)
       ctx = base_ring(a)
-      z = ($etype)(ctx, b, len, prec, val)
+      z = fqPolyRepRelPowerSeriesRingElem(ctx, b, len, prec, val)
       z.parent = a
       return z
     end
-
-  end # eval
-end # for

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -4,848 +4,848 @@
 #
 ###############################################################################
 
-    ###############################################################################
-    #
-    #   Data type and parent object methods
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Data type and parent object methods
+#
+###############################################################################
 
-    function O(a::FqPolyRepRelPowerSeriesRingElem)
-      val = pol_length(a) + valuation(a) - 1
-      val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
-      z = FqPolyRepRelPowerSeriesRingElem(base_ring(a), Vector{FqPolyRepFieldElem}(undef, 0), 0, val, val)
-      z.parent = parent(a)
-      return z
-    end
+function O(a::FqPolyRepRelPowerSeriesRingElem)
+  val = pol_length(a) + valuation(a) - 1
+  val < 0 && throw(DomainError(val, "Valuation must be non-negative"))
+  z = FqPolyRepRelPowerSeriesRingElem(base_ring(a), Vector{FqPolyRepFieldElem}(undef, 0), 0, val, val)
+  z.parent = parent(a)
+  return z
+end
 
-    elem_type(::Type{FqPolyRepRelPowerSeriesRing}) = FqPolyRepRelPowerSeriesRingElem
+elem_type(::Type{FqPolyRepRelPowerSeriesRing}) = FqPolyRepRelPowerSeriesRingElem
 
-    parent_type(::Type{FqPolyRepRelPowerSeriesRingElem}) = FqPolyRepRelPowerSeriesRing
+parent_type(::Type{FqPolyRepRelPowerSeriesRingElem}) = FqPolyRepRelPowerSeriesRing
 
-    base_ring(R::FqPolyRepRelPowerSeriesRing) = R.base_ring
+base_ring(R::FqPolyRepRelPowerSeriesRing) = R.base_ring
 
-    rel_series_type(::Type{FqPolyRepFieldElem}) = FqPolyRepRelPowerSeriesRingElem
+rel_series_type(::Type{FqPolyRepFieldElem}) = FqPolyRepRelPowerSeriesRingElem
 
-    var(a::FqPolyRepRelPowerSeriesRing) = a.S
+var(a::FqPolyRepRelPowerSeriesRing) = a.S
 
-    ###############################################################################
-    #
-    #   Basic manipulation
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
 
-    max_precision(R::FqPolyRepRelPowerSeriesRing) = R.prec_max
+max_precision(R::FqPolyRepRelPowerSeriesRing) = R.prec_max
 
-    function normalise(a::FqPolyRepRelPowerSeriesRingElem, len::Int)
-      ctx = base_ring(a)
-      if len > 0
-        c = base_ring(a)()
-        ccall((:fq_poly_get_coeff, libflint), Nothing,
-              (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, a, len - 1, ctx)
-      end
-      while len > 0 && iszero(c)
-        len -= 1
-        if len > 0
-          ccall((:fq_poly_get_coeff, libflint), Nothing,
-                (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-                c, a, len - 1, ctx)
-        end
-      end
-      return len
-    end
-
-    function pol_length(x::FqPolyRepRelPowerSeriesRingElem)
-      return ccall((:fq_poly_length, libflint), Int,
-                   (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
-    end
-
-    precision(x::FqPolyRepRelPowerSeriesRingElem) = x.prec
-
-    function polcoeff(x::FqPolyRepRelPowerSeriesRingElem, n::Int)
-      z = base_ring(x)()
-      if n < 0
-        return z
-      end
+function normalise(a::FqPolyRepRelPowerSeriesRingElem, len::Int)
+  ctx = base_ring(a)
+  if len > 0
+    c = base_ring(a)()
+    ccall((:fq_poly_get_coeff, libflint), Nothing,
+          (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, a, len - 1, ctx)
+  end
+  while len > 0 && iszero(c)
+    len -= 1
+    if len > 0
       ccall((:fq_poly_get_coeff, libflint), Nothing,
             (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, x, n, base_ring(x))
-      return z
+            c, a, len - 1, ctx)
     end
+  end
+  return len
+end
 
-    zero(R::FqPolyRepRelPowerSeriesRing) = R(0)
+function pol_length(x::FqPolyRepRelPowerSeriesRingElem)
+  return ccall((:fq_poly_length, libflint), Int,
+                (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
+end
 
-    one(R::FqPolyRepRelPowerSeriesRing) = R(1)
+precision(x::FqPolyRepRelPowerSeriesRingElem) = x.prec
 
-    function gen(R::FqPolyRepRelPowerSeriesRing)
-      z = FqPolyRepRelPowerSeriesRingElem(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
-      z.parent = R
-      return z
+function polcoeff(x::FqPolyRepRelPowerSeriesRingElem, n::Int)
+  z = base_ring(x)()
+  if n < 0
+    return z
+  end
+  ccall((:fq_poly_get_coeff, libflint), Nothing,
+        (Ref{FqPolyRepFieldElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, x, n, base_ring(x))
+  return z
+end
+
+zero(R::FqPolyRepRelPowerSeriesRing) = R(0)
+
+one(R::FqPolyRepRelPowerSeriesRing) = R(1)
+
+function gen(R::FqPolyRepRelPowerSeriesRing)
+  z = FqPolyRepRelPowerSeriesRingElem(base_ring(R), [base_ring(R)(1)], 1, max_precision(R) + 1, 1)
+  z.parent = R
+  return z
+end
+
+function deepcopy_internal(a::FqPolyRepRelPowerSeriesRingElem, dict::IdDict)
+  z = FqPolyRepRelPowerSeriesRingElem(base_ring(a), a)
+  z.prec = a.prec
+  z.val = a.val
+  z.parent = parent(a)
+  return z
+end
+
+function renormalize!(z::FqPolyRepRelPowerSeriesRingElem)
+  i = 0
+  zlen = pol_length(z)
+  zval = valuation(z)
+  zprec = precision(z)
+  while i < zlen && iszero(polcoeff(z, i))
+    i += 1
+  end
+  z.prec = zprec
+  if i == zlen
+    z.val = zprec
+  else
+    z.val = zval + i
+    ccall((:fq_poly_shift_right, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, i, base_ring(z))
+  end
+  return nothing
+end
+
+characteristic(R::FqPolyRepRelPowerSeriesRing) = characteristic(base_ring(R))
+
+###############################################################################
+#
+#   Similar
+#
+###############################################################################
+
+function similar(f::RelPowerSeriesRingElem, R::FqPolyRepField, max_prec::Int,
+    s::Symbol=var(parent(f)); cached::Bool=true)
+  par = FqPolyRepRelPowerSeriesRing(R, max_prec, s, cached)
+  z = FqPolyRepRelPowerSeriesRingElem(R)
+  if base_ring(f) === R && s == var(parent(f)) &&
+    f isa FqPolyRepRelPowerSeriesRingElem && max_precision(parent(f)) == max_prec
+    # steal parent in case it is not cached
+    z.parent = parent(f)
+  else
+    z.parent = par
+  end
+  z.prec = max_prec
+  z.val = max_prec
+  return z
+end
+
+###############################################################################
+#
+#   rel_series constructor
+#
+###############################################################################
+
+function rel_series(R::FqPolyRepField, arr::Vector{T},
+    len::Int, prec::Int, val::Int, var::VarName=:x;
+    max_precision::Int=prec, cached::Bool=true) where T
+  prec < len + val && error("Precision too small for given data")
+  coeffs = T == FqPolyRepFieldElem ? arr : map(R, arr)
+  coeffs = length(coeffs) == 0 ? FqPolyRepFieldElem[] : coeffs
+  par = FqPolyRepRelPowerSeriesRing(R, max_precision, Symbol(var), cached)
+  z = FqPolyRepRelPowerSeriesRingElem(R, coeffs, len, prec, val)
+  z.parent = par
+  return z
+end
+
+###############################################################################
+#
+#   Unary operators
+#
+###############################################################################
+
+-(x::FqPolyRepRelPowerSeriesRingElem) = neg!(parent(x)(), x)
+
+###############################################################################
+#
+#   Binary operators
+#
+###############################################################################
+
+function +(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  z = parent(a)()
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, a, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, a.val - b.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, a, b, lenz, ctx)
+  end
+  z.prec = prec
+  z.val = val
+  renormalize!(z)
+  return z
+end
+
+function -(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  lenz = max(lena, lenb)
+  z = parent(a)()
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_poly_neg, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}),
+          z, z, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, a, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, a.val - b.val, ctx)
+    ccall((:fq_poly_sub_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_poly_sub_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, a, b, lenz, ctx)
+  end
+  z.prec = prec
+  z.val = val
+  renormalize!(z)
+  return z
+end
+
+function *(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  check_parent(a, b)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec - aval, b.prec - bval)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z = parent(a)()
+  z.val = a.val + b.val
+  z.prec = prec + z.val
+  if lena == 0 || lenb == 0
+    return z
+  end
+  lenz = min(lena + lenb - 1, prec)
+  ccall((:fq_poly_mullow, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+          Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(a))
+  return z
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+function *(x::FqPolyRepFieldElem, y::FqPolyRepRelPowerSeriesRingElem)
+  z = parent(y)()
+  z.prec = y.prec
+  z.val = y.val
+  ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+          Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, y, x, base_ring(y))
+  return z
+end
+
+*(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem) = y * x
+
+###############################################################################
+#
+#   Shifting
+#
+###############################################################################
+
+function shift_left(x::FqPolyRepRelPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = pol_length(x)
+  z = FqPolyRepRelPowerSeriesRingElem(base_ring(x), x)
+  z.prec = x.prec + len
+  z.val = x.val + len
+  z.parent = parent(x)
+  return z
+end
+
+function shift_right(x::FqPolyRepRelPowerSeriesRingElem, len::Int)
+  len < 0 && throw(DomainError(len, "Shift must be non-negative"))
+  xlen = pol_length(x)
+  xval = valuation(x)
+  z = parent(x)()
+  if len >= xlen + xval
+    z.prec = max(0, x.prec - len)
+    z.val = max(0, x.prec - len)
+  else
+    z.prec = max(0, x.prec - len)
+    z.val = max(0, xval - len)
+    zlen = min(xlen + xval - len, xlen)
+    ccall((:fq_poly_shift_right, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Int, Ref{FqPolyRepField}),
+          z, x, xlen - zlen, base_ring(x))
+    renormalize!(z)
+  end
+  return z
+end
+
+###############################################################################
+#
+#   Truncation
+#
+###############################################################################
+
+function truncate(x::FqPolyRepRelPowerSeriesRingElem, k::Int)
+  return truncate!(deepcopy(x), k)
+end
+
+function truncate!(x::FqPolyRepRelPowerSeriesRingElem, k::Int)
+  k < 0 && throw(DomainError(k, "Index must be non-negative"))
+  if precision(x) <= k
+    return x
+  end
+  if k <= valuation(x)
+    x = zero!(x)
+    x.val = k
+  else
+    ccall((:fq_poly_truncate, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          x, k - valuation(x), base_ring(x))
+  end
+  x.prec = k
+  return x
+end
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(a::FqPolyRepRelPowerSeriesRingElem, b::Int)
+  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
+  if is_gen(a)
+    z = parent(a)()
+    z = setcoeff!(z, 0, base_ring(a)(1))
+    z.prec = a.prec + b - 1
+    z.val = b
+  elseif pol_length(a) == 0
+    z = parent(a)()
+    z.prec = b*valuation(a)
+    z.val = b*valuation(a)
+  elseif pol_length(a) == 1
+    return parent(a)([polcoeff(a, 0)^b], 1,
+                      (b - 1)*valuation(a) + precision(a), b*valuation(a))
+  elseif b == 0
+    return one(parent(a))
+  else
+    bit = ~((~UInt(0)) >> 1)
+    while (UInt(bit) & b) == 0
+      bit >>= 1
     end
-
-    function deepcopy_internal(a::FqPolyRepRelPowerSeriesRingElem, dict::IdDict)
-      z = FqPolyRepRelPowerSeriesRingElem(base_ring(a), a)
-      z.prec = a.prec
-      z.val = a.val
-      z.parent = parent(a)
-      return z
-    end
-
-    function renormalize!(z::FqPolyRepRelPowerSeriesRingElem)
-      i = 0
-      zlen = pol_length(z)
-      zval = valuation(z)
-      zprec = precision(z)
-      while i < zlen && iszero(polcoeff(z, i))
-        i += 1
+    z = a
+    bit >>= 1
+    while bit != 0
+      z = z*z
+      if (UInt(bit) & b) != 0
+        z *= a
       end
-      z.prec = zprec
-      if i == zlen
-        z.val = zprec
-      else
-        z.val = zval + i
-        ccall((:fq_poly_shift_right, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, i, base_ring(z))
-      end
-      return nothing
+      bit >>= 1
     end
+  end
+  return z
+end
 
-    characteristic(R::FqPolyRepRelPowerSeriesRing) = characteristic(base_ring(R))
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
 
-    ###############################################################################
-    #
-    #   Similar
-    #
-    ###############################################################################
+function ==(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem)
+  check_parent(x, y)
+  prec = min(x.prec, y.prec)
+  if prec <= x.val && prec <= y.val
+    return true
+  end
+  if x.val != y.val
+    return false
+  end
+  xlen = normalise(x, min(pol_length(x), prec - x.val))
+  ylen = normalise(y, min(pol_length(y), prec - y.val))
+  if xlen != ylen
+    return false
+  end
+  return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
+                    (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+                      Int, Ref{FqPolyRepField}),
+                    x, y, xlen, base_ring(x)))
+end
 
-    function similar(f::RelPowerSeriesRingElem, R::FqPolyRepField, max_prec::Int,
-        s::Symbol=var(parent(f)); cached::Bool=true)
-      par = FqPolyRepRelPowerSeriesRing(R, max_prec, s, cached)
-      z = FqPolyRepRelPowerSeriesRingElem(R)
-      if base_ring(f) === R && s == var(parent(f)) &&
-        f isa FqPolyRepRelPowerSeriesRingElem && max_precision(parent(f)) == max_prec
-        # steal parent in case it is not cached
-        z.parent = parent(f)
-      else
-        z.parent = par
-      end
-      z.prec = max_prec
-      z.val = max_prec
-      return z
+function isequal(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem)
+  if parent(x) != parent(y)
+    return false
+  end
+  if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
+    return false
+  end
+  return Bool(ccall((:fq_poly_equal, libflint), Cint,
+                    (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}),
+                    x, y, base_ring(x)))
+end
+
+###############################################################################
+#
+#   Exact division
+#
+###############################################################################
+
+function divexact(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  check_parent(x, y)
+  iszero(y) && throw(DivideError())
+  yval = valuation(y)
+  xval = valuation(x)
+  if yval != 0
+    if xval >= yval
+      x = shift_right(x, yval)
+      y = shift_right(y, yval)
     end
+  end
+  check && !is_unit(y) && error("Unable to invert power series")
+  prec = min(x.prec - x.val, y.prec - y.val)
+  z = parent(x)()
+  z.val = xval - yval
+  z.prec = prec + z.val
+  if prec != 0
+    ccall((:fq_poly_div_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, x, y, prec, base_ring(x))
+  end
+  return z
+end
 
-    ###############################################################################
-    #
-    #   rel_series constructor
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Ad hoc exact division
+#
+###############################################################################
 
-    function rel_series(R::FqPolyRepField, arr::Vector{T},
-        len::Int, prec::Int, val::Int, var::VarName=:x;
-        max_precision::Int=prec, cached::Bool=true) where T
-      prec < len + val && error("Precision too small for given data")
-      coeffs = T == FqPolyRepFieldElem ? arr : map(R, arr)
-      coeffs = length(coeffs) == 0 ? FqPolyRepFieldElem[] : coeffs
-      par = FqPolyRepRelPowerSeriesRing(R, max_precision, Symbol(var), cached)
-      z = FqPolyRepRelPowerSeriesRingElem(R, coeffs, len, prec, val)
-      z.parent = par
-      return z
-    end
+function divexact(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
+  iszero(y) && throw(DivideError())
+  z = parent(x)()
+  z.prec = x.prec
+  z.prec = x.prec
+  z.val = x.val
+  ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+          Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, x, y, base_ring(x))
+  return z
+end
 
-    ###############################################################################
-    #
-    #   Unary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Inversion
+#
+###############################################################################
 
-    -(x::FqPolyRepRelPowerSeriesRingElem) = neg!(parent(x)(), x)
+function inv(a::FqPolyRepRelPowerSeriesRingElem)
+  iszero(a) && throw(DivideError())
+  !is_unit(a) && error("Unable to invert power series")
+  ainv = parent(a)()
+  ainv.prec = a.prec
+  ainv.val = 0
+  ccall((:fq_poly_inv_series, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        ainv, a, a.prec, base_ring(a))
+  return ainv
+end
 
-    ###############################################################################
-    #
-    #   Binary operators
-    #
-    ###############################################################################
+###############################################################################
+#
+#   Square root
+#
+###############################################################################
 
-    function +(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      z = parent(a)()
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, a, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, a.val - b.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, a, b, lenz, ctx)
-      end
-      z.prec = prec
-      z.val = val
-      renormalize!(z)
-      return z
-    end
-
-    function -(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      lenz = max(lena, lenb)
-      z = parent(a)()
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_poly_neg, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}),
-              z, z, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, a, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, a.val - b.val, ctx)
-        ccall((:fq_poly_sub_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_poly_sub_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, a, b, lenz, ctx)
-      end
-      z.prec = prec
-      z.val = val
-      renormalize!(z)
-      return z
-    end
-
-    function *(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      check_parent(a, b)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec - aval, b.prec - bval)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z = parent(a)()
-      z.val = a.val + b.val
-      z.prec = prec + z.val
-      if lena == 0 || lenb == 0
-        return z
-      end
-      lenz = min(lena + lenb - 1, prec)
-      ccall((:fq_poly_mullow, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-             Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(a))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc binary operators
-    #
-    ###############################################################################
-
-    function *(x::FqPolyRepFieldElem, y::FqPolyRepRelPowerSeriesRingElem)
-      z = parent(y)()
-      z.prec = y.prec
-      z.val = y.val
-      ccall((:fq_poly_scalar_mul_fq, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-             Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, y, x, base_ring(y))
-      return z
-    end
-
-    *(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem) = y * x
-
-    ###############################################################################
-    #
-    #   Shifting
-    #
-    ###############################################################################
-
-    function shift_left(x::FqPolyRepRelPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = pol_length(x)
-      z = FqPolyRepRelPowerSeriesRingElem(base_ring(x), x)
-      z.prec = x.prec + len
-      z.val = x.val + len
-      z.parent = parent(x)
-      return z
-    end
-
-    function shift_right(x::FqPolyRepRelPowerSeriesRingElem, len::Int)
-      len < 0 && throw(DomainError(len, "Shift must be non-negative"))
-      xlen = pol_length(x)
-      xval = valuation(x)
-      z = parent(x)()
-      if len >= xlen + xval
-        z.prec = max(0, x.prec - len)
-        z.val = max(0, x.prec - len)
-      else
-        z.prec = max(0, x.prec - len)
-        z.val = max(0, xval - len)
-        zlen = min(xlen + xval - len, xlen)
-        ccall((:fq_poly_shift_right, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Int, Ref{FqPolyRepField}),
-              z, x, xlen - zlen, base_ring(x))
-        renormalize!(z)
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Truncation
-    #
-    ###############################################################################
-
-    function truncate(x::FqPolyRepRelPowerSeriesRingElem, k::Int)
-      return truncate!(deepcopy(x), k)
-    end
-
-    function truncate!(x::FqPolyRepRelPowerSeriesRingElem, k::Int)
-      k < 0 && throw(DomainError(k, "Index must be non-negative"))
-      if precision(x) <= k
-        return x
-      end
-      if k <= valuation(x)
-        x = zero!(x)
-        x.val = k
-      else
-        ccall((:fq_poly_truncate, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              x, k - valuation(x), base_ring(x))
-      end
-      x.prec = k
-      return x
-    end
-
-    ###############################################################################
-    #
-    #   Powering
-    #
-    ###############################################################################
-
-    function ^(a::FqPolyRepRelPowerSeriesRingElem, b::Int)
-      b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-      if is_gen(a)
-        z = parent(a)()
-        z = setcoeff!(z, 0, base_ring(a)(1))
-        z.prec = a.prec + b - 1
-        z.val = b
-      elseif pol_length(a) == 0
-        z = parent(a)()
-        z.prec = b*valuation(a)
-        z.val = b*valuation(a)
-      elseif pol_length(a) == 1
-        return parent(a)([polcoeff(a, 0)^b], 1,
-                         (b - 1)*valuation(a) + precision(a), b*valuation(a))
-      elseif b == 0
-        return one(parent(a))
-      else
-        bit = ~((~UInt(0)) >> 1)
-        while (UInt(bit) & b) == 0
-          bit >>= 1
-        end
-        z = a
-        bit >>= 1
-        while bit != 0
-          z = z*z
-          if (UInt(bit) & b) != 0
-            z *= a
-          end
-          bit >>= 1
-        end
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Comparison
-    #
-    ###############################################################################
-
-    function ==(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem)
-      check_parent(x, y)
-      prec = min(x.prec, y.prec)
-      if prec <= x.val && prec <= y.val
-        return true
-      end
-      if x.val != y.val
-        return false
-      end
-      xlen = normalise(x, min(pol_length(x), prec - x.val))
-      ylen = normalise(y, min(pol_length(y), prec - y.val))
-      if xlen != ylen
-        return false
-      end
-      return Bool(ccall((:fq_poly_equal_trunc, libflint), Cint,
-                        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-                         Int, Ref{FqPolyRepField}),
-                        x, y, xlen, base_ring(x)))
-    end
-
-    function isequal(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem)
-      if parent(x) != parent(y)
-        return false
-      end
-      if x.prec != y.prec || x.val != y.val || pol_length(x) != pol_length(y)
-        return false
-      end
-      return Bool(ccall((:fq_poly_equal, libflint), Cint,
-                        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}),
-                        x, y, base_ring(x)))
-    end
-
-    ###############################################################################
-    #
-    #   Exact division
-    #
-    ###############################################################################
-
-    function divexact(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      check_parent(x, y)
-      iszero(y) && throw(DivideError())
-      yval = valuation(y)
-      xval = valuation(x)
-      if yval != 0
-        if xval >= yval
-          x = shift_right(x, yval)
-          y = shift_right(y, yval)
-        end
-      end
-      check && !is_unit(y) && error("Unable to invert power series")
-      prec = min(x.prec - x.val, y.prec - y.val)
-      z = parent(x)()
-      z.val = xval - yval
-      z.prec = prec + z.val
-      if prec != 0
-        ccall((:fq_poly_div_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, x, y, prec, base_ring(x))
-      end
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Ad hoc exact division
-    #
-    ###############################################################################
-
-    function divexact(x::FqPolyRepRelPowerSeriesRingElem, y::FqPolyRepFieldElem; check::Bool=true)
-      iszero(y) && throw(DivideError())
-      z = parent(x)()
-      z.prec = x.prec
-      z.prec = x.prec
-      z.val = x.val
-      ccall((:fq_poly_scalar_div_fq, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-             Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, x, y, base_ring(x))
-      return z
-    end
-
-    ###############################################################################
-    #
-    #   Inversion
-    #
-    ###############################################################################
-
-    function inv(a::FqPolyRepRelPowerSeriesRingElem)
-      iszero(a) && throw(DivideError())
-      !is_unit(a) && error("Unable to invert power series")
-      ainv = parent(a)()
-      ainv.prec = a.prec
-      ainv.val = 0
-      ccall((:fq_poly_inv_series, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            ainv, a, a.prec, base_ring(a))
-      return ainv
-    end
-
-    ###############################################################################
-    #
-    #   Square root
-    #
-    ###############################################################################
-
-    function sqrt_classical_char2(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      R = base_ring(a)
-      prec = div(precision(a) + 1, 2)
-      if iszero(a)
-        asqrt = parent(a)()
-        asqrt = set_precision!(asqrt, prec)
-        asqrt = set_valuation!(asqrt, prec)
-        return true, asqrt
-      end
-      aval = valuation(a)
-      if check && !iseven(aval)
+function sqrt_classical_char2(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  R = base_ring(a)
+  prec = div(precision(a) + 1, 2)
+  if iszero(a)
+    asqrt = parent(a)()
+    asqrt = set_precision!(asqrt, prec)
+    asqrt = set_valuation!(asqrt, prec)
+    return true, asqrt
+  end
+  aval = valuation(a)
+  if check && !iseven(aval)
+    return false, S()
+  end
+  aval2 = div(aval, 2)
+  asqrt = parent(a)()
+  asqrt = set_precision!(asqrt, prec)
+  asqrt = set_valuation!(asqrt, aval2)
+  if check
+    for i = 1:2:precision(a) - aval - 1 # series must have even exponents
+      if !iszero(polcoeff(a, i))
         return false, S()
       end
-      aval2 = div(aval, 2)
-      asqrt = parent(a)()
-      asqrt = set_precision!(asqrt, prec)
-      asqrt = set_valuation!(asqrt, aval2)
-      if check
-        for i = 1:2:precision(a) - aval - 1 # series must have even exponents
-          if !iszero(polcoeff(a, i))
-            return false, S()
-          end
-        end
-      end
-      for i = 0:prec - aval2 - 1
-        c = polcoeff(a, 2*i)
-        if check && !is_square(c)
-          return false, S()
-        end
-        asqrt = setcoeff!(asqrt, i, sqrt(c; check=false))
-      end
-      return true, asqrt
     end
-
-    function sqrt_classical(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      S = parent(a)
-      R = base_ring(a)
-      v = valuation(a)
-      z = S()
-      v2 = div(v, 2)
-      if iszero(a)
-        z.prec = v2
-        z.val = v2
-        return true, z
-      end
-      if check && !iseven(v)
-        return false, S()
-      end
-      if characteristic(R) == 2
-        return sqrt_classical_char2(a; check=check)
-      end
-      z.prec = a.prec - v2
-      z.val = v2
-      c = coeff(a, v)
-      if check
-        flag, s = is_square_with_sqrt(c)
-        if !flag
-          return false, S()
-        end
-      else
-        s = sqrt(c; check=check)
-      end
-      a = divexact(a, c)
-      ccall((:fq_poly_sqrt_series, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-             Int, Ref{FqPolyRepField}),
-            z, a, a.prec, base_ring(a))
-      if !isone(s)
-        z *= s
-      end
-      return true, z
+  end
+  for i = 0:prec - aval2 - 1
+    c = polcoeff(a, 2*i)
+    if check && !is_square(c)
+      return false, S()
     end
+    asqrt = setcoeff!(asqrt, i, sqrt(c; check=false))
+  end
+  return true, asqrt
+end
 
-    function Base.sqrt(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
-      flag, q = sqrt_classical(a; check=check)
-      if check && !flag
-        error("Not a square in sqrt")
-      end
-      return q
+function sqrt_classical(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  S = parent(a)
+  R = base_ring(a)
+  v = valuation(a)
+  z = S()
+  v2 = div(v, 2)
+  if iszero(a)
+    z.prec = v2
+    z.val = v2
+    return true, z
+  end
+  if check && !iseven(v)
+    return false, S()
+  end
+  if characteristic(R) == 2
+    return sqrt_classical_char2(a; check=check)
+  end
+  z.prec = a.prec - v2
+  z.val = v2
+  c = coeff(a, v)
+  if check
+    flag, s = is_square_with_sqrt(c)
+    if !flag
+      return false, S()
     end
+  else
+    s = sqrt(c; check=check)
+  end
+  a = divexact(a, c)
+  ccall((:fq_poly_sqrt_series, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+          Int, Ref{FqPolyRepField}),
+        z, a, a.prec, base_ring(a))
+  if !isone(s)
+    z *= s
+  end
+  return true, z
+end
 
-    function is_square(a::FqPolyRepRelPowerSeriesRingElem)
-      flag, q = sqrt_classical(a; check=true)
-      return flag
-    end
+function Base.sqrt(a::FqPolyRepRelPowerSeriesRingElem; check::Bool=true)
+  flag, q = sqrt_classical(a; check=check)
+  if check && !flag
+    error("Not a square in sqrt")
+  end
+  return q
+end
 
-    function is_square_with_sqrt(a::FqPolyRepRelPowerSeriesRingElem)
-      return sqrt_classical(a; check=true)
-    end
+function is_square(a::FqPolyRepRelPowerSeriesRingElem)
+  flag, q = sqrt_classical(a; check=true)
+  return flag
+end
 
-    ###############################################################################
-    #
-    #   Unsafe functions
-    #
-    ###############################################################################
+function is_square_with_sqrt(a::FqPolyRepRelPowerSeriesRingElem)
+  return sqrt_classical(a; check=true)
+end
 
-    function zero!(x::FqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_poly_zero, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
-      x.prec = parent(x).prec_max
-      x.val = parent(x).prec_max
-      return x
-    end
+###############################################################################
+#
+#   Unsafe functions
+#
+###############################################################################
 
-    function one!(x::FqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_poly_one, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
-      x.prec = parent(x).prec_max
-      x.val = 0
-      return x
-    end
+function zero!(x::FqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_poly_zero, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
+  x.prec = parent(x).prec_max
+  x.val = parent(x).prec_max
+  return x
+end
 
-    function neg!(z::FqPolyRepRelPowerSeriesRingElem, x::FqPolyRepRelPowerSeriesRingElem)
-      ccall((:fq_poly_neg, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), z, x, base_ring(x))
-      z.prec = x.prec
-      z.val = x.val
-      return z
-    end
+function one!(x::FqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_poly_one, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), x, base_ring(x))
+  x.prec = parent(x).prec_max
+  x.val = 0
+  return x
+end
 
-    function fit!(z::FqPolyRepRelPowerSeriesRingElem, n::Int)
-      ccall((:fq_poly_fit_length, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, n, base_ring(z))
-      return nothing
-    end
+function neg!(z::FqPolyRepRelPowerSeriesRingElem, x::FqPolyRepRelPowerSeriesRingElem)
+  ccall((:fq_poly_neg, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepField}), z, x, base_ring(x))
+  z.prec = x.prec
+  z.val = x.val
+  return z
+end
 
-    function setcoeff!(z::FqPolyRepRelPowerSeriesRingElem, n::Int, x::ZZRingElem)
-      ccall((:fq_poly_set_coeff_fmpz, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{ZZRingElem}, Ref{FqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function fit!(z::FqPolyRepRelPowerSeriesRingElem, n::Int)
+  ccall((:fq_poly_fit_length, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, n, base_ring(z))
+  return nothing
+end
 
-    function setcoeff!(z::FqPolyRepRelPowerSeriesRingElem, n::Int, x::FqPolyRepFieldElem)
-      ccall((:fq_poly_set_coeff, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
-            z, n, x, base_ring(z))
-      return z
-    end
+function setcoeff!(z::FqPolyRepRelPowerSeriesRingElem, n::Int, x::ZZRingElem)
+  ccall((:fq_poly_set_coeff_fmpz, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{ZZRingElem}, Ref{FqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function mul!(z::FqPolyRepRelPowerSeriesRingElem, a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      aval = valuation(a)
-      bval = valuation(b)
-      prec = min(a.prec - aval, b.prec - bval)
-      lena = min(lena, prec)
-      lenb = min(lenb, prec)
-      z.val = a.val + b.val
-      z.prec = prec + z.val
-      lenz = min(lena + lenb - 1, prec)
-      if lena <= 0 || lenb <= 0
-        lenz = 0
-      end
-      ccall((:fq_poly_mullow, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-             Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            z, a, b, lenz, base_ring(z))
-      return z
-    end
+function setcoeff!(z::FqPolyRepRelPowerSeriesRingElem, n::Int, x::FqPolyRepFieldElem)
+  ccall((:fq_poly_set_coeff, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}),
+        z, n, x, base_ring(z))
+  return z
+end
 
-    function add!(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      ctx = base_ring(a)
-      if a.val < b.val
-        z = FqPolyRepRelPowerSeriesRingElem(base_ring(a))
-        z.parent = parent(a)
-        lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, b, max(0, lenz - b.val + a.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              z, z, b.val - a.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              a, a, z, lenz, ctx)
-      elseif b.val < a.val
-        lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fq_poly_truncate, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              a, max(0, lenz - a.val + b.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              a, a, a.val - b.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              a, a, b, lenz, ctx)
-      else
-        lenz = max(lena, lenb)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              a, a, b, lenz, ctx)
-      end
-      a.prec = prec
-      a.val = val
-      renormalize!(a)
-      return a
-    end
+function mul!(z::FqPolyRepRelPowerSeriesRingElem, a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  aval = valuation(a)
+  bval = valuation(b)
+  prec = min(a.prec - aval, b.prec - bval)
+  lena = min(lena, prec)
+  lenb = min(lenb, prec)
+  z.val = a.val + b.val
+  z.prec = prec + z.val
+  lenz = min(lena + lenb - 1, prec)
+  if lena <= 0 || lenb <= 0
+    lenz = 0
+  end
+  ccall((:fq_poly_mullow, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+          Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        z, a, b, lenz, base_ring(z))
+  return z
+end
 
-    function add!(c::FqPolyRepRelPowerSeriesRingElem, a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
-      if c === a
-        return add!(c, b)
-      elseif c === b
-        return add!(c, a)
-      end
-      lena = pol_length(a)
-      lenb = pol_length(b)
-      prec = min(a.prec, b.prec)
-      val = min(a.val, b.val)
-      lena = min(lena, prec - a.val)
-      lenb = min(lenb, prec - b.val)
-      ctx = base_ring(a)
-      if a.val < b.val
-        lenc = max(lena, lenb + b.val - a.val)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, b, max(0, lenc - b.val + a.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, c, b.val - a.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, c, a, lenc, ctx)
-      elseif b.val < a.val
-        lenc = max(lena + a.val - b.val, lenb)
-        ccall((:fq_poly_set_trunc, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, a, max(0, lenc - a.val + b.val), ctx)
-        ccall((:fq_poly_shift_left, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, c, a.val - b.val, ctx)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, c, b, lenc, ctx)
-      else
-        lenc = max(lena, lenb)
-        ccall((:fq_poly_add_series, libflint), Nothing,
-              (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
-               Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-              c, a, b, lenc, ctx)
-      end
-      c.prec = prec
-      c.val = val
-      renormalize!(c)
-      return c
-    end
+function add!(a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  ctx = base_ring(a)
+  if a.val < b.val
+    z = FqPolyRepRelPowerSeriesRingElem(base_ring(a))
+    z.parent = parent(a)
+    lenz = max(lena, lenb + b.val - a.val)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, b, max(0, lenz - b.val + a.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          z, z, b.val - a.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          a, a, z, lenz, ctx)
+  elseif b.val < a.val
+    lenz = max(lena + a.val - b.val, lenb)
+    ccall((:fq_poly_truncate, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          a, max(0, lenz - a.val + b.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          a, a, a.val - b.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          a, a, b, lenz, ctx)
+  else
+    lenz = max(lena, lenb)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          a, a, b, lenz, ctx)
+  end
+  a.prec = prec
+  a.val = val
+  renormalize!(a)
+  return a
+end
 
-    function set_length!(a::FqPolyRepRelPowerSeriesRingElem, n::Int)
-      ccall((:_fq_poly_set_length, libflint), Nothing,
-            (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
-            a, n, base_ring(a))
-      return a
-    end
+function add!(c::FqPolyRepRelPowerSeriesRingElem, a::FqPolyRepRelPowerSeriesRingElem, b::FqPolyRepRelPowerSeriesRingElem)
+  if c === a
+    return add!(c, b)
+  elseif c === b
+    return add!(c, a)
+  end
+  lena = pol_length(a)
+  lenb = pol_length(b)
+  prec = min(a.prec, b.prec)
+  val = min(a.val, b.val)
+  lena = min(lena, prec - a.val)
+  lenb = min(lenb, prec - b.val)
+  ctx = base_ring(a)
+  if a.val < b.val
+    lenc = max(lena, lenb + b.val - a.val)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, b, max(0, lenc - b.val + a.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, c, b.val - a.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, c, a, lenc, ctx)
+  elseif b.val < a.val
+    lenc = max(lena + a.val - b.val, lenb)
+    ccall((:fq_poly_set_trunc, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, a, max(0, lenc - a.val + b.val), ctx)
+    ccall((:fq_poly_shift_left, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, c, a.val - b.val, ctx)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, c, b, lenc, ctx)
+  else
+    lenc = max(lena, lenb)
+    ccall((:fq_poly_add_series, libflint), Nothing,
+          (Ref{FqPolyRepRelPowerSeriesRingElem}, Ref{FqPolyRepRelPowerSeriesRingElem},
+            Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+          c, a, b, lenc, ctx)
+  end
+  c.prec = prec
+  c.val = val
+  renormalize!(c)
+  return c
+end
 
-    ###############################################################################
-    #
-    #   Promotion rules
-    #
-    ###############################################################################
+function set_length!(a::FqPolyRepRelPowerSeriesRingElem, n::Int)
+  ccall((:_fq_poly_set_length, libflint), Nothing,
+        (Ref{FqPolyRepRelPowerSeriesRingElem}, Int, Ref{FqPolyRepField}),
+        a, n, base_ring(a))
+  return a
+end
 
-    promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = FqPolyRepRelPowerSeriesRingElem
+###############################################################################
+#
+#   Promotion rules
+#
+###############################################################################
 
-    promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{ZZRingElem}) = FqPolyRepRelPowerSeriesRingElem
+promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{T}) where {T <: Integer} = FqPolyRepRelPowerSeriesRingElem
 
-    promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{FqPolyRepFieldElem}) = FqPolyRepRelPowerSeriesRingElem
+promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{ZZRingElem}) = FqPolyRepRelPowerSeriesRingElem
 
-    ###############################################################################
-    #
-    #   Parent object call overload
-    #
-    ###############################################################################
+promote_rule(::Type{FqPolyRepRelPowerSeriesRingElem}, ::Type{FqPolyRepFieldElem}) = FqPolyRepRelPowerSeriesRingElem
 
-    function (a::FqPolyRepRelPowerSeriesRing)()
-      ctx = base_ring(a)
-      z = FqPolyRepRelPowerSeriesRingElem(ctx)
-      z.prec = a.prec_max
-      z.val = a.prec_max
-      z.parent = a
-      return z
-    end
+###############################################################################
+#
+#   Parent object call overload
+#
+###############################################################################
 
-    function (a::FqPolyRepRelPowerSeriesRing)(b::Integer)
-      return a(base_ring(a)(b))
-    end
+function (a::FqPolyRepRelPowerSeriesRing)()
+  ctx = base_ring(a)
+  z = FqPolyRepRelPowerSeriesRingElem(ctx)
+  z.prec = a.prec_max
+  z.val = a.prec_max
+  z.parent = a
+  return z
+end
 
-    function (a::FqPolyRepRelPowerSeriesRing)(b::ZZRingElem)
-      return a(base_ring(a)(b))
-    end
+function (a::FqPolyRepRelPowerSeriesRing)(b::Integer)
+  return a(base_ring(a)(b))
+end
 
-    function (a::FqPolyRepRelPowerSeriesRing)(b::FqPolyRepFieldElem)
-      ctx = base_ring(a)
-      if iszero(b)
-        z = FqPolyRepRelPowerSeriesRingElem(ctx)
-        z.prec = a.prec_max
-        z.val = a.prec_max
-      else
-        z = FqPolyRepRelPowerSeriesRingElem(ctx, [b], 1, a.prec_max, 0)
-      end
-      z.parent = a
-      return z
-    end
+function (a::FqPolyRepRelPowerSeriesRing)(b::ZZRingElem)
+  return a(base_ring(a)(b))
+end
 
-    function (a::FqPolyRepRelPowerSeriesRing)(b::FqPolyRepRelPowerSeriesRingElem)
-      parent(b) != a && error("Unable to coerce power series")
-      return b
-    end
+function (a::FqPolyRepRelPowerSeriesRing)(b::FqPolyRepFieldElem)
+  ctx = base_ring(a)
+  if iszero(b)
+    z = FqPolyRepRelPowerSeriesRingElem(ctx)
+    z.prec = a.prec_max
+    z.val = a.prec_max
+  else
+    z = FqPolyRepRelPowerSeriesRingElem(ctx, [b], 1, a.prec_max, 0)
+  end
+  z.parent = a
+  return z
+end
 
-    function (a::FqPolyRepRelPowerSeriesRing)(b::Vector{FqPolyRepFieldElem}, len::Int, prec::Int, val::Int)
-      ctx = base_ring(a)
-      z = FqPolyRepRelPowerSeriesRingElem(ctx, b, len, prec, val)
-      z.parent = a
-      return z
-    end
+function (a::FqPolyRepRelPowerSeriesRing)(b::FqPolyRepRelPowerSeriesRingElem)
+  parent(b) != a && error("Unable to coerce power series")
+  return b
+end
+
+function (a::FqPolyRepRelPowerSeriesRing)(b::Vector{FqPolyRepFieldElem}, len::Int, prec::Int, val::Int)
+  ctx = base_ring(a)
+  z = FqPolyRepRelPowerSeriesRingElem(ctx, b, len, prec, val)
+  z.parent = a
+  return z
+end


### PR DESCRIPTION
Inlining makes everything a lot more readable (at least for me). Furthermore, it enables us to grep for some flint function and find all places where it is called (of course if all similar places are inlined/unrolled as well).
And it makes the script in https://github.com/Nemocas/Nemo.jl/issues/1812#issuecomment-2230871229 a lot better in identifying the flint functions that we call from different locations

The corresponding tests are already in different files.