### PR TITLE
Export denominator! and numerator!

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -136,7 +136,7 @@ export degree_fmpz
 export degrees
 export degrees_fit_int
 export degrees_fmpz
-#export denominator!  # not exported for now to avoid clash with Hecke
+export denominator!
 export derivative
 export det
 export det_divisor
@@ -464,7 +464,7 @@ export nullspace_right_rational
 export number_field
 export number_of_partitions
 export numpart
-#export numerator!  # not exported for now to avoid clash with Hecke
+export numerator!
 export oct
 export one
 export one!

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1059,13 +1059,17 @@ function set!(c::QQFieldElemOrPtr, a::Union{Integer,ZZRingElemOrPtr})
   return c
 end
 
-function numerator!(z::ZZRingElem, y::QQFieldElem)
-  @ccall libflint.fmpq_numerator(z::Ref{ZZRingElem}, y::Ref{QQFieldElem})::Nothing
+function numerator!(z::ZZRingElemOrPtr, y::QQFieldElemOrPtr)
+  GC.@preserve y begin
+    set!(z, _num_ptr(y))
+  end
   return z
 end
 
 function denominator!(z::ZZRingElemOrPtr, y::QQFieldElemOrPtr)
-  @ccall libflint.fmpq_denominator(z::Ref{ZZRingElem}, y::Ref{QQFieldElem})::Nothing
+  GC.@preserve y begin
+    set!(z, _den_ptr(y))
+  end
   return z
 end
 

--- a/test/flint/fmpq-test.jl
+++ b/test/flint/fmpq-test.jl
@@ -193,6 +193,14 @@ end
 
   @test denominator(QQFieldElem(2, 3)) == 3
 
+  z = ZZRingElem()
+  @test numerator!(z, QQFieldElem(2, 3)) == 2
+  @test z == 2
+
+  z = ZZRingElem()
+  @test denominator!(z, QQFieldElem(2, 3)) == 3
+  @test z == 3
+
   @test characteristic(R) == 0
 
   @test nbits(QQFieldElem(12, 1)) == 5


### PR DESCRIPTION
Also allow passing pointers into `numerator!`, and change both to not
use `ccall`. This makes it a little bit faster.

Before:

    julia> using Nemo; z = ZZRingElem(); a = QQFieldElem(2, 3);

    julia> @btime Nemo.numerator!($z, $a);
      5.208 ns (0 allocations: 0 bytes)

    julia> @btime Nemo.denominator!($z, $a);
      5.166 ns (0 allocations: 0 bytes)

    julia> a = a^100;

    julia> @btime Nemo.numerator!($z, $a);
      7.083 ns (0 allocations: 0 bytes)

    julia> @btime Nemo.denominator!($z, $a);
      6.750 ns (0 allocations: 0 bytes)

After:

    julia> using Nemo; z = ZZRingElem(); a = QQFieldElem(2, 3);

    julia> @btime numerator!($z, $a);
      4.000 ns (0 allocations: 0 bytes)

    julia> @btime denominator!($z, $a);
      4.000 ns (0 allocations: 0 bytes)

    julia> a = a^100;

    julia> @btime numerator!($z, $a);
      5.875 ns (0 allocations: 0 bytes)

    julia> @btime denominator!($z, $a);
      5.625 ns (0 allocations: 0 bytes)

Resolves #1863

This is a breaking change because older Hecke versions define their own `numerator!` and would be broken by this change (though newer Hecke should be fine -- we'll see).