### PR TITLE
Allow coercion and conversion from `AcbFieldElem` and `ComplexFieldElem` to `Float64` and `ComplexF64`

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -79,7 +79,7 @@ characteristic(::ComplexField) = 0
 Converts $x$ to a `ComplexF64`, rounded to the nearest.
 The return value approximates the midpoint of the real and imaginary parts of $x$.
 """
-function ComplexF64(x::ComplexFieldElem)
+function Base.ComplexF64(x::ComplexFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     im = _imag_ptr(x)

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -73,7 +73,13 @@ characteristic(::ComplexField) = 0
 #
 ################################################################################
 
-function convert(::Type{ComplexF64}, x::ComplexFieldElem)
+@doc raw"""
+    ComplexF64(x::ComplexFieldElem)
+
+Converts $x$ to a `ComplexF64`, rounded to the nearest.
+The return value approximates the midpoint of the real and imaginary parts of $x$.
+"""
+function ComplexF64(x::ComplexFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     im = _imag_ptr(x)
@@ -85,6 +91,7 @@ function convert(::Type{ComplexF64}, x::ComplexFieldElem)
   end
   return complex(v, w)
 end
+
 @doc raw"""
     Float64(x::ComplexFieldElem)
 
@@ -101,6 +108,11 @@ function Float64(x::ComplexFieldElem)
   end
   return v
 end
+
+function convert(::Type{ComplexF64}, x::ComplexFieldElem)
+  return ComplexF64(x)
+end
+
 function convert(::Type{Float64}, x::ComplexFieldElem)
   return Float64(x)
 end

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -85,6 +85,25 @@ function convert(::Type{ComplexF64}, x::ComplexFieldElem)
   end
   return complex(v, w)
 end
+@doc raw"""
+    Float64(x::ComplexFieldElem)
+
+Converts $x$ to a `Float64`, rounded to the nearest.
+The return value approximates the midpoint of the real part of $x$.
+"""
+function Float64(x::ComplexFieldElem)
+  @req isreal(x) "conversion to float must have no imaginary part"
+  GC.@preserve x begin
+    re = _real_ptr(x)
+    t = _mid_ptr(re)
+    # 4 == round to nearest
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
+  end
+  return v
+end
+function convert(::Type{Float64}, x::ComplexFieldElem)
+  return Float64(x)
+end
 
 ################################################################################
 #

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -83,7 +83,22 @@ characteristic(::AcbField) = 0
 #
 ################################################################################
 
-function convert(::Type{ComplexF64}, x::AcbFieldElem)
+@doc raw"""
+    Float64(x::AcbFieldElem)
+
+Converts $x$ to a `Float64`, rounded to the nearest.
+The return value approximates the midpoint of $x$.
+"""
+function Float64(x::AcbFieldElem)
+  @req isreal(x) "conversion to float must have no imaginary part"
+  GC.@preserve x begin
+    re = _real_ptr(x)
+    t = _mid_ptr(re)
+    # 4 == round to nearest
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
+  end
+  return v
+end
   GC.@preserve x begin
     re = _real_ptr(x)
     im = _imag_ptr(x)
@@ -94,6 +109,9 @@ function convert(::Type{ComplexF64}, x::AcbFieldElem)
     w = @ccall libflint.arf_get_d(u::Ptr{arf_struct}, 4::Int)::Float64
   end
   return complex(v, w)
+end
+function convert(::Type{Float64}, x::AcbFieldElem)
+  return Float64(x)
 end
 
 ################################################################################

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -106,7 +106,7 @@ end
 Converts $x$ to a `ComplexF64`, rounded to the nearest.
 The return value approximates the midpoint of the real and imaginary parts of $x$.
 """
-function ComplexF64(x::AcbFieldElem)
+function Base.ComplexF64(x::AcbFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     im = _imag_ptr(x)

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -99,6 +99,14 @@ function Float64(x::AcbFieldElem)
   end
   return v
 end
+
+@doc raw"""
+    ComplexF64(x::AcbFieldElem)
+
+Converts $x$ to a `ComplexF64`, rounded to the nearest.
+The return value approximates the midpoint of the real and imaginary parts of $x$.
+"""
+function ComplexF64(x::AcbFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     im = _imag_ptr(x)
@@ -110,6 +118,11 @@ end
   end
   return complex(v, w)
 end
+
+function convert(::Type{ComplexF64}, x::AcbFieldElem)
+  return ComplexF64(x)
+end
+
 function convert(::Type{Float64}, x::AcbFieldElem)
   return Float64(x)
 end

--- a/test/arb/Complex-test.jl
+++ b/test/arb/Complex-test.jl
@@ -58,6 +58,13 @@ end
   @test real(b) == 2
   @test imag(b) == 3
 
+  @test Float64(CC(0.5)) == 0.5
+  @test convert(Float64, CC(0.5)) == 0.5
+  @test ComplexF64(CC(0.5, 1.5)) == 0.5 + 1.5im
+  @test convert(ComplexF64, CC(0.5, 1.5)) == 0.5 + 1.5im
+  @test_throws ArgumentError Float64(CC(2.0, 3.0))
+  @test_throws ArgumentError convert(Float64, CC(2.0, 3.0))
+
   @test CC(UInt(4), Int(2)) == CC(4.0, ZZ(2))
   @test CC("4 +/- 0", BigFloat(2)) == CC(RR(4), QQ(2))
   @test CC(UInt(8)//UInt(2), BigInt(2)) == CC(4, 2)

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -58,6 +58,13 @@ end
   @test real(b) == 2
   @test imag(b) == 3
 
+  @test Float64(CC(0.5)) == 0.5
+  @test convert(Float64, CC(0.5)) == 0.5
+  @test ComplexF64(CC(0.5, 1.5)) == 0.5 + 1.5im
+  @test convert(ComplexF64, CC(0.5, 1.5)) == 0.5 + 1.5im
+  @test_throws ArgumentError Float64(CC(2.0, 3.0))
+  @test_throws ArgumentError convert(Float64, CC(2.0, 3.0))  
+
   @test CC(UInt(4), Int(2)) == CC(4.0, ZZ(2))
   @test CC("4 +/- 0", BigFloat(2)) == CC(RR(4), QQ(2))
   @test CC(UInt(8)//UInt(2), BigInt(2)) == CC(4, 2)


### PR DESCRIPTION
This PR adds conversion functionality for `Float64` and type-based conversion for `ComplexF64` for `AcbFieldElem` and `ComplexFieldElem`. It follows the same structure as `ArbFieldElem` by splitting the conversion code into their types and using this in the appropriate `convert`.

This PR references oscar-system/Oscar.jl#4531.