### PR TITLE
Fix `root(RealFieldElem(0), 3)`

### DIFF
--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -1425,6 +1425,7 @@ function hypot(x::RealFieldElem, y::RealFieldElem, prec::Int = precision(Balls))
 end
 
 function root(x::RealFieldElem, n::UInt, prec::Int = precision(Balls))
+  is_zero(x) && return x
   z = RealFieldElem()
   @ccall libflint.arb_root(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, n::UInt, prec::Int)::Nothing
   return z

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -1423,6 +1423,7 @@ function hypot(x::ArbFieldElem, y::ArbFieldElem)
 end
 
 function root(x::ArbFieldElem, n::UInt)
+  is_zero(x) && return x
   z = parent(x)()
   @ccall libflint.arb_root(z::Ref{ArbFieldElem}, x::Ref{ArbFieldElem}, n::UInt, parent(x).prec::Int)::Nothing
   return z

--- a/test/arb/Real-test.jl
+++ b/test/arb/Real-test.jl
@@ -433,6 +433,12 @@ end
 
   @test_throws DomainError root(-x, 3)
 
+  a = RR(0)
+  @testset "root(0, i)" for i in 1:10
+    @test is_zero(root(a, i))
+    @test is_zero(root(a, UInt(i)))
+  end
+
   @test overlaps(factorial(x), RR("0.886581428719259125080918 +/- 6.66e-25"))
   @test factorial(UInt(10), RR) == 3628800
   @test factorial(Int(10), RR) == 3628800

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -401,6 +401,12 @@ end
 
   @test_throws DomainError root(-x, 3)
 
+  a = RR(0)
+  @testset "root(0, i)" for i in 1:10
+    @test is_zero(root(a, i))
+    @test is_zero(root(a, UInt(i)))
+  end
+
   @test overlaps(factorial(x), RR("0.886581428719259125080918 +/- 6.66e-25"))
   @test factorial(UInt(10), RR) == 3628800
   @test factorial(Int(10), RR) == 3628800


### PR DESCRIPTION
Fixes #1440

Perhaps there are more issues with RealField and ArbField (actually, I bet there are), but none are made really clear in that issue. This fixes the one concrete issue that was described.