### PR TITLE
Bump AbstractAlgebra to 0.44.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-AbstractAlgebra = "0.43.10"
+AbstractAlgebra = "0.44.0"
 FLINT_jll = "^300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"


### PR DESCRIPTION
Replaces and thus closes https://github.com/Nemocas/Nemo.jl/pull/1970.