### PR TITLE
Explicitly qualify constructors that are extended

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -97,7 +97,7 @@ end
 Converts $x$ to a `Float64`, rounded to the nearest.
 The return value approximates the midpoint of the real part of $x$.
 """
-function Float64(x::ComplexFieldElem)
+function Core.Float64(x::ComplexFieldElem)
   @req isreal(x) "conversion to float must have no imaginary part"
   GC.@preserve x begin
     re = _real_ptr(x)

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -97,7 +97,7 @@ end
 Converts $x$ to a `Float64`, rounded to the nearest.
 The return value approximates the midpoint of the real part of $x$.
 """
-function Core.Float64(x::ComplexFieldElem)
+function Base.Float64(x::ComplexFieldElem)
   @req isreal(x) "conversion to float must have no imaginary part"
   GC.@preserve x begin
     re = _real_ptr(x)

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -72,7 +72,7 @@ For `RoundNearest` the return value approximates the midpoint of $x$. For
 `RoundDown` or `RoundUp` the return value is a lower bound or upper bound for
 all values in $x$.
 """
-function Float64(x::RealFieldElem, round::RoundingMode=RoundNearest)
+function Core.Float64(x::RealFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_d(t, round)
 end
@@ -85,7 +85,7 @@ direction specified by $round$. For `RoundNearest` the return value
 approximates the midpoint of $x$. For `RoundDown` or `RoundUp` the return
 value is a lower bound or upper bound for all values in $x$.
 """
-function BigFloat(x::RealFieldElem, round::RoundingMode=RoundNearest)
+function Base.BigFloat(x::RealFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_mpfr(t, round)
 end
@@ -134,7 +134,7 @@ function ZZRingElem(x::RealFieldElem)
   error("Argument must represent a unique integer")
 end
 
-BigInt(x::RealFieldElem) = BigInt(ZZRingElem(x))
+Base.BigInt(x::RealFieldElem) = BigInt(ZZRingElem(x))
 
 function (::Type{T})(x::RealFieldElem) where {T <: Integer}
   typemin(T) <= x <= typemax(T) ||

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -72,7 +72,7 @@ For `RoundNearest` the return value approximates the midpoint of $x$. For
 `RoundDown` or `RoundUp` the return value is a lower bound or upper bound for
 all values in $x$.
 """
-function Core.Float64(x::RealFieldElem, round::RoundingMode=RoundNearest)
+function Base.Float64(x::RealFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_d(t, round)
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -89,7 +89,7 @@ characteristic(::AcbField) = 0
 Converts $x$ to a `Float64`, rounded to the nearest.
 The return value approximates the midpoint of $x$.
 """
-function Float64(x::AcbFieldElem)
+function Core.Float64(x::AcbFieldElem)
   @req isreal(x) "conversion to float must have no imaginary part"
   GC.@preserve x begin
     re = _real_ptr(x)

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -89,7 +89,7 @@ characteristic(::AcbField) = 0
 Converts $x$ to a `Float64`, rounded to the nearest.
 The return value approximates the midpoint of $x$.
 """
-function Core.Float64(x::AcbFieldElem)
+function Base.Float64(x::AcbFieldElem)
   @req isreal(x) "conversion to float must have no imaginary part"
   GC.@preserve x begin
     re = _real_ptr(x)

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -73,7 +73,7 @@ For `RoundNearest` the return value approximates the midpoint of $x$. For
 `RoundDown` or `RoundUp` the return value is a lower bound or upper bound for
 all values in $x$.
 """
-function Core.Float64(x::ArbFieldElem, round::RoundingMode=RoundNearest)
+function Base.Float64(x::ArbFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_d(t, round)
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -73,7 +73,7 @@ For `RoundNearest` the return value approximates the midpoint of $x$. For
 `RoundDown` or `RoundUp` the return value is a lower bound or upper bound for
 all values in $x$.
 """
-function Float64(x::ArbFieldElem, round::RoundingMode=RoundNearest)
+function Core.Float64(x::ArbFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_d(t, round)
 end
@@ -86,7 +86,7 @@ direction specified by $round$. For `RoundNearest` the return value
 approximates the midpoint of $x$. For `RoundDown` or `RoundUp` the return
 value is a lower bound or upper bound for all values in $x$.
 """
-function BigFloat(x::ArbFieldElem, round::RoundingMode=RoundNearest)
+function Base.BigFloat(x::ArbFieldElem, round::RoundingMode=RoundNearest)
   t = _arb_get_arf(x, round)
   return _arf_get_mpfr(t, round)
 end
@@ -151,7 +151,7 @@ function ZZRingElem(x::ArbFieldElem)
   error("Argument must represent a unique integer")
 end
 
-BigInt(x::ArbFieldElem) = BigInt(ZZRingElem(x))
+Base.BigInt(x::ArbFieldElem) = BigInt(ZZRingElem(x))
 
 function (::Type{T})(x::ArbFieldElem) where {T <: Integer}
   typemin(T) <= x <= typemax(T) ||

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1291,7 +1291,7 @@ function Base.BigFloat(a::QQFieldElem)
   return r
 end
 
-Core.Float64(a::QQFieldElem) = Float64(BigFloat(a))
+Base.Float64(a::QQFieldElem) = Float64(BigFloat(a))
 
 ###############################################################################
 #

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -1285,13 +1285,13 @@ end
 
 @inline __get_rounding_mode() = Base.Rounding.rounding_raw(BigFloat)
 
-function BigFloat(a::QQFieldElem)
+function Base.BigFloat(a::QQFieldElem)
   r = BigFloat(0)
   @ccall libflint.fmpq_get_mpfr(r::Ref{BigFloat}, a::Ref{QQFieldElem}, __get_rounding_mode()::Int32)::Cint
   return r
 end
 
-Float64(a::QQFieldElem) = Float64(BigFloat(a))
+Core.Float64(a::QQFieldElem) = Float64(BigFloat(a))
 
 ###############################################################################
 #

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2916,7 +2916,7 @@ end
 (::Type{Int128})(a::ZZRingElem) = Int128(BigInt(a))
 (::Type{UInt128})(a::ZZRingElem) = UInt128(BigInt(a))
 
-Integer(a::ZZRingElem) = BigInt(a)
+Core.Integer(a::ZZRingElem) = BigInt(a)
 
 convert(::Type{T}, a::ZZRingElem) where T <: Integer = T(a)
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2916,7 +2916,7 @@ end
 (::Type{Int128})(a::ZZRingElem) = Int128(BigInt(a))
 (::Type{UInt128})(a::ZZRingElem) = UInt128(BigInt(a))
 
-Core.Integer(a::ZZRingElem) = BigInt(a)
+Base.Integer(a::ZZRingElem) = BigInt(a)
 
 convert(::Type{T}, a::ZZRingElem) where T <: Integer = T(a)
 


### PR DESCRIPTION
to silence the warnings introduced in https://github.com/JuliaLang/julia/pull/57311.