### PR TITLE
fix: mention matrix dimension in BoundsError

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -462,6 +462,16 @@ include("julia/Integer.jl")
 include("julia/Rational.jl")
 include("julia/Float.jl")
 
+################################################################################
+#
+#  Better error message for BoundsError of flint matrices
+#
+################################################################################
+
+function Base.summary(io::IO, A::T) where {T <: _MatTypes}
+  print(io, nrows(A), "x", ncols(A), " ", T)
+end
+
 ###############################################################################
 #
 #   satellite functionality


### PR DESCRIPTION
Before:
```
julia> F[2 ;  5][3, 3]
ERROR: BoundsError: attempt to access FqMatrix at index [3, 3]
Stacktrace:
 [1] throw_boundserror(A::FqMatrix, I::Tuple{Int64, Int64})
   @ Base ./essentials.jl:14
```
After:
```
```
julia> F[2 ;  5][3, 3]
ERROR: BoundsError: attempt to access 2x1 FqMatrix at index [3, 3]
Stacktrace:
 [1] throw_boundserror(A::FqMatrix, I::Tuple{Int64, Int64})
   @ Base ./essentials.jl:14
```