### PR TITLE
Optimize map_coefficients, change_base_ring for some inputs

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -182,21 +182,6 @@ function Base.hash(f::zzModMPolyRingElem, h::UInt)
   return UInt(1) # TODO: enhance or throw error
 end
 
-function AbstractAlgebra.map_coefficients(F::fpField, f::QQMPolyRingElem; parent=polynomial_ring(F, nvars(parent(f)), cached=false)[1])
-  dF = denominator(f)
-  d = F(dF)
-  if iszero(d)
-    error("Denominator divisible by p!")
-  end
-  m = inv(d)
-  ctx = MPolyBuildCtx(parent)
-  for x in zip(coefficients(f), exponent_vectors(f))
-    el = numerator(x[1] * dF)
-    push_term!(ctx, F(el) * m, x[2])
-  end
-  return finish(ctx)
-end
-
 function tdivpow2!(B::ZZMatrix, t::Int)
   @ccall libflint.fmpz_mat_scalar_tdiv_q_2exp(B::Ref{ZZMatrix}, B::Ref{ZZMatrix}, t::Cint)::Nothing
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1008,8 +1008,8 @@ const flint_orderings = [:lex, :deglex, :degrevlex]
 
 @attributes mutable struct ZZMPolyRing <: MPolyRing{ZZRingElem}
   nvars::Int
-  nfields::Cint
-  ord::Int
+  nfields::Int
+  ord::Cint
   deg::Cint
   rev::Cint
   lut::NTuple{Base.GMP.BITS_PER_LIMB, Int}
@@ -1136,8 +1136,8 @@ end
 
 @attributes mutable struct QQMPolyRing <: MPolyRing{QQFieldElem}
   nvars::Int
-  nfields::Cint
-  ord::Int
+  nfields::Int
+  ord::Cint
   deg::Cint
   rev::Cint
   lut::NTuple{Base.GMP.BITS_PER_LIMB, Int}

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -813,3 +813,50 @@ end
   @test abc - a - b == c
   @test abc - ab == c
 end
+
+@testset "QQMPolyRingElem.convert_to_ZZMPolyRingElem" begin
+  Qxy, (x,y) = QQ[:x,:y]
+  f = 11*(x^2/2 + ZZ(3)^50*x*y^5/7 + y^6/12)
+
+  R = ZZ
+  Rxy, (u,v) = polynomial_ring(R, [:u,:v])
+  g = 462*u^2 + 94762534375324541717672868*u*v^5 + 77*v^6
+
+  @test g == @inferred mul!(zero(Rxy), f, 84)
+  @test g == change_base_ring(R, f*84; parent = Rxy)
+  @test g == map_coefficients(R, f*84; parent = Rxy)
+
+  # test error handling
+  @test_throws ArgumentError change_base_ring(R, f/5; parent = Rxy)
+  @test_throws ArgumentError map_coefficients(R, f/5; parent = Rxy)
+
+  # test ordering mismatch
+  Rxy, (u,v) = polynomial_ring(R, [:u,:v]; internal_ordering = :deglex)
+  g = 462*u^2 + 94762534375324541717672868*u*v^5 + 77*v^6
+
+  @test g == change_base_ring(R, f*84; parent = Rxy)
+  @test g == map_coefficients(R, f*84; parent = Rxy)
+end
+
+@testset "QQMPolyRingElem.convert_to_fpMPolyRing" begin
+  Qxy, (x,y) = QQ[:x,:y]
+  f = 11*(x^2/2 + ZZ(3)^50*x*y^5/7 + y^6/12)
+
+  R = Native.GF(5)
+  Rxy, (u,v) = polynomial_ring(R, [:u,:v])
+  g = 462*u^2 + 94762534375324541717672868*u*v^5 + 77*v^6
+
+  @test g == change_base_ring(R, f*84; parent = Rxy)
+  @test g == map_coefficients(R, f*84; parent = Rxy)
+
+  # test error handling
+  @test_throws ArgumentError change_base_ring(R, f/5; parent = Rxy)
+  @test_throws ArgumentError map_coefficients(R, f/5; parent = Rxy)
+
+  # test ordering mismatch
+  Rxy, (u,v) = polynomial_ring(R, [:u,:v]; internal_ordering = :deglex)
+  g = 462*u^2 + 94762534375324541717672868*u*v^5 + 77*v^6
+
+  @test g == change_base_ring(R, f*84; parent = Rxy)
+  @test g == map_coefficients(R, f*84; parent = Rxy)
+end


### PR DESCRIPTION
Namely if the input polynomial is a `QQMPolyRingElem` and the transformation "function" is `ZZ` resp. a `fpField`.

Before this patch:

    julia> Qxy,(x,y) = QQ[:x,:y]; Zxy,_ = ZZ[:u,:v];

    julia> f = 11*(x^2/2 + ZZ(3)^50*x*y^5/7 + y^6/12);

    julia> @b $f*84
    160.000 ns (4 allocs: 200 bytes)

    julia> @b change_base_ring($ZZ, $f*84)
    1.559 μs (45 allocs: 1.633 KiB)

    julia> @b change_base_ring($ZZ, $f*84; parent = $Zxy)
    1.002 μs (24 allocs: 808 bytes)

    julia> @b map_coefficients($ZZ, $f*84; parent = $Zxy)
    996.680 ns (24 allocs: 808 bytes)

After this patch:

    julia> Qxy,(x,y) = QQ[:x,:y]; Zxy,_ = ZZ[:u,:v];

    julia> f = 11*(x^2/2 + ZZ(3)^50*x*y^5/7 + y^6/12);

    julia> @b $f*84
    111.693 ns (4 allocs: 200 bytes)

    julia> @b change_base_ring($ZZ, $f*84)
    733.806 ns (30 allocs: 1.227 KiB)

    julia> @b change_base_ring($ZZ, $f*84; parent = $Zxy)
    242.117 ns (9 allocs: 392 bytes)

    julia> @b map_coefficients($ZZ, $f*84; parent = $Zxy)
    249.607 ns (9 allocs: 392 bytes)

As a bonus we now also have a special `mul!` method which is even faster but is not suitable for the faint of heart:

    julia> @b mul!($Zxy(), $f, 84)
    129.041 ns (5 allocs: 192 bytes)


----


This needs work, at least tests. But I didn't want to forget this, plus this way I can get feedback.

