### PR TITLE
Bump version to 0.47.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.47.2"
+version = "0.47.3"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
There are already >20 PRs merged since the last release. And the downstream tests in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1867 wait for another Nemo release that contains https://github.com/Nemocas/Nemo.jl/pull/1926.