### PR TITLE
Remove workaround in `powermod(::FqPolyRingElem, ::ZZRingElem, ::FqPolyRingElem)`

### DIFF
--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -419,12 +419,7 @@ function powermod(x::FqPolyRingElem, n::ZZRingElem, y::FqPolyRingElem)
     end
     n = -n
   end
-  # https://github.com/flintlib/flint2/pull/1261
-  if _fq_default_ctx_type(base_ring(parent(x))) == 4
-    @ccall libflint.nmod_poly_powmod_fmpz_binexp(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, n::Ref{ZZRingElem}, y::Ref{FqPolyRingElem})::Nothing
-  else
-    @ccall libflint.fq_default_poly_powmod_fmpz_binexp(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, n::Ref{ZZRingElem}, y::Ref{FqPolyRingElem}, base_ring(parent(x))::Ref{FqField})::Nothing
-  end
+  @ccall libflint.fq_default_poly_powmod_fmpz_binexp(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, n::Ref{ZZRingElem}, y::Ref{FqPolyRingElem}, base_ring(parent(x))::Ref{FqField})::Nothing
   return z
 end
 


### PR DESCRIPTION
The fix in https://github.com/flintlib/flint2/pull/1261 has been released as part of FLINT 3.0.0, so we can assume it arrived in Nemo.