### PR TITLE
Restrict FLINT versions to use

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 AbstractAlgebra = "0.44.2"
-FLINT_jll = "^300.100.100"
+FLINT_jll = "~300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"
 Random = "1.6"


### PR DESCRIPTION
Since we access FLINT's internals, we should be a bit more cautious which FLINT versions we wanna use.
With the current compat specifier, if FLINT's current 3.3.0-DEV would get released as FLINT_jll 300.300.0, this would break Nemo and Oscar (until https://github.com/Nemocas/Nemo.jl/pull/1999 is merged an released).

This does not help past versions (and thus in particular not Oscar 1.0, 1.1, or 1.2), but would be good for the future.
We should even think about retroactively adapting compat bounds in the General registry to prevent this kind of breakage for current Oscar versions.
This would mean to change
https://github.com/JuliaRegistries/General/blob/6acf0f4c7717f1a3add21a698912636376b767d8/N/Nemo/Compat.toml#L302
to
```julia
FLINT_jll = "300.100.100-300.100"
```