### PR TITLE
Add dummy hash functions for arb types

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -318,6 +318,11 @@ function isequal(x::ComplexFieldElem, y::ComplexFieldElem)
   return Bool(r)
 end
 
+function Base.hash(x::ComplexFieldElem, h::UInt)
+  # TODO: improve me
+  return h
+end
+
 function ==(x::ComplexFieldElem, y::ComplexFieldElem)
   r = @ccall libflint.acb_eq(x::Ref{ComplexFieldElem}, y::Ref{ComplexFieldElem})::Cint
   return Bool(r)

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -336,6 +336,11 @@ function isequal(x::RealFieldElem, y::RealFieldElem)
   return Bool(r)
 end
 
+function Base.hash(x::RealFieldElem, h::UInt)
+  # TODO: improve me
+  return h
+end
+
 function ==(x::RealFieldElem, y::RealFieldElem)
   return Bool(@ccall libflint.arb_eq(x::Ref{RealFieldElem}, y::Ref{RealFieldElem})::Cint)
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -329,6 +329,11 @@ function isequal(x::AcbFieldElem, y::AcbFieldElem)
   return Bool(r)
 end
 
+function Base.hash(x::AcbFieldElem, h::UInt)
+  # TODO: improve me
+  return h
+end
+
 function ==(x::AcbFieldElem, y::AcbFieldElem)
   r = @ccall libflint.acb_eq(x::Ref{AcbFieldElem}, y::Ref{AcbFieldElem})::Cint
   return Bool(r)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -352,6 +352,11 @@ function isequal(x::ArbFieldElem, y::ArbFieldElem)
   return Bool(r)
 end
 
+function Base.hash(x::ArbFieldElem, h::UInt)
+  # TODO: improve me
+  return h
+end
+
 function ==(x::ArbFieldElem, y::ArbFieldElem)
   return Bool(@ccall libflint.arb_eq(x::Ref{ArbFieldElem}, y::Ref{ArbFieldElem})::Cint)
 end


### PR DESCRIPTION
Some progress towards https://github.com/oscar-system/Oscar.jl/issues/2222, actually resolves all Nemo cases listed there.

These hash functions are valid, but not good. Once we have a way to safely access the `mid` and `rad`, these can be improved by delegating to hash functions for `arf` or `mag` (which then need someone to look at flint implementations).