### PR TITLE
Remove redundant methods

### DIFF
--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -23,8 +23,6 @@ function set_length!(x::ComplexPolyRingElem, n::Int)
   return x
 end
 
-degree(x::ComplexPolyRingElem) = length(x) - 1
-
 function coeff(a::ComplexPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = ComplexFieldElem()
@@ -47,10 +45,6 @@ end
 function is_gen(a::ComplexPolyRingElem)
   return isequal(a, gen(parent(a)))
 end
-
-#function iszero(a::ComplexPolyRingElem)
-#   return length(a) == 0
-#end
 
 #function isone(a::ComplexPolyRingElem)
 #   return isequal(a, one(parent(a)))

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -23,8 +23,6 @@ function set_length!(x::RealPolyRingElem, n::Int)
   return x
 end
 
-degree(x::RealPolyRingElem) = length(x) - 1
-
 function coeff(a::RealPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = base_ring(parent(a))()
@@ -47,10 +45,6 @@ end
 function is_gen(a::RealPolyRingElem)
   return isequal(a, gen(parent(a)))
 end
-
-#function iszero(a::RealPolyRingElem)
-#   return length(a) == 0
-#end
 
 #function isone(a::RealPolyRingElem)
 #   return strongequal(a, one(parent(a)))

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -23,8 +23,6 @@ function set_length!(x::AcbPolyRingElem, n::Int)
   return x
 end
 
-degree(x::AcbPolyRingElem) = length(x) - 1
-
 function coeff(a::AcbPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = parent(a).base_ring()
@@ -47,10 +45,6 @@ end
 function is_gen(a::AcbPolyRingElem)
   return isequal(a, gen(parent(a)))
 end
-
-#function iszero(a::AcbPolyRingElem)
-#   return length(a) == 0
-#end
 
 #function isone(a::AcbPolyRingElem)
 #   return isequal(a, one(parent(a)))

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -23,8 +23,6 @@ function set_length!(x::ArbPolyRingElem, n::Int)
   return x
 end
 
-degree(x::ArbPolyRingElem) = length(x) - 1
-
 function coeff(a::ArbPolyRingElem, n::Int)
   n < 0 && throw(DomainError(n, "Index must be non-negative"))
   t = parent(a).base_ring()
@@ -47,10 +45,6 @@ end
 function is_gen(a::ArbPolyRingElem)
   return isequal(a, gen(parent(a)))
 end
-
-#function iszero(a::ArbPolyRingElem)
-#   return length(a) == 0
-#end
 
 #function isone(a::ArbPolyRingElem)
 #   return strongequal(a, one(parent(a)))

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -90,17 +90,8 @@ function isone(a::QQMPolyRingElem)
   return Bool(b)
 end
 
-function iszero(a::QQMPolyRingElem)
-  b = @ccall libflint.fmpq_mpoly_is_zero(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Cint
-  return Bool(b)
-end
-
 function is_monomial(a::QQMPolyRingElem)
   return length(a) == 1 && coeff(a, 1) == 1
-end
-
-function is_term(a::QQMPolyRingElem)
-  return length(a) == 1
 end
 
 function is_constant(a::QQMPolyRingElem)

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -102,10 +102,6 @@ for (etype, rtype, ftype, ctype) in (
       return length(a) == 1 && isone(coeff(a, 1))
     end
 
-    function is_term(a::($etype))
-      return length(a) == 1
-    end
-
     function is_constant(a::($etype))
       return Bool(@ccall libflint.fmpz_mod_mpoly_is_fmpz(a::Ref{($etype)}, parent(a)::Ref{($rtype)})::Cint)
     end

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -59,10 +59,6 @@ gen(R::ZmodNFmpzPolyRing) = R([ZZRingElem(0), ZZRingElem(1)])
 is_gen(a::Zmodn_fmpz_poly) = (degree(a) == 1 &&
                               iszero(coeff(a,0)) && isone(coeff(a,1)))
 
-function iszero(a::T) where {T <: Zmodn_fmpz_poly}
-  return a.length == 0
-end
-
 var(R::ZmodNFmpzPolyRing) = R.S
 
 modulus(a::Zmodn_fmpz_poly) = a.parent.n

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -81,17 +81,8 @@ function isone(a::ZZMPolyRingElem)
   return Bool(b)
 end
 
-function iszero(a::ZZMPolyRingElem)
-  b = @ccall libflint.fmpz_mpoly_is_zero(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Cint
-  return Bool(b)
-end
-
 function is_monomial(a::ZZMPolyRingElem)
   return length(a) == 1 && coeff(a, 1) == 1
-end
-
-function is_term(a::ZZMPolyRingElem)
-  return length(a) == 1
 end
 
 function is_constant(a::ZZMPolyRingElem)

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -58,20 +58,8 @@ function isone(a::FqMPolyRingElem)
   return isone(a.data)
 end
 
-function iszero(a::FqMPolyRingElem)
-  return iszero(a.data)
-end
-
 function is_monomial(a::FqMPolyRingElem)
   return is_monomial(a.data)
-end
-
-function is_term(a::FqMPolyRingElem)
-  return is_term(a.data)
-end
-
-function is_unit(a::FqMPolyRingElem)
-  return is_unit(a.data)
 end
 
 function is_constant(a::FqMPolyRingElem)

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -56,11 +56,7 @@ gen(a::FqPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 is_gen(x::FqPolyRingElem) = @ccall libflint.fq_default_poly_is_gen(x::Ref{FqPolyRingElem}, base_ring(x.parent)::Ref{FqField})::Bool
 
-iszero(x::FqPolyRingElem) = @ccall libflint.fq_default_poly_is_zero(x::Ref{FqPolyRingElem}, base_ring(x.parent)::Ref{FqField})::Bool
-
 isone(x::FqPolyRingElem) = @ccall libflint.fq_default_poly_is_one(x::Ref{FqPolyRingElem}, base_ring(x.parent)::Ref{FqField})::Bool
-
-degree(f::FqPolyRingElem) = length(f) - 1
 
 function deepcopy_internal(a::FqPolyRingElem, dict::IdDict)
   z = FqPolyRingElem(a, base_ring(a))

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -78,17 +78,8 @@ function isone(a::fqPolyRepMPolyRingElem)
   return Bool(b)
 end
 
-function iszero(a::fqPolyRepMPolyRingElem)
-  b = @ccall libflint.fq_nmod_mpoly_is_zero(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Cint
-  return Bool(b)
-end
-
 function is_monomial(a::fqPolyRepMPolyRingElem)
   return length(a) == 1 && isone(coeff(a, 1))
-end
-
-function is_term(a::fqPolyRepMPolyRingElem)
-  return length(a) == 1
 end
 
 function is_constant(a::fqPolyRepMPolyRingElem)

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -49,13 +49,9 @@ one(a::fqPolyRepPolyRing) = a(one(base_ring(a)))
 
 gen(a::fqPolyRepPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
-iszero(x::fqPolyRepPolyRingElem) = @ccall libflint.fq_nmod_poly_is_zero(x::Ref{fqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{fqPolyRepField})::Bool
-
 isone(x::fqPolyRepPolyRingElem) = @ccall libflint.fq_nmod_poly_is_one(x::Ref{fqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{fqPolyRepField})::Bool
 
 is_gen(x::fqPolyRepPolyRingElem) = @ccall libflint.fq_nmod_poly_is_gen(x::Ref{fqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{fqPolyRepField})::Bool
-
-degree(f::fqPolyRepPolyRingElem) = f.length - 1
 
 function deepcopy_internal(a::fqPolyRepPolyRingElem, dict::IdDict)
   z = fqPolyRepPolyRingElem(a)

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -51,11 +51,7 @@ gen(a::FqPolyRepPolyRing) = a([zero(base_ring(a)), one(base_ring(a))])
 
 is_gen(x::FqPolyRepPolyRingElem) = @ccall libflint.fq_poly_is_gen(x::Ref{FqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{FqPolyRepField})::Bool
 
-iszero(x::FqPolyRepPolyRingElem) = @ccall libflint.fq_poly_is_zero(x::Ref{FqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{FqPolyRepField})::Bool
-
 isone(x::FqPolyRepPolyRingElem) = @ccall libflint.fq_poly_is_one(x::Ref{FqPolyRepPolyRingElem}, base_ring(x.parent)::Ref{FqPolyRepField})::Bool
-
-degree(f::FqPolyRepPolyRingElem) = f.length - 1
 
 function deepcopy_internal(a::FqPolyRepPolyRingElem, dict::IdDict)
   z = FqPolyRepPolyRingElem(a)

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -96,10 +96,6 @@ for (etype, rtype, ftype, ctype, utype) in (
       return length(a) == 1 && coeff(a, 1) == 1
     end
 
-    function is_term(a::($etype))
-      return length(a) == 1
-    end
-
     function is_constant(a::($etype))
       return Bool(@ccall libflint.nmod_mpoly_is_ui(a::Ref{($etype)}, parent(a)::Ref{($rtype)})::Cint)
     end


### PR DESCRIPTION
We have these equivalent default methods in AA:

    degree(a::PolynomialElem) = length(a) - 1
    is_zero(a::PolynomialElem) = length(a) == 0
    is_zero(x::MPolyRingElem) = length(x) == 0
    is_term(x::MPolyRingElem) = length(x) == 1

These are all defined via `length` and nothing else.

There are other generic methods for e.g. `is_one`, `is_constant`, etc. which I did not touch here as there it is not obvious that they lead to code that is as efficient -- each case would require individual verification. So it doesn't seem worth the bother