### PR TITLE
Make low-level ZZRingElem accessors more powerful

### DIFF
--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -504,6 +504,12 @@ end
   @test rem(-12, ZZRingElem(3)) == 0
 
   @test_throws ArgumentError divexact(ZZ(2), 3)
+
+  b = ZZ(123)
+  @test b % UInt == 123 % UInt
+  @test -b % UInt == -123 % UInt
+  @test b^29 % UInt == big(123)^29 % UInt
+  @test -b^29 % UInt == -big(123)^29 % UInt
 end
 
 @testset "ZZRingElem.shift.." begin


### PR DESCRIPTION
... and their code more readable (at least to me).

Also implement `rem(::ZZRingElem, ::Type{UInt})` and use that to
speed up `iseven`, `isodd`, `sign`, `signbit` and `is_squarefree`
for `ZZRingElem`.

When tested in isolation using BenchmarkTools, the new methods
are usually a little bit faster, and never slower,
than the old ones. The main gain however is in code using them:
unlike opaque `ccall`s the compiler can inline these helper and
possibly perform further optimizations.