### PR TITLE
FinField: use concrete types for sub-/overfield morphisms to improve inferrability

### DIFF
--- a/src/embedding/embedding.jl
+++ b/src/embedding/embedding.jl
@@ -10,18 +10,18 @@
 #
 ################################################################################
 
-function overfields(k::FinField)
+function overfields(k::T) where T <: FinField
   if !isdefined(k, :overfields)
-    k.overfields = Dict{Int, Vector{FinFieldMorphism}}()
+    k.overfields = Dict{Int, Vector{FinFieldMorphism{T,T}}}()
   end
-  return k.overfields
+  return k.overfields::Dict{Int, Vector{FinFieldMorphism{T,T}}}
 end
 
-function subfields(k::FinField)
+function subfields(k::T) where T <: FinField
   if !isdefined(k, :subfields)
-    k.subfields = Dict{Int, Vector{FinFieldMorphism}}()
+    k.subfields = Dict{Int, Vector{FinFieldMorphism{T,T}}}()
   end
-  return k.subfields
+  return k.subfields::Dict{Int, Vector{FinFieldMorphism{T,T}}}
 end
 
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1845,8 +1845,8 @@ See [`FqPolyRepField`](@ref) for $p$ being a [`ZZRingElem`](@ref). See [`fqPolyR
   var :: Ptr{Nothing}
   # end of flint struct
 
-  overfields :: Dict{Int, Vector{FinFieldMorphism}}
-  subfields :: Dict{Int, Vector{FinFieldMorphism}}
+  overfields :: Dict{Int, Vector{FinFieldMorphism{fqPolyRepField, fqPolyRepField}}}
+  subfields :: Dict{Int, Vector{FinFieldMorphism{fqPolyRepField, fqPolyRepField}}}
 
   function fqPolyRepField(c::UInt, deg::Int, s::Symbol, cached::Bool = true; check::Bool = true)
     check && !is_prime(c) &&
@@ -1973,8 +1973,8 @@ A finite field. The constructor automatically determines a fast implementation.
 
   var::String
 
-  overfields::Dict{Int, Vector{FinFieldMorphism}}
-  subfields::Dict{Int, Vector{FinFieldMorphism}}
+  overfields::Dict{Int, Vector{FinFieldMorphism{FqField, FqField}}}
+  subfields::Dict{Int, Vector{FinFieldMorphism{FqField, FqField}}}
 
   isstandard::Bool
   # isstandard means, that defining_polynomial(F) === modulus(F)
@@ -2148,8 +2148,8 @@ See [`fqPolyRepField`](@ref) for $p$ being an [`Int`](@ref). See [`FqPolyRepFiel
   var::Ptr{Nothing}
   # end of flint struct
 
-  overfields :: Dict{Int, Vector{FinFieldMorphism}}
-  subfields :: Dict{Int, Vector{FinFieldMorphism}}
+  overfields :: Dict{Int, Vector{FinFieldMorphism{FqPolyRepField, FqPolyRepField}}}
+  subfields :: Dict{Int, Vector{FinFieldMorphism{FqPolyRepField, FqPolyRepField}}}
 
   function FqPolyRepField(char::ZZRingElem, deg::Int, s::Symbol, cached::Bool = true; check::Bool = true)
     check && !is_probable_prime(char) &&


### PR DESCRIPTION
Both functions modifying these dicts already restrict the types in the same way:
```julia
function AddOverfield!(F::T, f::FinFieldMorphism{T, T}) where T <: FinField
function AddSubfield!(F::T, f::FinFieldMorphism{T, T}) where T <: FinField
```

Without this PR:
```julia
julia> using Oscar
...
julia> F = finite_field(3)[1]
Prime field of characteristic 3

julia> a = F(0)
0

julia> @time @eval a*a
 48.451252 seconds (221.69 M allocations: 10.308 GiB, 6.01% gc time, 99.98% compilation time: 100% of which was recompilation)
0
```
(Any further calls will be fast since it is already compiled)

With the changes in this PR:
```julia
julia> using Oscar
...
julia> F = finite_field(3)[1]
Prime field of characteristic 3

julia> a = F(0)
0

julia> @time @eval a*a
  0.000158 seconds (56 allocations: 2.203 KiB)
0
```

Without the changes here the return type of `Nemo.domain(::FinFieldMorphism)` which is used inside `Nemo.intersections(::FinField,::FinField)` cannot be inferred. Then the compiler seems to look at all possible `embed(Any,Any)` functions which takes very long, especially the branch for `Hecke.embed(S::ZZLat, G::ZZGenus)`.

For Nemo alone the difference is less significant, but it does improve allocations during compilation quite a bit.
`0.47.5`:
```
julia> @time @eval a*a
  0.806358 seconds (2.61 M allocations: 128.606 MiB, 2.89% gc time, 99.97% compilation time)
0
```

this PR:
```
julia> @time @eval a*a
  0.836485 seconds (1.29 M allocations: 63.900 MiB, 1.45% gc time, 99.97% compilation time)
0
```

cc: @flenzen @thofma @fingolfin 

<details>
<summary>flamegraph for snoop_inference without this PR:</summary>


![fieldmul_flamegraph](https://github.com/user-attachments/assets/7b18c76a-c347-4a6c-aab4-febbf6fa1ded)

</details>