### PR TITLE
Add global guassian parents without `Flint` in name

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -585,13 +585,8 @@ const FlintZZ = ZZ
 @doc qq_field_doc
 const FlintQQ = QQ
 
-###############################################################################
-#
-#   Set domain for RR, CC to Arb
-#
-###############################################################################
+const FlintZZi = ZZi
 
-GaussianIntegers() = FlintZZi
 GaussianRationals() = FlintQQi
 
 ###############################################################################

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -587,7 +587,7 @@ const FlintQQ = QQ
 
 const FlintZZi = ZZi
 
-GaussianRationals() = FlintQQi
+const FlintQQi = QQi
 
 ###############################################################################
 #

--- a/src/gaussiannumbers/GaussianNumberTypes.jl
+++ b/src/gaussiannumbers/GaussianNumberTypes.jl
@@ -14,7 +14,8 @@ end
 struct QQiField <: Field
 end
 
-const FlintQQi = QQiField()
+const QQi = QQiField()
+GaussianRationals() = QQi
 
 struct QQiFieldElem <: FieldElem
   num::ZZiRingElem

--- a/src/gaussiannumbers/GaussianNumberTypes.jl
+++ b/src/gaussiannumbers/GaussianNumberTypes.jl
@@ -3,7 +3,8 @@
 struct ZZiRing <: Ring
 end
 
-const FlintZZi = ZZiRing()
+const ZZi = ZZiRing()
+GaussianIntegers() = ZZi
 
 struct ZZiRingElem <: RingElem
   x::ZZRingElem

--- a/src/gaussiannumbers/QQi.jl
+++ b/src/gaussiannumbers/QQi.jl
@@ -8,7 +8,7 @@ elem_type(::Type{QQiField}) = QQiFieldElem
 
 parent_type(::Type{QQiFieldElem}) = QQiField
 
-parent(a::QQiFieldElem) = FlintQQi
+parent(a::QQiFieldElem) = QQi
 
 base_ring_type(::Type{QQiField}) = ZZiRing
 
@@ -460,22 +460,22 @@ for (A, Bs) in [
         return QQiFieldElem
       end
       function +(a::($A), b::($B))
-        return FlintQQi(a) + FlintQQi(b)
+        return QQi(a) + QQi(b)
       end
       function +(a::($B), b::($A))
-        return FlintQQi(a) + FlintQQi(b)
+        return QQi(a) + QQi(b)
       end
       function -(a::($A), b::($B))
-        return FlintQQi(a) - FlintQQi(b)
+        return QQi(a) - QQi(b)
       end
       function -(a::($B), b::($A))
-        return FlintQQi(a) - FlintQQi(b)
+        return QQi(a) - QQi(b)
       end
       function *(a::($A), b::($B))
-        return FlintQQi(a) * FlintQQi(b)
+        return QQi(a) * QQi(b)
       end
       function *(a::($B), b::($A))
-        return FlintQQi(a) * FlintQQi(b)
+        return QQi(a) * QQi(b)
       end
     end
   end
@@ -491,7 +491,7 @@ for (As, Bs) in [
   for A in As, B in Bs
     @eval begin
       function //(a::($A), b::($B))
-        return divexact(FlintQQi(a), FlintQQi(b))
+        return divexact(QQi(a), QQi(b))
       end
     end
   end

--- a/src/gaussiannumbers/QQi.jl
+++ b/src/gaussiannumbers/QQi.jl
@@ -12,7 +12,7 @@ parent(a::QQiFieldElem) = FlintQQi
 
 base_ring_type(::Type{QQiField}) = ZZiRing
 
-base_ring(a::QQiField) = FlintZZi
+base_ring(a::QQiField) = ZZi
 
 is_domain_type(::Type{QQiFieldElem}) = true
 
@@ -155,7 +155,7 @@ end
 function rand_bits(a::QQiField, b::Int)
   b = max(1, b)
   t = clamp(cld(rand(0:b)^2, b), 1, b)  # average b/3 for the denominator
-  return reduce!(QQiFieldElem(rand_bits(FlintZZi, clamp(b - t, 0, b)), rand_bits(ZZ, t)))
+  return reduce!(QQiFieldElem(rand_bits(ZZi, clamp(b - t, 0, b)), rand_bits(ZZ, t)))
 end
 
 ###############################################################################
@@ -186,11 +186,11 @@ function abs2(a::QQiFieldElem)
 end
 
 function zero(a::QQiField)
-  return QQiFieldElem(zero(FlintZZi), ZZRingElem(1))
+  return QQiFieldElem(zero(ZZi), ZZRingElem(1))
 end
 
 function one(a::QQiField)
-  return QQiFieldElem(one(FlintZZi), ZZRingElem(1))
+  return QQiFieldElem(one(ZZi), ZZRingElem(1))
 end
 
 function iszero(a::QQiFieldElem)

--- a/src/gaussiannumbers/ZZi.jl
+++ b/src/gaussiannumbers/ZZi.jl
@@ -8,7 +8,7 @@ elem_type(::Type{ZZiRing}) = ZZiRingElem
 
 parent_type(::Type{ZZiRingElem}) = ZZiRing
 
-parent(a::ZZiRingElem) = FlintZZi
+parent(a::ZZiRingElem) = ZZi
 
 base_ring_type(::Type{ZZiRing}) = ZZRing
 
@@ -70,7 +70,7 @@ function (a::ZZiRing)(b::IntegerUnion, c::IntegerUnion)
 end
 
 function (R::ZZiRing)(a::Complex{T}) where T <: Integer
-  return FlintZZi(ZZRingElem(real(a)), ZZRingElem(imag(a)))
+  return ZZi(ZZRingElem(real(a)), ZZRingElem(imag(a)))
 end
 
 ###############################################################################
@@ -736,14 +736,14 @@ end
 function gcdx(a::ZZiRingElem, b::ZZiRingElem)
   if iszero(a)
     if iszero(b)
-      return (zero(FlintZZi), zero(FlintZZi), zero(FlintZZi))
+      return (zero(ZZi), zero(ZZi), zero(ZZi))
     else
       u = canonical_unit(b)
-      return (divexact(b, u), zero(FlintZZi), inv(u))
+      return (divexact(b, u), zero(ZZi), inv(u))
     end
   elseif iszero(b)
     u = canonical_unit(a)
-    return (divexact(a, u), inv(u), zero(FlintZZi))
+    return (divexact(a, u), inv(u), zero(ZZi))
   end
   m = zero_matrix(ZZ, 4, 2)
   m[1,1] =  a.x; m[1,2] = a.y
@@ -844,8 +844,8 @@ promote_rule(a::Type{<:Complex{<:Integer}}, b::Type{ZZRingElem}) = ZZiRingElem
 
 promote_rule(a::Type{ZZiRingElem}, b::Type{<:Complex{<:Integer}}) = ZZiRingElem
 promote_rule(a::Type{<:Complex{<:Integer}}, b::Type{ZZiRingElem}) = ZZiRingElem
-*(a::ZZiRingElem, b::Complex{<:Integer}) = a*FlintZZi(b)
-*(b::Complex{<:Integer}, a::ZZiRingElem) = a*FlintZZi(b)
+*(a::ZZiRingElem, b::Complex{<:Integer}) = a*ZZi(b)
+*(b::Complex{<:Integer}, a::ZZiRingElem) = a*ZZi(b)
 +(a::ZZiRingElem, b::Complex{<:Integer}) = ZZiRingElem(a.x + real(b), a.y + imag(b))
 +(b::Complex{<:Integer}, a::ZZiRingElem) = ZZiRingElem(a.x + real(b), a.y + imag(b))
 -(a::ZZiRingElem, b::Complex{<:Integer}) = ZZiRingElem(a.x - real(b), a.y - imag(b))


### PR DESCRIPTION
As discussed in https://github.com/Nemocas/Nemo.jl/pull/1935#issuecomment-2459500735

Once this is merged, I'll update https://github.com/Nemocas/Nemo.jl/pull/1935, which will then reduce to removing the 4 constants definition in `Nemo.jl` and the corresponding exports.