### PR TITLE
fix: aliasing bug in mul!

### DIFF
--- a/src/flint/gfp_fmpz_elem.jl
+++ b/src/flint/gfp_fmpz_elem.jl
@@ -364,10 +364,13 @@ end
 
 function mul!(z::FpFieldElem, x::FpFieldElem, y::ZZRingElem)
   R = parent(x)
-  @ccall libflint.fmpz_mod(z.data::Ref{ZZRingElem}, y::Ref{ZZRingElem}, R.n::Ref{ZZRingElem})::Nothing
-
-  @ccall libflint.fmpz_mod_mul(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, z.data::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
+  if z !== x
+    @ccall libflint.fmpz_mod(z.data::Ref{ZZRingElem}, y::Ref{ZZRingElem}, R.n::Ref{ZZRingElem})::Nothing
+    @ccall libflint.fmpz_mod_mul(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, z.data::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+    return z
+  else
+    return mul!(z, x, R(y))
+  end
 end
 
 function add!(z::FpFieldElem, x::FpFieldElem, y::FpFieldElem)

--- a/test/flint/gfp_fmpz-test.jl
+++ b/test/flint/gfp_fmpz-test.jl
@@ -532,3 +532,10 @@ end
   R = Native.GF(ZZ(19))
   @test R([5]) == R(5)
 end
+
+@testset "gfp_fmpz.bug" begin
+  R = Native.GF(ZZRingElem(123456789012345678949))
+  z = R(1)
+  mul!(z, z, ZZ(10))
+  @test z == 10
+end


### PR DESCRIPTION
Before:
```
julia> R = Native.GF(ZZRingElem(123456789012345678949));

julia> z = R(1);

julia> mul!(z, z, ZZ(10))
100
```

I am open for alternative solutions.

CC: @fieker 