### PR TITLE
Deduplicate FLINT finalizers

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5028,6 +5028,38 @@ end
 #
 ################################################################################
 
+function _fmpq_clear_fn(a::QQFieldElem)
+  @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
+end
+
+function _fmpq_mat_clear_fn(a::QQMatrix)
+  @ccall libflint.fmpq_mat_clear(a::Ref{QQMatrix})::Nothing
+end
+
+function _fmpq_mpoly_clear_fn(a::QQMPolyRingElem)
+  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
+end
+
+function _fmpq_mpoly_ctx_clear_fn(a::QQMPolyRing)
+  @ccall libflint.fmpq_mpoly_ctx_clear(a::Ref{QQMPolyRing})::Nothing
+end
+
+function _fmpq_mpoly_factor_clear_fn(f::fmpq_mpoly_factor)
+  @ccall libflint.fmpq_mpoly_factor_clear(f::Ref{fmpq_mpoly_factor}, f.parent::Ref{QQMPolyRing})::Nothing
+end
+
+function _fmpq_poly_clear_fn(a::QQPolyRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQPolyRingElem})::Nothing
+end
+
+function _fmpq_poly_clear_fn(a::QQRelPowerSeriesRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
+end
+
+function _fmpq_poly_clear_fn(a::QQAbsPowerSeriesRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
+end
+
 function _fmpz_clear_fn(a::ZZRingElem)
   @ccall libflint.fmpz_clear(a::Ref{ZZRingElem})::Nothing
 end
@@ -5036,168 +5068,80 @@ function _fmpz_factor_clear_fn(a::fmpz_factor)
   @ccall libflint.fmpz_factor_clear(a::Ref{fmpz_factor})::Nothing
 end
 
-function _fmpq_clear_fn(a::QQFieldElem)
-  @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
-end
-
-function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
-end
-
-function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
-  @ccall libflint.fmpz_poly_factor_clear(f::Ref{fmpz_poly_factor})::Nothing
-end
-
-function _fmpq_poly_clear_fn(a::QQPolyRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQPolyRingElem})::Nothing
+function _fmpz_mat_clear_fn(a::ZZMatrix)
+  @ccall libflint.fmpz_mat_clear(a::Ref{ZZMatrix})::Nothing
 end
 
 function _fmpz_mod_ctx_clear_fn(a::fmpz_mod_ctx_struct)
   @ccall libflint.fmpz_mod_ctx_clear(a::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _nmod_poly_clear_fn(x::zzModPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModPolyRingElem})::Nothing
+function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
+  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing
 end
 
-function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
-end
-
-function _nmod_poly_clear_fn(x::fpPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
-end
-
-function _nmod_poly_factor_clear_fn(a::gfp_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(x::ZZModPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{ZZModPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{fmpz_mod_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mpoly_ctx_clear_fn(a::ZZMPolyRing)
-  @ccall libflint.fmpz_mpoly_ctx_clear(a::Ref{ZZMPolyRing})::Nothing
-end
-
-function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
-  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
-end
-
-function _fmpz_mpoly_factor_clear_fn(f::fmpz_mpoly_factor)
-  @ccall libflint.fmpz_mpoly_factor_clear(f::Ref{fmpz_mpoly_factor}, f.parent::Ref{ZZMPolyRing})::Nothing
-end
-
-function _fmpq_mpoly_ctx_clear_fn(a::QQMPolyRing)
-  @ccall libflint.fmpq_mpoly_ctx_clear(a::Ref{QQMPolyRing})::Nothing
-end
-
-function _fmpq_mpoly_clear_fn(a::QQMPolyRingElem)
-  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
-end
-
-function _fmpq_mpoly_factor_clear_fn(f::fmpq_mpoly_factor)
-  @ccall libflint.fmpq_mpoly_factor_clear(f::Ref{fmpq_mpoly_factor}, f.parent::Ref{QQMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_ctx_clear_fn(a::zzModMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{zzModMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, a.parent::Ref{zzModMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
-  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{nmod_mpoly_factor}, f.parent::Ref{zzModMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_ctx_clear_fn(a::fpMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_clear_fn(a::fpMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
-  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
-end
-
-function _fmpz_mod_mpoly_ctx_clear_fn(a::FpMPolyRing)
-  @ccall libflint.fmpz_mod_mpoly_ctx_clear(a::Ref{FpMPolyRing})::Nothing
+function _fmpz_mod_mat_clear_fn(mat::FpMatrix)
+  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing
 end
 
 function _fmpz_mod_mpoly_clear_fn(a::FpMPolyRingElem)
   @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, a.parent::Ref{FpMPolyRing})::Nothing
 end
 
+function _fmpz_mod_mpoly_ctx_clear_fn(a::FpMPolyRing)
+  @ccall libflint.fmpz_mod_mpoly_ctx_clear(a::Ref{FpMPolyRing})::Nothing
+end
+
 function _fmpz_mod_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
   @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
 end
 
-function _fq_nmod_ctx_clear_fn(a::fqPolyRepField)
-  @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
+function _fmpz_mod_poly_clear_fn(x::ZZModPolyRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(x::Ref{ZZModPolyRingElem}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
-  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
+function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_default_ctx_clear_fn(a::FqField)
-  @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
+function _fmpz_mod_poly_clear_fn(a::FpRelPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_default_clear_fn(a::FqFieldElem)
-  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
+function _fmpz_mod_poly_clear_fn(a::ZZModRelPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_ctx_clear_fn(a::FqPolyRepField)
-  @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
+function _fmpz_mod_poly_clear_fn(a::FpAbsPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_clear_fn(a::FqPolyRepFieldElem)
-  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, a.parent::Ref{FqPolyRepField})::Nothing
+function _fmpz_mod_poly_clear_fn(a::ZZModAbsPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_nmod_mpoly_ctx_clear_fn(a::fqPolyRepMPolyRing)
-  @ccall libflint.fq_nmod_mpoly_ctx_clear(a::Ref{fqPolyRepMPolyRing})::Nothing
+function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
+  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{fmpz_mod_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_nmod_mpoly_clear_fn(a::fqPolyRepMPolyRingElem)
-  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Nothing
+function _fmpz_mod_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
+  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_nmod_mpoly_factor_clear_fn(f::fq_nmod_mpoly_factor)
-  @ccall libflint.fq_nmod_mpoly_factor_clear(f::Ref{fq_nmod_mpoly_factor}, f.parent::Ref{fqPolyRepMPolyRing})::Nothing
+function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
+  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
 end
 
-function _padic_ctx_clear_fn(a::PadicField)
-  @ccall libflint.padic_ctx_clear(a::Ref{PadicField})::Nothing
+function _fmpz_mpoly_ctx_clear_fn(a::ZZMPolyRing)
+  @ccall libflint.fmpz_mpoly_ctx_clear(a::Ref{ZZMPolyRing})::Nothing
 end
 
-function _padic_clear_fn(a::PadicFieldElem)
-  @ccall libflint.padic_clear(a::Ref{PadicFieldElem})::Nothing
+function _fmpz_mpoly_factor_clear_fn(f::fmpz_mpoly_factor)
+  @ccall libflint.fmpz_mpoly_factor_clear(f::Ref{fmpz_mpoly_factor}, f.parent::Ref{ZZMPolyRing})::Nothing
 end
 
-function _qadic_ctx_clear_fn(a::QadicField)
-  @ccall libflint.qadic_ctx_clear(a::Ref{QadicField})::Nothing
-end
-
-function _qadic_clear_fn(a::QadicFieldElem)
-  @ccall libflint.qadic_clear(a::Ref{QadicFieldElem})::Nothing
+function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
+  @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
 end
 
 function _fmpz_poly_clear_fn(a::ZZRelPowerSeriesRingElem)
@@ -5212,44 +5156,28 @@ function _fmpz_poly_clear_fn(a::ZZLaurentSeriesRingElem)
   @ccall libflint.fmpz_poly_clear(a::Ref{ZZLaurentSeriesRingElem})::Nothing
 end
 
-function _fmpq_poly_clear_fn(a::QQRelPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
+function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
+  @ccall libflint.fmpz_poly_factor_clear(f::Ref{fmpz_poly_factor})::Nothing
 end
 
-function _fmpq_poly_clear_fn(a::QQAbsPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
+function _fq_clear_fn(a::FqPolyRepFieldElem)
+  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, a.parent::Ref{FqPolyRepField})::Nothing
 end
 
-function _nmod_poly_clear_fn(a::fpRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
+function _fq_ctx_clear_fn(a::FqPolyRepField)
+  @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
 end
 
-function _nmod_poly_clear_fn(a::zzModRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
+function _fq_default_clear_fn(a::FqFieldElem)
+  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
 end
 
-function _fmpz_mod_poly_clear_fn(a::FpRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function _fq_default_ctx_clear_fn(a::FqField)
+  @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
 end
 
-function _fmpz_mod_poly_clear_fn(a::ZZModRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::FpAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _nmod_poly_clear_fn(x::zzModAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
-end
-
-function _nmod_poly_clear_fn(x::fpAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::ZZModAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function _fq_default_mat_clear_fn(a::FqMatrix)
+  @ccall libflint.fq_default_mat_clear(a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
 end
 
 function _fq_default_poly_clear_fn(a::FqRelPowerSeriesRingElem)
@@ -5257,19 +5185,46 @@ function _fq_default_poly_clear_fn(a::FqRelPowerSeriesRingElem)
   @ccall libflint.fq_default_poly_clear(a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
 end
 
-function _fq_poly_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-end
-
 function _fq_default_poly_clear_fn(a::FqAbsPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_default_poly_clear(a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
 end
 
-function _fq_poly_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
+function _fq_default_poly_clear_fn(a::FqPolyRingElem)
+  @ccall libflint.fq_default_poly_clear(a::Ref{FqPolyRingElem}, base_ring(a)::Ref{FqField})::Nothing
+end
+
+function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
+  K = a.base_field
+  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, K::Ref{FqField})::Nothing
+end
+
+function _fq_mat_clear_fn(a::FqPolyRepMatrix)
+  @ccall libflint.fq_mat_clear(a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
+  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_nmod_ctx_clear_fn(a::fqPolyRepField)
+  @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_nmod_mat_clear_fn(a::fqPolyRepMatrix)
+  @ccall libflint.fq_nmod_mat_clear(a::Ref{fqPolyRepMatrix}, base_ring(a)::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_nmod_mpoly_clear_fn(a::fqPolyRepMPolyRingElem)
+  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Nothing
+end
+
+function _fq_nmod_mpoly_ctx_clear_fn(a::fqPolyRepMPolyRing)
+  @ccall libflint.fq_nmod_mpoly_ctx_clear(a::Ref{fqPolyRepMPolyRing})::Nothing
+end
+
+function _fq_nmod_mpoly_factor_clear_fn(f::fq_nmod_mpoly_factor)
+  @ccall libflint.fq_nmod_mpoly_factor_clear(f::Ref{fq_nmod_mpoly_factor}, f.parent::Ref{fqPolyRepMPolyRing})::Nothing
 end
 
 function _fq_nmod_poly_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
@@ -5282,37 +5237,22 @@ function _fq_nmod_poly_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
   @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
 end
 
-function _fmpq_mat_clear_fn(a::QQMatrix)
-  @ccall libflint.fmpq_mat_clear(a::Ref{QQMatrix})::Nothing
+function _fq_nmod_poly_clear_fn(a::fqPolyRepPolyRingElem)
+  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepPolyRingElem})::Nothing
 end
 
-function _fmpz_mat_clear_fn(a::ZZMatrix)
-  @ccall libflint.fmpz_mat_clear(a::Ref{ZZMatrix})::Nothing
+function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
+  @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
 end
 
-function _nmod_mat_clear_fn(mat::zzModMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{zzModMatrix})::Nothing
+function _fq_poly_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
 end
 
-function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
-end
-
-function _fmpz_mod_mat_clear_fn(mat::FpMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
-end
-
-function _nmod_mat_clear_fn(mat::fpMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
-end
-
-function _fq_default_poly_clear_fn(a::FqPolyRingElem)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqPolyRingElem}, base_ring(a)::Ref{FqField})::Nothing
-end
-
-function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
-  K = a.base_field
-  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, K::Ref{FqField})::Nothing
+function _fq_poly_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
 end
 
 function _fq_poly_clear_fn(a::FqPolyRepPolyRingElem)
@@ -5323,24 +5263,84 @@ function _fq_poly_factor_clear_fn(a::fq_poly_factor)
   @ccall libflint.fq_poly_factor_clear(a::Ref{fq_poly_factor}, a.base_field::Ref{FqPolyRepField})::Nothing
 end
 
-function _fq_nmod_poly_clear_fn(a::fqPolyRepPolyRingElem)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepPolyRingElem})::Nothing
+function _nmod_mat_clear_fn(mat::zzModMatrix)
+  @ccall libflint.nmod_mat_clear(mat::Ref{zzModMatrix})::Nothing
 end
 
-function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
-  @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
+function _nmod_mat_clear_fn(mat::fpMatrix)
+  @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
 end
 
-function _fq_default_mat_clear_fn(a::FqMatrix)
-  @ccall libflint.fq_default_mat_clear(a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
+function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
+  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, a.parent::Ref{zzModMPolyRing})::Nothing
 end
 
-function _fq_mat_clear_fn(a::FqPolyRepMatrix)
-  @ccall libflint.fq_mat_clear(a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
+function _nmod_mpoly_clear_fn(a::fpMPolyRingElem)
+  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
 end
 
-function _fq_nmod_mat_clear_fn(a::fqPolyRepMatrix)
-  @ccall libflint.fq_nmod_mat_clear(a::Ref{fqPolyRepMatrix}, base_ring(a)::Ref{fqPolyRepField})::Nothing
+function _nmod_mpoly_ctx_clear_fn(a::zzModMPolyRing)
+  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{zzModMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_ctx_clear_fn(a::fpMPolyRing)
+  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
+  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{nmod_mpoly_factor}, f.parent::Ref{zzModMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
+  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
+end
+
+function _nmod_poly_clear_fn(x::zzModPolyRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{zzModPolyRingElem})::Nothing
+end
+
+function _nmod_poly_clear_fn(x::fpPolyRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
+end
+
+function _nmod_poly_clear_fn(a::fpRelPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
+end
+
+function _nmod_poly_clear_fn(a::zzModRelPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
+end
+
+function _nmod_poly_clear_fn(x::zzModAbsPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
+end
+
+function _nmod_poly_clear_fn(x::fpAbsPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
+end
+
+function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
+  @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
+end
+
+function _nmod_poly_factor_clear_fn(a::gfp_poly_factor)
+  @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
+end
+
+function _padic_clear_fn(a::PadicFieldElem)
+  @ccall libflint.padic_clear(a::Ref{PadicFieldElem})::Nothing
+end
+
+function _padic_ctx_clear_fn(a::PadicField)
+  @ccall libflint.padic_ctx_clear(a::Ref{PadicField})::Nothing
+end
+
+function _qadic_clear_fn(a::QadicFieldElem)
+  @ccall libflint.qadic_clear(a::Ref{QadicFieldElem})::Nothing
+end
+
+function _qadic_ctx_clear_fn(a::QadicField)
+  @ccall libflint.qadic_ctx_clear(a::Ref{QadicField})::Nothing
 end
 
 if NEW_FLINT

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5037,7 +5037,7 @@ function _fmpq_mat_clear_fn(a::QQMatrix)
 end
 
 function _fmpq_mpoly_clear_fn(a::QQMPolyRingElem)
-  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
+  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, parent(a)::Ref{QQMPolyRing})::Nothing
 end
 
 function _fmpq_mpoly_ctx_clear_fn(a::QQMPolyRing)
@@ -5056,8 +5056,8 @@ function _fmpz_clear_fn(a::ZZRingElem)
   @ccall libflint.fmpz_clear(a::Ref{ZZRingElem})::Nothing
 end
 
-function _fmpz_factor_clear_fn(a::fmpz_factor)
-  @ccall libflint.fmpz_factor_clear(a::Ref{fmpz_factor})::Nothing
+function _fmpz_factor_clear_fn(f::fmpz_factor)
+  @ccall libflint.fmpz_factor_clear(f::Ref{fmpz_factor})::Nothing
 end
 
 function _fmpz_mat_clear_fn(a::ZZMatrix)
@@ -5073,7 +5073,7 @@ function _fmpz_mod_mat_clear_fn(mat::T) where T <: Union{ZZModMatrix, FpMatrix}
 end
 
 function _fmpz_mod_mpoly_clear_fn(a::FpMPolyRingElem)
-  @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, a.parent::Ref{FpMPolyRing})::Nothing
+  @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, parent(a)::Ref{FpMPolyRing})::Nothing
 end
 
 function _fmpz_mod_mpoly_ctx_clear_fn(a::FpMPolyRing)
@@ -5088,12 +5088,12 @@ function _fmpz_mod_poly_clear_fn(x::T) where T <: Union{ZZModPolyRingElem, FpPol
   @ccall libflint.fmpz_mod_poly_clear(x::Ref{T}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fmpz_mod_poly_factor_clear_fn(a::T) where T <: Union{fmpz_mod_poly_factor, gfp_fmpz_poly_factor}
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{T}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
+function _fmpz_mod_poly_factor_clear_fn(f::T) where T <: Union{fmpz_mod_poly_factor, gfp_fmpz_poly_factor}
+  @ccall libflint.fmpz_mod_poly_factor_clear(f::Ref{T}, f.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
-  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
+  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, parent(a)::Ref{ZZMPolyRing})::Nothing
 end
 
 function _fmpz_mpoly_ctx_clear_fn(a::ZZMPolyRing)
@@ -5113,7 +5113,7 @@ function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
 end
 
 function _fq_clear_fn(a::FqPolyRepFieldElem)
-  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, a.parent::Ref{FqPolyRepField})::Nothing
+  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, parent(a)::Ref{FqPolyRepField})::Nothing
 end
 
 function _fq_ctx_clear_fn(a::FqPolyRepField)
@@ -5121,7 +5121,7 @@ function _fq_ctx_clear_fn(a::FqPolyRepField)
 end
 
 function _fq_default_clear_fn(a::FqFieldElem)
-  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
+  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, parent(a)::Ref{FqField})::Nothing
 end
 
 function _fq_default_ctx_clear_fn(a::FqField)
@@ -5136,8 +5136,8 @@ function _fq_default_poly_clear_fn(a::T) where T <: Union{FqPolyRingElem, FqRelP
   @ccall libflint.fq_default_poly_clear(a::Ref{T}, base_ring(a)::Ref{FqField})::Nothing
 end
 
-function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
-  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, a.base_field::Ref{FqField})::Nothing
+function _fq_default_poly_factor_clear_fn(f::fq_default_poly_factor)
+  @ccall libflint.fq_default_poly_factor_clear(f::Ref{fq_default_poly_factor}, f.base_field::Ref{FqField})::Nothing
 end
 
 function _fq_mat_clear_fn(a::FqPolyRepMatrix)
@@ -5145,7 +5145,7 @@ function _fq_mat_clear_fn(a::FqPolyRepMatrix)
 end
 
 function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
-  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
+  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, parent(a)::Ref{fqPolyRepField})::Nothing
 end
 
 function _fq_nmod_ctx_clear_fn(a::fqPolyRepField)
@@ -5157,7 +5157,7 @@ function _fq_nmod_mat_clear_fn(a::fqPolyRepMatrix)
 end
 
 function _fq_nmod_mpoly_clear_fn(a::fqPolyRepMPolyRingElem)
-  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Nothing
+  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, parent(a)::Ref{fqPolyRepMPolyRing})::Nothing
 end
 
 function _fq_nmod_mpoly_ctx_clear_fn(a::fqPolyRepMPolyRing)
@@ -5172,16 +5172,16 @@ function _fq_nmod_poly_clear_fn(a::T) where T <: Union{fqPolyRepPolyRingElem, fq
   @ccall libflint.fq_nmod_poly_clear(a::Ref{T}, base_ring(a)::Ref{fqPolyRepField})::Nothing
 end
 
-function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
-  @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
+function _fq_nmod_poly_factor_clear_fn(f::fq_nmod_poly_factor)
+  @ccall libflint.fq_nmod_poly_factor_clear(f::Ref{fq_nmod_poly_factor}, f.base_field::Ref{fqPolyRepField})::Nothing
 end
 
 function _fq_poly_clear_fn(a::T) where T <: Union{FqPolyRepPolyRingElem, FqPolyRepRelPowerSeriesRingElem, FqPolyRepAbsPowerSeriesRingElem}
   @ccall libflint.fq_poly_clear(a::Ref{T}, base_ring(a)::Ref{FqPolyRepField})::Nothing
 end
 
-function _fq_poly_factor_clear_fn(a::fq_poly_factor)
-  @ccall libflint.fq_poly_factor_clear(a::Ref{fq_poly_factor}, a.base_field::Ref{FqPolyRepField})::Nothing
+function _fq_poly_factor_clear_fn(f::fq_poly_factor)
+  @ccall libflint.fq_poly_factor_clear(f::Ref{fq_poly_factor}, f.base_field::Ref{FqPolyRepField})::Nothing
 end
 
 function _nmod_mat_clear_fn(mat::T) where T <: Union{zzModMatrix, fpMatrix}
@@ -5189,11 +5189,11 @@ function _nmod_mat_clear_fn(mat::T) where T <: Union{zzModMatrix, fpMatrix}
 end
 
 function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, a.parent::Ref{zzModMPolyRing})::Nothing
+  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, parent(a)::Ref{zzModMPolyRing})::Nothing
 end
 
 function _nmod_mpoly_clear_fn(a::fpMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
+  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, parent(a)::Ref{fpMPolyRing})::Nothing
 end
 
 function _nmod_mpoly_ctx_clear_fn(a::T) where T <: Union{zzModMPolyRing, fpMPolyRing}
@@ -5212,8 +5212,8 @@ function _nmod_poly_clear_fn(x::T) where T <: Union{zzModPolyRingElem, fpPolyRin
   @ccall libflint.nmod_poly_clear(x::Ref{T})::Nothing
 end
 
-function _nmod_poly_factor_clear_fn(a::T) where T <: Union{nmod_poly_factor, gfp_poly_factor}
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{T})::Nothing
+function _nmod_poly_factor_clear_fn(f::T) where T <: Union{nmod_poly_factor, gfp_poly_factor}
+  @ccall libflint.nmod_poly_factor_clear(f::Ref{T})::Nothing
 end
 
 function _padic_clear_fn(a::PadicFieldElem)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -640,7 +640,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   function fpPolyRingElem(n::UInt)
     z = new()
     @ccall libflint.nmod_poly_init(z::Ref{fpPolyRingElem}, n::UInt)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -657,7 +657,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   function fpPolyRingElem(n::UInt, arr::Vector{ZZRingElem})
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     for i in 1:length(arr)
       setcoeff!(z, i - 1, arr[i])
     end
@@ -667,7 +667,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   function fpPolyRingElem(n::UInt, arr::Vector{UInt})
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     for i in 1:length(arr)
       setcoeff!(z, i - 1, arr[i])
     end
@@ -677,7 +677,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   function fpPolyRingElem(n::UInt, arr::Vector{fpFieldElem})
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(arr)::Int)::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     for i in 1:length(arr)
       setcoeff!(z, i-1, arr[i].data)
     end
@@ -688,7 +688,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(f)::Int)::Nothing
     @ccall libflint.fmpz_poly_get_nmod_poly(z::Ref{fpPolyRingElem}, f::Ref{ZZPolyRingElem})::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -696,7 +696,7 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_poly_init2(z::Ref{fpPolyRingElem}, n::UInt, length(f)::Int)::Nothing
     @ccall libflint.nmod_poly_set(z::Ref{fpPolyRingElem}, f::Ref{fpPolyRingElem})::Nothing
-    finalizer(_gfp_poly_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 end
@@ -712,7 +712,7 @@ mutable struct gfp_poly_factor
     z = new()
     @ccall libflint.nmod_poly_factor_init(z::Ref{gfp_poly_factor})::Nothing
     z.n = n
-    finalizer(_gfp_poly_factor_clear_fn, z)
+    finalizer(_nmod_poly_factor_clear_fn, z)
     return z
   end
 end
@@ -980,7 +980,7 @@ mutable struct gfp_fmpz_poly_factor
     z = new()
     @ccall libflint.fmpz_mod_poly_factor_init(z::Ref{gfp_fmpz_poly_factor}, n::Ref{fmpz_mod_ctx_struct})::Nothing
     z.n = n
-    finalizer(_gfp_fmpz_poly_factor_clear_fn, z)
+    finalizer(_fmpz_mod_poly_factor_clear_fn, z)
     return z
   end
 
@@ -1433,7 +1433,7 @@ end
       @ccall libflint.nmod_mpoly_ctx_init(z::Ref{fpMPolyRing}, length(s)::Int, ord::Cint, UInt(modulus(R))::UInt)::Nothing
       z.base_ring = R
       z.S = s
-      finalizer(_gfp_mpoly_ctx_clear_fn, z)
+      finalizer(_nmod_mpoly_ctx_clear_fn, z)
       return z
     end
   end
@@ -1456,7 +1456,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_mpoly_init(z::Ref{fpMPolyRingElem}, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_mpoly_clear_fn, z)
+    finalizer(_nmod_mpoly_clear_fn, z)
     return z
   end
 
@@ -1464,7 +1464,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_mpoly_clear_fn, z)
+    finalizer(_nmod_mpoly_clear_fn, z)
 
     for i in 1:length(a)
       @ccall libflint.nmod_mpoly_push_term_ui_ui(z::Ref{fpMPolyRingElem}, a[i].data::UInt, b[i]::Ptr{UInt}, ctx::Ref{fpMPolyRing})::Nothing
@@ -1479,7 +1479,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_mpoly_clear_fn, z)
+    finalizer(_nmod_mpoly_clear_fn, z)
 
     for i in 1:length(a)
       @ccall libflint.nmod_mpoly_push_term_ui_ui(z::Ref{fpMPolyRingElem}, a[i].data::UInt, b[i]::Ptr{Int}, ctx::Ref{fpMPolyRing})::Nothing
@@ -1494,7 +1494,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_mpoly_clear_fn, z)
+    finalizer(_nmod_mpoly_clear_fn, z)
 
     for i in 1:length(a)
       @ccall libflint.nmod_mpoly_push_term_ui_fmpz(z::Ref{fpMPolyRingElem}, a[i].data::UInt, b[i]::Ptr{Ref{ZZRingElem}}, ctx::Ref{fpMPolyRing})::Nothing
@@ -1532,7 +1532,7 @@ mutable struct gfp_mpoly_factor
     z = new()
     @ccall libflint.nmod_mpoly_factor_init(z::Ref{gfp_mpoly_factor}, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_mpoly_factor_clear_fn, z)
+    finalizer(_nmod_mpoly_factor_clear_fn, z)
     return z
   end
 end
@@ -1583,7 +1583,7 @@ end
       @ccall libflint.fmpz_mod_mpoly_ctx_init(z::Ref{FpMPolyRing}, length(s)::Int, ord::Cint, modulus(R)::Ref{ZZRingElem})::Nothing
       z.base_ring = R
       z.S = s
-      finalizer(_gfp_fmpz_mpoly_ctx_clear_fn, z)
+      finalizer(_fmpz_mod_mpoly_ctx_clear_fn, z)
       return z
     end
   end
@@ -1606,7 +1606,7 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
     z = new()
     @ccall libflint.fmpz_mod_mpoly_init(z::Ref{FpMPolyRingElem}, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_fmpz_mpoly_clear_fn, z)
+    finalizer(_fmpz_mod_mpoly_clear_fn, z)
     return z
   end
 
@@ -1614,7 +1614,7 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
     z = new()
     @ccall libflint.fmpz_mod_mpoly_init2(z::Ref{FpMPolyRingElem}, length(a)::Int, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_fmpz_mpoly_clear_fn, z)
+    finalizer(_fmpz_mod_mpoly_clear_fn, z)
 
     for i in 1:length(a)
       if T == ZZRingElem
@@ -1650,7 +1650,7 @@ mutable struct gfp_fmpz_mpoly_factor
     z = new()
     @ccall libflint.fmpz_mod_mpoly_factor_init(z::Ref{gfp_fmpz_mpoly_factor}, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx
-    finalizer(_gfp_fmpz_mpoly_factor_clear_fn, z)
+    finalizer(_fmpz_mod_mpoly_factor_clear_fn, z)
     return z
   end
 end
@@ -1700,7 +1700,7 @@ See [`FqPolyRepField`](@ref) for $p$ being a [`ZZRingElem`](@ref). See [`fqPolyR
     return get_cached!(FqNmodFiniteFieldID, (c, deg, s), cached) do
       d = new()
       @ccall libflint.fq_nmod_ctx_init_ui(d::Ref{fqPolyRepField}, c::UInt, deg::Int, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqNmodFiniteField_clear_fn, d)
+      finalizer(_fq_nmod_ctx_clear_fn, d)
       return d
     end
   end
@@ -1715,7 +1715,7 @@ See [`FqPolyRepField`](@ref) for $p$ being a [`ZZRingElem`](@ref). See [`fqPolyR
     return get_cached!(FqNmodFiniteFieldIDNmodPol, (parent(f), f, s), cached) do
       z = new()
       @ccall libflint.fq_nmod_ctx_init_modulus(z::Ref{fqPolyRepField}, f::Ref{zzModPolyRingElem}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqNmodFiniteField_clear_fn, z)
+      finalizer(_fq_nmod_ctx_clear_fn, z)
       return z
     end
   end
@@ -1725,7 +1725,7 @@ See [`FqPolyRepField`](@ref) for $p$ being a [`ZZRingElem`](@ref). See [`fqPolyR
     return get_cached!(FqNmodFiniteFieldIDGFPPol, (parent(f), f, s), cached) do
       z = new()
       @ccall libflint.fq_nmod_ctx_init_modulus(z::Ref{fqPolyRepField}, f::Ref{fpPolyRingElem}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqNmodFiniteField_clear_fn, z)
+      finalizer(_fq_nmod_ctx_clear_fn, z)
       return z
     end
   end
@@ -1832,7 +1832,7 @@ A finite field. The constructor automatically determines a fast implementation.
       d.var = string(s)
       d.isabsolute = true
       d.isstandard = true
-      finalizer(_FqDefaultFiniteField_clear_fn, d)
+      finalizer(_fq_default_ctx_clear_fn, d)
       @ccall libflint.fq_default_ctx_init(d::Ref{FqField}, char::Ref{ZZRingElem}, deg::Int, d.var::Ptr{UInt8})::Nothing
       return d
     end
@@ -1847,7 +1847,7 @@ A finite field. The constructor automatically determines a fast implementation.
       z.isstandard = true
       z.var = string(s)
       @ccall libflint.fq_default_ctx_init_modulus(z::Ref{FqField}, f::Ref{ZZModPolyRingElem}, base_ring(parent(f)).ninv::Ref{fmpz_mod_ctx_struct}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqDefaultFiniteField_clear_fn, z)
+      finalizer(_fq_default_ctx_clear_fn, z)
       return z
     end
   end
@@ -1860,7 +1860,7 @@ A finite field. The constructor automatically determines a fast implementation.
       z.isstandard = true
       z.var = string(s)
       @ccall libflint.fq_default_ctx_init_modulus(z::Ref{FqField}, f::Ref{FpPolyRingElem}, base_ring(parent(f)).ninv::Ref{fmpz_mod_ctx_struct}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqDefaultFiniteField_clear_fn, z)
+      finalizer(_fq_default_ctx_clear_fn, z)
       return z
     end
   end
@@ -1874,7 +1874,7 @@ A finite field. The constructor automatically determines a fast implementation.
       z.isstandard = true
       z.var = string(s)
       @ccall libflint.fq_default_ctx_init_modulus_nmod(z::Ref{FqField}, f::Ref{zzModPolyRingElem}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqDefaultFiniteField_clear_fn, z)
+      finalizer(_fq_default_ctx_clear_fn, z)
       return z
     end
   end
@@ -1887,7 +1887,7 @@ A finite field. The constructor automatically determines a fast implementation.
       z.isstandard = true
       z.var = string(s)
       @ccall libflint.fq_default_ctx_init_modulus_nmod(z::Ref{FqField}, f::Ref{fpPolyRingElem}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqDefaultFiniteField_clear_fn, z)
+      finalizer(_fq_default_ctx_clear_fn, z)
       return z
     end
   end
@@ -1986,7 +1986,7 @@ See [`fqPolyRepField`](@ref) for $p$ being an [`Int`](@ref). See [`FqPolyRepFiel
     throw(DomainError(char, "the characteristic must be a prime"))
     return get_cached!(FqFiniteFieldID, (char, deg, s), cached) do
       d = new()
-      finalizer(_FqFiniteField_clear_fn, d)
+      finalizer(_fq_ctx_clear_fn, d)
       @ccall libflint.fq_ctx_init(d::Ref{FqPolyRepField}, char::Ref{ZZRingElem}, deg::Int, string(s)::Ptr{UInt8})::Nothing
       return d
     end
@@ -1998,7 +1998,7 @@ See [`fqPolyRepField`](@ref) for $p$ being an [`Int`](@ref). See [`FqPolyRepFiel
     return get_cached!(FqFiniteFieldIDFmpzPol, (f, s), cached) do
       z = new()
       @ccall libflint.fq_ctx_init_modulus(z::Ref{FqPolyRepField}, f::Ref{ZZModPolyRingElem}, base_ring(parent(f)).ninv::Ref{fmpz_mod_ctx_struct}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqFiniteField_clear_fn, z)
+      finalizer(_fq_ctx_clear_fn, z)
       return z
     end
   end
@@ -2008,7 +2008,7 @@ See [`fqPolyRepField`](@ref) for $p$ being an [`Int`](@ref). See [`FqPolyRepFiel
     return get_cached!(FqFiniteFieldIDGFPPol, (f, s), cached) do
       z = new()
       @ccall libflint.fq_ctx_init_modulus(z::Ref{FqPolyRepField}, f::Ref{FpPolyRingElem}, base_ring(parent(f)).ninv::Ref{fmpz_mod_ctx_struct}, string(s)::Ptr{UInt8})::Nothing
-      finalizer(_FqFiniteField_clear_fn, z)
+      finalizer(_fq_ctx_clear_fn, z)
       return z
     end
   end
@@ -2402,7 +2402,7 @@ mutable struct ZZRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZRingElem}
   function ZZRelPowerSeriesRingElem()
     z = new()
     @ccall libflint.fmpz_poly_init(z::Ref{ZZRelPowerSeriesRingElem})::Nothing
-    finalizer(_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2414,7 +2414,7 @@ mutable struct ZZRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZRingElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2454,7 +2454,7 @@ mutable struct ZZAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZRingElem}
   function ZZAbsPowerSeriesRingElem()
     z = new()
     @ccall libflint.fmpz_poly_init(z::Ref{ZZAbsPowerSeriesRingElem})::Nothing
-    finalizer(_fmpz_abs_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2465,7 +2465,7 @@ mutable struct ZZAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZRingElem}
       @ccall libflint.fmpz_poly_set_coeff_fmpz(z::Ref{ZZAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem})::Nothing
     end
     z.prec = prec
-    finalizer(_fmpz_abs_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2561,7 +2561,7 @@ mutable struct ZZLaurentSeriesRingElem <: RingElem
   function ZZLaurentSeriesRingElem()
     z = new()
     @ccall libflint.fmpz_poly_init(z::Ref{ZZLaurentSeriesRingElem})::Nothing
-    finalizer(_fmpz_laurent_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2574,7 +2574,7 @@ mutable struct ZZLaurentSeriesRingElem <: RingElem
     z.prec = prec
     z.val = val
     z.scale = scale
-    finalizer(_fmpz_laurent_series_clear_fn, z)
+    finalizer(_fmpz_poly_clear_fn, z)
     return z
   end
 
@@ -2618,7 +2618,7 @@ mutable struct QQRelPowerSeriesRingElem <: RelPowerSeriesRingElem{QQFieldElem}
   function QQRelPowerSeriesRingElem()
     z = new()
     @ccall libflint.fmpq_poly_init(z::Ref{QQRelPowerSeriesRingElem})::Nothing
-    finalizer(_fmpq_rel_series_clear_fn, z)
+    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
@@ -2630,7 +2630,7 @@ mutable struct QQRelPowerSeriesRingElem <: RelPowerSeriesRingElem{QQFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_fmpq_rel_series_clear_fn, z)
+    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
@@ -2673,7 +2673,7 @@ mutable struct QQAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{QQFieldElem}
   function QQAbsPowerSeriesRingElem()
     z = new()
     @ccall libflint.fmpq_poly_init(z::Ref{QQAbsPowerSeriesRingElem})::Nothing
-    finalizer(_fmpq_abs_series_clear_fn, z)
+    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
@@ -2684,7 +2684,7 @@ mutable struct QQAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{QQFieldElem}
       @ccall libflint.fmpq_poly_set_coeff_fmpq(z::Ref{QQAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{QQFieldElem})::Nothing
     end
     z.prec = prec
-    finalizer(_fmpq_abs_series_clear_fn, z)
+    finalizer(_fmpq_poly_clear_fn, z)
     return z
   end
 
@@ -2731,7 +2731,7 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
   function fpRelPowerSeriesRingElem(p::UInt)
     z = new()
     @ccall libflint.nmod_poly_init(z::Ref{fpRelPowerSeriesRingElem}, p::UInt)::Nothing
-    finalizer(_gfp_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2744,7 +2744,7 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_gfp_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2756,7 +2756,7 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_gfp_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2768,7 +2768,7 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_gfp_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2819,7 +2819,7 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
   function zzModRelPowerSeriesRingElem(p::UInt)
     z = new()
     @ccall libflint.nmod_poly_init(z::Ref{zzModRelPowerSeriesRingElem}, p::UInt)::Nothing
-    finalizer(_nmod_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2832,7 +2832,7 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     end
     z.prec = prec
     z.val = val
-    finalizer(_nmod_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2844,7 +2844,7 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     end
     z.prec = prec
     z.val = val
-    finalizer(_nmod_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2856,7 +2856,7 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     end
     z.prec = prec
     z.val = val
-    finalizer(_nmod_rel_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -2906,7 +2906,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
   function FpRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct)
     z = new()
     @ccall libflint.fmpz_mod_poly_init(z::Ref{FpRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_gfp_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -2923,7 +2923,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_gfp_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -2941,7 +2941,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_gfp_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -2955,7 +2955,7 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
     p = base_ring(parent(a)).ninv
     @ccall libflint.fmpz_mod_poly_init(z::Ref{FpRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     @ccall libflint.fmpz_mod_poly_set(z::Ref{FpRelPowerSeriesRingElem}, a::Ref{FpRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_gfp_fmpz_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     if isdefined(a, :parent)
       z.parent = a.parent
     end
@@ -2998,7 +2998,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
   function ZZModRelPowerSeriesRingElem(p::fmpz_mod_ctx_struct)
     z = new()
     @ccall libflint.fmpz_mod_poly_init(z::Ref{ZZModRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_fmpz_mod_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3015,7 +3015,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     end
     z.prec = prec
     z.val = val
-    finalizer(_fmpz_mod_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3033,7 +3033,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     end
     z.prec = prec
     z.val = val
-    finalizer(_fmpz_mod_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3047,7 +3047,7 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
     p = base_ring(parent(a)).ninv
     @ccall libflint.fmpz_mod_poly_init(z::Ref{ZZModRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     @ccall libflint.fmpz_mod_poly_set(z::Ref{ZZModRelPowerSeriesRingElem}, a::Ref{ZZModRelPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_fmpz_mod_rel_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     if isdefined(a, :parent)
       z.parent = a.parent
     end
@@ -3089,7 +3089,7 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
   function FpAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct)
     z = new()
     @ccall libflint.fmpz_mod_poly_init(z::Ref{FpAbsPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_gfp_fmpz_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3105,7 +3105,7 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
       @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     end
     z.prec = prec
-    finalizer(_gfp_fmpz_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3121,7 +3121,7 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
       @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{FpAbsPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     end
     z.prec = prec
-    finalizer(_gfp_fmpz_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3180,7 +3180,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
   function zzModAbsPowerSeriesRingElem(n::UInt)
     z = new()
     @ccall libflint.nmod_poly_init(z::Ref{zzModAbsPowerSeriesRingElem}, n::UInt)::Nothing
-    finalizer(_nmod_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3192,7 +3192,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
       @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_nmod_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3203,7 +3203,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
       @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i - 1)::Int, arr[i]::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_nmod_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3214,7 +3214,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
       @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{zzModAbsPowerSeriesRingElem}, (i-1)::Int, arr[i].data::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_nmod_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3224,7 +3224,7 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
     @ccall libflint.nmod_poly_init2(z::Ref{zzModAbsPowerSeriesRingElem}, R.n::UInt, length(a)::Int)::Nothing
     @ccall libflint.nmod_poly_set(z::Ref{zzModAbsPowerSeriesRingElem}, a::Ref{zzModAbsPowerSeriesRingElem})::Nothing
     z.prec = a.prec
-    finalizer(_nmod_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 end
@@ -3268,7 +3268,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
   function fpAbsPowerSeriesRingElem(n::UInt)
     z = new()
     @ccall libflint.nmod_poly_init(z::Ref{fpAbsPowerSeriesRingElem}, n::UInt)::Nothing
-    finalizer(_gfp_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3280,7 +3280,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
       @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i - 1)::Int, tt::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_gfp_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3291,7 +3291,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
       @ccall libflint.nmod_poly_series_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i - 1)::Int, arr[i]::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_gfp_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3302,7 +3302,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
       @ccall libflint.nmod_poly_set_coeff_ui(z::Ref{fpAbsPowerSeriesRingElem}, (i-1)::Int, arr[i].data::UInt)::Nothing
     end
     z.prec = prec
-    finalizer(_gfp_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3312,7 +3312,7 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
     @ccall libflint.nmod_poly_init2(z::Ref{fpAbsPowerSeriesRingElem}, R.n::UInt, length(a)::Int)::Nothing
     @ccall libflint.nmod_poly_set(z::Ref{fpAbsPowerSeriesRingElem}, a::Ref{fpAbsPowerSeriesRingElem})::Nothing
     z.prec = a.prec
-    finalizer(_gfp_abs_series_clear_fn, z)
+    finalizer(_nmod_poly_clear_fn, z)
     return z
   end
 end
@@ -3351,7 +3351,7 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
   function ZZModAbsPowerSeriesRingElem(p::fmpz_mod_ctx_struct)
     z = new()
     @ccall libflint.fmpz_mod_poly_init(z::Ref{ZZModAbsPowerSeriesRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_fmpz_mod_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3367,7 +3367,7 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
       @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     end
     z.prec = prec
-    finalizer(_fmpz_mod_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3383,7 +3383,7 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
       @ccall libflint.fmpz_mod_poly_set_coeff_fmpz(z::Ref{ZZModAbsPowerSeriesRingElem}, (i - 1)::Int, data(a[i])::Ref{ZZRingElem}, p::Ref{fmpz_mod_ctx_struct})::Nothing
     end
     z.prec = prec
-    finalizer(_fmpz_mod_abs_series_clear_fn, z)
+    finalizer(_fmpz_mod_poly_clear_fn, z)
     return z
   end
 
@@ -3437,7 +3437,7 @@ mutable struct FqRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqFieldElem}
   function FqRelPowerSeriesRingElem(ctx::FqField)
     z = new()
     @ccall libflint.fq_default_poly_init(z::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-    finalizer(_fq_default_rel_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 
@@ -3449,7 +3449,7 @@ mutable struct FqRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqFieldElem}
     end
     z.prec = prec
     z.val = val
-    finalizer(_fq_default_rel_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 
@@ -3457,7 +3457,7 @@ mutable struct FqRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqFieldElem}
     z = new()
     @ccall libflint.fq_default_poly_init(z::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_set(z::Ref{FqRelPowerSeriesRingElem}, a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-    finalizer(_fq_default_rel_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 end
@@ -3494,7 +3494,7 @@ mutable struct FqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqPolyR
   function FqPolyRepRelPowerSeriesRingElem(ctx::FqPolyRepField)
     z = new()
     @ccall libflint.fq_poly_init(z::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-    finalizer(_fq_rel_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 
@@ -3506,7 +3506,7 @@ mutable struct FqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqPolyR
     end
     z.prec = prec
     z.val = val
-    finalizer(_fq_rel_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 
@@ -3514,7 +3514,7 @@ mutable struct FqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqPolyR
     z = new()
     @ccall libflint.fq_poly_init(z::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
     @ccall libflint.fq_poly_set(z::Ref{FqPolyRepRelPowerSeriesRingElem}, a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-    finalizer(_fq_rel_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 end
@@ -3551,7 +3551,7 @@ mutable struct FqAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqFieldElem}
   function FqAbsPowerSeriesRingElem(ctx::FqField)
     z = new()
     @ccall libflint.fq_default_poly_init(z::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-    finalizer(_fq_default_abs_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 
@@ -3562,7 +3562,7 @@ mutable struct FqAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqFieldElem}
       @ccall libflint.fq_default_poly_set_coeff(z::Ref{FqAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{FqFieldElem}, ctx::Ref{FqField})::Nothing
     end
     z.prec = prec
-    finalizer(_fq_default_abs_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 
@@ -3570,7 +3570,7 @@ mutable struct FqAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqFieldElem}
     z = new()
     @ccall libflint.fq_default_poly_init(z::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
     @ccall libflint.fq_default_poly_set(z::Ref{FqAbsPowerSeriesRingElem}, a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-    finalizer(_fq_default_abs_series_clear_fn, z)
+    finalizer(_fq_default_poly_clear_fn, z)
     return z
   end
 end
@@ -3606,7 +3606,7 @@ mutable struct FqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqPolyR
   function FqPolyRepAbsPowerSeriesRingElem(ctx::FqPolyRepField)
     z = new()
     @ccall libflint.fq_poly_init(z::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-    finalizer(_fq_abs_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 
@@ -3617,7 +3617,7 @@ mutable struct FqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqPolyR
       @ccall libflint.fq_poly_set_coeff(z::Ref{FqPolyRepAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{FqPolyRepFieldElem}, ctx::Ref{FqPolyRepField})::Nothing
     end
     z.prec = prec
-    finalizer(_fq_abs_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 
@@ -3625,7 +3625,7 @@ mutable struct FqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqPolyR
     z = new()
     @ccall libflint.fq_poly_init(z::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
     @ccall libflint.fq_poly_set(z::Ref{FqPolyRepAbsPowerSeriesRingElem}, a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-    finalizer(_fq_abs_series_clear_fn, z)
+    finalizer(_fq_poly_clear_fn, z)
     return z
   end
 end
@@ -3663,7 +3663,7 @@ mutable struct fqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fqPolyR
   function fqPolyRepRelPowerSeriesRingElem(ctx::fqPolyRepField)
     z = new()
     @ccall libflint.fq_nmod_poly_init(z::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-    finalizer(_fq_nmod_rel_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3675,7 +3675,7 @@ mutable struct fqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fqPolyR
     end
     z.prec = prec
     z.val = val
-    finalizer(_fq_nmod_rel_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3683,7 +3683,7 @@ mutable struct fqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fqPolyR
     z = new()
     @ccall libflint.fq_nmod_poly_init(z::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
     @ccall libflint.fq_nmod_poly_set(z::Ref{fqPolyRepRelPowerSeriesRingElem}, a::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-    finalizer(_fq_nmod_rel_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 end
@@ -3720,7 +3720,7 @@ mutable struct fqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fqPolyR
   function fqPolyRepAbsPowerSeriesRingElem(ctx::fqPolyRepField)
     z = new()
     @ccall libflint.fq_nmod_poly_init(z::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-    finalizer(_fq_nmod_abs_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3731,7 +3731,7 @@ mutable struct fqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fqPolyR
       @ccall libflint.fq_nmod_poly_set_coeff(z::Ref{fqPolyRepAbsPowerSeriesRingElem}, (i - 1)::Int, a[i]::Ref{fqPolyRepFieldElem}, ctx::Ref{fqPolyRepField})::Nothing
     end
     z.prec = prec
-    finalizer(_fq_nmod_abs_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 
@@ -3739,7 +3739,7 @@ mutable struct fqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fqPolyR
     z = new()
     @ccall libflint.fq_nmod_poly_init(z::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
     @ccall libflint.fq_nmod_poly_set(z::Ref{fqPolyRepAbsPowerSeriesRingElem}, a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-    finalizer(_fq_nmod_abs_series_clear_fn, z)
+    finalizer(_fq_nmod_poly_clear_fn, z)
     return z
   end
 end
@@ -4136,7 +4136,7 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
   function FpMatrix(r::Int, c::Int, ctx::fmpz_mod_ctx_struct)
     z = new()
     @ccall libflint.fmpz_mod_mat_init(z::Ref{FpMatrix}, r::Int, c::Int, ctx::Ref{fmpz_mod_ctx_struct})::Nothing
-    finalizer(_gfp_fmpz_mat_clear_fn, z)
+    finalizer(_fmpz_mod_mat_clear_fn, z)
     return z
   end
 
@@ -4237,7 +4237,7 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   function fpMatrix(r::Int, c::Int, n::UInt)
     z = new()
     @ccall libflint.nmod_mat_init(z::Ref{fpMatrix}, r::Int, c::Int, n::UInt)::Nothing
-    finalizer(_gfp_mat_clear_fn, z)
+    finalizer(_nmod_mat_clear_fn, z)
     return z
   end
 
@@ -5064,11 +5064,11 @@ function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
   @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
 end
 
-function _gfp_poly_clear_fn(x::fpPolyRingElem)
+function _nmod_poly_clear_fn(x::fpPolyRingElem)
   @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
 end
 
-function _gfp_poly_factor_clear_fn(a::gfp_poly_factor)
+function _nmod_poly_factor_clear_fn(a::gfp_poly_factor)
   @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
 end
 
@@ -5084,7 +5084,7 @@ function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
   @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _gfp_fmpz_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
+function _fmpz_mod_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
   @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
@@ -5124,31 +5124,31 @@ function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
   @ccall libflint.nmod_mpoly_factor_clear(f::Ref{nmod_mpoly_factor}, f.parent::Ref{zzModMPolyRing})::Nothing
 end
 
-function _gfp_mpoly_ctx_clear_fn(a::fpMPolyRing)
+function _nmod_mpoly_ctx_clear_fn(a::fpMPolyRing)
   @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
 end
 
-function _gfp_mpoly_clear_fn(a::fpMPolyRingElem)
+function _nmod_mpoly_clear_fn(a::fpMPolyRingElem)
   @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
 end
 
-function _gfp_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
+function _nmod_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
   @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
 end
 
-function _gfp_fmpz_mpoly_ctx_clear_fn(a::FpMPolyRing)
+function _fmpz_mod_mpoly_ctx_clear_fn(a::FpMPolyRing)
   @ccall libflint.fmpz_mod_mpoly_ctx_clear(a::Ref{FpMPolyRing})::Nothing
 end
 
-function _gfp_fmpz_mpoly_clear_fn(a::FpMPolyRingElem)
+function _fmpz_mod_mpoly_clear_fn(a::FpMPolyRingElem)
   @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, a.parent::Ref{FpMPolyRing})::Nothing
 end
 
-function _gfp_fmpz_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
+function _fmpz_mod_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
   @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
 end
 
-function _FqNmodFiniteField_clear_fn(a::fqPolyRepField)
+function _fq_nmod_ctx_clear_fn(a::fqPolyRepField)
   @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
 end
 
@@ -5156,7 +5156,7 @@ function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
   @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
 end
 
-function _FqDefaultFiniteField_clear_fn(a::FqField)
+function _fq_default_ctx_clear_fn(a::FqField)
   @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
 end
 
@@ -5164,7 +5164,7 @@ function _fq_default_clear_fn(a::FqFieldElem)
   @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
 end
 
-function _FqFiniteField_clear_fn(a::FqPolyRepField)
+function _fq_ctx_clear_fn(a::FqPolyRepField)
   @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
 end
 
@@ -5200,84 +5200,84 @@ function _qadic_clear_fn(a::QadicFieldElem)
   @ccall libflint.qadic_clear(a::Ref{QadicFieldElem})::Nothing
 end
 
-function _fmpz_rel_series_clear_fn(a::ZZRelPowerSeriesRingElem)
+function _fmpz_poly_clear_fn(a::ZZRelPowerSeriesRingElem)
   @ccall libflint.fmpz_poly_clear(a::Ref{ZZRelPowerSeriesRingElem})::Nothing
 end
 
-function _fmpz_abs_series_clear_fn(a::ZZAbsPowerSeriesRingElem)
+function _fmpz_poly_clear_fn(a::ZZAbsPowerSeriesRingElem)
   @ccall libflint.fmpz_poly_clear(a::Ref{ZZAbsPowerSeriesRingElem})::Nothing
 end
 
-function _fmpz_laurent_series_clear_fn(a::ZZLaurentSeriesRingElem)
+function _fmpz_poly_clear_fn(a::ZZLaurentSeriesRingElem)
   @ccall libflint.fmpz_poly_clear(a::Ref{ZZLaurentSeriesRingElem})::Nothing
 end
 
-function _fmpq_rel_series_clear_fn(a::QQRelPowerSeriesRingElem)
+function _fmpq_poly_clear_fn(a::QQRelPowerSeriesRingElem)
   @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
 end
 
-function _fmpq_abs_series_clear_fn(a::QQAbsPowerSeriesRingElem)
+function _fmpq_poly_clear_fn(a::QQAbsPowerSeriesRingElem)
   @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
 end
 
-function _gfp_rel_series_clear_fn(a::fpRelPowerSeriesRingElem)
+function _nmod_poly_clear_fn(a::fpRelPowerSeriesRingElem)
   @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
 end
 
-function _nmod_rel_series_clear_fn(a::zzModRelPowerSeriesRingElem)
+function _nmod_poly_clear_fn(a::zzModRelPowerSeriesRingElem)
   @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
 end
 
-function _gfp_fmpz_rel_series_clear_fn(a::FpRelPowerSeriesRingElem)
+function _fmpz_mod_poly_clear_fn(a::FpRelPowerSeriesRingElem)
   @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fmpz_mod_rel_series_clear_fn(a::ZZModRelPowerSeriesRingElem)
+function _fmpz_mod_poly_clear_fn(a::ZZModRelPowerSeriesRingElem)
   @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _gfp_fmpz_abs_series_clear_fn(a::FpAbsPowerSeriesRingElem)
+function _fmpz_mod_poly_clear_fn(a::FpAbsPowerSeriesRingElem)
   @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _nmod_abs_series_clear_fn(x::zzModAbsPowerSeriesRingElem)
+function _nmod_poly_clear_fn(x::zzModAbsPowerSeriesRingElem)
   @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
 end
 
-function _gfp_abs_series_clear_fn(x::fpAbsPowerSeriesRingElem)
+function _nmod_poly_clear_fn(x::fpAbsPowerSeriesRingElem)
   @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
 end
 
-function _fmpz_mod_abs_series_clear_fn(a::ZZModAbsPowerSeriesRingElem)
+function _fmpz_mod_poly_clear_fn(a::ZZModAbsPowerSeriesRingElem)
   @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fq_default_rel_series_clear_fn(a::FqRelPowerSeriesRingElem)
+function _fq_default_poly_clear_fn(a::FqRelPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_default_poly_clear(a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
 end
 
-function _fq_rel_series_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
+function _fq_poly_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
 end
 
-function _fq_default_abs_series_clear_fn(a::FqAbsPowerSeriesRingElem)
+function _fq_default_poly_clear_fn(a::FqAbsPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_default_poly_clear(a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
 end
 
-function _fq_abs_series_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
+function _fq_poly_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
 end
 
-function _fq_nmod_rel_series_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
+function _fq_nmod_poly_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
 end
 
-function _fq_nmod_abs_series_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
+function _fq_nmod_poly_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
   ctx = base_ring(a)
   @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
 end
@@ -5298,11 +5298,11 @@ function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
   @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
 end
 
-function _gfp_fmpz_mat_clear_fn(mat::FpMatrix)
+function _fmpz_mod_mat_clear_fn(mat::FpMatrix)
   @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
 end
 
-function _gfp_mat_clear_fn(mat::fpMatrix)
+function _nmod_mat_clear_fn(mat::fpMatrix)
   @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
 end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5048,16 +5048,8 @@ function _fmpq_mpoly_factor_clear_fn(f::fmpq_mpoly_factor)
   @ccall libflint.fmpq_mpoly_factor_clear(f::Ref{fmpq_mpoly_factor}, f.parent::Ref{QQMPolyRing})::Nothing
 end
 
-function _fmpq_poly_clear_fn(a::QQPolyRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQPolyRingElem})::Nothing
-end
-
-function _fmpq_poly_clear_fn(a::QQRelPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
-end
-
-function _fmpq_poly_clear_fn(a::QQAbsPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
+function _fmpq_poly_clear_fn(a::T) where T <: Union{QQPolyRingElem, QQRelPowerSeriesRingElem, QQAbsPowerSeriesRingElem}
+  @ccall libflint.fmpq_poly_clear(a::Ref{T})::Nothing
 end
 
 function _fmpz_clear_fn(a::ZZRingElem)
@@ -5076,12 +5068,8 @@ function _fmpz_mod_ctx_clear_fn(a::fmpz_mod_ctx_struct)
   @ccall libflint.fmpz_mod_ctx_clear(a::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing
-end
-
-function _fmpz_mod_mat_clear_fn(mat::FpMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing
+function _fmpz_mod_mat_clear_fn(mat::T) where T <: Union{ZZModMatrix, FpMatrix}
+  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{T}, C_NULL::Ref{Nothing})::Nothing
 end
 
 function _fmpz_mod_mpoly_clear_fn(a::FpMPolyRingElem)
@@ -5096,36 +5084,12 @@ function _fmpz_mod_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
   @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
 end
 
-function _fmpz_mod_poly_clear_fn(x::ZZModPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{ZZModPolyRingElem}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+function _fmpz_mod_poly_clear_fn(x::T) where T <: Union{ZZModPolyRingElem, FpPolyRingElem, ZZModRelPowerSeriesRingElem, FpRelPowerSeriesRingElem, ZZModAbsPowerSeriesRingElem, FpAbsPowerSeriesRingElem}
+  @ccall libflint.fmpz_mod_poly_clear(x::Ref{T}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
-function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, (base_ring(parent(x))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::FpRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::ZZModRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::FpAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_clear_fn(a::ZZModAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, (base_ring(parent(a))).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{fmpz_mod_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-function _fmpz_mod_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
+function _fmpz_mod_poly_factor_clear_fn(a::T) where T <: Union{fmpz_mod_poly_factor, gfp_fmpz_poly_factor}
+  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{T}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
@@ -5140,20 +5104,8 @@ function _fmpz_mpoly_factor_clear_fn(f::fmpz_mpoly_factor)
   @ccall libflint.fmpz_mpoly_factor_clear(f::Ref{fmpz_mpoly_factor}, f.parent::Ref{ZZMPolyRing})::Nothing
 end
 
-function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
-end
-
-function _fmpz_poly_clear_fn(a::ZZRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZRelPowerSeriesRingElem})::Nothing
-end
-
-function _fmpz_poly_clear_fn(a::ZZAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZAbsPowerSeriesRingElem})::Nothing
-end
-
-function _fmpz_poly_clear_fn(a::ZZLaurentSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZLaurentSeriesRingElem})::Nothing
+function _fmpz_poly_clear_fn(a::T) where T <: Union{ZZPolyRingElem, ZZRelPowerSeriesRingElem, ZZAbsPowerSeriesRingElem, ZZLaurentSeriesRingElem}
+  @ccall libflint.fmpz_poly_clear(a::Ref{T})::Nothing
 end
 
 function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
@@ -5180,23 +5132,12 @@ function _fq_default_mat_clear_fn(a::FqMatrix)
   @ccall libflint.fq_default_mat_clear(a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
 end
 
-function _fq_default_poly_clear_fn(a::FqRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-end
-
-function _fq_default_poly_clear_fn(a::FqAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-end
-
-function _fq_default_poly_clear_fn(a::FqPolyRingElem)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqPolyRingElem}, base_ring(a)::Ref{FqField})::Nothing
+function _fq_default_poly_clear_fn(a::T) where T <: Union{FqPolyRingElem, FqRelPowerSeriesRingElem, FqAbsPowerSeriesRingElem}
+  @ccall libflint.fq_default_poly_clear(a::Ref{T}, base_ring(a)::Ref{FqField})::Nothing
 end
 
 function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
-  K = a.base_field
-  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, K::Ref{FqField})::Nothing
+  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, a.base_field::Ref{FqField})::Nothing
 end
 
 function _fq_mat_clear_fn(a::FqPolyRepMatrix)
@@ -5227,48 +5168,24 @@ function _fq_nmod_mpoly_factor_clear_fn(f::fq_nmod_mpoly_factor)
   @ccall libflint.fq_nmod_mpoly_factor_clear(f::Ref{fq_nmod_mpoly_factor}, f.parent::Ref{fqPolyRepMPolyRing})::Nothing
 end
 
-function _fq_nmod_poly_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-end
-
-function _fq_nmod_poly_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-end
-
-function _fq_nmod_poly_clear_fn(a::fqPolyRepPolyRingElem)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepPolyRingElem})::Nothing
+function _fq_nmod_poly_clear_fn(a::T) where T <: Union{fqPolyRepPolyRingElem, fqPolyRepRelPowerSeriesRingElem, fqPolyRepAbsPowerSeriesRingElem}
+  @ccall libflint.fq_nmod_poly_clear(a::Ref{T}, base_ring(a)::Ref{fqPolyRepField})::Nothing
 end
 
 function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
   @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
 end
 
-function _fq_poly_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-end
-
-function _fq_poly_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-end
-
-function _fq_poly_clear_fn(a::FqPolyRepPolyRingElem)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepPolyRingElem})::Nothing
+function _fq_poly_clear_fn(a::T) where T <: Union{FqPolyRepPolyRingElem, FqPolyRepRelPowerSeriesRingElem, FqPolyRepAbsPowerSeriesRingElem}
+  @ccall libflint.fq_poly_clear(a::Ref{T}, base_ring(a)::Ref{FqPolyRepField})::Nothing
 end
 
 function _fq_poly_factor_clear_fn(a::fq_poly_factor)
   @ccall libflint.fq_poly_factor_clear(a::Ref{fq_poly_factor}, a.base_field::Ref{FqPolyRepField})::Nothing
 end
 
-function _nmod_mat_clear_fn(mat::zzModMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{zzModMatrix})::Nothing
-end
-
-function _nmod_mat_clear_fn(mat::fpMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
+function _nmod_mat_clear_fn(mat::T) where T <: Union{zzModMatrix, fpMatrix}
+  @ccall libflint.nmod_mat_clear(mat::Ref{T})::Nothing
 end
 
 function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
@@ -5279,12 +5196,8 @@ function _nmod_mpoly_clear_fn(a::fpMPolyRingElem)
   @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
 end
 
-function _nmod_mpoly_ctx_clear_fn(a::zzModMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{zzModMPolyRing})::Nothing
-end
-
-function _nmod_mpoly_ctx_clear_fn(a::fpMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
+function _nmod_mpoly_ctx_clear_fn(a::T) where T <: Union{zzModMPolyRing, fpMPolyRing}
+  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{T})::Nothing
 end
 
 function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
@@ -5295,36 +5208,12 @@ function _nmod_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
   @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
 end
 
-function _nmod_poly_clear_fn(x::zzModPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModPolyRingElem})::Nothing
+function _nmod_poly_clear_fn(x::T) where T <: Union{zzModPolyRingElem, fpPolyRingElem, zzModRelPowerSeriesRingElem, fpRelPowerSeriesRingElem, zzModAbsPowerSeriesRingElem, fpAbsPowerSeriesRingElem}
+  @ccall libflint.nmod_poly_clear(x::Ref{T})::Nothing
 end
 
-function _nmod_poly_clear_fn(x::fpPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
-end
-
-function _nmod_poly_clear_fn(a::fpRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
-end
-
-function _nmod_poly_clear_fn(a::zzModRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
-end
-
-function _nmod_poly_clear_fn(x::zzModAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
-end
-
-function _nmod_poly_clear_fn(x::fpAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
-end
-
-function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
-end
-
-function _nmod_poly_factor_clear_fn(a::gfp_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
+function _nmod_poly_factor_clear_fn(a::T) where T <: Union{nmod_poly_factor, gfp_poly_factor}
+  @ccall libflint.nmod_poly_factor_clear(a::Ref{T})::Nothing
 end
 
 function _padic_clear_fn(a::PadicFieldElem)

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5036,8 +5036,9 @@ function _fmpz_factor_clear_fn(a::fmpz_factor)
   @ccall libflint.fmpz_factor_clear(a::Ref{fmpz_factor})::Nothing
 end
 
-_fmpq_clear_fn(a::QQFieldElem) = @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
-
+function _fmpq_clear_fn(a::QQFieldElem)
+  @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
+end
 
 function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
   @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
@@ -5045,7 +5046,6 @@ end
 
 function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
   @ccall libflint.fmpz_poly_factor_clear(f::Ref{fmpz_poly_factor})::Nothing
-  nothing
 end
 
 function _fmpq_poly_clear_fn(a::QQPolyRingElem)
@@ -5148,7 +5148,7 @@ function _gfp_fmpz_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
   @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
 end
 
-function _FqNmodFiniteField_clear_fn(a :: fqPolyRepField)
+function _FqNmodFiniteField_clear_fn(a::fqPolyRepField)
   @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
 end
 
@@ -5156,7 +5156,7 @@ function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
   @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
 end
 
-function _FqDefaultFiniteField_clear_fn(a :: FqField)
+function _FqDefaultFiniteField_clear_fn(a::FqField)
   @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
 end
 
@@ -5164,7 +5164,7 @@ function _fq_default_clear_fn(a::FqFieldElem)
   @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
 end
 
-function _FqFiniteField_clear_fn(a :: FqPolyRepField)
+function _FqFiniteField_clear_fn(a::FqPolyRepField)
   @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
 end
 
@@ -5345,13 +5345,11 @@ end
 
 if NEW_FLINT
   function _rand_ctx_clear_fn(a::rand_ctx)
-    @ccall libflint.flint_rand_clear(a::Ref{rand_ctx})::Cvoid
-    nothing
+    @ccall libflint.flint_rand_clear(a::Ref{rand_ctx})::Nothing
   end
 else
   function _rand_ctx_clear_fn(a::rand_ctx)
-    @ccall libflint.flint_randclear(a::Ref{rand_ctx})::Cvoid
-    nothing
+    @ccall libflint.flint_randclear(a::Ref{rand_ctx})::Nothing
   end
 end
 

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -87,10 +87,6 @@ mutable struct ZZRingElem <: RingElem
   ZZRingElem(x::ZZRingElem) = x
 end
 
-function _fmpz_clear_fn(a::ZZRingElem)
-  @ccall libflint.fmpz_clear(a::Ref{ZZRingElem})::Nothing
-end
-
 mutable struct fmpz_factor
   sign::Cint
   p::Ptr{Nothing} # Array of fmpz_struct's
@@ -104,10 +100,6 @@ mutable struct fmpz_factor
     finalizer(_fmpz_factor_clear_fn, z)
     return z
   end
-end
-
-function _fmpz_factor_clear_fn(a::fmpz_factor)
-  @ccall libflint.fmpz_factor_clear(a::Ref{fmpz_factor})::Nothing
 end
 
 struct ZZRingElemUnitRange <: AbstractUnitRange{ZZRingElem}
@@ -219,8 +211,6 @@ mutable struct QQFieldElem <: FracElem{ZZRingElem}
   QQFieldElem(a::QQFieldElem) = a
 end
 
-_fmpq_clear_fn(a::QQFieldElem) = @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
-
 ###############################################################################
 #
 #   ZZPolyRing / ZZPolyRingElem
@@ -267,10 +257,6 @@ mutable struct ZZPolyRingElem <: PolyRingElem{ZZRingElem}
   ZZPolyRingElem(a::ZZPolyRingElem) = set!(ZZPolyRingElem(), a)
 end
 
-function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
-end
-
 mutable struct fmpz_poly_factor
   d::Int # ZZRingElem
   p::Ptr{ZZPolyRingElem} # array of flint fmpz_poly_struct's
@@ -284,11 +270,6 @@ mutable struct fmpz_poly_factor
     finalizer(_fmpz_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
-  @ccall libflint.fmpz_poly_factor_clear(f::Ref{fmpz_poly_factor})::Nothing
-  nothing
 end
 
 ###############################################################################
@@ -343,10 +324,6 @@ mutable struct QQPolyRingElem <: PolyRingElem{QQFieldElem}
 
   QQPolyRingElem(a::ZZPolyRingElem) = set!(QQPolyRingElem(), a)
   QQPolyRingElem(a::QQPolyRingElem) = set!(QQPolyRingElem(), a)
-end
-
-function _fmpq_poly_clear_fn(a::QQPolyRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQPolyRingElem})::Nothing
 end
 
 ###############################################################################
@@ -445,10 +422,6 @@ mutable struct fmpz_mod_ctx_struct
     finalizer(_fmpz_mod_ctx_clear_fn, z)
     return z
   end
-end
-
-function _fmpz_mod_ctx_clear_fn(a::fmpz_mod_ctx_struct)
-  @ccall libflint.fmpz_mod_ctx_clear(a::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 @doc raw"""
@@ -618,10 +591,6 @@ mutable struct zzModPolyRingElem <: PolyRingElem{zzModRingElem}
   end
 end
 
-function _nmod_poly_clear_fn(x::zzModPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModPolyRingElem})::Nothing
-end
-
 mutable struct nmod_poly_factor
   poly::Ptr{zzModPolyRingElem}  # array of flint nmod_poly_struct's
   exp::Ptr{Int}
@@ -636,10 +605,6 @@ mutable struct nmod_poly_factor
     finalizer(_nmod_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
 end
 
 ################################################################################
@@ -736,10 +701,6 @@ mutable struct fpPolyRingElem <: PolyRingElem{fpFieldElem}
   end
 end
 
-function _gfp_poly_clear_fn(x::fpPolyRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
-end
-
 mutable struct gfp_poly_factor
   poly::Ptr{fpPolyRingElem}  # array of flint nmod_poly_struct's
   exp::Ptr{Int}
@@ -754,10 +715,6 @@ mutable struct gfp_poly_factor
     finalizer(_gfp_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _gfp_poly_factor_clear_fn(a::gfp_poly_factor)
-  @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
 end
 
 ###############################################################################
@@ -874,10 +831,6 @@ mutable struct ZZModPolyRingElem <: PolyRingElem{ZZModRingElem}
   end
 end
 
-function _fmpz_mod_poly_clear_fn(x::ZZModPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{ZZModPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
 mutable struct fmpz_mod_poly_factor
   poly::Ptr{ZZModPolyRingElem}
   exp::Ptr{Int}
@@ -898,10 +851,6 @@ mutable struct fmpz_mod_poly_factor
   function fmpz_mod_poly_factor(R::ZZModRing)
     return fmpz_mod_poly_factor(R.ninv)
   end
-end
-
-function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{fmpz_mod_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 ###############################################################################
@@ -1018,10 +967,6 @@ mutable struct FpPolyRingElem <: PolyRingElem{FpFieldElem}
   end
 end
 
-function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
 mutable struct gfp_fmpz_poly_factor
   poly::Ptr{FpPolyRingElem}
   exp::Ptr{Int}
@@ -1042,10 +987,6 @@ mutable struct gfp_fmpz_poly_factor
   function gfp_fmpz_poly_factor(R::FpField)
     return gfp_fmpz_poly_factor(R.ninv)
   end
-end
-
-function _gfp_fmpz_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
-  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 ###############################################################################
@@ -1088,10 +1029,6 @@ const flint_orderings = [:lex, :deglex, :degrevlex]
   end
 end
 ZZMPolyRing(::ZZRing, s::Vector{Symbol}, S::Symbol, cached::Bool=true) = ZZMPolyRing(s, S, cached)
-
-function _fmpz_mpoly_ctx_clear_fn(a::ZZMPolyRing)
-  @ccall libflint.fmpz_mpoly_ctx_clear(a::Ref{ZZMPolyRing})::Nothing
-end
 
 const FmpzMPolyID = CacheDictType{Tuple{Vector{Symbol}, Symbol}, ZZMPolyRing}()
 
@@ -1162,10 +1099,6 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   ZZMPolyRingElem(ctx::ZZMPolyRing, a::Integer) = set!(ZZMPolyRingElem(ctx), a)
 end
 
-function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
-  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
-end
-
 mutable struct fmpz_mpoly_factor
   constant::Int
   constant_den::Int
@@ -1184,10 +1117,6 @@ mutable struct fmpz_mpoly_factor
     finalizer(_fmpz_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fmpz_mpoly_factor_clear_fn(f::fmpz_mpoly_factor)
-  @ccall libflint.fmpz_mpoly_factor_clear(f::Ref{fmpz_mpoly_factor}, f.parent::Ref{ZZMPolyRing})::Nothing
 end
 
 ###############################################################################
@@ -1228,10 +1157,6 @@ end
   end
 end
 QQMPolyRing(::QQField, s::Vector{Symbol}, S::Symbol, cached::Bool=true) = QQMPolyRing(s, S, cached)
-
-function _fmpq_mpoly_ctx_clear_fn(a::QQMPolyRing)
-  @ccall libflint.fmpq_mpoly_ctx_clear(a::Ref{QQMPolyRing})::Nothing
-end
 
 const FmpqMPolyID = CacheDictType{Tuple{Vector{Symbol}, Symbol}, QQMPolyRing}()
 
@@ -1306,10 +1231,6 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
 
 end
 
-function _fmpq_mpoly_clear_fn(a::QQMPolyRingElem)
-  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
-end
-
 mutable struct fmpq_mpoly_factor
   constant_num::Int
   constant_den::Int
@@ -1328,10 +1249,6 @@ mutable struct fmpq_mpoly_factor
     finalizer(_fmpq_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fmpq_mpoly_factor_clear_fn(f::fmpq_mpoly_factor)
-  @ccall libflint.fmpq_mpoly_factor_clear(f::Ref{fmpq_mpoly_factor}, f.parent::Ref{QQMPolyRing})::Nothing
 end
 
 ###############################################################################
@@ -1377,10 +1294,6 @@ end
       return z
     end
   end
-end
-
-function _nmod_mpoly_ctx_clear_fn(a::zzModMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{zzModMPolyRing})::Nothing
 end
 
 const NmodMPolyID = CacheDictType{Tuple{zzModRing, Vector{Symbol}, Symbol}, zzModMPolyRing}()
@@ -1462,10 +1375,6 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 end
 
-function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, a.parent::Ref{zzModMPolyRing})::Nothing
-end
-
 mutable struct nmod_mpoly_factor
   constant::UInt
   poly::Ptr{Nothing}
@@ -1483,10 +1392,6 @@ mutable struct nmod_mpoly_factor
     finalizer(_nmod_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
-  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{nmod_mpoly_factor}, f.parent::Ref{zzModMPolyRing})::Nothing
 end
 
 ################################################################################
@@ -1532,10 +1437,6 @@ end
       return z
     end
   end
-end
-
-function _gfp_mpoly_ctx_clear_fn(a::fpMPolyRing)
-  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
 end
 
 const GFPMPolyID = CacheDictType{Tuple{fpField, Vector{Symbol}, Symbol}, fpMPolyRing}()
@@ -1617,10 +1518,6 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 end
 
-function _gfp_mpoly_clear_fn(a::fpMPolyRingElem)
-  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
-end
-
 mutable struct gfp_mpoly_factor
   constant::UInt
   poly::Ptr{Nothing}
@@ -1638,10 +1535,6 @@ mutable struct gfp_mpoly_factor
     finalizer(_gfp_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _gfp_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
-  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
 end
 
 ################################################################################
@@ -1696,10 +1589,6 @@ end
   end
 end
 
-function _gfp_fmpz_mpoly_ctx_clear_fn(a::FpMPolyRing)
-  @ccall libflint.fmpz_mod_mpoly_ctx_clear(a::Ref{FpMPolyRing})::Nothing
-end
-
 const GFPFmpzMPolyID = CacheDictType{Tuple{FpField, Vector{Symbol}, Symbol}, FpMPolyRing}()
 
 mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
@@ -1747,10 +1636,6 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
   end
 end
 
-function _gfp_fmpz_mpoly_clear_fn(a::FpMPolyRingElem)
-  @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, a.parent::Ref{FpMPolyRing})::Nothing
-end
-
 mutable struct gfp_fmpz_mpoly_factor
   constant::Int
   poly::Ptr{Nothing}
@@ -1768,10 +1653,6 @@ mutable struct gfp_fmpz_mpoly_factor
     finalizer(_gfp_fmpz_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _gfp_fmpz_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
-  @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
 end
 
 ###############################################################################
@@ -1860,10 +1741,6 @@ const FqNmodFiniteFieldIDGFPPol = CacheDictType{Tuple{fpPolyRing, fpPolyRingElem
                                                 fqPolyRepField}()
 
 
-function _FqNmodFiniteField_clear_fn(a :: fqPolyRepField)
-  @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
-end
-
 @doc raw"""
     fqPolyRepFieldElem <: FinFieldElem
 
@@ -1910,10 +1787,6 @@ mutable struct fqPolyRepFieldElem <: FinFieldElem
     set!(d, x)
     return d
   end
-end
-
-function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
-  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
 end
 
 ###############################################################################
@@ -2030,10 +1903,6 @@ const FqDefaultFiniteFieldIDNmodPol = CacheDictType{Tuple{zzModPolyRingElem, Sym
 
 const FqDefaultFiniteFieldIDGFPNmodPol = CacheDictType{Tuple{fpPolyRingElem, Symbol}, FqField}()
 
-function _FqDefaultFiniteField_clear_fn(a :: FqField)
-  @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
-end
-
 @doc raw"""
     FqFieldElem <: FinFieldElem
 
@@ -2069,10 +1938,6 @@ mutable struct FqFieldElem <: FinFieldElem
     set!(d, x)
     return d
   end
-end
-
-function _fq_default_clear_fn(a::FqFieldElem)
-  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
 end
 
 ###############################################################################
@@ -2156,10 +2021,6 @@ const FqFiniteFieldIDFmpzPol = CacheDictType{Tuple{ZZModPolyRingElem, Symbol}, F
 
 const FqFiniteFieldIDGFPPol = CacheDictType{Tuple{FpPolyRingElem, Symbol}, FqPolyRepField}()
 
-function _FqFiniteField_clear_fn(a :: FqPolyRepField)
-  @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
-end
-
 @doc raw"""
     FqPolyRepFieldElem <: FinFieldElem
 
@@ -2193,10 +2054,6 @@ mutable struct FqPolyRepFieldElem <: FinFieldElem
     set!(d, x)
     return d
   end
-end
-
-function _fq_clear_fn(a::FqPolyRepFieldElem)
-  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, a.parent::Ref{FqPolyRepField})::Nothing
 end
 
 
@@ -2262,10 +2119,6 @@ end
       return z
     end
   end
-end
-
-function _fq_nmod_mpoly_ctx_clear_fn(a::fqPolyRepMPolyRing)
-  @ccall libflint.fq_nmod_mpoly_ctx_clear(a::Ref{fqPolyRepMPolyRing})::Nothing
 end
 
 const FqNmodMPolyID = CacheDictType{Tuple{fqPolyRepField, Vector{Symbol}, Symbol}, fqPolyRepMPolyRing}()
@@ -2351,10 +2204,6 @@ mutable struct fqPolyRepMPolyRingElem <: MPolyRingElem{fqPolyRepFieldElem}
   end
 end
 
-function _fq_nmod_mpoly_clear_fn(a::fqPolyRepMPolyRingElem)
-  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Nothing
-end
-
 mutable struct fq_nmod_mpoly_factor
   constant_coeffs::Ptr{Nothing}
   constant_alloc::Int
@@ -2378,10 +2227,6 @@ mutable struct fq_nmod_mpoly_factor
     finalizer(_fq_nmod_mpoly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fq_nmod_mpoly_factor_clear_fn(f::fq_nmod_mpoly_factor)
-  @ccall libflint.fq_nmod_mpoly_factor_clear(f::Ref{fq_nmod_mpoly_factor}, f.parent::Ref{fqPolyRepMPolyRing})::Nothing
 end
 
 ###############################################################################
@@ -2441,10 +2286,6 @@ end
 
 const PadicBase = CacheDictType{ZZRingElem, PadicField}()
 
-function _padic_ctx_clear_fn(a::PadicField)
-  @ccall libflint.padic_ctx_clear(a::Ref{PadicField})::Nothing
-end
-
 @doc raw"""
     PadicFieldElem <: FlintLocalFieldElem <: NonArchLocalFieldElem <: FieldElem
 
@@ -2462,10 +2303,6 @@ mutable struct PadicFieldElem <: FlintLocalFieldElem
     finalizer(_padic_clear_fn, d)
     return d
   end
-end
-
-function _padic_clear_fn(a::PadicFieldElem)
-  @ccall libflint.padic_clear(a::Ref{PadicFieldElem})::Nothing
 end
 
 ###############################################################################
@@ -2512,10 +2349,6 @@ end
 
 const QadicBase = CacheDictType{Tuple{PadicField, Int}, QadicField}()
 
-function _qadic_ctx_clear_fn(a::QadicField)
-  @ccall libflint.qadic_ctx_clear(a::Ref{QadicField})::Nothing
-end
-
 @doc raw"""
     QadicFieldElem <: FlintLocalFieldElem <: NonArchLocalFieldElem <: FieldElem
 
@@ -2535,10 +2368,6 @@ mutable struct QadicFieldElem <: FlintLocalFieldElem
     finalizer(_qadic_clear_fn, z)
     return z
   end
-end
-
-function _qadic_clear_fn(a::QadicFieldElem)
-  @ccall libflint.qadic_clear(a::Ref{QadicFieldElem})::Nothing
 end
 
 ###############################################################################
@@ -2596,10 +2425,6 @@ mutable struct ZZRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZRingElem}
   end
 end
 
-function _fmpz_rel_series_clear_fn(a::ZZRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZRelPowerSeriesRingElem})::Nothing
-end
-
 ###############################################################################
 #
 #   ZZAbsPowerSeriesRing / ZZAbsPowerSeriesRingElem
@@ -2649,10 +2474,6 @@ mutable struct ZZAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZRingElem}
     @ccall libflint.fmpz_poly_set(z::Ref{ZZAbsPowerSeriesRingElem}, a::Ref{ZZAbsPowerSeriesRingElem})::Nothing
     return z
   end
-end
-
-function _fmpz_abs_series_clear_fn(a::ZZAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZAbsPowerSeriesRingElem})::Nothing
 end
 
 ###############################################################################
@@ -2764,10 +2585,6 @@ mutable struct ZZLaurentSeriesRingElem <: RingElem
   end
 end
 
-function _fmpz_laurent_series_clear_fn(a::ZZLaurentSeriesRingElem)
-  @ccall libflint.fmpz_poly_clear(a::Ref{ZZLaurentSeriesRingElem})::Nothing
-end
-
 ###############################################################################
 #
 #   QQRelPowerSeriesRing / QQRelPowerSeriesRingElem
@@ -2824,10 +2641,6 @@ mutable struct QQRelPowerSeriesRingElem <: RelPowerSeriesRingElem{QQFieldElem}
   end
 end
 
-function _fmpq_rel_series_clear_fn(a::QQRelPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
-end
-
 ###############################################################################
 #
 #   QQAbsPowerSeriesRing / QQAbsPowerSeriesRingElem
@@ -2880,10 +2693,6 @@ mutable struct QQAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{QQFieldElem}
     @ccall libflint.fmpq_poly_set(z::Ref{QQAbsPowerSeriesRingElem}, a::Ref{QQAbsPowerSeriesRingElem})::Nothing
     return z
   end
-end
-
-function _fmpq_abs_series_clear_fn(a::QQAbsPowerSeriesRingElem)
-  @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
 end
 
 ###############################################################################
@@ -2974,10 +2783,6 @@ mutable struct fpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fpFieldElem}
   end
 end
 
-function _gfp_rel_series_clear_fn(a::fpRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
-end
-
 ###############################################################################
 #
 #   zzModRelPowerSeriesRing / zzModRelPowerSeriesRingElem
@@ -3064,10 +2869,6 @@ mutable struct zzModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{zzModRingEl
     end
     return z
   end
-end
-
-function _nmod_rel_series_clear_fn(a::zzModRelPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
 end
 
 ###############################################################################
@@ -3162,10 +2963,6 @@ mutable struct FpRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FpFieldElem}
   end
 end
 
-function _gfp_fmpz_rel_series_clear_fn(a::FpRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
 ###############################################################################
 #
 #   ZZModRelPowerSeriesRing / ZZModRelPowerSeriesRingElem
@@ -3258,10 +3055,6 @@ mutable struct ZZModRelPowerSeriesRingElem <: RelPowerSeriesRingElem{ZZModRingEl
   end
 end
 
-function _fmpz_mod_rel_series_clear_fn(a::ZZModRelPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
 ###############################################################################
 #
 #   FpAbsPowerSeriesRing / FpAbsPowerSeriesRingElem
@@ -3346,10 +3139,6 @@ mutable struct FpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FpFieldElem}
     end
     return z
   end
-end
-
-function _gfp_fmpz_abs_series_clear_fn(a::FpAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
 end
 
 ###############################################################################
@@ -3440,10 +3229,6 @@ mutable struct zzModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{zzModRingEl
   end
 end
 
-function _nmod_abs_series_clear_fn(x::zzModAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
-end
-
 ###############################################################################
 #
 #   fpAbsPowerSeriesRing / fpAbsPowerSeriesRingElem
@@ -3530,10 +3315,6 @@ mutable struct fpAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fpFieldElem}
     finalizer(_gfp_abs_series_clear_fn, z)
     return z
   end
-end
-
-function _gfp_abs_series_clear_fn(x::fpAbsPowerSeriesRingElem)
-  @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
 end
 
 ###############################################################################
@@ -3623,11 +3404,6 @@ mutable struct ZZModAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{ZZModRingEl
   end
 end
 
-function _fmpz_mod_abs_series_clear_fn(a::ZZModAbsPowerSeriesRingElem)
-  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-end
-
-
 ###############################################################################
 #
 #   FqRelPowerSeriesRing / FqRelPowerSeriesRingElem
@@ -3684,11 +3460,6 @@ mutable struct FqRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqFieldElem}
     finalizer(_fq_default_rel_series_clear_fn, z)
     return z
   end
-end
-
-function _fq_default_rel_series_clear_fn(a::FqRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
 end
 
 ###############################################################################
@@ -3748,11 +3519,6 @@ mutable struct FqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{FqPolyR
   end
 end
 
-function _fq_rel_series_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
-end
-
 ###############################################################################
 #
 #   FqAbsPowerSeriesRing / FqAbsPowerSeriesRingElem
@@ -3809,11 +3575,6 @@ mutable struct FqAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqFieldElem}
   end
 end
 
-function _fq_default_abs_series_clear_fn(a::FqAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
-end
-
 ###############################################################################
 #
 #   FqPolyRepAbsPowerSeriesRing / FqPolyRepAbsPowerSeriesRingElem
@@ -3867,11 +3628,6 @@ mutable struct FqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{FqPolyR
     finalizer(_fq_abs_series_clear_fn, z)
     return z
   end
-end
-
-function _fq_abs_series_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
 end
 
 ###############################################################################
@@ -3932,11 +3688,6 @@ mutable struct fqPolyRepRelPowerSeriesRingElem <: RelPowerSeriesRingElem{fqPolyR
   end
 end
 
-function _fq_nmod_rel_series_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-end
-
 ###############################################################################
 #
 #   fqPolyRepAbsPowerSeriesRing / fqPolyRepAbsPowerSeriesRingElem
@@ -3993,11 +3744,6 @@ mutable struct fqPolyRepAbsPowerSeriesRingElem <: AbsPowerSeriesRingElem{fqPolyR
   end
 end
 
-function _fq_nmod_abs_series_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
-  ctx = base_ring(a)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
-end
-
 ###############################################################################
 #
 #   QQMatrixSpace / QQMatrix
@@ -4038,10 +3784,6 @@ mutable struct QQMatrix <: MatElem{QQFieldElem}
   end
 end
 
-function _fmpq_mat_clear_fn(a::QQMatrix)
-  @ccall libflint.fmpq_mat_clear(a::Ref{QQMatrix})::Nothing
-end
-
 ###############################################################################
 #
 #   ZZMatrixSpace / ZZMatrix
@@ -4080,10 +3822,6 @@ mutable struct ZZMatrix <: MatElem{ZZRingElem}
     finalizer(_fmpz_mat_clear_fn, z)
     return z
   end
-end
-
-function _fmpz_mat_clear_fn(a::ZZMatrix)
-  @ccall libflint.fmpz_mat_clear(a::Ref{ZZMatrix})::Nothing
 end
 
 ###############################################################################
@@ -4217,10 +3955,6 @@ mutable struct zzModMatrix <: MatElem{zzModRingElem}
     error("Modulus must be smaller than ", ZZRingElem(typemax(UInt)))
     return zzModMatrix(UInt(n), b)
   end
-end
-
-function _nmod_mat_clear_fn(mat::zzModMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{zzModMatrix})::Nothing
 end
 
 ###############################################################################
@@ -4369,11 +4103,6 @@ mutable struct ZZModMatrix <: MatElem{ZZModRingElem}
   end
 end
 
-
-function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
-end
-
 ###############################################################################
 #
 #   FpMatrixSpace / FpMatrix
@@ -4472,10 +4201,6 @@ mutable struct FpMatrix <: MatElem{FpFieldElem}
     end
     return z
   end
-end
-
-function _gfp_fmpz_mat_clear_fn(mat::FpMatrix)
-  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
 end
 
 ################################################################################
@@ -4609,10 +4334,6 @@ mutable struct fpMatrix <: MatElem{fpFieldElem}
   end
 end
 
-function _gfp_mat_clear_fn(mat::fpMatrix)
-  @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
-end
-
 ###############################################################################
 #
 #   FqPolyRing / FqPolyRingElem
@@ -4725,10 +4446,6 @@ mutable struct FqPolyRingElem <: PolyRingElem{FqFieldElem}
   end
 end
 
-function _fq_default_poly_clear_fn(a::FqPolyRingElem)
-  @ccall libflint.fq_default_poly_clear(a::Ref{FqPolyRingElem}, base_ring(a)::Ref{FqField})::Nothing
-end
-
 mutable struct fq_default_poly_factor
   # fq_default_ctx_struct is 32 bytes on 64 bit machine
   opaque::NTuple{32, Int8}
@@ -4742,11 +4459,6 @@ mutable struct fq_default_poly_factor
     finalizer(_fq_default_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
-  K = a.base_field
-  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, K::Ref{FqField})::Nothing
 end
 
 ###############################################################################
@@ -4834,10 +4546,6 @@ mutable struct FqPolyRepPolyRingElem <: PolyRingElem{FqPolyRepFieldElem}
   end
 end
 
-function _fq_poly_clear_fn(a::FqPolyRepPolyRingElem)
-  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepPolyRingElem})::Nothing
-end
-
 mutable struct fq_poly_factor
   poly::Ptr{FqPolyRepPolyRingElem}
   exp::Ptr{Int}
@@ -4852,10 +4560,6 @@ mutable struct fq_poly_factor
     finalizer(_fq_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fq_poly_factor_clear_fn(a::fq_poly_factor)
-  @ccall libflint.fq_poly_factor_clear(a::Ref{fq_poly_factor}, a.base_field::Ref{FqPolyRepField})::Nothing
 end
 
 ###############################################################################
@@ -4943,10 +4647,6 @@ mutable struct fqPolyRepPolyRingElem <: PolyRingElem{fqPolyRepFieldElem}
   end
 end
 
-function _fq_nmod_poly_clear_fn(a::fqPolyRepPolyRingElem)
-  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepPolyRingElem})::Nothing
-end
-
 mutable struct fq_nmod_poly_factor
   poly::Ptr{fqPolyRepPolyRingElem}
   exp::Ptr{Int}
@@ -4961,10 +4661,6 @@ mutable struct fq_nmod_poly_factor
     finalizer(_fq_nmod_poly_factor_clear_fn, z)
     return z
   end
-end
-
-function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
-  @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
 end
 
 ###############################################################################
@@ -5061,10 +4757,6 @@ mutable struct FqMatrix <: MatElem{FqFieldElem}
   end
 end
 
-function _fq_default_mat_clear_fn(a::FqMatrix)
-  @ccall libflint.fq_default_mat_clear(a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
-end
-
 ###############################################################################
 #
 #   FqPolyRepMatrixSpace/FqPolyRepMatrix
@@ -5140,10 +4832,6 @@ mutable struct FqPolyRepMatrix <: MatElem{FqPolyRepFieldElem}
     end
     return z
   end
-end
-
-function _fq_mat_clear_fn(a::FqPolyRepMatrix)
-  @ccall libflint.fq_mat_clear(a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
 end
 
 ###############################################################################
@@ -5223,10 +4911,6 @@ mutable struct fqPolyRepMatrix <: MatElem{fqPolyRepFieldElem}
   end
 end
 
-function _fq_nmod_mat_clear_fn(a::fqPolyRepMatrix)
-  @ccall libflint.fq_nmod_mat_clear(a::Ref{fqPolyRepMatrix}, base_ring(a)::Ref{fqPolyRepField})::Nothing
-end
-
 ################################################################################
 #
 #   Rand state
@@ -5246,11 +4930,6 @@ if NEW_FLINT
       return a
     end
   end
-
-  function _rand_ctx_clear_fn(a::rand_ctx)
-    @ccall libflint.flint_rand_clear(a::Ref{rand_ctx})::Cvoid
-    nothing
-  end
 else
   mutable struct rand_ctx
     data::NTuple{56, Int8}
@@ -5261,11 +4940,6 @@ else
       finalizer(_rand_ctx_clear_fn, a)
       return a
     end
-  end
-
-  function _rand_ctx_clear_fn(a::rand_ctx)
-    @ccall libflint.flint_randclear(a::Ref{rand_ctx})::Cvoid
-    nothing
   end
 end
 
@@ -5346,6 +5020,339 @@ macro fq_default_mpoly_do_op(f, R, a...)
     end
   end
   return res
+end
+
+################################################################################
+#
+#   Finalizer
+#
+################################################################################
+
+function _fmpz_clear_fn(a::ZZRingElem)
+  @ccall libflint.fmpz_clear(a::Ref{ZZRingElem})::Nothing
+end
+
+function _fmpz_factor_clear_fn(a::fmpz_factor)
+  @ccall libflint.fmpz_factor_clear(a::Ref{fmpz_factor})::Nothing
+end
+
+_fmpq_clear_fn(a::QQFieldElem) = @ccall libflint.fmpq_clear(a::Ref{QQFieldElem})::Nothing
+
+
+function _fmpz_poly_clear_fn(a::ZZPolyRingElem)
+  @ccall libflint.fmpz_poly_clear(a::Ref{ZZPolyRingElem})::Nothing
+end
+
+function _fmpz_poly_factor_clear_fn(f::fmpz_poly_factor)
+  @ccall libflint.fmpz_poly_factor_clear(f::Ref{fmpz_poly_factor})::Nothing
+  nothing
+end
+
+function _fmpq_poly_clear_fn(a::QQPolyRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQPolyRingElem})::Nothing
+end
+
+function _fmpz_mod_ctx_clear_fn(a::fmpz_mod_ctx_struct)
+  @ccall libflint.fmpz_mod_ctx_clear(a::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _nmod_poly_clear_fn(x::zzModPolyRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{zzModPolyRingElem})::Nothing
+end
+
+function _nmod_poly_factor_clear_fn(a::nmod_poly_factor)
+  @ccall libflint.nmod_poly_factor_clear(a::Ref{nmod_poly_factor})::Nothing
+end
+
+function _gfp_poly_clear_fn(x::fpPolyRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{fpPolyRingElem})::Nothing
+end
+
+function _gfp_poly_factor_clear_fn(a::gfp_poly_factor)
+  @ccall libflint.nmod_poly_factor_clear(a::Ref{gfp_poly_factor})::Nothing
+end
+
+function _fmpz_mod_poly_clear_fn(x::ZZModPolyRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(x::Ref{ZZModPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _fmpz_mod_poly_factor_clear_fn(a::fmpz_mod_poly_factor)
+  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{fmpz_mod_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _fmpz_mod_poly_clear_fn(x::FpPolyRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(x::Ref{FpPolyRingElem}, base_ring(parent(x)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _gfp_fmpz_poly_factor_clear_fn(a::gfp_fmpz_poly_factor)
+  @ccall libflint.fmpz_mod_poly_factor_clear(a::Ref{gfp_fmpz_poly_factor}, a.n::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _fmpz_mpoly_ctx_clear_fn(a::ZZMPolyRing)
+  @ccall libflint.fmpz_mpoly_ctx_clear(a::Ref{ZZMPolyRing})::Nothing
+end
+
+function _fmpz_mpoly_clear_fn(a::ZZMPolyRingElem)
+  @ccall libflint.fmpz_mpoly_clear(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
+end
+
+function _fmpz_mpoly_factor_clear_fn(f::fmpz_mpoly_factor)
+  @ccall libflint.fmpz_mpoly_factor_clear(f::Ref{fmpz_mpoly_factor}, f.parent::Ref{ZZMPolyRing})::Nothing
+end
+
+function _fmpq_mpoly_ctx_clear_fn(a::QQMPolyRing)
+  @ccall libflint.fmpq_mpoly_ctx_clear(a::Ref{QQMPolyRing})::Nothing
+end
+
+function _fmpq_mpoly_clear_fn(a::QQMPolyRingElem)
+  @ccall libflint.fmpq_mpoly_clear(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
+end
+
+function _fmpq_mpoly_factor_clear_fn(f::fmpq_mpoly_factor)
+  @ccall libflint.fmpq_mpoly_factor_clear(f::Ref{fmpq_mpoly_factor}, f.parent::Ref{QQMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_ctx_clear_fn(a::zzModMPolyRing)
+  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{zzModMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_clear_fn(a::zzModMPolyRingElem)
+  @ccall libflint.nmod_mpoly_clear(a::Ref{zzModMPolyRingElem}, a.parent::Ref{zzModMPolyRing})::Nothing
+end
+
+function _nmod_mpoly_factor_clear_fn(f::nmod_mpoly_factor)
+  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{nmod_mpoly_factor}, f.parent::Ref{zzModMPolyRing})::Nothing
+end
+
+function _gfp_mpoly_ctx_clear_fn(a::fpMPolyRing)
+  @ccall libflint.nmod_mpoly_ctx_clear(a::Ref{fpMPolyRing})::Nothing
+end
+
+function _gfp_mpoly_clear_fn(a::fpMPolyRingElem)
+  @ccall libflint.nmod_mpoly_clear(a::Ref{fpMPolyRingElem}, a.parent::Ref{fpMPolyRing})::Nothing
+end
+
+function _gfp_mpoly_factor_clear_fn(f::gfp_mpoly_factor)
+  @ccall libflint.nmod_mpoly_factor_clear(f::Ref{gfp_mpoly_factor}, f.parent::Ref{fpMPolyRing})::Nothing
+end
+
+function _gfp_fmpz_mpoly_ctx_clear_fn(a::FpMPolyRing)
+  @ccall libflint.fmpz_mod_mpoly_ctx_clear(a::Ref{FpMPolyRing})::Nothing
+end
+
+function _gfp_fmpz_mpoly_clear_fn(a::FpMPolyRingElem)
+  @ccall libflint.fmpz_mod_mpoly_clear(a::Ref{FpMPolyRingElem}, a.parent::Ref{FpMPolyRing})::Nothing
+end
+
+function _gfp_fmpz_mpoly_factor_clear_fn(f::gfp_fmpz_mpoly_factor)
+  @ccall libflint.fmpz_mod_mpoly_factor_clear(f::Ref{gfp_fmpz_mpoly_factor}, f.parent::Ref{FpMPolyRing})::Nothing
+end
+
+function _FqNmodFiniteField_clear_fn(a :: fqPolyRepField)
+  @ccall libflint.fq_nmod_ctx_clear(a::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_nmod_clear_fn(a::fqPolyRepFieldElem)
+  @ccall libflint.fq_nmod_clear(a::Ref{fqPolyRepFieldElem}, a.parent::Ref{fqPolyRepField})::Nothing
+end
+
+function _FqDefaultFiniteField_clear_fn(a :: FqField)
+  @ccall libflint.fq_default_ctx_clear(a::Ref{FqField})::Nothing
+end
+
+function _fq_default_clear_fn(a::FqFieldElem)
+  @ccall libflint.fq_default_clear(a::Ref{FqFieldElem}, a.parent::Ref{FqField})::Nothing
+end
+
+function _FqFiniteField_clear_fn(a :: FqPolyRepField)
+  @ccall libflint.fq_ctx_clear(a::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_clear_fn(a::FqPolyRepFieldElem)
+  @ccall libflint.fq_clear(a::Ref{FqPolyRepFieldElem}, a.parent::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_nmod_mpoly_ctx_clear_fn(a::fqPolyRepMPolyRing)
+  @ccall libflint.fq_nmod_mpoly_ctx_clear(a::Ref{fqPolyRepMPolyRing})::Nothing
+end
+
+function _fq_nmod_mpoly_clear_fn(a::fqPolyRepMPolyRingElem)
+  @ccall libflint.fq_nmod_mpoly_clear(a::Ref{fqPolyRepMPolyRingElem}, a.parent::Ref{fqPolyRepMPolyRing})::Nothing
+end
+
+function _fq_nmod_mpoly_factor_clear_fn(f::fq_nmod_mpoly_factor)
+  @ccall libflint.fq_nmod_mpoly_factor_clear(f::Ref{fq_nmod_mpoly_factor}, f.parent::Ref{fqPolyRepMPolyRing})::Nothing
+end
+
+function _padic_ctx_clear_fn(a::PadicField)
+  @ccall libflint.padic_ctx_clear(a::Ref{PadicField})::Nothing
+end
+
+function _padic_clear_fn(a::PadicFieldElem)
+  @ccall libflint.padic_clear(a::Ref{PadicFieldElem})::Nothing
+end
+
+function _qadic_ctx_clear_fn(a::QadicField)
+  @ccall libflint.qadic_ctx_clear(a::Ref{QadicField})::Nothing
+end
+
+function _qadic_clear_fn(a::QadicFieldElem)
+  @ccall libflint.qadic_clear(a::Ref{QadicFieldElem})::Nothing
+end
+
+function _fmpz_rel_series_clear_fn(a::ZZRelPowerSeriesRingElem)
+  @ccall libflint.fmpz_poly_clear(a::Ref{ZZRelPowerSeriesRingElem})::Nothing
+end
+
+function _fmpz_abs_series_clear_fn(a::ZZAbsPowerSeriesRingElem)
+  @ccall libflint.fmpz_poly_clear(a::Ref{ZZAbsPowerSeriesRingElem})::Nothing
+end
+
+function _fmpz_laurent_series_clear_fn(a::ZZLaurentSeriesRingElem)
+  @ccall libflint.fmpz_poly_clear(a::Ref{ZZLaurentSeriesRingElem})::Nothing
+end
+
+function _fmpq_rel_series_clear_fn(a::QQRelPowerSeriesRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQRelPowerSeriesRingElem})::Nothing
+end
+
+function _fmpq_abs_series_clear_fn(a::QQAbsPowerSeriesRingElem)
+  @ccall libflint.fmpq_poly_clear(a::Ref{QQAbsPowerSeriesRingElem})::Nothing
+end
+
+function _gfp_rel_series_clear_fn(a::fpRelPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(a::Ref{fpRelPowerSeriesRingElem})::Nothing
+end
+
+function _nmod_rel_series_clear_fn(a::zzModRelPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(a::Ref{zzModRelPowerSeriesRingElem})::Nothing
+end
+
+function _gfp_fmpz_rel_series_clear_fn(a::FpRelPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _fmpz_mod_rel_series_clear_fn(a::ZZModRelPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModRelPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _gfp_fmpz_abs_series_clear_fn(a::FpAbsPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{FpAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _nmod_abs_series_clear_fn(x::zzModAbsPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{zzModAbsPowerSeriesRingElem})::Nothing
+end
+
+function _gfp_abs_series_clear_fn(x::fpAbsPowerSeriesRingElem)
+  @ccall libflint.nmod_poly_clear(x::Ref{fpAbsPowerSeriesRingElem})::Nothing
+end
+
+function _fmpz_mod_abs_series_clear_fn(a::ZZModAbsPowerSeriesRingElem)
+  @ccall libflint.fmpz_mod_poly_clear(a::Ref{ZZModAbsPowerSeriesRingElem}, base_ring(parent(a)).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+end
+
+function _fq_default_rel_series_clear_fn(a::FqRelPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_default_poly_clear(a::Ref{FqRelPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
+end
+
+function _fq_rel_series_clear_fn(a::FqPolyRepRelPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepRelPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_default_abs_series_clear_fn(a::FqAbsPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_default_poly_clear(a::Ref{FqAbsPowerSeriesRingElem}, ctx::Ref{FqField})::Nothing
+end
+
+function _fq_abs_series_clear_fn(a::FqPolyRepAbsPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_nmod_rel_series_clear_fn(a::fqPolyRepRelPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepRelPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_nmod_abs_series_clear_fn(a::fqPolyRepAbsPowerSeriesRingElem)
+  ctx = base_ring(a)
+  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepAbsPowerSeriesRingElem}, ctx::Ref{fqPolyRepField})::Nothing
+end
+
+function _fmpq_mat_clear_fn(a::QQMatrix)
+  @ccall libflint.fmpq_mat_clear(a::Ref{QQMatrix})::Nothing
+end
+
+function _fmpz_mat_clear_fn(a::ZZMatrix)
+  @ccall libflint.fmpz_mat_clear(a::Ref{ZZMatrix})::Nothing
+end
+
+function _nmod_mat_clear_fn(mat::zzModMatrix)
+  @ccall libflint.nmod_mat_clear(mat::Ref{zzModMatrix})::Nothing
+end
+
+function _fmpz_mod_mat_clear_fn(mat::ZZModMatrix)
+  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{ZZModMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
+end
+
+function _gfp_fmpz_mat_clear_fn(mat::FpMatrix)
+  @ccall libflint.fmpz_mod_mat_clear(mat::Ref{FpMatrix}, C_NULL::Ref{Nothing})::Nothing # Hack
+end
+
+function _gfp_mat_clear_fn(mat::fpMatrix)
+  @ccall libflint.nmod_mat_clear(mat::Ref{fpMatrix})::Nothing
+end
+
+function _fq_default_poly_clear_fn(a::FqPolyRingElem)
+  @ccall libflint.fq_default_poly_clear(a::Ref{FqPolyRingElem}, base_ring(a)::Ref{FqField})::Nothing
+end
+
+function _fq_default_poly_factor_clear_fn(a::fq_default_poly_factor)
+  K = a.base_field
+  @ccall libflint.fq_default_poly_factor_clear(a::Ref{fq_default_poly_factor}, K::Ref{FqField})::Nothing
+end
+
+function _fq_poly_clear_fn(a::FqPolyRepPolyRingElem)
+  @ccall libflint.fq_poly_clear(a::Ref{FqPolyRepPolyRingElem})::Nothing
+end
+
+function _fq_poly_factor_clear_fn(a::fq_poly_factor)
+  @ccall libflint.fq_poly_factor_clear(a::Ref{fq_poly_factor}, a.base_field::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_nmod_poly_clear_fn(a::fqPolyRepPolyRingElem)
+  @ccall libflint.fq_nmod_poly_clear(a::Ref{fqPolyRepPolyRingElem})::Nothing
+end
+
+function _fq_nmod_poly_factor_clear_fn(a::fq_nmod_poly_factor)
+  @ccall libflint.fq_nmod_poly_factor_clear(a::Ref{fq_nmod_poly_factor}, a.base_field::Ref{fqPolyRepField})::Nothing
+end
+
+function _fq_default_mat_clear_fn(a::FqMatrix)
+  @ccall libflint.fq_default_mat_clear(a::Ref{FqMatrix}, base_ring(a)::Ref{FqField})::Nothing
+end
+
+function _fq_mat_clear_fn(a::FqPolyRepMatrix)
+  @ccall libflint.fq_mat_clear(a::Ref{FqPolyRepMatrix}, base_ring(a)::Ref{FqPolyRepField})::Nothing
+end
+
+function _fq_nmod_mat_clear_fn(a::fqPolyRepMatrix)
+  @ccall libflint.fq_nmod_mat_clear(a::Ref{fqPolyRepMatrix}, base_ring(a)::Ref{fqPolyRepField})::Nothing
+end
+
+if NEW_FLINT
+  function _rand_ctx_clear_fn(a::rand_ctx)
+    @ccall libflint.flint_rand_clear(a::Ref{rand_ctx})::Cvoid
+    nothing
+  end
+else
+  function _rand_ctx_clear_fn(a::rand_ctx)
+    @ccall libflint.flint_randclear(a::Ref{rand_ctx})::Cvoid
+    nothing
+  end
 end
 
 ################################################################################

--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -542,7 +542,7 @@ function _fq_field_from_fmpz_mod_poly_in_disguise(f::FqPolyRingElem, s::Symbol)
   #         (Ref{FqField}, Ref{FqPolyRingElem}, Ptr{Nothing}, Ptr{UInt8}),
   #         #z, f, _K.ninv, string(s))
   #         z, f, pointer_from_objref(K) + 2 * sizeof(Cint), ss)
-  #   finalizer(_FqDefaultFiniteField_clear_fn, z)
+  #   finalizer(_fq_default_ctx_clear_fn, z)
   # end
   _K = _get_raw_type(FpField, K)
   ff = map_coefficients(c -> _K(lift(ZZ, c)), f; cached = false)
@@ -577,7 +577,7 @@ function _fq_field_from_nmod_poly_in_disguise(f::FqPolyRingElem, s::Symbol)
   ss = string(s)
   GC.@preserve ss begin
     @ccall libflint.fq_default_ctx_init_modulus_nmod(z::Ref{FqField}, f::Ref{FqPolyRingElem}, ss::Ptr{UInt8})::Nothing
-    finalizer(_FqDefaultFiniteField_clear_fn, z)
+    finalizer(_fq_default_ctx_clear_fn, z)
   end
   z.isabsolute = true
   z.isstandard = true


### PR DESCRIPTION
> [...] several high-level Julia structs wrap the same underlying FLINT structs (e.g. `fmpz_poly_struct ` is wrapped by `ZZPolyRingElem`, `ZZAbsPowerSeriesRingElem` and `ZZRelPowerSeriesRingElem`) and so they could use the same finalizer (well technically they already could do that now).
> excerpt from https://github.com/Nemocas/Nemo.jl/pull/1889#discussion_r1796798948 by @fingolfin 

implements exactly this by first moving all of them to a common block, renaming them w.r.t. the called flint function, sorting alphabetically, and then merging neighboring ones where appropriate.