### PR TITLE
Add some specialized methods for universal polynomials

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -439,6 +439,8 @@ include("Infinity.jl")
 include("HeckeMiscFiniteField.jl")
 include("HeckeMoreStuff.jl")
 
+include("UnivPoly.jl")
+
 # More functionality for Julia types
 include("julia/Integer.jl")
 include("julia/Rational.jl")

--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -1,0 +1,1 @@
+denominator(f::UniversalPolyRingElem{QQFieldElem}) = denominator(data(f))

--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -1,1 +1,11 @@
+###############################################################################
+#
+#   Specialized methods for universal polynomials
+#
+###############################################################################
+
+# These methods speed up some computations with specific universal
+# polynomial rings which would otherwise be handled by more generic
+# code. This mainly concerns rings over the rationals.
+
 denominator(f::UniversalPolyRingElem{QQFieldElem}) = denominator(data(f))

--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -9,3 +9,27 @@
 # code. This mainly concerns rings over the rationals.
 
 denominator(f::UniversalPolyRingElem{QQFieldElem}) = denominator(data(f))
+
+function +(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
+  S = parent(p)
+  return Generic.UnivPoly{T}(data(p)+n, S)
+end
+
++(n::ZZRingElem, p::Generic.UnivPoly) = p+n
+
+function -(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
+  S = parent(p)
+  return Generic.UnivPoly{T}(data(p)-n, S)
+end
+
+function -(n::ZZRingElem, p::Generic.UnivPoly{T}) where {T}
+  S = parent(p)
+  return Generic.UnivPoly{T}(n-data(p), S)
+end
+
+function *(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
+  S = parent(p)
+  return Generic.UnivPoly{T}(data(p)*n, S)
+end
+
+*(n::ZZRingElem, p::Generic.UnivPoly) = p*n

--- a/test/Generic-test.jl
+++ b/test/Generic-test.jl
@@ -1,5 +1,6 @@
 include("generic/Poly-test.jl")
 include("generic/MPoly-test.jl")
+include("generic/UnivPoly-test.jl")
 include("generic/Matrix-test.jl")
 include("generic/Module-test.jl")
 include("generic/AbsMSeries-test.jl")

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -1,0 +1,7 @@
+@testset "UnivPoly.specialized_methods" begin
+  R = universal_polynomial_ring(QQ)
+  x = gen(R, :x)
+
+  @test denominator(1//2*x+1//3*x^2) == 6
+  @test denominator(2//3*x) == 3
+end

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -4,4 +4,13 @@
 
   @test denominator(1//2*x+1//3*x^2) == 6
   @test denominator(2//3*x) == 3
+
+  @test ZZ(1)+x == 1+x
+  @test x+ZZ(1) == x+1
+
+  @test x-ZZ(1) == x-1
+  @test ZZ(1)-x == 1-x
+
+  @test ZZ(2)*x == 2*x
+  @test x*ZZ(2) == x*2
 end


### PR DESCRIPTION
As @fingolfin mentioned in https://github.com/Nemocas/AbstractAlgebra.jl/issues/1753#issuecomment-2613978634, it would be nice to have some methods for certain universal polynomial rings. This is a first implementation of `denominator`. I think there should be some more methods that are useful. But I haven't found them yet as I currently only need `denominator`.

Resolves https://github.com/oscar-system/GenericCharacterTables.jl/pull/203