### PR TITLE
Add is_zero_initialized for FLINT backed matrix types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-AbstractAlgebra = "0.44.0"
+AbstractAlgebra = "0.44.1"
 FLINT_jll = "^300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -180,6 +180,7 @@ import AbstractAlgebra: Group
 import AbstractAlgebra: howell_form!
 import AbstractAlgebra: Indent
 import AbstractAlgebra: is_terse
+import AbstractAlgebra: is_zero_initialized
 import AbstractAlgebra: Lowercase
 import AbstractAlgebra: LowercaseOff
 import AbstractAlgebra: Module

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -27,6 +27,8 @@ base_ring(a::ComplexMatrix) = ComplexField()
 
 dense_matrix_type(::Type{ComplexFieldElem}) = ComplexMatrix
 
+is_zero_initialized(::Type{ComplexMatrix}) = true
+
 function getindex!(z::ComplexFieldElem, x::ComplexMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -27,6 +27,8 @@ base_ring(a::RealMatrix) = RealField()
 
 dense_matrix_type(::Type{RealFieldElem}) = RealMatrix
 
+is_zero_initialized(::Type{RealMatrix}) = true
+
 function getindex!(z::ArbFieldElem, x::RealMatrix, r::Int, c::Int)
   GC.@preserve x begin
     v = mat_entry_ptr(x, r, c)

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -27,6 +27,8 @@ base_ring(a::AcbMatrix) = a.base_ring
 
 dense_matrix_type(::Type{AcbFieldElem}) = AcbMatrix
 
+is_zero_initialized(::Type{AcbMatrix}) = true
+
 precision(x::AcbMatrixSpace) = precision(base_ring(x))
 
 function getindex!(z::AcbFieldElem, x::AcbMatrix, r::Int, c::Int)

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -27,6 +27,8 @@ base_ring(a::ArbMatrix) = a.base_ring
 
 dense_matrix_type(::Type{ArbFieldElem}) = ArbMatrix
 
+is_zero_initialized(::Type{ArbMatrix}) = true
+
 precision(x::ArbMatrixSpace) = precision(x.base_ring)
 
 function getindex!(z::ArbFieldElem, x::ArbMatrix, r::Int, c::Int)

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -14,6 +14,8 @@ base_ring(a::QQMatrix) = QQ
 
 dense_matrix_type(::Type{QQFieldElem}) = QQMatrix
 
+is_zero_initialized(::Type{QQMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -14,6 +14,8 @@ base_ring(a::ZZMatrix) = ZZ
 
 dense_matrix_type(::Type{ZZRingElem}) = ZZMatrix
 
+is_zero_initialized(::Type{ZZMatrix}) = true
+
 ###############################################################################
 #
 #   similar & zero

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{ZZModRingElem}) = ZZModMatrix
 
+is_zero_initialized(::Type{ZZModMatrix}) = true
+
 ###############################################################################
 #
 #   Similar

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{FqFieldElem}) = FqMatrix
 
+is_zero_initialized(::Type{FqMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{FqPolyRepFieldElem}) = FqPolyRepMatrix
 
+is_zero_initialized(::Type{FqPolyRepMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{fqPolyRepFieldElem}) = fqPolyRepMatrix
 
+is_zero_initialized(::Type{fqPolyRepMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{FpFieldElem}) = FpMatrix
 
+is_zero_initialized(::Type{FpMatrix}) = true
+
 ###############################################################################
 #
 #   Similar

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{fpFieldElem}) = fpMatrix
 
+is_zero_initialized(::Type{fpMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -12,6 +12,8 @@
 
 dense_matrix_type(::Type{zzModRingElem}) = zzModMatrix
 
+is_zero_initialized(::Type{zzModMatrix}) = true
+
 ###############################################################################
 #
 #   Similar & zero


### PR DESCRIPTION
Complementing https://github.com/Nemocas/AbstractAlgebra.jl/pull/1929

However I think this is independent of that PR, it just won't do
anything useful without it.
