### PR TITLE
Direct access to `length` of FLINT (m)polys

### DIFF
--- a/src/arb/ArbTypes.jl
+++ b/src/arb/ArbTypes.jl
@@ -453,8 +453,8 @@ const RealPolyRingID = CacheDictType{Tuple{Symbol}, RealPolyRing}()
 
 mutable struct RealPolyRingElem <: PolyRingElem{RealFieldElem}
   coeffs::Ptr{Nothing}
-  length::Int
   alloc::Int
+  length::Int
   parent::RealPolyRing
 
   function RealPolyRingElem()
@@ -530,8 +530,8 @@ const ArbPolyRingID = CacheDictType{Tuple{ArbField, Symbol}, ArbPolyRing}()
 
 mutable struct ArbPolyRingElem <: PolyRingElem{ArbFieldElem}
   coeffs::Ptr{Nothing}
-  length::Int
   alloc::Int
+  length::Int
   parent::ArbPolyRing
 
   function ArbPolyRingElem()
@@ -612,8 +612,8 @@ const ComplexPolyRingID = CacheDictType{Tuple{Symbol}, ComplexPolyRing}()
 
 mutable struct ComplexPolyRingElem <: PolyRingElem{ComplexFieldElem}
   coeffs::Ptr{Nothing}
-  length::Int
   alloc::Int
+  length::Int
   parent::ComplexPolyRing
 
   function ComplexPolyRingElem()
@@ -696,8 +696,8 @@ const AcbPolyRingID = CacheDictType{Tuple{AcbField, Symbol}, AcbPolyRing}()
 
 mutable struct AcbPolyRingElem <: PolyRingElem{AcbFieldElem}
   coeffs::Ptr{Nothing}
-  length::Int
   alloc::Int
+  length::Int
   parent::AcbPolyRing
 
   function AcbPolyRingElem()

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -16,7 +16,7 @@ elem_type(::Type{ComplexPolyRing}) = ComplexPolyRingElem
 
 dense_poly_type(::Type{ComplexFieldElem}) = ComplexPolyRingElem
 
-length(x::ComplexPolyRingElem) = @ccall libflint.acb_poly_length(x::Ref{ComplexPolyRingElem})::Int
+length(x::ComplexPolyRingElem) = x.length
 
 function set_length!(x::ComplexPolyRingElem, n::Int)
   @ccall libflint._acb_poly_set_length(x::Ref{ComplexPolyRingElem}, n::Int)::Nothing

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -16,7 +16,7 @@ elem_type(::Type{RealPolyRing}) = RealPolyRingElem
 
 dense_poly_type(::Type{RealFieldElem}) = RealPolyRingElem
 
-length(x::RealPolyRingElem) = @ccall libflint.arb_poly_length(x::Ref{RealPolyRingElem})::Int
+length(x::RealPolyRingElem) = x.length
 
 function set_length!(x::RealPolyRingElem, n::Int)
   @ccall libflint._arb_poly_set_length(x::Ref{RealPolyRingElem}, n::Int)::Nothing

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -16,7 +16,7 @@ elem_type(::Type{AcbPolyRing}) = AcbPolyRingElem
 
 dense_poly_type(::Type{AcbFieldElem}) = AcbPolyRingElem
 
-length(x::AcbPolyRingElem) = @ccall libflint.acb_poly_length(x::Ref{AcbPolyRingElem})::Int
+length(x::AcbPolyRingElem) = x.length
 
 function set_length!(x::AcbPolyRingElem, n::Int)
   @ccall libflint._acb_poly_set_length(x::Ref{AcbPolyRingElem}, n::Int)::Nothing

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -16,7 +16,7 @@ elem_type(::Type{ArbPolyRing}) = ArbPolyRingElem
 
 dense_poly_type(::Type{ArbFieldElem}) = ArbPolyRingElem
 
-length(x::ArbPolyRingElem) = @ccall libflint.arb_poly_length(x::Ref{ArbPolyRingElem})::Int
+length(x::ArbPolyRingElem) = x.length
 
 function set_length!(x::ArbPolyRingElem, n::Int)
   @ccall libflint._arb_poly_set_length(x::Ref{ArbPolyRingElem}, n::Int)::Nothing

--- a/src/flint/fmpq_abs_series.jl
+++ b/src/flint/fmpq_abs_series.jl
@@ -64,9 +64,7 @@ function coeff(x::QQAbsPowerSeriesRingElem, n::Int)
   return z
 end
 
-function length(x::QQAbsPowerSeriesRingElem)
-  return @ccall libflint.fmpq_poly_length(x::Ref{QQAbsPowerSeriesRingElem})::Int
-end
+length(x::QQAbsPowerSeriesRingElem) = x.length
 
 precision(x::QQAbsPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -68,10 +68,7 @@ function deepcopy_internal(a::QQMPolyRingElem, dict::IdDict)
   return set!(z, a)
 end
 
-function length(a::QQMPolyRingElem)
-  n = @ccall libflint.fmpq_mpoly_length(a::Ref{QQMPolyRingElem})::Int
-  return n
-end
+length(a::QQMPolyRingElem) = a.length
 
 function one(R::QQMPolyRing)
   z = R()

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -40,7 +40,7 @@ function denominator(a::QQPolyRingElem)
   return z
 end
 
-length(x::QQPolyRingElem) = @ccall libflint.fmpq_poly_length(x::Ref{QQPolyRingElem})::Int
+length(x::QQPolyRingElem) = x.length
 
 function set_length!(x::QQPolyRingElem, n::Int)
   @ccall libflint._fmpq_poly_set_length(x::Ref{QQPolyRingElem}, n::Int)::Nothing

--- a/src/flint/fmpq_rel_series.jl
+++ b/src/flint/fmpq_rel_series.jl
@@ -50,9 +50,7 @@ function normalise(a::QQRelPowerSeriesRingElem, len::Int)
   return len
 end
 
-function pol_length(x::QQRelPowerSeriesRingElem)
-  return @ccall libflint.fmpq_poly_length(x::Ref{QQRelPowerSeriesRingElem})::Int
-end
+pol_length(x::QQRelPowerSeriesRingElem) = x.length
 
 precision(x::QQRelPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fmpz_abs_series.jl
+++ b/src/flint/fmpz_abs_series.jl
@@ -54,9 +54,7 @@ function normalise(a::ZZAbsPowerSeriesRingElem, len::Int)
   return len
 end
 
-function length(x::ZZAbsPowerSeriesRingElem)
-  return @ccall libflint.fmpz_poly_length(x::Ref{ZZAbsPowerSeriesRingElem})::Int
-end
+length(x::ZZAbsPowerSeriesRingElem) = x.length
 
 precision(x::ZZAbsPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -33,10 +33,7 @@ end
 #
 ################################################################################
 
-function length(x::T) where {T <: Zmodn_fmpz_poly}
-  return x.length
-  #   return @ccall libflint.fmpz_mod_poly_length(x::Ref{T}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Int
-end
+length(x::T) where {T <: Zmodn_fmpz_poly} = x.length
 
 function degree(x::T) where {T <: Zmodn_fmpz_poly}
   return x.length - 1

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -67,10 +67,7 @@ function deepcopy_internal(a::ZZMPolyRingElem, dict::IdDict)
   return set!(z, a)
 end
 
-function length(a::ZZMPolyRingElem)
-  n = @ccall libflint.fmpz_mpoly_length(a::Ref{ZZMPolyRingElem})::Int
-  return n
-end
+length(a::ZZMPolyRingElem) = a.length
 
 one(R::ZZMPolyRing) = one!(R())
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -28,7 +28,7 @@ var(a::ZZPolyRing) = a.S
 #
 ###############################################################################
 
-length(x::ZZPolyRingElem) = @ccall libflint.fmpz_poly_length(x::Ref{ZZPolyRingElem})::Int
+length(x::ZZPolyRingElem) = x.length
 
 function coeff(x::ZZPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))

--- a/src/flint/fmpz_rel_series.jl
+++ b/src/flint/fmpz_rel_series.jl
@@ -50,9 +50,7 @@ function normalise(a::ZZRelPowerSeriesRingElem, len::Int)
   return len
 end
 
-function pol_length(x::ZZRelPowerSeriesRingElem)
-  return @ccall libflint.fmpz_poly_length(x::Ref{ZZRelPowerSeriesRingElem})::Int
-end
+pol_length(x::ZZRelPowerSeriesRingElem) = x.length
 
 precision(x::ZZRelPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fq_abs_series.jl
+++ b/src/flint/fq_abs_series.jl
@@ -55,9 +55,7 @@ function normalise(a::FqPolyRepAbsPowerSeriesRingElem, len::Int)
   return len
 end
 
-function length(x::FqPolyRepAbsPowerSeriesRingElem)
-  return @ccall libflint.fq_poly_length(x::Ref{FqPolyRepAbsPowerSeriesRingElem}, base_ring(x)::Ref{FqPolyRepField})::Int
-end
+length(x::FqPolyRepAbsPowerSeriesRingElem) = x.length
 
 precision(x::FqPolyRepAbsPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fq_nmod_abs_series.jl
+++ b/src/flint/fq_nmod_abs_series.jl
@@ -55,9 +55,7 @@ function normalise(a::fqPolyRepAbsPowerSeriesRingElem, len::Int)
   return len
 end
 
-function length(x::fqPolyRepAbsPowerSeriesRingElem)
-  return @ccall libflint.fq_nmod_poly_length(x::Ref{fqPolyRepAbsPowerSeriesRingElem}, base_ring(x)::Ref{fqPolyRepField})::Int
-end
+length(x::fqPolyRepAbsPowerSeriesRingElem) = x.length
 
 precision(x::fqPolyRepAbsPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -64,10 +64,7 @@ function deepcopy_internal(a::fqPolyRepMPolyRingElem, dict::IdDict)
   return z
 end
 
-function length(a::fqPolyRepMPolyRingElem)
-  n = @ccall libflint.fq_nmod_mpoly_length(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Int
-  return n
-end
+length(a::fqPolyRepMPolyRingElem) = a.length
 
 one(R::fqPolyRepMPolyRing) = one!(R())
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -28,7 +28,7 @@ var(a::fqPolyRepPolyRing) = a.S
 #
 ################################################################################
 
-length(x::fqPolyRepPolyRingElem) = @ccall libflint.fq_nmod_poly_length(x::Ref{fqPolyRepPolyRingElem})::Int
+length(x::fqPolyRepPolyRingElem) = x.length
 
 function set_length!(x::fqPolyRepPolyRingElem, n::Int)
   @ccall libflint._fq_nmod_poly_set_length(x::Ref{fqPolyRepPolyRingElem}, n::Int)::Nothing

--- a/src/flint/fq_nmod_rel_series.jl
+++ b/src/flint/fq_nmod_rel_series.jl
@@ -51,9 +51,7 @@ function normalise(a::fqPolyRepRelPowerSeriesRingElem, len::Int)
   return len
 end
 
-function pol_length(x::fqPolyRepRelPowerSeriesRingElem)
-  return @ccall libflint.fq_nmod_poly_length(x::Ref{fqPolyRepRelPowerSeriesRingElem}, base_ring(x)::Ref{fqPolyRepField})::Int
-end
+pol_length(x::fqPolyRepRelPowerSeriesRingElem) = x.length
 
 precision(x::fqPolyRepRelPowerSeriesRingElem) = x.prec
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -28,7 +28,7 @@ var(a::FqPolyRepPolyRing) = a.S
 #
 ################################################################################
 
-length(x::FqPolyRepPolyRingElem) = @ccall libflint.fq_poly_length(x::Ref{FqPolyRepPolyRingElem})::Int
+length(x::FqPolyRepPolyRingElem) = x.length
 
 function coeff(x::FqPolyRepPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))

--- a/src/flint/fq_rel_series.jl
+++ b/src/flint/fq_rel_series.jl
@@ -51,9 +51,7 @@ function normalise(a::FqPolyRepRelPowerSeriesRingElem, len::Int)
   return len
 end
 
-function pol_length(x::FqPolyRepRelPowerSeriesRingElem)
-  return @ccall libflint.fq_poly_length(x::Ref{FqPolyRepRelPowerSeriesRingElem}, base_ring(x)::Ref{FqPolyRepField})::Int
-end
+pol_length(x::FqPolyRepRelPowerSeriesRingElem) = x.length
 
 precision(x::FqPolyRepRelPowerSeriesRingElem) = x.prec
 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -52,7 +52,7 @@ end
 #
 ################################################################################
 
-length(x::T) where T <: Zmodn_poly = @ccall libflint.nmod_poly_length(x::Ref{T})::Int
+length(x::T) where T <: Zmodn_poly = x.length
 
 degree(x::T) where T <: Zmodn_poly = @ccall libflint.nmod_poly_degree(x::Ref{T})::Int
 

--- a/src/flint/nmod_rel_series.jl
+++ b/src/flint/nmod_rel_series.jl
@@ -56,9 +56,7 @@ for (etype, rtype, mtype, brtype) in (
       return len
     end
 
-    function pol_length(x::($etype))
-      return @ccall libflint.nmod_poly_length(x::Ref{($etype)})::Int
-    end
+    pol_length(x::($etype)) = x.length
 
     precision(x::($etype)) = x.prec
 


### PR DESCRIPTION
The resulting code can be inlined by the Julia compiler (unlike a `ccall`) and thus may enable additional optimizations.

Also fix order of entries in arb poly structs.
