### PR TITLE
Add optimized is_trivial methods for zzModRing and ZZModRing

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -463,6 +463,10 @@ For the modulus being an [`Int`](@ref) see [`zzModRing`](@ref).
   ninv::fmpz_mod_ctx_struct
 
   function ZZModRing(n::ZZRingElem, cached::Bool=true)
+    # Modulus of zero cannot be supported. E.g. Flint library could not be expected to
+    # do matrices over Z/0 using a Z/nZ type. The former is multiprecision, the latter not.
+    n <= 0 && throw(DomainError(n, "Modulus must be positive"))
+
     return get_cached!(FmpzModRingID, n, cached) do
       ninv = fmpz_mod_ctx_struct()
       @ccall libflint.fmpz_mod_ctx_init(ninv::Ref{fmpz_mod_ctx_struct}, n::Ref{ZZRingElem})::Nothing

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -56,12 +56,14 @@ is_unit(a::ZZModRingElem) = a.parent.n == 1 ? iszero(a.data) : isone(gcd(a.data,
 
 modulus(R::ZZModRing) = R.n
 
+characteristic(R::ZZModRing) = modulus(R)
+
+is_trivial(a::ZZModRing) = is_one(modulus(a))  # constructor ensures the modulus is > 0
+
 function deepcopy_internal(a::ZZModRingElem, dict::IdDict)
   R = parent(a)
   return ZZModRingElem(deepcopy(a.data), R)
 end
-
-characteristic(R::ZZModRing) = modulus(R)
 
 function _reduce(a::ZZRingElem, ctx::fmpz_mod_ctx_struct)
   b = ZZRingElem()
@@ -449,9 +451,6 @@ end
 ###############################################################################
 
 function residue_ring(R::ZZRing, n::ZZRingElem; cached::Bool=true)
-  # Modulus of zero cannot be supported. E.g. Flint library could not be expected to
-  # do matrices over Z/0 using a Z/nZ type. The former is multiprecision, the latter not.
-  n <= 0 && throw(DomainError(n, "Modulus must be positive"))
   S = ZZModRing(n, cached)
   f = Generic.EuclideanRingResidueMap(R, S)
   return S, f

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -56,12 +56,14 @@ is_unit(a::zzModRingElem) = a.parent.n == 1 ? a.data == 0 : gcd(a.data, a.parent
 
 modulus(R::zzModRing) = R.n
 
+characteristic(R::zzModRing) = ZZRingElem(modulus(R))
+
+is_trivial(a::zzModRing) = is_unit(modulus(a))
+
 function deepcopy_internal(a::zzModRingElem, dict::IdDict)
   R = parent(a)
   return zzModRingElem(deepcopy(a.data), R)
 end
-
-characteristic(R::zzModRing) = ZZRingElem(modulus(R))
 
 ###############################################################################
 #


### PR DESCRIPTION
These checks compile down to just a few machine code instructions and zero allocations. Nice.