### PR TITLE
Fix crash computing `zero(ZZ[t]) - zero(ZZ)`

### DIFF
--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -875,7 +875,13 @@ function sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZPolyRingElemO
 end
 
 function sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZRingElemOrPtr)
-  @ccall libflint.fmpz_poly_sub_fmpz(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZRingElem})::Nothing
+  if is_zero(y)
+    # HACK HACK HACK: workaround a crash in fmpz_poly_sub_fmpz when subtracting
+    # 0 from a zero polynomial; see https://github.com/flintlib/flint/pull/2102
+    set!(z, x)
+  else
+    @ccall libflint.fmpz_poly_sub_fmpz(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZRingElem})::Nothing
+  end
   return z
 end
 

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -152,6 +152,9 @@ end
   @test 12 - g == -x^3-3*x+10
 
   @test ZZRingElem(12) - g == -x^3-3*x+10
+
+  # verify bugfix (used to crash)
+  @test is_zero(zero(R) - ZZ(0))
 end
 
 @testset "ZZPolyRingElem.comparison" begin


### PR DESCRIPTION
The following lead to a crash (uncovered by https://github.com/Nemocas/AbstractAlgebra.jl/pull/1867)
```julia
using Nemo
R, t = ZZ[:t]
zero(R) - ZZ(0)
```
The backtrace is always the same:
```
[57675] signal 11 (2): Segmentation fault: 11
in expression starting at REPL[4]:1
fmpz_neg at /Users/mhorn/.julia/artifacts/f76e8c291f81b2f313a6368345a2c17de479af1e/lib/libflint.19.0.dylib (unknown line)
sub! at /Users/mhorn/Projekte/OSCAR/Nemo.jl/src/flint/fmpz_poly.jl:878
- at /Users/mhorn/Projekte/OSCAR/Nemo.jl/src/flint/fmpz_poly.jl:153
...
```

This is due to a bug in FLINT's `fmpz_poly_sub_fmpz`, which does this:
```
void fmpz_poly_sub_fmpz(fmpz_poly_t res, const fmpz_poly_t poly, fmpz_t c)
{
    if (poly->length == 0)
    {
        fmpz_poly_set_fmpz(res, c);
        fmpz_neg(res->coeffs + 0, res->coeffs + 0);   // <- CRASH IS HERE
    }
    else
    {
        fmpz_poly_set(res, poly);
        fmpz_sub(res->coeffs + 0, res->coeffs + 0, c);
        _fmpz_poly_normalise(res);
    }
}

```
The problem is that even after the `fmpz_poly_set_fmpz(res, c)` we still have `res->length == 0`.

Fix for FLINT: https://github.com/flintlib/flint/pull/2102