### PR TITLE
fix: irreducibility of constant polynomials over finite fields

### DIFF
--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -645,6 +645,7 @@ end
 
 function is_irreducible(x::ZZModPolyRingElem)
   !is_probable_prime(modulus(x)) && error("Modulus not prime in is_irreducible")
+  is_constant(x) && return false
   return Bool(@ccall libflint.fmpz_mod_poly_is_irreducible(x::Ref{ZZModPolyRingElem}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Cint)
 end
 

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -513,6 +513,7 @@ end
 ################################################################################
 
 function is_irreducible(x::FqPolyRingElem)
+  is_constant(x) && return false
   return Bool(@ccall libflint.fq_default_poly_is_irreducible(x::Ref{FqPolyRingElem}, base_ring(parent(x))::Ref{FqField})::Int32)
 end
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -519,6 +519,7 @@ end
 ################################################################################
 
 function is_irreducible(x::fqPolyRepPolyRingElem)
+  is_constant(x) && return false
   return Bool(@ccall libflint.fq_nmod_poly_is_irreducible(x::Ref{fqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{fqPolyRepField})::Int32)
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -519,6 +519,7 @@ end
 ################################################################################
 
 function is_irreducible(x::FqPolyRepPolyRingElem)
+  is_constant(x) && return false
   return Bool(@ccall libflint.fq_poly_is_irreducible(x::Ref{FqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{FqPolyRepField})::Int32)
 end
 

--- a/src/flint/gfp_fmpz_poly.jl
+++ b/src/flint/gfp_fmpz_poly.jl
@@ -242,6 +242,7 @@ end
 ################################################################################
 
 function is_irreducible(x::FpPolyRingElem)
+  is_constant(x) && return false
   return Bool(@ccall libflint.fmpz_mod_poly_is_irreducible(x::Ref{FpPolyRingElem}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Cint)
 end
 

--- a/src/flint/gfp_poly.jl
+++ b/src/flint/gfp_poly.jl
@@ -302,6 +302,7 @@ end
 ################################################################################
 
 function is_irreducible(x::fpPolyRingElem)
+  is_constant(x) && return false
   return Bool(@ccall libflint.nmod_poly_is_irreducible(x::Ref{fpPolyRingElem})::Int32)
 end
 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -641,6 +641,7 @@ end
 
 function is_irreducible(x::zzModPolyRingElem)
   !is_prime(modulus(x)) && error("Modulus not prime in is_irreducible")
+  is_constant(x) && return false
   return Bool(@ccall libflint.nmod_poly_is_irreducible(x::Ref{zzModPolyRingElem})::Int32)
 end
 

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -498,6 +498,9 @@ end
   f = x^2 + 2x + 1
 
   @test is_irreducible(f) == false
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "ZZModPolyRingElem.is_squarefree" begin

--- a/test/flint/fq_default_poly-test.jl
+++ b/test/flint/fq_default_poly-test.jl
@@ -490,6 +490,9 @@ end
   @test is_irreducible(x)
 
   @test is_irreducible(x^16+2*x^9+x^8+x^2+x+1)
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "FqPolyRingElem.is_squarefree" begin

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -501,6 +501,9 @@ end
   @test is_irreducible(x)
 
   @test is_irreducible(x^16+2*x^9+x^8+x^2+x+1)
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "fqPolyRepPolyRingElem.is_squarefree" begin

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -502,6 +502,9 @@ end
   @test is_irreducible(x)
 
   @test is_irreducible(x^16+2*x^9+x^8+x^2+x+1)
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "FqPolyRepPolyRingElem.is_squarefree" begin

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -497,6 +497,9 @@ end
   f = x^2 + 2x + 1
 
   @test is_irreducible(f) == false
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "FpPolyRingElem.is_squarefree" begin

--- a/test/flint/gfp_poly-test.jl
+++ b/test/flint/gfp_poly-test.jl
@@ -564,6 +564,9 @@ end
   @test is_irreducible(x)
 
   @test is_irreducible(x^16+2*x^9+x^8+x^2+x+1)
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "fpPolyRingElem.is_squarefree" begin

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -587,6 +587,9 @@ end
   @test is_irreducible(x)
 
   @test is_irreducible(x^16+2*x^9+x^8+x^2+x+1)
+
+  @test !is_irreducible(x^0)
+  @test !is_irreducible(0*x^0)
 end
 
 @testset "zzModPolyRingElem.is_squarefree" begin


### PR DESCRIPTION
Flint currently considers all constant polynomials irreducible, which is a bit questionable. This PR here makes these methods follow our convention, see
```
help?> is_irreducible
search: is_irreducible is_invertible isimmutable is_compatible isexecutable isreadable

  is_irreducible(a::RingElement)

  Return true if a is irreducible, else return false. Zero and units are by definition never
  irreducible.
```
(and the corresponding generic method.)

Whether this is a bug upstream is to be decided, see https://github.com/flintlib/flint/issues/2140.