### PR TITLE
OscarCI: try testing oscar master with released Hecke+Singular

### DIFF
--- a/OscarCI.toml
+++ b/OscarCI.toml
@@ -14,3 +14,11 @@ title = "metadata for Oscar CI run"
 
   [pkgs.Hecke]
   test = false
+
+[include]
+  [include.justoscarmaster]
+  Oscar = "master"
+  Singular = "release"
+  Hecke = "release"
+  julia-version = "1.10"
+  os = "ubuntu-latest"


### PR DESCRIPTION
This should test with the released versions (except for oscar). But it will be skipped if the Nemo master is too new for released Hecke or Singular.