### PR TITLE
Fix regression: ambiguity in +,*,- for UnivPoly{ZZRingElem} & ZZRingElem

### DIFF
--- a/src/UnivPoly.jl
+++ b/src/UnivPoly.jl
@@ -10,26 +10,13 @@
 
 denominator(f::UniversalPolyRingElem{QQFieldElem}) = denominator(data(f))
 
-function +(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
-  S = parent(p)
-  return Generic.UnivPoly{T}(data(p)+n, S)
+for op in (:+, :*, :-)
+  @eval begin
+    $op(a::T, b::ZZRingElem) where {T <: Generic.UnivPoly} = T($op(data(a), b), parent(a))
+    $op(a::ZZRingElem, b::T) where {T <: Generic.UnivPoly} = T($op(a, data(b)), parent(b))
+
+    # to avoid ambiguity
+    $op(a::T, b::ZZRingElem) where {T <: Generic.UnivPoly{ZZRingElem}} = T($op(data(a), b), parent(a))
+    $op(a::ZZRingElem, b::T) where {T <: Generic.UnivPoly{ZZRingElem}} = T($op(a, data(b)), parent(b))
+  end
 end
-
-+(n::ZZRingElem, p::Generic.UnivPoly) = p+n
-
-function -(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
-  S = parent(p)
-  return Generic.UnivPoly{T}(data(p)-n, S)
-end
-
-function -(n::ZZRingElem, p::Generic.UnivPoly{T}) where {T}
-  S = parent(p)
-  return Generic.UnivPoly{T}(n-data(p), S)
-end
-
-function *(p::Generic.UnivPoly{T}, n::ZZRingElem) where {T}
-  S = parent(p)
-  return Generic.UnivPoly{T}(data(p)*n, S)
-end
-
-*(n::ZZRingElem, p::Generic.UnivPoly) = p*n

--- a/test/generic/UnivPoly-test.jl
+++ b/test/generic/UnivPoly-test.jl
@@ -1,9 +1,14 @@
-@testset "UnivPoly.specialized_methods" begin
+@testset "UnivPoly.denominator" begin
   R = universal_polynomial_ring(QQ)
   x = gen(R, :x)
 
   @test denominator(1//2*x+1//3*x^2) == 6
   @test denominator(2//3*x) == 3
+end
+
+@testset "UnivPoly.specialized_methods over $R" for R in (ZZ, QQ)
+  S = universal_polynomial_ring(R)
+  x = gen(S, :x)
 
   @test ZZ(1)+x == 1+x
   @test x+ZZ(1) == x+1


### PR DESCRIPTION
Since the problem affects all our tests I decided to go ahead and quickly implement the fix myself.

Sorry @SoongNoonien I hope you didn't already spend time on this.