### PR TITLE
Add many unsafe ops for QQBarElem

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -390,14 +390,6 @@ for T in (QQFieldElem, ZZRingElem, Int, UInt, Integer, Rational)
   end
 end
 
-# todo: want qqbar_pow_fmpz, qqbar_pow_fmpq, qqbar_pow_si
-^(a::QQBarFieldElem, b::ZZRingElem) = a ^ QQBarFieldElem(b)
-^(a::QQBarFieldElem, b::QQFieldElem) = a ^ QQBarFieldElem(b)
-^(a::QQBarFieldElem, b::Int) = a ^ QQBarFieldElem(b)
-^(a::ZZRingElem, b::QQBarFieldElem) = QQBarFieldElem(a) ^ b
-^(a::QQFieldElem, b::QQBarFieldElem) = QQBarFieldElem(a) ^ b
-^(a::Int, b::QQBarFieldElem) = QQBarFieldElem(a) ^ b
-
 ###############################################################################
 #
 #   Exact division

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -353,109 +353,41 @@ end
 #
 ###############################################################################
 
-function +(a::QQBarFieldElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_add(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
++(a::QQBarFieldElem, b::QQBarFieldElem) = add!(QQBarFieldElem(), a, b)
 
-function +(a::QQBarFieldElem, b::QQFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_add_fmpq(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQFieldElem})::Nothing
-  return z
-end
+-(a::QQBarFieldElem, b::QQBarFieldElem) = sub!(QQBarFieldElem(), a, b)
 
-function +(a::QQBarFieldElem, b::ZZRingElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_add_fmpz(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{ZZRingElem})::Nothing
-  return z
-end
-
-function +(a::QQBarFieldElem, b::Int)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_add_si(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Int)::Nothing
-  return z
-end
-
-+(a::QQFieldElem, b::QQBarFieldElem) = b + a
-+(a::ZZRingElem, b::QQBarFieldElem) = b + a
-+(a::Int, b::QQBarFieldElem) = b + a
-
-function -(a::QQBarFieldElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_sub(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
-
-function -(a::QQBarFieldElem, b::QQFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_sub_fmpq(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQFieldElem})::Nothing
-  return z
-end
-
-function -(a::QQBarFieldElem, b::ZZRingElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_sub_fmpz(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{ZZRingElem})::Nothing
-  return z
-end
-
-function -(a::QQBarFieldElem, b::Int)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_sub_si(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Int)::Nothing
-  return z
-end
-
-function -(a::QQFieldElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_fmpq_sub(z::Ref{QQBarFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
-
-function -(a::ZZRingElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_fmpz_sub(z::Ref{QQBarFieldElem}, a::Ref{ZZRingElem}, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
-
-function -(a::Int, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_si_sub(z::Ref{QQBarFieldElem}, a::Int, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
-
-function *(a::QQBarFieldElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_mul(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Nothing
-  return z
-end
-
-function *(a::QQBarFieldElem, b::QQFieldElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_mul_fmpq(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQFieldElem})::Nothing
-  return z
-end
-
-function *(a::QQBarFieldElem, b::ZZRingElem)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_mul_fmpz(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{ZZRingElem})::Nothing
-  return z
-end
-
-function *(a::QQBarFieldElem, b::Int)
-  z = QQBarFieldElem()
-  @ccall libflint.qqbar_mul_si(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Int)::Nothing
-  return z
-end
-
-*(a::QQFieldElem, b::QQBarFieldElem) = b * a
-*(a::ZZRingElem, b::QQBarFieldElem) = b * a
-*(a::Int, b::QQBarFieldElem) = b * a
+*(a::QQBarFieldElem, b::QQBarFieldElem) = mul!(QQBarFieldElem(), a, b)
 
 function ^(a::QQBarFieldElem, b::QQBarFieldElem)
-  z = QQBarFieldElem()
-  ok = Bool(@ccall libflint.qqbar_pow(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Cint)
+  ok, z = pow!(QQBarFieldElem(), a, b)
   !ok && throw(DomainError((a, b)))
   return z
+end
+
+###############################################################################
+#
+#   Ad hoc binary operators
+#
+###############################################################################
+
+for T in (QQFieldElem, ZZRingElem, Int, UInt, Integer, Rational)
+  @eval begin
+    +(a::QQBarFieldElem, b::$T) = add!(QQBarFieldElem(), a, b)
+    +(a::$T, b::QQBarFieldElem) = add!(QQBarFieldElem(), a, b)
+
+    -(a::QQBarFieldElem, b::$T) = sub!(QQBarFieldElem(), a, b)
+    -(a::$T, b::QQBarFieldElem) = sub!(QQBarFieldElem(), a, b)
+
+    *(a::QQBarFieldElem, b::$T) = mul!(QQBarFieldElem(), a, b)
+    *(a::$T, b::QQBarFieldElem) = mul!(QQBarFieldElem(), a, b)
+
+    function ^(a::QQBarFieldElem, b::$T)
+      is_zero(a) && b < 0 && throw(DivideError())
+      return pow!(QQBarFieldElem(), a, b)
+    end
+    ^(a::$T, b::QQBarFieldElem) = QQBarFieldElem(a) ^ b
+  end
 end
 
 # todo: want qqbar_pow_fmpz, qqbar_pow_fmpq, qqbar_pow_si
@@ -1419,30 +1351,161 @@ convert(::Type{T}, a::QQBarFieldElem) where {T <: RationalUnion} = T(a)
 #
 ###############################################################################
 
-function zero!(z::QQBarFieldElem)
-  @ccall libflint.qqbar_zero(z::Ref{QQBarFieldElem})::Nothing
+function zero!(z::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_zero(z::Ref{QQBarFieldElemOrPtr})::Nothing
   return z
 end
 
-function one!(z::QQBarFieldElem)
-  @ccall libflint.qqbar_one(z::Ref{QQBarFieldElem})::Nothing
+function one!(z::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_one(z::Ref{QQBarFieldElemOrPtr})::Nothing
   return z
 end
 
-function neg!(z::QQBarFieldElem, a::QQBarFieldElem)
-  @ccall libflint.qqbar_neg(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem})::Nothing
+function neg!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_neg(z::Ref{QQBarFieldElemOrPtr}, a::Ref{QQBarFieldElemOrPtr})::Nothing
   return z
 end
 
-function mul!(z::QQBarFieldElem, x::QQBarFieldElem, y::QQBarFieldElem)
-  @ccall libflint.qqbar_mul(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQBarFieldElem})::Nothing
+#
+
+function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_add(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQBarFieldElemOrPtr})::Nothing
   return z
 end
 
-function add!(z::QQBarFieldElem, x::QQBarFieldElem, y::QQBarFieldElem)
-  @ccall libflint.qqbar_add(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQBarFieldElem})::Nothing
+function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+  @ccall libflint.qqbar_add_fmpq(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQFieldElem})::Nothing
   return z
 end
+
+function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+  @ccall libflint.qqbar_add_fmpz(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+  @ccall libflint.qqbar_add_si(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Int)::Nothing
+  return z
+end
+
+function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+  @ccall libflint.qqbar_add_ui(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::UInt)::Nothing
+  return z
+end
+
+add!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = add!(c, a, flintify(b))
+add!(c::QQBarFieldElemOrPtr, a::Union{QQFieldElemOrPtr, ZZRingElemOrPtr, Integer, Rational}, b::QQBarFieldElemOrPtr) = add!(c, b, a)
+
+#
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_sub(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+  @ccall libflint.qqbar_sub_fmpq(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQFieldElem})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+  @ccall libflint.qqbar_sub_fmpz(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+  @ccall libflint.qqbar_sub_si(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Int)::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+  @ccall libflint.qqbar_sub_ui(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::UInt)::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::QQFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_fmpq_sub(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQFieldElem}, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::ZZRingElemOrPtr, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_fmpz_sub(z::Ref{QQBarFieldElemOrPtr}, x::Ref{ZZRingElem}, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::Int, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_si_sub(z::Ref{QQBarFieldElemOrPtr}, x::Int, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+function sub!(z::QQBarFieldElemOrPtr, x::UInt, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_ui_sub(z::Ref{QQBarFieldElemOrPtr}, x::UInt, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+sub!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = sub!(c, a, flintify(b))
+sub!(c::QQBarFieldElemOrPtr, a::Union{QQFieldElemOrPtr, ZZRingElemOrPtr, Integer, Rational}, b::QQBarFieldElemOrPtr) = sub!(c, flintify(a), b)
+
+#
+
+function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+  @ccall libflint.qqbar_mul(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQBarFieldElemOrPtr})::Nothing
+  return z
+end
+
+function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+  @ccall libflint.qqbar_mul_fmpq(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{QQFieldElem})::Nothing
+  return z
+end
+
+function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+  @ccall libflint.qqbar_mul_fmpz(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+  @ccall libflint.qqbar_mul_si(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::Int)::Nothing
+  return z
+end
+
+function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+  @ccall libflint.qqbar_mul_ui(z::Ref{QQBarFieldElemOrPtr}, x::Ref{QQBarFieldElemOrPtr}, y::UInt)::Nothing
+  return z
+end
+
+mul!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = mul!(c, a, flintify(b))
+mul!(c::QQBarFieldElemOrPtr, a::Union{QQFieldElemOrPtr, ZZRingElemOrPtr, Integer, Rational}, b::QQBarFieldElemOrPtr) = mul!(c, b, a)
+
+#
+
+
+function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::QQBarFieldElemOrPtr)
+  ok = Bool(@ccall libflint.qqbar_pow(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Cint)
+  return ok, z
+end
+
+function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::ZZRingElemOrPtr)
+  @ccall libflint.qqbar_pow_fmpz(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::QQFieldElemOrPtr)
+  @ccall libflint.qqbar_pow_fmpq(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQFieldElem})::Nothing
+  return z
+end
+
+function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Int)
+  @ccall libflint.qqbar_pow_si(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Int)::Nothing
+  return z
+end
+
+function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::UInt)
+  @ccall libflint.qqbar_pow_ui(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::UInt)::Nothing
+  return z
+end
+
+pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = pow!(z, a, flintify(b))
+
 
 ###############################################################################
 #

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -286,34 +286,14 @@ conj(x::QQFieldElem) = x
 #
 ###############################################################################
 
-for T in (ZZRingElem, Int, UInt)
+for T in (ZZRingElem, Int, UInt, Integer, Rational)
   @eval begin
     +(a::QQFieldElem, b::$T) = add!(QQFieldElem(), a, b)
     +(a::$T, b::QQFieldElem) = add!(QQFieldElem(), a, b)
-  end
-end
 
-+(a::QQFieldElem, b::Integer) = a + flintify(b)
-+(a::Integer, b::QQFieldElem) = b + a
-
-+(a::QQFieldElem, b::Rational{T}) where {T <: Integer} = a + QQFieldElem(b)
-+(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = b + a
-
-for T in (ZZRingElem, Int, UInt)
-  @eval begin
     -(a::QQFieldElem, b::$T) = sub!(QQFieldElem(), a, b)
     -(a::$T, b::QQFieldElem) = sub!(QQFieldElem(), a, b)
-  end
-end
 
--(a::QQFieldElem, b::Integer) = a - flintify(b)
--(a::Integer, b::QQFieldElem) = flintify(a) - b
-
--(a::QQFieldElem, b::Rational{T}) where {T <: Integer} = a - QQFieldElem(b)
--(a::Rational{T}, b::QQFieldElem) where {T <: Integer} = QQFieldElem(a) - b
-
-for T in (ZZRingElem, Int, UInt, Integer, Rational)
-  @eval begin
     *(a::QQFieldElem, b::$T) = mul!(QQFieldElem(), a, b)
     *(a::$T, b::QQFieldElem) = mul!(QQFieldElem(), a, b)
   end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -497,32 +497,18 @@ end
 #
 ###############################################################################
 
-+(a::ZZRingElem, b::Int) = add!(ZZRingElem(), a, b)
-+(a::Int, b::ZZRingElem) = b + a
+for T in (Int, UInt, Integer)
+  @eval begin
+    +(a::ZZRingElem, b::$T) = add!(ZZRingElem(), a, b)
+    +(a::$T, b::ZZRingElem) = add!(ZZRingElem(), a, b)
 
-+(a::ZZRingElem, b::UInt) = add!(ZZRingElem(), a, b)
-+(a::UInt, b::ZZRingElem) = b + a
+    -(a::ZZRingElem, b::$T) = sub!(ZZRingElem(), a, b)
+    -(a::$T, b::ZZRingElem) = sub!(ZZRingElem(), a, b)
 
-+(a::ZZRingElem, b::Integer) = a + flintify(b)
-+(a::Integer, b::ZZRingElem) = flintify(a) + b
-
--(a::ZZRingElem, b::Int) = sub!(ZZRingElem(), a, b)
--(a::Int, b::ZZRingElem) = neg!(b - a)
-
--(a::ZZRingElem, b::UInt) = sub!(ZZRingElem(), a, b)
--(a::UInt, b::ZZRingElem) = neg!(b - a)
-
--(a::ZZRingElem, b::Integer) = a - flintify(b)
--(a::Integer, b::ZZRingElem) = flintify(a) - b
-
-*(a::ZZRingElem, b::Int) = mul!(ZZRingElem(), a, b)
-*(a::Int, b::ZZRingElem) = b * a
-
-*(a::ZZRingElem, b::UInt) = mul!(ZZRingElem(), a, b)
-*(a::UInt, b::ZZRingElem) = b * a
-
-*(a::ZZRingElem, b::Integer) = a*flintify(b)
-*(a::Integer, b::ZZRingElem) = flintify(a)*b
+    *(a::ZZRingElem, b::$T) = mul!(ZZRingElem(), a, b)
+    *(a::$T, b::ZZRingElem) = mul!(ZZRingElem(), a, b)
+  end
+end
 
 *(a::ZZRingElem, b::AbstractFloat) = BigInt(a) * b
 *(a::AbstractFloat, b::ZZRingElem) = a * BigInt(b)

--- a/test/calcium/qqbar-test.jl
+++ b/test/calcium/qqbar-test.jl
@@ -48,6 +48,42 @@ end
 
 end
 
+@testset "QQBarFieldElem.unsafe" begin
+  a = QQBarFieldElem(32//17)
+  b = QQBarFieldElem(23//11)
+  c = one(QQ)
+  b_copy = deepcopy(b)
+  c_copy = deepcopy(c)
+
+  a = zero!(a)
+  @test iszero(a)
+  a = mul!(a, a, b)
+  @test iszero(a)
+
+  a = add!(a, a, b)
+  @test a == b
+  a = add!(a, a, 1)
+  @test a == b + 1
+  a = add!(a, a, ZZRingElem(0))
+  @test a == b + 1
+
+  a = add!(a, b^2)
+  @test a == 1 + b + b^2
+
+  a = mul!(a, a, b)
+  @test a == (1 + b + b^2) * b
+  a = mul!(a, a, 3)
+  @test a == (1 + b + b^2) * b * 3
+  a = mul!(a, a, ZZRingElem(3))
+  @test a == (1 + b + b^2) * b * 9
+
+  a = addmul!(a, a, c)
+  @test a == 2 * (1 + b + b^2) * b * 9
+
+  @test b_copy == b
+  @test c_copy == c
+end
+
 @testset "QQBarFieldElem.printing" begin
   R = algebraic_closure(QQ)
   a = R(1)


### PR DESCRIPTION
Also tweak QQFieldElem & ZZRingElem adhoc binary ops delegation to unsafe ops: don't use flintify to implement the adhoc ops, instead rely on add!/sub!/mul! handling everything passed to them suitably. This way future optimizations for the unsafe ops automatically benefit the adhoc binary ops.

TODO for follow-up PRs
- more tests
- add `divexact!`
- add `inv!`

