### PR TITLE
fix: remove parts of docstrings which make :fix sad

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -1108,10 +1108,6 @@ julia> QQBar = algebraic_closure(QQ);
 
 julia> x = sinpi(QQBar(1//3))
 Root 0.866025 of 4x^2 - 3
-
-julia> sinpi(x)
-ERROR: DomainError with Root 0.866025 of 4x^2 - 3:
-nonrational algebraic number
 ```
 """
 function sinpi(a::QQBarFieldElem)
@@ -1136,10 +1132,6 @@ julia> QQBar = algebraic_closure(QQ);
 
 julia> x = cospi(QQBar(1//6))
 Root 0.866025 of 4x^2 - 3
-
-julia> cospi(x)
-ERROR: DomainError with Root 0.866025 of 4x^2 - 3:
-nonrational algebraic number
 ```
 """
 function cospi(a::QQBarFieldElem)
@@ -1164,10 +1156,6 @@ julia> QQBar = algebraic_closure(QQ);
 
 julia> s, c = sincospi(QQBar(1//3))
 (Root 0.866025 of 4x^2 - 3, Root 0.500000 of 2x - 1)
-
-julia> sincospi(s)
-ERROR: DomainError with Root 0.866025 of 4x^2 - 3:
-nonrational algebraic number
 ```
 """
 function sincospi(a::QQBarFieldElem)


### PR DESCRIPTION
See https://github.com/JuliaDocs/Documenter.jl/issues/2511 for the corresponding Documenter bug/issue. @fingolfin I hope you don't mind.

 It gets more annoying for Hecke:
- We need to include a Nemo docstring (for `cyclotomic_field`).
- This means Hecke does `modules = [Hecke, Nemo]`.
- This means that `doctest = :fix` for Hecke is *also* run for Nemo by Documenter.
- This means that the doctest in `qqbar.jl` is "fixed".
- This means that Documenter wants to make changes in `pathtoNemo/src/.../qqbar.jl`.
- But Nemo is not dev'ed, so this file is readonly, making everything fail.