### PR TITLE
Replace more `ccall` syntax

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -259,7 +259,7 @@ end
 function Base.setprecision(x::BigFloat, p::Int)
   setprecision(BigFloat, p) do
     y = BigFloat()
-    ccall((:mpfr_set, :libmpfr), Nothing, (Ref{BigFloat}, Ref{BigFloat}, Int32), y, x, Base.MPFR.ROUNDING_MODE[])
+    @ccall :libmpfr.mpfr_set(y::Ref{BigFloat}, x::Ref{BigFloat}, Base.MPFR.ROUNDING_MODE[]::Int32)::Nothing
     return y
   end
 end

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -292,9 +292,8 @@ function Base.divrem(x::ComplexPolyRingElem, y::ComplexPolyRingElem)
   iszero(y) && throw(DivideError())
   q = parent(x)()
   r = parent(x)()
-  if (ccall((:acb_poly_divrem, libflint), Int,
-            (Ref{ComplexPolyRingElem}, Ref{ComplexPolyRingElem}, Ref{ComplexPolyRingElem}, Ref{ComplexPolyRingElem}, Int),
-            q, r, x, y, precision(Balls)) == 1)
+  success = @ccall libflint.acb_poly_divrem(q::Ref{ComplexPolyRingElem}, r::Ref{ComplexPolyRingElem}, x::Ref{ComplexPolyRingElem}, y::Ref{ComplexPolyRingElem}, precision(Balls)::Int)::Int
+  if success == 1
     return (q, r)
   else
     throw(DivideError())
@@ -342,8 +341,7 @@ end
 #function reverse(x::ComplexPolyRingElem, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:acb_poly_reverse, libflint), Nothing,
-#                (Ref{ComplexPolyRingElem}, Ref{ComplexPolyRingElem}, Int), z, x, len)
+#   @ccall libflint.acb_poly_reverse(z::Ref{ComplexPolyRingElem}, x::Ref{ComplexPolyRingElem}, len::Int)::Nothing
 #   return z
 #end
 
@@ -565,10 +563,8 @@ function roots(x::ComplexPolyRingElem; target=0, isolate_real=false, initial_pre
           im = _imag_ptr(roots + i * sizeof(acb_struct))
           t = _rad_ptr(re)
           u = _rad_ptr(im)
-          ok = ok && (ccall((:mag_cmp_2exp_si, libflint), Cint,
-                            (Ptr{mag_struct}, Int), t, -target) <= 0)
-          ok = ok && (ccall((:mag_cmp_2exp_si, libflint), Cint,
-                            (Ptr{mag_struct}, Int), u, -target) <= 0)
+          ok = ok && (@ccall libflint.mag_cmp_2exp_si(t::Ptr{mag_struct}, (-target)::Int)::Cint) <= 0
+          ok = ok && (@ccall libflint.mag_cmp_2exp_si(u::Ptr{mag_struct}, (-target)::Int)::Cint) <= 0
         end
       end
 

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -279,9 +279,8 @@ function Base.divrem(x::RealPolyRingElem, y::RealPolyRingElem)
   iszero(y) && throw(DivideError())
   q = parent(x)()
   r = parent(x)()
-  if (ccall((:arb_poly_divrem, libflint), Int,
-            (Ref{RealPolyRingElem}, Ref{RealPolyRingElem}, Ref{RealPolyRingElem}, Ref{RealPolyRingElem}, Int),
-            q, r, x, y, precision(Balls)) == 1)
+  success = @ccall libflint.arb_poly_divrem(q::Ref{RealPolyRingElem}, r::Ref{RealPolyRingElem}, x::Ref{RealPolyRingElem}, y::Ref{RealPolyRingElem}, precision(Balls)::Int)::Int
+  if success == 1
     return (q, r)
   else
     throw(DivideError())
@@ -329,8 +328,7 @@ end
 #function reverse(x::RealPolyRingElem, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:arb_poly_reverse, libflint), Nothing,
-#                (Ref{RealPolyRingElem}, Ref{RealPolyRingElem}, Int), z, x, len)
+#   @ccall libflint.arb_poly_reverse(z::Ref{RealPolyRingElem}, x::Ref{RealPolyRingElem}, len::Int)::Nothing
 #   return z
 #end
 

--- a/src/arb/acb_calc.jl
+++ b/src/arb/acb_calc.jl
@@ -44,10 +44,7 @@ function integrate(C::ComplexField, F, a, b;
   else
     t = BigFloat(abs_tol, RoundDown)
     expo = Ref{Clong}()
-    d = ccall((:mpfr_get_d_2exp, :libmpfr), Float64,
-              (Ref{Clong}, Ref{BigFloat}, Cint),
-              expo, t,
-              Base.convert(Base.MPFR.MPFRRoundingMode, RoundDown))
+    d = @ccall :libmpfr.mpfr_get_d_2exp(expo::Ref{Clong}, t::Ref{BigFloat},Base.convert(Base.MPFR.MPFRRoundingMode, RoundDown)::Cint)::Float64
     @ccall libflint.mag_set_d(ctol::Ref{mag_struct}, d::Float64)::Nothing
     @ccall libflint.mag_mul_2exp_si(ctol::Ref{mag_struct}, ctol::Ref{mag_struct}, Int(expo[])::Int)::Nothing
   end

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -302,9 +302,8 @@ function Base.divrem(x::AcbPolyRingElem, y::AcbPolyRingElem)
   iszero(y) && throw(DivideError())
   q = parent(x)()
   r = parent(x)()
-  if (ccall((:acb_poly_divrem, libflint), Int,
-            (Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Int),
-            q, r, x, y, precision(parent(x))) == 1)
+  success = @ccall libflint.acb_poly_divrem(q::Ref{AcbPolyRingElem}, r::Ref{AcbPolyRingElem}, x::Ref{AcbPolyRingElem}, y::Ref{AcbPolyRingElem}, precision(parent(x))::Int)::Int
+  if success == 1
     return (q, r)
   else
     throw(DivideError())
@@ -352,8 +351,7 @@ end
 #function reverse(x::AcbPolyRingElem, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:acb_poly_reverse, libflint), Nothing,
-#                (Ref{AcbPolyRingElem}, Ref{AcbPolyRingElem}, Int), z, x, len)
+#   @ccall libflint.acb_poly_reverse(z::Ref{AcbPolyRingElem}, x::Ref{AcbPolyRingElem}, len::Int)::Nothing
 #   return z
 #end
 
@@ -561,10 +559,8 @@ function roots(x::AcbPolyRingElem; target=0, isolate_real=false, initial_prec=0,
           im = _imag_ptr(roots + i * sizeof(acb_struct))
           t = _rad_ptr(re)
           u = _rad_ptr(im)
-          ok = ok && (ccall((:mag_cmp_2exp_si, libflint), Cint,
-                            (Ptr{mag_struct}, Int), t, -target) <= 0)
-          ok = ok && (ccall((:mag_cmp_2exp_si, libflint), Cint,
-                            (Ptr{mag_struct}, Int), u, -target) <= 0)
+          ok = ok && (@ccall libflint.mag_cmp_2exp_si(t::Ptr{mag_struct}, (-target)::Int)::Cint) <= 0
+          ok = ok && (@ccall libflint.mag_cmp_2exp_si(u::Ptr{mag_struct}, (-target)::Int)::Cint) <= 0
         end
       end
 

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -294,9 +294,8 @@ function Base.divrem(x::ArbPolyRingElem, y::ArbPolyRingElem)
   iszero(y) && throw(DivideError())
   q = parent(x)()
   r = parent(x)()
-  if (ccall((:arb_poly_divrem, libflint), Int,
-            (Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}, Int),
-            q, r, x, y, precision(parent(x))) == 1)
+  success = @ccall libflint.arb_poly_divrem(q::Ref{ArbPolyRingElem}, r::Ref{ArbPolyRingElem}, x::Ref{ArbPolyRingElem}, y::Ref{ArbPolyRingElem}, precision(parent(x))::Int)::Int
+  if success == 1
     return (q, r)
   else
     throw(DivideError())
@@ -344,8 +343,7 @@ end
 #function reverse(x::ArbPolyRingElem, len::Int)
 #   len < 0 && throw(DomainError())
 #   z = parent(x)()
-#   ccall((:arb_poly_reverse, libflint), Nothing,
-#                (Ref{ArbPolyRingElem}, Ref{ArbPolyRingElem}, Int), z, x, len)
+#   @ccall libflint.arb_poly_reverse(z::Ref{ArbPolyRingElem}, x::Ref{ArbPolyRingElem}, len::Int)::Nothing
 #   return z
 #end
 

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -767,7 +767,7 @@ Equivalently, $\operatorname{csgn}(x) = x / \sqrt{x^2}$ except that the value is
 at zero. The value is returned as a Julia integer.
 """
 function csgn(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(ccall((:qqbar_csgn, libflint), Cint, (Ref{QQBarFieldElem}, ), a)))
+  return QQBarFieldElem(Int(@ccall libflint.qqbar_csgn(a::Ref{QQBarFieldElem})::Cint))
 end
 
 @doc raw"""
@@ -776,8 +776,7 @@ end
 Return the sign of the real part of `a` as a Julia integer.
 """
 function sign_real(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(ccall((:qqbar_sgn_re, libflint),
-                                  Cint, (Ref{QQBarFieldElem}, ), a)))
+  return QQBarFieldElem(Int(@ccall libflint.qqbar_sgn_re(a::Ref{QQBarFieldElem})::Cint))
 end
 
 @doc raw"""
@@ -786,8 +785,7 @@ end
 Return the sign of the imaginary part of `a` as a Julia integer.
 """
 function sign_imag(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(ccall((:qqbar_sgn_im, libflint),
-                                  Cint, (Ref{QQBarFieldElem}, ), a)))
+  return QQBarFieldElem(Int(@ccall libflint.qqbar_sgn_im(a::Ref{QQBarFieldElem})::Cint))
 end
 
 function floor(a::QQBarFieldElem)

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -767,7 +767,7 @@ Equivalently, $\operatorname{csgn}(x) = x / \sqrt{x^2}$ except that the value is
 at zero. The value is returned as a Julia integer.
 """
 function csgn(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(@ccall libflint.qqbar_csgn(a::Ref{QQBarFieldElem})::Cint))
+  return QQBarFieldElem(@ccall libflint.qqbar_csgn(a::Ref{QQBarFieldElem})::Cint)
 end
 
 @doc raw"""
@@ -776,7 +776,7 @@ end
 Return the sign of the real part of `a` as a Julia integer.
 """
 function sign_real(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(@ccall libflint.qqbar_sgn_re(a::Ref{QQBarFieldElem})::Cint))
+  return QQBarFieldElem(@ccall libflint.qqbar_sgn_re(a::Ref{QQBarFieldElem})::Cint)
 end
 
 @doc raw"""
@@ -785,7 +785,7 @@ end
 Return the sign of the imaginary part of `a` as a Julia integer.
 """
 function sign_imag(a::QQBarFieldElem)
-  return QQBarFieldElem(Int(@ccall libflint.qqbar_sgn_im(a::Ref{QQBarFieldElem})::Cint))
+  return QQBarFieldElem(@ccall libflint.qqbar_sgn_im(a::Ref{QQBarFieldElem})::Cint)
 end
 
 function floor(a::QQBarFieldElem)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -4168,8 +4168,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, libflint), Nothing,
-              (Ref{ZZRingElem}, Ref{ZZRingElem}, UInt), t, arr[i, j], n)
+        @ccall libflint.fmpz_mod_ui(t::Ref{ZZRingElem}, arr[i, j]::Ref{ZZRingElem}, n::UInt)::Nothing
         setindex_raw!(z, t, i, j)
       end
     end
@@ -4543,8 +4542,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
     t = ZZRingElem()
     for i = 1:r
       for j = 1:c
-        ccall((:fmpz_mod_ui, libflint), Nothing,
-              (Ref{ZZRingElem}, Ref{ZZRingElem}, UInt), t, arr[i, j], n)
+        @ccall libflint.fmpz_mod_ui(t::Ref{ZZRingElem}, arr[i, j]::Ref{ZZRingElem}, n::UInt)::Nothing
         setindex_raw!(z, t, i, j)
       end
     end

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -172,16 +172,12 @@ function +(a::QQRelPowerSeriesRingElem, b::QQRelPowerSeriesRingElem)
   z = parent(a)()
   if a.val < b.val
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    @ccall libflint.fmpq_poly_set_trunc(z::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          z, a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpq_poly_set_trunc(z::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -206,17 +202,13 @@ function -(a::QQRelPowerSeriesRingElem, b::QQRelPowerSeriesRingElem)
   z = parent(a)()
   if a.val < b.val
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    @ccall libflint.fmpq_poly_set_trunc(z::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_neg(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem})::Nothing
     @ccall libflint.fmpq_poly_add_series(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          z, a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpq_poly_set_trunc(z::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_sub_series(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -834,16 +826,12 @@ function add!(a::QQRelPowerSeriesRingElem, b::QQRelPowerSeriesRingElem)
     z = QQRelPowerSeriesRingElem()
     z.parent = parent(a)
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    @ccall libflint.fmpq_poly_set_trunc(z::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(z::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(a::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, z::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpq_poly_truncate, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Int),
-          a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpq_poly_truncate(a::Ref{QQRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(a::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(a::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -870,16 +858,12 @@ function add!(c::QQRelPowerSeriesRingElem, a::QQRelPowerSeriesRingElem, b::QQRel
   lenb = min(lenb, prec - b.val)
   if a.val < b.val
     lenc = max(lena, lenb + b.val - a.val)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          c, b, max(0, lenc - b.val + a.val))
+    @ccall libflint.fmpq_poly_set_trunc(c::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, max(0, lenc - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(c::Ref{QQRelPowerSeriesRingElem}, c::Ref{QQRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(c::Ref{QQRelPowerSeriesRingElem}, c::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, lenc::Int)::Nothing
   elseif b.val < a.val
     lenc = max(lena + a.val - b.val, lenb)
-    ccall((:fmpq_poly_set_trunc, libflint), Nothing,
-          (Ref{QQRelPowerSeriesRingElem}, Ref{QQRelPowerSeriesRingElem}, Int),
-          c, a, max(0, lenc - a.val + b.val))
+    @ccall libflint.fmpq_poly_set_trunc(c::Ref{QQRelPowerSeriesRingElem}, a::Ref{QQRelPowerSeriesRingElem}, max(0, lenc - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_shift_left(c::Ref{QQRelPowerSeriesRingElem}, c::Ref{QQRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpq_poly_add_series(c::Ref{QQRelPowerSeriesRingElem}, c::Ref{QQRelPowerSeriesRingElem}, b::Ref{QQRelPowerSeriesRingElem}, lenc::Int)::Nothing
   else

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -884,9 +884,9 @@ end
 
 function cmp(a::BigFloat, b::ZZRingElem)
   if _fmpz_is_small(b)
-    return Int(ccall((:mpfr_cmp_si, :libmpfr), Cint, (Ref{BigFloat}, Int), a, b.d))
+    return Int(@ccall :libmpfr.mpfr_cmp_si(a::Ref{BigFloat}, b.d::Int)::Cint)
   end
-  return Int(ccall((:mpfr_cmp_z, :libmpfr), Cint, (Ref{BigFloat}, UInt), a, unsigned(b.d) << 2))
+  return Int(@ccall :libmpfr.mpfr_cmp_z(a::Ref{BigFloat}, (unsigned(b.d) << 2)::UInt)::Cint)
 end
 
 ==(x::ZZRingElem, y::BigFloat) = cmp(y, x) == 0
@@ -1052,8 +1052,8 @@ julia> sqrtmod(ZZ(12), ZZ(13))
 function sqrtmod(x::ZZRingElem, m::ZZRingElem)
   m <= 0 && throw(DomainError(m, "Modulus must be non-negative"))
   z = ZZRingElem()
-  if (ccall((:fmpz_sqrtmod, libflint), Cint,
-            (Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}), z, x, m) == 0)
+  success = @ccall libflint.fmpz_sqrtmod(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, m::Ref{ZZRingElem})::Cint
+  if success == 0
     error("no square root exists or modulus is not prime")
   end
   return z
@@ -1700,9 +1700,7 @@ function remove(a::BigInt, b::BigInt)
   b <= 1 && error("Factor <= 1")
   a == 0 && error("Not yet implemented")
   q = BigInt()
-  v =  ccall((:__gmpz_remove, :libgmp), Culong,
-             (Ref{BigInt}, Ref{BigInt}, Ref{BigInt}),
-             q, a, b)
+  v = @ccall :libgmp.__gmpz_remove(q::Ref{BigInt}, a::Ref{BigInt}, b::Ref{BigInt})::Culong
   return (Int(v), q)
 end
 

--- a/src/flint/fmpz_laurent_series.jl
+++ b/src/flint/fmpz_laurent_series.jl
@@ -1155,8 +1155,7 @@ function eta_qexp(x::ZZLaurentSeriesRingElem)
   z = parent(x)()
   zscale = valuation(x)
   prec = max_precision(parent(x))
-  ccall((:fmpz_poly_eta_qexp, libflint), Nothing,
-        (Ref{ZZLaurentSeriesRingElem}, Int, Int), z, 1, div(prec + zscale - 1, zscale))
+  @ccall libflint.fmpz_poly_eta_qexp(z::Ref{ZZLaurentSeriesRingElem}, 1::Int, div(prec + zscale - 1, zscale)::Int)::Nothing
   z = set_scale!(z, zscale)
   z = set_valuation!(z, 0)
   z = set_precision!(z, prec)

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -287,8 +287,7 @@ function divides(a::ZZModRingElem, b::ZZModRingElem)
   end
   ub = divexact(B, gb)
   b1 = ZZRingElem()
-  ccall((:fmpz_invmod, libflint), Nothing, (Ref{ZZRingElem}, Ref{ZZRingElem}, Ref{ZZRingElem}),
-        b1, ub, divexact(m, gb))
+  @ccall libflint.fmpz_invmod(b1::Ref{ZZRingElem}, ub::Ref{ZZRingElem}, divexact(m, gb)::Ref{ZZRingElem})::Nothing
   rr = R(q)*b1
   return true, rr
 end

--- a/src/flint/fmpz_mod_abs_series.jl
+++ b/src/flint/fmpz_mod_abs_series.jl
@@ -63,9 +63,6 @@ for (etype, rtype, ctype, mtype, brtype) in (
 
     function length(x::($etype))
       return x.length
-      #   return ccall((:fmpz_mod_poly_length, libflint), Int,
-      #                (Ref{($etype)}, Ref{($ctype)}),
-      #                x, x.parent.base_ring.ninv)
     end
 
     precision(x::($etype)) = x.prec
@@ -547,9 +544,7 @@ for (etype, rtype, ctype, mtype, brtype) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{$(ctype)}),
-            a, n, a.parent.base_ring.ninv)
+      @ccall libflint._fmpz_mod_poly_set_length(a::Ref{($etype)}, n::Int, a.parent.base_ring.ninv::Ref{($ctype)})::Nothing
       return a
     end
 

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -84,9 +84,6 @@ for (etype, rtype, ftype, ctype) in (
 
     function length(a::($etype))
       return a.length
-      #   return ccall((:fmpz_mod_mpoly_length, libflint), Int,
-      #                (Ref{T}, Ref{parent_type(T)}),
-      #                a, a.parent)
     end
 
     one(R::($rtype)) = one!(R())

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -61,9 +61,6 @@ is_gen(a::Zmodn_fmpz_poly) = (degree(a) == 1 &&
 
 function iszero(a::T) where {T <: Zmodn_fmpz_poly}
   return a.length == 0
-  #  return Bool(ccall((:fmpz_mod_poly_is_zero, libflint), Cint,
-  #                    (Ref{T}, Ref{fmpz_mod_ctx_struct}),
-  #                    a, a.parent.base_ring.ninv))
 end
 
 var(R::ZmodNFmpzPolyRing) = R.S

--- a/src/flint/fmpz_mod_rel_series.jl
+++ b/src/flint/fmpz_mod_rel_series.jl
@@ -59,9 +59,6 @@ for (etype, rtype, ctype, mtype, brtype) in (
 
     function pol_length(x::($etype))
       return x.length
-      #   return ccall((:fmpz_mod_poly_length, libflint), Int,
-      #                (Ref{($etype)}, Ref{($ctype)}),
-      #                x, x.parent.base_ring.ninv)
     end
 
     precision(x::($etype)) = x.prec
@@ -188,18 +185,12 @@ for (etype, rtype, ctype, mtype, brtype) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              z, b, max(0, lenz - b.val + a.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, a::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              z, a, max(0, lenz - a.val + b.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(z::Ref{($etype)}, a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (a.val - b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, b::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       else
@@ -225,19 +216,13 @@ for (etype, rtype, ctype, mtype, brtype) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              z, b, max(0, lenz - b.val + a.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_neg(z::Ref{($etype)}, z::Ref{($etype)}, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, a::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              z, a, max(0, lenz - a.val + b.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(z::Ref{($etype)}, a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (a.val - b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_sub_series(z::Ref{($etype)}, z::Ref{($etype)}, b::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       else
@@ -356,9 +341,7 @@ for (etype, rtype, ctype, mtype, brtype) in (
         x = zero!(x)
         x.val = k
       else
-        ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
-              (Ref{($etype)}, Int, Ref{$(ctype)}),
-              x, k - valuation(x), x.parent.base_ring.ninv)
+        @ccall libflint.fmpz_mod_poly_truncate(x::Ref{($etype)}, (k - valuation(x))::Int, x.parent.base_ring.ninv::Ref{$(ctype)})::Nothing
       end
       x.prec = k
       return x
@@ -587,9 +570,7 @@ for (etype, rtype, ctype, mtype, brtype) in (
         d[k + 1] = divexact(base_ring(a)(s), k).data
       end
       z = parent(a)(d, preca, preca, 0)
-      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{($ctype)}),
-            z, normalise(z, preca), a.parent.base_ring.ninv)
+      @ccall libflint._fmpz_mod_poly_set_length(z::Ref{($etype)}, normalise(z, preca)::Int, a.parent.base_ring.ninv::Ref{($ctype)})::Nothing
       return z
     end
 
@@ -659,17 +640,12 @@ for (etype, rtype, ctype, mtype, brtype) in (
         z = ($etype)(p)
         z.parent = parent(a)
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              z, b, max(0, lenz - b.val + a.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(a::Ref{($etype)}, a::Ref{($etype)}, z::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:fmpz_mod_poly_truncate, libflint), Nothing,
-              (Ref{($etype)}, Int, Ref{($ctype)}),
-              a, max(0, lenz - a.val + b.val), p)
+        @ccall libflint.fmpz_mod_poly_truncate(a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(a::Ref{($etype)}, a::Ref{($etype)}, (a.val - b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(a::Ref{($etype)}, a::Ref{($etype)}, b::Ref{($etype)}, lenz::Int, p::Ref{($ctype)})::Nothing
       else
@@ -697,18 +673,12 @@ for (etype, rtype, ctype, mtype, brtype) in (
       p = a.parent.base_ring.ninv
       if a.val < b.val
         lenc = max(lena, lenb + b.val - a.val)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              c, b, max(0, lenc - b.val + a.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(c::Ref{($etype)}, b::Ref{($etype)}, max(0, lenc - b.val + a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(c::Ref{($etype)}, c::Ref{($etype)}, (b.val - a.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(c::Ref{($etype)}, c::Ref{($etype)}, a::Ref{($etype)}, lenc::Int, p::Ref{($ctype)})::Nothing
       elseif b.val < a.val
         lenc = max(lena + a.val - b.val, lenb)
-        ccall((:fmpz_mod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int,
-               Ref{($ctype)}),
-              c, a, max(0, lenc - a.val + b.val), p)
+        @ccall libflint.fmpz_mod_poly_set_trunc(c::Ref{($etype)}, a::Ref{($etype)}, max(0, lenc - a.val + b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_shift_left(c::Ref{($etype)}, c::Ref{($etype)}, (a.val - b.val)::Int, p::Ref{($ctype)})::Nothing
         @ccall libflint.fmpz_mod_poly_add_series(c::Ref{($etype)}, c::Ref{($etype)}, b::Ref{($etype)}, lenc::Int, p::Ref{($ctype)})::Nothing
       else
@@ -722,9 +692,7 @@ for (etype, rtype, ctype, mtype, brtype) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall((:_fmpz_mod_poly_set_length, libflint), Nothing,
-            (Ref{($etype)}, Int, Ref{$(ctype)}),
-            a, n, a.parent.base_ring.ninv)
+      @ccall libflint._fmpz_mod_poly_set_length(a::Ref{($etype)}, n::Int, a.parent.base_ring.ninv::Ref{($ctype)})::Nothing
       return a
     end
 

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -171,17 +171,13 @@ function +(a::ZZRelPowerSeriesRingElem, b::ZZRelPowerSeriesRingElem)
   lenb = min(lenb, prec - b.val)
   z = parent(a)()
   if a.val < b.val
-    lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    lenz = max(lena, lenb + b.val - a.val)       
+    @ccall libflint.fmpz_poly_set_trunc(z::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpz_poly_set_trunc(z::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -206,17 +202,13 @@ function -(a::ZZRelPowerSeriesRingElem, b::ZZRelPowerSeriesRingElem)
   z = parent(a)()
   if a.val < b.val
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    @ccall libflint.fmpz_poly_set_trunc(z::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_neg(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem})::Nothing
     @ccall libflint.fmpz_poly_add_series(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpz_poly_set_trunc(z::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_sub_series(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -579,16 +571,12 @@ function add!(a::ZZRelPowerSeriesRingElem, b::ZZRelPowerSeriesRingElem)
     z = ZZRelPowerSeriesRingElem()
     z.parent = parent(a)
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          z, b, max(0, lenz - b.val + a.val))
+    @ccall libflint.fmpz_poly_set_trunc(z::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(a::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, z::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fmpz_poly_truncate, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Int),
-          a, max(0, lenz - a.val + b.val))
+    @ccall libflint.fmpz_poly_truncate(a::Ref{ZZRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(a::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(a::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, lenz::Int)::Nothing
   else
@@ -615,16 +603,12 @@ function add!(c::ZZRelPowerSeriesRingElem, a::ZZRelPowerSeriesRingElem, b::ZZRel
   lenb = min(lenb, prec - b.val)
   if a.val < b.val
     lenc = max(lena, lenb + b.val - a.val)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          c, b, max(0, lenc - b.val + a.val))
+    @ccall libflint.fmpz_poly_set_trunc(c::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, max(0, lenc - b.val + a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(c::Ref{ZZRelPowerSeriesRingElem}, c::Ref{ZZRelPowerSeriesRingElem}, (b.val - a.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(c::Ref{ZZRelPowerSeriesRingElem}, c::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, lenc::Int)::Nothing
   elseif b.val < a.val
     lenc = max(lena + a.val - b.val, lenb)
-    ccall((:fmpz_poly_set_trunc, libflint), Nothing,
-          (Ref{ZZRelPowerSeriesRingElem}, Ref{ZZRelPowerSeriesRingElem}, Int),
-          c, a, max(0, lenc - a.val + b.val))
+    @ccall libflint.fmpz_poly_set_trunc(c::Ref{ZZRelPowerSeriesRingElem}, a::Ref{ZZRelPowerSeriesRingElem}, max(0, lenc - a.val + b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_shift_left(c::Ref{ZZRelPowerSeriesRingElem}, c::Ref{ZZRelPowerSeriesRingElem}, (a.val - b.val)::Int)::Nothing
     @ccall libflint.fmpz_poly_add_series(c::Ref{ZZRelPowerSeriesRingElem}, c::Ref{ZZRelPowerSeriesRingElem}, b::Ref{ZZRelPowerSeriesRingElem}, lenc::Int)::Nothing
   else

--- a/src/flint/fq_default_embed.jl
+++ b/src/flint/fq_default_embed.jl
@@ -82,11 +82,15 @@ function _fq_default_embed_matrices(
   sub_ctx1 = _as_fq_finite_field(sub_ctx)
   sup_ctx1 = _as_fq_finite_field(sup_ctx)
 
-  ccall((:fq_embed_matrices, libflint), Nothing,
-        (Ref{FpMatrix}, Ref{FpMatrix}, Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField},
-         Ref{FqPolyRepFieldElem}, Ref{FqPolyRepField}, Ref{FpPolyRingElem}),
-        emb, pro, _unchecked_coerce(sub_ctx1, gen_sub), sub_ctx1,
-        _unchecked_coerce(sup_ctx1, gen_sup), sup_ctx1, gen_minpoly)
+  @ccall libflint.fq_embed_matrices(
+    emb::Ref{FpMatrix},
+    pro::Ref{FpMatrix},
+    _unchecked_coerce(sub_ctx1, gen_sub)::Ref{FqPolyRepFieldElem},
+    sub_ctx1::Ref{FqPolyRepField},
+    _unchecked_coerce(sup_ctx1, gen_sup)::Ref{FqPolyRepFieldElem},
+    sup_ctx1::Ref{FqPolyRepField},
+    gen_minpoly::Ref{FpPolyRingElem}
+  )::Nothing
 end
 
 function embed_matrices(k::FqField, K::FqField)

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -248,7 +248,7 @@ end
 function mul!(a::FqMatrix, b::FqMatrix, c::FqFieldElem)
   F = base_ring(a)
   if _fq_default_ctx_type(F) == _FQ_DEFAULT_NMOD
-    ccall((:nmod_mat_scalar_mul, libflint), Nothing, (Ref{FqMatrix}, Ref{FqMatrix}, UInt), a, b, UInt(lift(ZZ, c)))
+    @ccall libflint.nmod_mat_scalar_mul(a::Ref{FqMatrix}, b::Ref{FqMatrix}, UInt(lift(ZZ, c))::UInt)::Nothing
     return a
   end
   GC.@preserve a begin

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -297,9 +297,8 @@ function Base.div(x::FqPolyRingElem, y::FqPolyRingElem)
   return divrem(x, y)[1]
   # The following function does not exist in flint
   #z = parent(x)()
-  #ccall((:fq_default_poly_div_basecase, libflint), Nothing,
-  #      (Ref{FqPolyRingElem}, Ref{FqPolyRingElem}, Ref{FqPolyRingElem},
-  #      Ref{FqField}), z, x, y, base_ring(parent(x)))
+  #@ccall libflint.fq_default_poly_div_basecase(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, y::Ref{FqPolyRingElem},
+  #      base_ring(parent(x))::Ref{FqField})::Nothing
   #return z
 end
 

--- a/src/flint/fq_default_rel_series.jl
+++ b/src/flint/fq_default_rel_series.jl
@@ -172,16 +172,12 @@ function +(a::FqRelPowerSeriesRingElem, b::FqRelPowerSeriesRingElem)
   ctx = base_ring(a)
   if a.val < b.val
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          z, b, max(0, lenz - b.val + a.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(z::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, (b.val - a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          z, a, max(0, lenz - a.val + b.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(z::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, (a.val - b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   else
@@ -207,17 +203,13 @@ function -(a::FqRelPowerSeriesRingElem, b::FqRelPowerSeriesRingElem)
   ctx = base_ring(a)
   if a.val < b.val
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          z, b, max(0, lenz - b.val + a.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(z::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, (b.val - a.val)::Int, ctx::Ref{FqField})::Nothing
     z = neg!(z)
     @ccall libflint.fq_default_poly_add_series(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          z, a, max(0, lenz - a.val + b.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(z::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, (a.val - b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_sub_series(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   else
@@ -656,16 +648,12 @@ function add!(a::FqRelPowerSeriesRingElem, b::FqRelPowerSeriesRingElem)
     z = FqRelPowerSeriesRingElem(base_ring(a))
     z.parent = parent(a)
     lenz = max(lena, lenb + b.val - a.val)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          z, b, max(0, lenz - b.val + a.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(z::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - b.val + a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(z::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, (b.val - a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(a::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, z::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   elseif b.val < a.val
     lenz = max(lena + a.val - b.val, lenb)
-    ccall((:fq_default_poly_truncate, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          a, max(0, lenz - a.val + b.val), ctx)
+    @ccall libflint.fq_default_poly_truncate(a::Ref{FqRelPowerSeriesRingElem}, max(0, lenz - a.val + b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(a::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, (a.val - b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(a::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, lenz::Int, ctx::Ref{FqField})::Nothing
   else
@@ -693,16 +681,12 @@ function add!(c::FqRelPowerSeriesRingElem, a::FqRelPowerSeriesRingElem, b::FqRel
   ctx = base_ring(a)
   if a.val < b.val
     lenc = max(lena, lenb + b.val - a.val)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          c, b, max(0, lenc - b.val + a.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(c::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, max(0, lenc - b.val + a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(c::Ref{FqRelPowerSeriesRingElem}, c::Ref{FqRelPowerSeriesRingElem}, (b.val - a.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(c::Ref{FqRelPowerSeriesRingElem}, c::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, lenc::Int, ctx::Ref{FqField})::Nothing
   elseif b.val < a.val
     lenc = max(lena + a.val - b.val, lenb)
-    ccall((:fq_default_poly_set_trunc, libflint), Nothing,
-          (Ref{FqRelPowerSeriesRingElem}, Ref{FqRelPowerSeriesRingElem}, Int, Ref{FqField}),
-          c, a, max(0, lenc - a.val + b.val), ctx)
+    @ccall libflint.fq_default_poly_set_trunc(c::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, max(0, lenc - a.val + b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_shift_left(c::Ref{FqRelPowerSeriesRingElem}, c::Ref{FqRelPowerSeriesRingElem}, (a.val - b.val)::Int, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_add_series(c::Ref{FqRelPowerSeriesRingElem}, c::Ref{FqRelPowerSeriesRingElem}, b::Ref{FqRelPowerSeriesRingElem}, lenc::Int, ctx::Ref{FqField})::Nothing
   else

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -135,15 +135,13 @@ end
 # There is no transpose for FqPolyRepMatrix
 #function transpose(a::FqPolyRepMatrix)
 #  z = FqPolyRepMatrixSpace(base_ring(a), ncols(a), nrows(a))()
-#  ccall((:fq_mat_transpose, libflint), Nothing,
-#        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), z, a, base_ring(a))
+#  @ccall libflint.fq_mat_transpose(z::Ref{FqPolyRepMatrix}, a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
 #  return z
 #end
 #
 #function transpose!(a::FqPolyRepMatrix)
 #  !is_square(a) && error("Matrix must be a square matrix")
-#  ccall((:fq_mat_transpose, libflint), Nothing,
-#        (Ref{FqPolyRepMatrix}, Ref{FqPolyRepMatrix}, Ref{FqPolyRepField}), a, a, base_ring(a))
+#  @ccall libflint.fq_mat_transpose(a::Ref{FqPolyRepMatrix}, a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
 #end
 
 ###############################################################################

--- a/src/flint/fq_nmod_embed.jl
+++ b/src/flint/fq_nmod_embed.jl
@@ -30,9 +30,13 @@ function embed_gens(k::fqPolyRepField, K::fqPolyRepField)
   PR = polynomial_ring(R, "T")[1]
   P = PR()
 
-  ccall((:fq_nmod_embed_gens, libflint), Nothing, (Ref{fqPolyRepFieldElem}, Ref{fqPolyRepFieldElem},
-                                                   Ref{fpPolyRingElem}, Ref{fqPolyRepField}, Ref{fqPolyRepField}), a, b,
-        P, k, K)
+  @ccall libflint.fq_nmod_embed_gens(
+    a::Ref{fqPolyRepFieldElem},
+    b::Ref{fqPolyRepFieldElem},
+    P::Ref{fpPolyRingElem},
+    k::Ref{fqPolyRepField},
+    K::Ref{fqPolyRepField}
+  )::Nothing
 
   return a, b, P
 end

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -304,8 +304,7 @@ function divides(a::zzModRingElem, b::zzModRingElem)
   end
   ub = divexact(B, gb)
   # The Julia invmod function does not give the correct result for me
-  b1 = ccall((:n_invmod, libflint), UInt, (UInt, UInt),
-             ub, divexact(m, gb))
+  b1 = @ccall libflint.n_invmod(ub::UInt, divexact(m, gb)::UInt)::UInt
   rr = R(q)*b1
   return true, rr
 end

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -78,9 +78,6 @@ for (etype, rtype, ftype, ctype, utype) in (
 
     function length(a::($etype))
       return a.length
-      #   return ccall((:nmod_mpoly_length, libflint), Int,
-      #                (Ref{T}, Ref{parent_type(T)}),
-      #                a, a.parent)
     end
 
     one(R::($rtype)) = one!(R())

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -845,8 +845,7 @@ function setcoeff!(x::T, n::Int, y::UInt) where T <: Zmodn_poly
 end
 
 function setcoeff!(x::T, n::Int, y::Int) where T <: Zmodn_poly
-  ccall((:nmod_poly_set_coeff_ui, libflint), Nothing,
-        (Ref{T}, Int, UInt), x, n, mod(y, x.mod_n))
+  @ccall libflint.nmod_poly_set_coeff_ui(x::Ref{T}, n::Int, mod(y, x.mod_n)::UInt)::Nothing
   return x
 end
 

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -176,16 +176,12 @@ for (etype, rtype, mtype, brtype) in (
       z = parent(a)()
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, b, max(0, lenz - b.val + a.val))
+        @ccall libflint.nmod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, a::Ref{($etype)}, lenz::Int)::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, a, max(0, lenz - a.val + b.val))
+        @ccall libflint.nmod_poly_set_trunc(z::Ref{($etype)}, a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (a.val - b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, b::Ref{($etype)}, lenz::Int)::Nothing
       else
@@ -210,17 +206,13 @@ for (etype, rtype, mtype, brtype) in (
       z = parent(a)()
       if a.val < b.val
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, b, max(0, lenz - b.val + a.val))
+        @ccall libflint.nmod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_neg(z::Ref{($etype)}, z::Ref{($etype)})::Nothing
         @ccall libflint.nmod_poly_add_series(z::Ref{($etype)}, z::Ref{($etype)}, a::Ref{($etype)}, lenz::Int)::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, a, max(0, lenz - a.val + b.val))
+        @ccall libflint.nmod_poly_set_trunc(z::Ref{($etype)}, a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (a.val - b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_sub_series(z::Ref{($etype)}, z::Ref{($etype)}, b::Ref{($etype)}, lenz::Int)::Nothing
       else
@@ -285,9 +277,7 @@ for (etype, rtype, mtype, brtype) in (
       z = parent(y)()
       z.prec = y.prec
       z.val = y.val
-      ccall((:nmod_poly_scalar_mul_nmod, libflint), Nothing,
-            (Ref{($etype)}, Ref{($etype)}, UInt),
-            z, y, mod(x, modulus(y)))
+      @ccall libflint.nmod_poly_scalar_mul_nmod(z::Ref{($etype)}, y::Ref{($etype)}, mod(x, modulus(y))::UInt)::Nothing
       renormalize!(z)
       return z
     end
@@ -615,8 +605,7 @@ for (etype, rtype, mtype, brtype) in (
         d[k + 1] = divexact(base_ring(a)(s), k)
       end
       z = parent(a)(d, preca, preca, 0)
-      ccall((:_nmod_poly_set_length, libflint), Nothing,
-            (Ref{($etype)}, Int), z, normalise(z, preca))
+      @ccall libflint._nmod_poly_set_length(z::Ref{($etype)}, normalise(z, preca)::Int)::Nothing
       return z
     end
 
@@ -700,16 +689,12 @@ for (etype, rtype, mtype, brtype) in (
         z = ($etype)(n)
         z.parent = parent(a)
         lenz = max(lena, lenb + b.val - a.val)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              z, b, max(0, lenz - b.val + a.val))
+        @ccall libflint.nmod_poly_set_trunc(z::Ref{($etype)}, b::Ref{($etype)}, max(0, lenz - b.val + a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(z::Ref{($etype)}, z::Ref{($etype)}, (b.val - a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(a::Ref{($etype)}, a::Ref{($etype)}, z::Ref{($etype)}, lenz::Int)::Nothing
       elseif b.val < a.val
         lenz = max(lena + a.val - b.val, lenb)
-        ccall((:nmod_poly_truncate, libflint), Nothing,
-              (Ref{($etype)}, Int),
-              a, max(0, lenz - a.val + b.val))
+        @ccall libflint.nmod_poly_truncate(a::Ref{($etype)}, max(0, lenz - a.val + b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(a::Ref{($etype)}, a::Ref{($etype)}, (a.val - b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(a::Ref{($etype)}, a::Ref{($etype)}, b::Ref{($etype)}, lenz::Int)::Nothing
       else
@@ -736,16 +721,12 @@ for (etype, rtype, mtype, brtype) in (
       lenb = min(lenb, prec - b.val)
       if a.val < b.val
         lenc = max(lena, lenb + b.val - a.val)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              c, b, max(0, lenc - b.val + a.val))
+        @ccall libflint.nmod_poly_set_trunc(c::Ref{($etype)}, b::Ref{($etype)}, max(0, lenc - b.val + a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(c::Ref{($etype)}, c::Ref{($etype)}, (b.val - a.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(c::Ref{($etype)}, c::Ref{($etype)}, a::Ref{($etype)}, lenc::Int)::Nothing
       elseif b.val < a.val
         lenc = max(lena + a.val - b.val, lenb)
-        ccall((:nmod_poly_set_trunc, libflint), Nothing,
-              (Ref{($etype)}, Ref{($etype)}, Int),
-              c, a, max(0, lenc - a.val + b.val))
+        @ccall libflint.nmod_poly_set_trunc(c::Ref{($etype)}, a::Ref{($etype)}, max(0, lenc - a.val + b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_shift_left(c::Ref{($etype)}, c::Ref{($etype)}, (a.val - b.val)::Int)::Nothing
         @ccall libflint.nmod_poly_add_series(c::Ref{($etype)}, c::Ref{($etype)}, b::Ref{($etype)}, lenc::Int)::Nothing
       else
@@ -759,8 +740,7 @@ for (etype, rtype, mtype, brtype) in (
     end
 
     function set_length!(a::($etype), n::Int)
-      ccall((:_nmod_poly_set_length, libflint), Nothing,
-            (Ref{$(etype)}, Int), a, n::Int)
+      @ccall libflint._nmod_poly_set_length(a::Ref{($etype)}, n::Int)::Nothing
       return a
     end
 

--- a/src/julia/Float.jl
+++ b/src/julia/Float.jl
@@ -1,4 +1,4 @@
 function setprecision!(x::BigFloat, p::Int)
-  ccall((:mpfr_prec_round, :libmpfr), Nothing, (Ref{BigFloat}, Clong, Int32), x, p, Base.MPFR.ROUNDING_MODE[])
+  @ccall :libmpfr.mpfr_prec_round(x::Ref{BigFloat}, p::Clong, Base.MPFR.ROUNDING_MODE[]::Int32)::Nothing
 end
 

--- a/test/arb/Real-test.jl
+++ b/test/arb/Real-test.jl
@@ -39,12 +39,8 @@ end
 @testset "arf.hecke_semantics" begin
   x = Nemo.arf_struct(0, 0, 0, 0)
   y = ZZRingElem(3)^100
-  ccall((:arf_set_fmpz, Nemo.libflint), Nothing,
-        (Ref{Nemo.arf_struct}, Ref{ZZRingElem}),
-        x, y)
-  ccall((:arf_clear, Nemo.libflint), Nothing,
-        (Ref{Nemo.arf_struct},),
-        x)
+  @ccall Nemo.libflint.arf_set_fmpz(x::Ref{Nemo.arf_struct}, y::Ref{ZZRingElem})::Nothing
+  @ccall Nemo.libflint.arf_clear(x::Ref{Nemo.arf_struct})::Nothing
 end
 
 @testset "RealFieldElem.printing" begin

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -16,12 +16,8 @@ end
 @testset "arf.hecke_semantics" begin
   x = Nemo.arf_struct(0, 0, 0, 0)
   y = ZZRingElem(3)^100
-  ccall((:arf_set_fmpz, Nemo.libflint), Nothing,
-        (Ref{Nemo.arf_struct}, Ref{ZZRingElem}),
-        x, y)
-  ccall((:arf_clear, Nemo.libflint), Nothing,
-        (Ref{Nemo.arf_struct},),
-        x)
+  @ccall Nemo.libflint.arf_set_fmpz(x::Ref{Nemo.arf_struct}, y::Ref{ZZRingElem})::Nothing
+  @ccall Nemo.libflint.arf_clear(x::Ref{Nemo.arf_struct})::Nothing
 end
 
 @testset "ArbFieldElem.printing" begin

--- a/test/gaussiannumbers/continued_fraction-test.jl
+++ b/test/gaussiannumbers/continued_fraction-test.jl
@@ -105,7 +105,7 @@ end
     (ZZRingElem[-1, 1, 2, 7], matrix(ZZ, [-7 -1; 22 3]))
 
     z = CC()
-    ccall((:arb_zero_pm_one, Nemo.libflint), Nothing, (Ref{ArbFieldElem},), z)
+    @ccall Nemo.libflint.arb_zero_pm_one(z::Ref{ArbFieldElem})::Nothing
     @test_throws Exception continued_fraction(inv(z))
     # need exact intervals [-1, 1], [543//512, 17/16], [542//512, 17//16] here
     @test continued_fraction(z) == ZZRingElem[]


### PR DESCRIPTION
These are (most of) the changes that the automatic way in https://github.com/Nemocas/Nemo.jl/pull/1932 wasn't able to do. Instead, I applied some semi-automatic rewriting (custom regexes for some often occurring cases etc.).