### PR TITLE
Replace hardcoded rounding modes with named for arb

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -85,9 +85,8 @@ function Base.ComplexF64(x::ComplexFieldElem)
     im = _imag_ptr(x)
     t = _mid_ptr(re)
     u = _mid_ptr(im)
-    # 4 == round to nearest
-    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
-    w = @ccall libflint.arf_get_d(u::Ptr{arf_struct}, 4::Int)::Float64
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
+    w = @ccall libflint.arf_get_d(u::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
   end
   return complex(v, w)
 end
@@ -103,8 +102,7 @@ function Float64(x::ComplexFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     t = _mid_ptr(re)
-    # 4 == round to nearest
-    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
   end
   return v
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -94,8 +94,7 @@ function Float64(x::AcbFieldElem)
   GC.@preserve x begin
     re = _real_ptr(x)
     t = _mid_ptr(re)
-    # 4 == round to nearest
-    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
   end
   return v
 end
@@ -112,9 +111,8 @@ function Base.ComplexF64(x::AcbFieldElem)
     im = _imag_ptr(x)
     t = _mid_ptr(re)
     u = _mid_ptr(im)
-    # 4 == round to nearest
-    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, 4::Int)::Float64
-    w = @ccall libflint.arf_get_d(u::Ptr{arf_struct}, 4::Int)::Float64
+    v = @ccall libflint.arf_get_d(t::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
+    w = @ccall libflint.arf_get_d(u::Ptr{arf_struct}, ARB_RND_NEAR::Int)::Float64
   end
   return complex(v, w)
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -113,9 +113,9 @@ for (b, f) in ((RoundingMode{:Down}, :arb_get_lbound_arf),
   end
 end
 
-for (b, i) in ((RoundingMode{:Down}, 2),
-               (RoundingMode{:Up}, 3),
-               (RoundingMode{:Nearest}, 4))
+for (b, i) in ((RoundingMode{:Down}, ARB_RND_FLOOR),
+               (RoundingMode{:Up}, ARB_RND_CEIL),
+               (RoundingMode{:Nearest}, ARB_RND_NEAR))
   @eval begin
     function _arf_get_d(t::arf_struct, ::$b)
       d = @ccall libflint.arf_get_d(t::Ref{arf_struct}, $i::Int)::Float64


### PR DESCRIPTION
This PR replaces instances of hardcoded rounding mode values in usages of `arf_get_d` with their named counterparts. 

After looking through the FLINT documentation, this doesn't require any new constants as the rounding modes in `ArbTypes.jl` refers to the correct values from `arf_get_d` and uses `arf_rnd_t`.