### PR TITLE
Don't compute `_fq_default_ctx_type` multipe times

### DIFF
--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -605,10 +605,11 @@ function FqField(f::FqPolyRingElem, s::Symbol, cached::Bool = false, absolute::B
       # K is F_p
       # f is either nmod_poly or fmpz_mod_poly
       # we can define K[t]/(f) directly on the C side with the right modulus
-      if _fq_default_ctx_type(K) == _FQ_DEFAULT_NMOD
+      _fq_ctx_type = _fq_default_ctx_type(K)
+      if _fq_ctx_type == _FQ_DEFAULT_NMOD
         z = _fq_field_from_nmod_poly_in_disguise(f, s)
       else
-        @assert _fq_default_ctx_type(K) == _FQ_DEFAULT_FMPZ_NMOD
+        @assert _fq_ctx_type == _FQ_DEFAULT_FMPZ_NMOD
         z = _fq_field_from_fmpz_mod_poly_in_disguise(f, s)
       end
     else
@@ -774,12 +775,13 @@ function (F::FqField)(p::FqPolyRingElem)
     @assert is_absolute(F)
     K = base_field(F)
     characteristic(base_ring(p)) != characteristic(F) && error("Polynomial has wrong coefficient ring")
-    if _fq_default_ctx_type(K) == _FQ_DEFAULT_NMOD
+    _fq_ctx_type = _fq_default_ctx_type(K)
+    if _fq_ctx_type == _FQ_DEFAULT_NMOD
       y = FqFieldElem(F)
       @ccall libflint.fq_default_set_nmod_poly(y::Ref{FqFieldElem}, p::Ref{FqPolyRingElem}, F::Ref{FqField})::Nothing
       return y
     else
-      @assert _fq_default_ctx_type(K) == _FQ_DEFAULT_FMPZ_NMOD
+      @assert _fq_ctx_type == _FQ_DEFAULT_FMPZ_NMOD
       y = FqFieldElem(F)
       @ccall libflint.fq_default_set_fmpz_mod_poly(y::Ref{FqFieldElem}, p::Ref{FqPolyRingElem}, F::Ref{FqField})::Nothing
       return y
@@ -798,11 +800,12 @@ function _lift_standard(R::FqPolyRing, a::FqFieldElem)
   F = base_ring(R)
   p = R()
   @assert F === base_field(parent(a))
-  if _fq_default_ctx_type(F) == _FQ_DEFAULT_NMOD
+  _fq_ctx_type = _fq_default_ctx_type(F)
+  if _fq_ctx_type == _FQ_DEFAULT_NMOD
     @ccall libflint.fq_default_get_nmod_poly(p::Ref{FqPolyRingElem}, a::Ref{FqFieldElem}, K::Ref{FqField})::Nothing
     return p
   else
-    @assert _fq_default_ctx_type(F) == _FQ_DEFAULT_FMPZ_NMOD
+    @assert _fq_ctx_type == _FQ_DEFAULT_FMPZ_NMOD
     @ccall libflint.fq_default_get_fmpz_mod_poly(p::Ref{FqPolyRingElem}, a::Ref{FqFieldElem}, K::Ref{FqField})::Nothing
     return p
   end

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -114,10 +114,11 @@ isequal(a::FqMatrix, b::FqMatrix) = ==(a, b)
 
 function transpose(a::FqMatrix)
   z = similar(a, ncols(a), nrows(a))
-  if _fq_default_ctx_type(base_ring(a)) == _FQ_DEFAULT_NMOD
+  _fq_ctx_type = _fq_default_ctx_type(base_ring(a))
+  if _fq_ctx_type == _FQ_DEFAULT_NMOD
     @ccall libflint.nmod_mat_transpose(z::Ref{FqMatrix}, a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
     return z
-  elseif _fq_default_ctx_type(base_ring(a)) == _FQ_DEFAULT_FMPZ_NMOD
+  elseif _fq_ctx_type == _FQ_DEFAULT_FMPZ_NMOD
     @ccall libflint.fmpz_mod_mat_transpose(z::Ref{FqMatrix}, a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
     return z
   end


### PR DESCRIPTION
instead, put it into a local variable. This enables some switch-case-like optimization by the compiler