### PR TITLE
[DO NOT MERGE] Change FLINT's matrix structs to accomodate v3.3.0

### DIFF
--- a/src/ZZMatrix-linalg.jl
+++ b/src/ZZMatrix-linalg.jl
@@ -794,12 +794,10 @@ end
 
 #saves essentially the allocation of A.rows
 function view!(A::ZZMatrix, B::ZZMatrix, r::UnitRange{Int}, ::Colon)
+  A.entries = B.entries + B.stride * sizeof(ZZRingElem) * (r.start - 1)
   A.r = length(r)
   A.c = B.c
-  A.entries = B.entries
-  for i=1:A.r
-    unsafe_store!(A.rows, unsafe_load(B.rows, r.start+i-1), i)# + 8*(c.start -1))
-  end
+  A.stride = B.stride
   A.view_parent = (B, )
   return A
 end

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -3767,7 +3767,7 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   entries::Ptr{QQFieldElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{QQFieldElem}}
+  stride::Int
   view_parent
 
   # MatElem interface
@@ -3807,7 +3807,7 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
   entries::Ptr{ZZRingElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{ZZRingElem}}
+  stride::Int
   view_parent
 
   # MatElem interface
@@ -3845,7 +3845,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
   entries::Ptr{UInt}
   r::Int                  # Int
   c::Int                  # Int
-  rows::Ptr{Ptr{UInt}}
+  stride::Int
   n::UInt                # mp_limb_t / Culong
   ninv::UInt             # mp_limb_t / Culong
   norm::UInt             # mp_limb_t / Culong
@@ -3877,7 +3877,7 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
         u[i+m] = z.entries + (i-1)*c*8
       end
       z.view_parent = u
-      z.rows = z.entries + m*8
+      z.stride = c
       z.r = r
       z.c = c
       @ccall libflint.nmod_mat_set_mod(z::Ref{zzModMatrix}, n::UInt)::Nothing
@@ -3991,7 +3991,7 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   entries::Ptr{ZZRingElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{ZZRingElem}}
+  stride::Int
   # end flint struct
 
   base_ring::ZZModRing
@@ -4137,7 +4137,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   entries::Ptr{ZZRingElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{ZZRingElem}}
+  stride::Int
   # end flint struct
 
   base_ring::FpField
@@ -4237,7 +4237,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   entries::Ptr{UInt}
   r::Int                  # Int
   c::Int                  # Int
-  rows::Ptr{Ptr{UInt}}
+  stride::Int
   n::UInt                # mp_limb_t / Culong
   ninv::UInt             # mp_limb_t / Culong
   norm::UInt             # mp_limb_t / Culong
@@ -4269,7 +4269,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
         u[i+m] = z.entries + (i-1)*c*8
       end
       z.view_parent = u
-      z.rows = z.entries + m*8
+      z.stride = c
       z.r = r
       z.c = c
       @ccall libflint.nmod_mat_set_mod(z::Ref{fpMatrix}, n::UInt)::Nothing
@@ -4806,7 +4806,7 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
   entries::Ptr{FqPolyRepFieldElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{FqPolyRepFieldElem}}
+  stride::Int
   base_ring::FqPolyRepField
   view_parent
 
@@ -4883,7 +4883,7 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   entries::Ptr{fqPolyRepFieldElem}
   r::Int
   c::Int
-  rows::Ptr{Ptr{fqPolyRepFieldElem}}
+  stride::Int
   base_ring::fqPolyRepField
   view_parent
 

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -151,9 +151,9 @@ function Base.hash(a::QQMatrix, h::UInt)
     c = ncols(a)
     h = hash(r, h)
     h = hash(c, h)
-    rowptr = convert(Ptr{Ptr{Int}}, a.rows)
+    entries = convert(Ptr{Int}, a.entries)
     for i in 1:r
-      h = _hash_integer_array(unsafe_load(rowptr, i), 2*c, h)
+      h = _hash_integer_array(entries + (i - 1) * a.stride * sizeof(Int), 2 * c, h)
     end
     return xor(h, 0xb591d5c795885682%UInt)
   end
@@ -836,7 +836,7 @@ end
 #
 ################################################################################
 
-mat_entry_ptr(A::QQMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(QQFieldElem)
+mat_entry_ptr(A::QQMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * sizeof(QQFieldElem)
 
 ################################################################################
 #

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -165,9 +165,9 @@ function Base.hash(a::ZZMatrix, h::UInt)
     c = ncols(a)
     h = hash(r, h)
     h = hash(c, h)
-    rowptr = convert(Ptr{Ptr{Int}}, a.rows)
+    entries = convert(Ptr{Int}, a.entries)
     for i in 1:r
-      h = _hash_integer_array(unsafe_load(rowptr, i), c, h)
+      h = _hash_integer_array(entries + (i - 1) * a.stride * sizeof(Int), c, h)
     end
     return xor(h, 0x5c22af6d5986f453%UInt)
   end
@@ -2238,5 +2238,4 @@ end
 #
 ################################################################################
 
-mat_entry_ptr(A::ZZMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(ZZRingElem)
-
+mat_entry_ptr(A::ZZMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * sizeof(ZZRingElem)

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -684,4 +684,4 @@ end
 #
 ################################################################################
 
-mat_entry_ptr(A::ZZModMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(ZZRingElem)
+mat_entry_ptr(A::ZZModMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * sizeof(ZZRingElem)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -651,4 +651,4 @@ end
 #   length :: Int
 # The `parent` member of struct FqPolyRepFieldElem is not replicated in each
 # struct member, so we cannot use `sizeof(FqPolyRepFieldElem)`.
-mat_entry_ptr(A::FqPolyRepMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*(sizeof(Ptr)+2*sizeof(Int))
+mat_entry_ptr(A::FqPolyRepMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * (sizeof(Ptr) + 2 * sizeof(Int))

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -643,4 +643,4 @@ end
 #   norm :: Int
 # The `parent` member of struct fqPolyRepFieldElem is not replicated in each
 # struct member, so we cannot simply use `sizeof(fqPolyRepFieldElem)`.
-mat_entry_ptr(A::fqPolyRepMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*(sizeof(Ptr)+5*sizeof(Int))
+mat_entry_ptr(A::fqPolyRepMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * (sizeof(Ptr) + 5 * sizeof(Int))

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -354,4 +354,4 @@ end
 #
 ################################################################################
 
-mat_entry_ptr(A::FpMatrix, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(ZZRingElem)
+mat_entry_ptr(A::FpMatrix, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * sizeof(ZZRingElem)

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -766,4 +766,4 @@ end
 #
 ################################################################################
 
-mat_entry_ptr(A::Zmodn_mat, i::Int, j::Int) = unsafe_load(A.rows, i) + (j-1)*sizeof(UInt)
+mat_entry_ptr(A::Zmodn_mat, i::Int, j::Int) = A.entries + ((i - 1) * A.stride + (j - 1)) * sizeof(UInt)


### PR DESCRIPTION
Since v3.3.0, they rely on stride instead of pointers to rows.

There are still some unsafe things that has to be fixed, I didn't know how to fix them.