### PR TITLE
Add div and divrem with rounding argument

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -651,39 +651,17 @@ div(x::ZZRingElem, y::Integer) = div(x, ZZRingElem(y))
 
 # Note Base.div is different to Nemo.div
 Base.div(x::ZZRingElem, y::Integer) = Base.div(x, ZZRingElem(y))
-Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundToZero)) = Base.div(x, ZZ(y), RoundToZero)
-Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundUp)) = Base.div(x, ZZ(y), RoundUp)
-Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundDown)) = Base.div(x, ZZ(y), RoundDown)
+Base.div(x::ZZRingElem, y::Integer, r::RoundingMode) = Base.div(x, ZZ(y), r)
 
 divrem(x::ZZRingElem, y::Integer) = divrem(x, ZZRingElem(y))
 
 divrem(x::Integer, y::ZZRingElem) = divrem(ZZRingElem(x), y)
 
 # Without the functions below, Julia defaults to `(div(x, y), rem(x, y))`
-Base.divrem(x::ZZRingElem, y::Integer) = (
-  Base.divrem(x, ZZ(y))
-)
-Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundToZero)) = (
-  Base.divrem(x, ZZ(y), RoundToZero)
-)
-Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundUp)) = (
-  Base.divrem(x, ZZ(y), RoundUp)
-)
-Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundDown)) = (
-  Base.divrem(x, ZZ(y), RoundDown)
-)
-Base.divrem(x::Integer, y::ZZRingElem) = (
-  Base.divrem(ZZ(x), y)
-)
-Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundToZero)) = (
-  Base.divrem(ZZ(x), y, RoundToZero)
-)
-Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundUp)) = (
-  Base.divrem(ZZ(x), y, RoundUp)
-)
-Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundDown)) = (
-  Base.divrem(ZZ(x), y, RoundDown)
-)
+Base.divrem(x::ZZRingElem, y::Integer) = Base.divrem(x, ZZ(y))
+Base.divrem(x::ZZRingElem, y::Integer, r::RoundingMode) = Base.divrem(x, ZZ(y), r)
+Base.divrem(x::Integer, y::ZZRingElem) = Base.divrem(ZZ(x), y)
+Base.divrem(x::Integer, y::ZZRingElem, r::RoundingMode) = Base.divrem(ZZ(x), y, r)
 
 ###############################################################################
 #

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -410,9 +410,9 @@ function Base.div(x::ZZRingElem, y::ZZRingElem)
   return z
 end
 
-Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundToZero)) = tdiv(x, c)
-Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundUp)) = cdiv(x, c)
-Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundDown)) = fdiv(x, c)
+Base.div(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundToZero)) = tdiv(x, y)
+Base.div(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundUp)) = cdiv(x, y)
+Base.div(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundDown)) = fdiv(x, y)
 
 function divexact(x::ZZRingElem, y::ZZRingElem; check::Bool=true)
   iszero(y) && throw(DivideError())
@@ -645,17 +645,32 @@ div(x::Integer, y::ZZRingElem) = div(ZZRingElem(x), y)
 
 # Note Base.div is different to Nemo.div
 Base.div(x::Integer, y::ZZRingElem) = Base.div(ZZRingElem(x), y)
+Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundToZero)) = Base.div(ZZ(x), y, RoundToZero)
+Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundUp)) = Base.div(ZZ(x), y, RoundUp)
+Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundDown)) = Base.div(ZZ(x), y, RoundDown)
 
 div(x::ZZRingElem, y::Integer) = div(x, ZZRingElem(y))
 
 # Note Base.div is different to Nemo.div
 Base.div(x::ZZRingElem, y::Integer) = Base.div(x, ZZRingElem(y))
+Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundToZero)) = Base.div(x, ZZ(y), RoundToZero)
+Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundUp)) = Base.div(x, ZZ(y), RoundUp)
+Base.div(x::ZZRingElem, y::Integer, ::typeof(RoundDown)) = Base.div(x, ZZ(y), RoundDown)
 
 divrem(x::ZZRingElem, y::Integer) = divrem(x, ZZRingElem(y))
 
 divrem(x::Integer, y::ZZRingElem) = divrem(ZZRingElem(x), y)
 
-Base.divrem(x::ZZRingElem, y::Int) = (Base.div(x, y), Base.rem(x, y))
+Base.divrem(x::ZZRingElem, y::Integer) = Base.divrem(x, ZZ(y))
+Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundToZero)) = (
+  Base.divrem(x, ZZ(y), RoundToZero)
+)
+Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundUp)) = (
+  Base.divrem(x, ZZ(y), RoundUp)
+)
+Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundDown)) = (
+  Base.divrem(x, ZZ(y), RoundDown)
+)
 
 ###############################################################################
 #
@@ -668,13 +683,10 @@ function divrem(x::ZZRingElem, y::ZZRingElem)
 end
 
 # N.B. Base.divrem differs from Nemo.divrem
-function Base.divrem(x::ZZRingElem, y::ZZRingElem)
-  return tdivrem(x, y)
-end
-
-Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundToZero)) = tdivrem(x, c)
-Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundUp)) = cdivrem(x, c)
-Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundDown)) = fdivrem(x, c)
+Base.divrem(x::ZZRingElem, y::ZZRingElem) = tdivrem(x, y)
+Base.divrem(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundToZero)) = tdivrem(x, y)
+Base.divrem(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundUp)) = cdivrem(x, y)
+Base.divrem(x::ZZRingElem, y::ZZRingElem, ::typeof(RoundDown)) = fdivrem(x, y)
 
 function tdivrem(x::ZZRingElem, y::ZZRingElem)
   iszero(y) && throw(DivideError())

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -410,6 +410,10 @@ function Base.div(x::ZZRingElem, y::ZZRingElem)
   return z
 end
 
+Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundToZero)) = tdiv(x, c)
+Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundUp)) = cdiv(x, c)
+Base.div(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundDown)) = fdiv(x, c)
+
 function divexact(x::ZZRingElem, y::ZZRingElem; check::Bool=true)
   iszero(y) && throw(DivideError())
   if check
@@ -667,6 +671,10 @@ end
 function Base.divrem(x::ZZRingElem, y::ZZRingElem)
   return tdivrem(x, y)
 end
+
+Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundToZero)) = tdivrem(x, c)
+Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundUp)) = cdivrem(x, c)
+Base.divrem(x::ZZRingElem, c::ZZRingElem, ::typeof(RoundDown)) = fdivrem(x, c)
 
 function tdivrem(x::ZZRingElem, y::ZZRingElem)
   iszero(y) && throw(DivideError())

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -645,9 +645,7 @@ div(x::Integer, y::ZZRingElem) = div(ZZRingElem(x), y)
 
 # Note Base.div is different to Nemo.div
 Base.div(x::Integer, y::ZZRingElem) = Base.div(ZZRingElem(x), y)
-Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundToZero)) = Base.div(ZZ(x), y, RoundToZero)
-Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundUp)) = Base.div(ZZ(x), y, RoundUp)
-Base.div(x::Integer, y::ZZRingElem, ::typeof(RoundDown)) = Base.div(ZZ(x), y, RoundDown)
+Base.div(x::Integer, y::ZZRingElem, r::RoundingMode) = Base.div(ZZ(x), y, r)
 
 div(x::ZZRingElem, y::Integer) = div(x, ZZRingElem(y))
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -661,7 +661,10 @@ divrem(x::ZZRingElem, y::Integer) = divrem(x, ZZRingElem(y))
 
 divrem(x::Integer, y::ZZRingElem) = divrem(ZZRingElem(x), y)
 
-Base.divrem(x::ZZRingElem, y::Integer) = Base.divrem(x, ZZ(y))
+# Without the functions below, Julia defaults to `(div(x, y), rem(x, y))`
+Base.divrem(x::ZZRingElem, y::Integer) = (
+  Base.divrem(x, ZZ(y))
+)
 Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundToZero)) = (
   Base.divrem(x, ZZ(y), RoundToZero)
 )
@@ -670,6 +673,18 @@ Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundUp)) = (
 )
 Base.divrem(x::ZZRingElem, y::Integer, ::typeof(RoundDown)) = (
   Base.divrem(x, ZZ(y), RoundDown)
+)
+Base.divrem(x::Integer, y::ZZRingElem) = (
+  Base.divrem(ZZ(x), y)
+)
+Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundToZero)) = (
+  Base.divrem(ZZ(x), y, RoundToZero)
+)
+Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundUp)) = (
+  Base.divrem(ZZ(x), y, RoundUp)
+)
+Base.divrem(x::Integer, y::ZZRingElem, ::typeof(RoundDown)) = (
+  Base.divrem(ZZ(x), y, RoundDown)
 )
 
 ###############################################################################

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -708,6 +708,26 @@ end
   @test Nemo.divrem(-ZZRingElem(2), 3) == (-ZZRingElem(1), ZZRingElem(1))
 end
 
+@testset "divrem and div with other rings" begin
+  for (x, y) in [(12, 5), (-12, 5)]
+    for r in [RoundToZero, RoundUp, RoundDown]
+      @test (
+        ZZ(Base.div(x, y, r))
+        == Base.div(ZZ(x), y, r)
+        == Base.div(x, ZZ(y), r)
+        == Base.div(ZZ(x), ZZ(y), r)
+      )
+      a, b = Base.divrem(x, y, r)
+      @test (
+        (ZZ(a), ZZ(b))
+        == Base.divrem(ZZ(x), y, r)
+        == Base.divrem(x, ZZ(y), r)
+        == Base.divrem(ZZ(x), ZZ(y), r)
+      )
+    end
+  end
+end
+
 @testset "ZZRingElem.roots" begin
   @test sqrt(ZZRingElem(16)) == 4
   @test sqrt(ZZRingElem()) == 0


### PR DESCRIPTION
We add the standard Julia notation
    `div(5, 2, RoundUp)`
also for the type `ZZRingElem`, so that we can write
    `div(ZZ(5), ZZ(2), RoundUp)`.

Also, we fix a bug. Namely, before there was the line:

```
Base.divrem(x::ZZRingElem, y::Int) = (Base.div(x, y), Base.rem(x, y))
```

But that is inefficient. The whole point of having a `divrem` function is to find the dividend and the remainder together. I have changed the above to

```
Base.divrem(x::ZZRingElem, y::Integer) = Base.divrem(x, ZZ(y))