### PR TITLE
Remove is_irreducible(a::QQMPolyRingElem)

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -291,11 +291,6 @@ function mod(f::ZZPolyRingElem, p::ZZRingElem)
   return g
 end
 
-function is_irreducible(a::QQMPolyRingElem)
-  af = factor(a)
-  return !(length(af.fac) > 1 || any(x -> x > 1, values(af.fac)))
-end
-
 #Assuming that the denominator of a is one, reduces all the coefficients modulo p
 # non-symmetric (positive) residue system
 function mod!(a::AbsSimpleNumFieldElem, b::ZZRingElem)


### PR DESCRIPTION
It was redundant as AA has a generic method which performs
no worse. It also did not handle constants in accordance do
our documentation (it should return false for zero and units
but instead produced an error resp. returned true).
