### PR TITLE
chore: bump version to 0.48.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.48.3"
+version = "0.48.4"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
To be merged and released immediately after https://github.com/Nemocas/Nemo.jl/pull/2026. 