### PR TITLE
Add FLINT bindings for `pow` and `reverse`

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -109,6 +109,7 @@ import Base: Rational
 import Base: real
 import Base: rem
 import Base: reverse
+import Base: reverse!
 import Base: round
 import Base: setindex!
 import Base: show

--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -406,12 +406,11 @@ end
 ###############################################################################
 
 function ^(a::AbsSimpleNumFieldElem, n::Int)
-  r = a.parent()
-  @ccall libflint.nf_elem_pow(r::Ref{AbsSimpleNumFieldElem}, a::Ref{AbsSimpleNumFieldElem}, abs(n)::Int, a.parent::Ref{AbsSimpleNumField})::Nothing
+  z = pow!(parent(a)(), a, abs(n))
   if n < 0
-    r = inv(r)
+    z = inv!(z)
   end
-  return r
+  return z
 end
 
 ###############################################################################
@@ -688,6 +687,13 @@ functions automatically reduce their outputs.
 function reduce!(x::AbsSimpleNumFieldElem)
   @ccall libflint.nf_elem_reduce(x::Ref{AbsSimpleNumFieldElem}, parent(x)::Ref{AbsSimpleNumField})::Nothing
   return x
+end
+
+#
+
+function pow!(z::AbsSimpleNumFieldElem, a::AbsSimpleNumFieldElem, n::Integer)
+  @ccall libflint.nf_elem_pow(z::Ref{AbsSimpleNumFieldElem}, a::Ref{AbsSimpleNumFieldElem}, n::UInt, a.parent::Ref{AbsSimpleNumField})::Nothing
+  return z
 end
 
 ###############################################################################

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -387,18 +387,9 @@ isless(a::QQFieldElem, b::Float64) = isless(BigFloat(a), b)
 #
 ###############################################################################
 
-function ^(a::QQFieldElem, b::Int)
+function ^(a::QQFieldElemOrPtr, b::IntegerUnionOrPtr)
   iszero(a) && b < 0 && throw(DivideError())
-  temp = QQFieldElem()
-  @ccall libflint.fmpq_pow_si(temp::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Int)::Nothing
-  return temp
-end
-
-function ^(a::QQFieldElem, k::ZZRingElem)
-  is_zero(a) && return QQFieldElem(is_zero(k) ? 1 : 0)
-  is_one(a) && return QQFieldElem(1)
-  a == -1 && return QQFieldElem(isodd(k) ? -1 : 1)
-  return a^Int(k)
+  return pow!(QQFieldElem(), a, b)
 end
 
 ###############################################################################
@@ -1153,6 +1144,21 @@ end
 
 function divexact!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
   @ccall libflint.fmpq_div_fmpz(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+#
+
+function pow!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, n::Integer)
+  @ccall libflint.fmpq_pow_si(z::Ref{QQFieldElem}, x::Ref{QQFieldElem}, Int(n)::Int)::Nothing
+  return  z
+end
+
+function pow!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, n::ZZRingElemOrPtr)
+  ok = Bool(@ccall libflint.fmpq_pow_fmpz(z::Ref{QQFieldElem}, x::Ref{QQFieldElem}, n::Ref{ZZRingElem})::Cint)
+  if !ok
+    error("unable to compute power")
+  end
   return z
 end
 

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -387,7 +387,14 @@ isless(a::QQFieldElem, b::Float64) = isless(BigFloat(a), b)
 #
 ###############################################################################
 
-function ^(a::QQFieldElemOrPtr, b::IntegerUnionOrPtr)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(a::QQFieldElem, b::Int)
+  iszero(a) && is_negative(b) && throw(DivideError())
+  return pow!(QQFieldElem(), a, b)
+end
+
+function ^(a::QQFieldElem, b::ZZRingElem)
   iszero(a) && is_negative(b) && throw(DivideError())
   return pow!(QQFieldElem(), a, b)
 end

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -388,7 +388,7 @@ isless(a::QQFieldElem, b::Float64) = isless(BigFloat(a), b)
 ###############################################################################
 
 function ^(a::QQFieldElemOrPtr, b::IntegerUnionOrPtr)
-  iszero(a) && b < 0 && throw(DivideError())
+  iszero(a) && is_negative(b) && throw(DivideError())
   return pow!(QQFieldElem(), a, b)
 end
 

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -309,7 +309,14 @@ end
 #
 ###############################################################################
 
-function ^(x::QQMPolyRingElem, n::IntegerUnionOrPtr)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::QQMPolyRingElem, n::Int)
+  is_negative(n) && throw(DomainError("Exponent must be non-negative"))
+  return pow!(parent(x)(), x, n)
+end
+
+function ^(x::QQMPolyRingElem, n::ZZRingElem)
   is_negative(n) && throw(DomainError("Exponent must be non-negative"))
   return pow!(parent(x)(), x, n)
 end
@@ -793,7 +800,7 @@ end
 #
 
 function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::Integer)
-  ok = Bool(libflint.fmpq_mpoly_pow_ui(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, UInt(n)::UInt, parent(a)::Ref{QQMPolyRing})::Cint)
+  ok = Bool(@ccall libflint.fmpq_mpoly_pow_ui(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, UInt(n)::UInt, parent(a)::Ref{QQMPolyRing})::Cint)
   if !ok
     error("unable to compute power")
   end
@@ -801,7 +808,7 @@ function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::Integer)
 end
 
 function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::ZZRingElemOrPtr)
-  ok = Bool(libflint.fmpq_mpoly_pow_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{QQMPolyRing})::Cint)
+  ok = Bool(@ccall libflint.fmpq_mpoly_pow_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{QQMPolyRing})::Cint)
   if !ok
     error("unable to compute power")
   end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -309,18 +309,9 @@ end
 #
 ###############################################################################
 
-function ^(a::QQMPolyRingElem, b::Int)
-  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-  z = parent(a)()
-  @ccall libflint.fmpq_mpoly_pow_ui(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, b::Int, parent(a)::Ref{QQMPolyRing})::Nothing
-  return z
-end
-
-function ^(a::QQMPolyRingElem, b::ZZRingElem)
-  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-  z = parent(a)()
-  @ccall libflint.fmpq_mpoly_pow_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, b::Ref{ZZRingElem}, parent(a)::Ref{QQMPolyRing})::Nothing
-  return z
+function ^(x::QQMPolyRingElem, n::IntegerUnionOrPtr)
+  n < 0 && throw(DomainError("Exponent must be non-negative"))
+  return pow!(parent(x)(), x, n)
 end
 
 ################################################################################
@@ -797,6 +788,24 @@ setcoeff!(a, i, QQFieldElem(c))
 function combine_like_terms!(a::QQMPolyRingElem)
   @ccall libflint.fmpq_mpoly_combine_like_terms(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
   return a
+end
+
+#
+
+function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::Integer)
+  ok = Bool(libflint.fmpq_mpoly_pow_ui(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, UInt(n)::UInt, parent(a)::Ref{QQMPolyRing})::Cint)
+  if !ok
+    error("unable to compute power")
+  end
+  return z
+end
+
+function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::ZZRingElemOrPtr)
+  ok = Bool(libflint.fmpq_mpoly_pow_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{QQMPolyRing})::Cint)
+  if !ok
+    error("unable to compute power")
+  end
+  return z
 end
 
 ###############################################################################

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -310,7 +310,7 @@ end
 ###############################################################################
 
 function ^(x::QQMPolyRingElem, n::IntegerUnionOrPtr)
-  n < 0 && throw(DomainError("Exponent must be non-negative"))
+  is_negative(n) && throw(DomainError("Exponent must be non-negative"))
   return pow!(parent(x)(), x, n)
 end
 

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -162,7 +162,14 @@ end
 #
 ###############################################################################
 
-function ^(x::QQPolyRingElem, y::IntegerUnion)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::QQPolyRingElem, y::Int)
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
+  return pow!(parent(x)(), x, y)
+end
+
+function ^(x::QQPolyRingElem, y::ZZRingElem)
   is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
   return pow!(parent(x)(), x, y)
 end
@@ -805,7 +812,7 @@ end
 
 #
 
-function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElem, len::Int)
+function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
   @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
   return z
 end

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -239,9 +239,7 @@ end
 
 function reverse(x::QQPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Length must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ###############################################################################
@@ -799,6 +797,13 @@ end
 mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Union{Integer, Rational}) = mul!(z, x, flintify(y))
 
 mul!(z::QQPolyRingElemOrPtr, x::RationalUnionOrPtr, y::QQPolyRingElemOrPtr) = mul!(z, y, x)
+
+#
+
+function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElem, len::Int)
+  @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
+  return z
+end
 
 ###############################################################################
 #

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -163,7 +163,7 @@ end
 ###############################################################################
 
 function ^(x::QQPolyRingElem, y::IntegerUnion)
-  y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
   return pow!(parent(x)(), x, y)
 end
 

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -247,6 +247,11 @@ function reverse(x::QQPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
+  @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
+  return z
+end
+
 ###############################################################################
 #
 #   Shifting
@@ -807,13 +812,6 @@ mul!(z::QQPolyRingElemOrPtr, x::RationalUnionOrPtr, y::QQPolyRingElemOrPtr) = mu
 
 function pow!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, n::IntegerUnion)
   @ccall libflint.fmpq_poly_pow(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, UInt(n)::UInt)::Nothing
-  return z
-end
-
-#
-
-function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
-  @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
   return z
 end
 

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -162,11 +162,9 @@ end
 #
 ###############################################################################
 
-function ^(x::QQPolyRingElem, y::Int)
+function ^(x::QQPolyRingElem, y::IntegerUnion)
   y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fmpq_poly_pow(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Int)::Nothing
-  return z
+  return pow!(parent(x)(), x, y)
 end
 
 ###############################################################################
@@ -797,6 +795,13 @@ end
 mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Union{Integer, Rational}) = mul!(z, x, flintify(y))
 
 mul!(z::QQPolyRingElemOrPtr, x::RationalUnionOrPtr, y::QQPolyRingElemOrPtr) = mul!(z, y, x)
+
+#
+
+function pow!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, n::IntegerUnion)
+  @ccall libflint.fmpq_poly_pow(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, UInt(n)::UInt)::Nothing
+  return z
+end
 
 #
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -759,8 +759,23 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZRingElemOrPtr, y::IntegerUnionOrPtr)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::ZZRingElem, y::Int)
   if is_negative(y)
+    if abs(x) == 1
+      return isodd(y) ? deepcopy(x) : one(x)
+    end
+    throw(DomainError(y, "Exponent must be non-negative"))
+  end
+  return pow!(ZZRingElem(), x, y)
+end
+
+function ^(x::ZZRingElem, y::ZZRingElem)
+  if is_negative(y)
+    if abs(x) == 1
+      return isodd(y) ? deepcopy(x) : one(x)
+    end
     throw(DomainError(y, "Exponent must be non-negative"))
   end
   return pow!(ZZRingElem(), x, y)
@@ -772,9 +787,9 @@ end
 #
 ###############################################################################
 
-^(a::T, n::IntegerUnion) where {T<:RingElem} = _generic_power(a, n)
+^(a::T, n::ZZRingElem) where {T<:RingElem} = _generic_power(a, n)
 
-function _generic_power(a, n::IntegerUnion)
+function _generic_power(a, n::ZZRingElem)
   fits(Int, n) && return a^Int(n)
   if is_negative(n)
     a = inv(a)
@@ -3238,5 +3253,3 @@ function resultant(f::ZZPolyRingElem, g::ZZPolyRingElem, d::ZZRingElem, nb::Int)
   @ccall libflint.fmpz_poly_resultant_modular_div(z::Ref{ZZRingElem}, f::Ref{ZZPolyRingElem}, g::Ref{ZZPolyRingElem}, d::Ref{ZZRingElem}, nb::Int)::Nothing
   return z
 end
-
-

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -759,7 +759,7 @@ end
 #
 ###############################################################################
 
-function ^(x::IntegerUnionOrPtr, y::IntegerUnionOrPtr)
+function ^(x::ZZRingElemOrPtr, y::IntegerUnionOrPtr)
   if y < 0
     throw(DomainError(y, "Exponent must be non-negative"))
   end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -760,7 +760,7 @@ end
 ###############################################################################
 
 function ^(x::ZZRingElemOrPtr, y::IntegerUnionOrPtr)
-  if y < 0
+  if is_negative(y)
     throw(DomainError(y, "Exponent must be non-negative"))
   end
   return pow!(ZZRingElem(), x, y)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -348,7 +348,15 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZMatrix, y::IntegerUnion)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::ZZMatrix, y::Int)
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
+  nrows(x) != ncols(x) && error("Incompatible matrix dimensions")
+  return pow!(similar(x), x, y)
+end
+
+function ^(x::ZZMatrix, y::ZZRingElem)
   is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
   nrows(x) != ncols(x) && error("Incompatible matrix dimensions")
   return pow!(similar(x), x, y)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -349,7 +349,7 @@ end
 ###############################################################################
 
 function ^(x::ZZMatrix, y::IntegerUnion)
-  y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
   nrows(x) != ncols(x) && error("Incompatible matrix dimensions")
   return pow!(similar(x), x, y)
 end

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -348,12 +348,10 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZMatrix, y::Int)
+function ^(x::ZZMatrix, y::IntegerUnion)
   y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
   nrows(x) != ncols(x) && error("Incompatible matrix dimensions")
-  z = similar(x)
-  @ccall libflint.fmpz_mat_pow(z::Ref{ZZMatrix}, x::Ref{ZZMatrix}, y::Int)::Nothing
-  return z
+  return pow!(similar(x), x, y)
 end
 
 ###############################################################################
@@ -1969,6 +1967,11 @@ function shift!(g::ZZMatrix, l::Int)
     end
   end
   return g
+end
+
+function pow!(z::ZZMatrixOrPtr, x::ZZMatrixOrPtr, n::IntegerUnion)
+  @ccall libflint.fmpz_mat_pow(z::Ref{ZZMatrix}, x::Ref{ZZMatrix}, UInt(n)::UInt)::Nothing
+  return z
 end
 
 ################################################################################

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -205,8 +205,7 @@ end
 function ^(x::ZZModRingElem, y::Int)
   if y < 0
     z = inv(x)
-    x = pow!(x, z, -y)
-    swap!(inv!(z), x)
+    z = pow!(z, z, -y)
   else
     z = pow!(parent(x)(), x, y)
   end

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -202,7 +202,7 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZModRingElem, y::Integer)
+function ^(x::ZZModRingElem, y::Int)
   if y < 0
     z = inv(x)
     x = pow!(x, z, -y)
@@ -214,7 +214,7 @@ function ^(x::ZZModRingElem, y::Integer)
 end
 
 # FLINT accepts negative values for the exponent if it is a ZZRingElem
-function ^(x::ZZModRingElem, n::ZZRingElemOrPtr)
+function ^(x::ZZModRingElem, n::ZZRingElem)
   return pow!(parent(x)(), x, n)
 end
 
@@ -419,7 +419,7 @@ end
 
 function pow!(z::ZZModRingElem, x::ZZModRingElem, n::ZZRingElemOrPtr)
   R = parent(z)
-  ok = Bool(@ccall libflint.fmpz_mod_pow(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, n::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Cint)
+  ok = Bool(@ccall libflint.fmpz_mod_pow_fmpz(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, n::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Cint)
   if !ok
     error("not invertible")
   end

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -206,7 +206,7 @@ function ^(x::ZZModRingElem, y::Integer)
   if y < 0
     z = inv(x)
     x = pow!(x, z, -y)
-    swap!(z, x)
+    swap!(inv!(z), x)
   else
     z = pow!(parent(x)(), x, y)
   end
@@ -400,9 +400,7 @@ end
 #
 
 function inv!(x::ZZModRingElem)
-  R = parent(x)
-  @ccall libflint.fmpz_mod_inv(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
+  return inv!(x, x)
 end
 
 function inv!(z::ZZModRingElem, x::ZZModRingElem)

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -202,6 +202,8 @@ end
 #
 ###############################################################################
 
+# Cannot use IntegerUnion here to avoid ambiguity.
+
 function ^(x::ZZModRingElem, y::Int)
   if y < 0
     z = inv(x)
@@ -398,14 +400,6 @@ end
 
 #
 
-function inv!(z::ZZModRingElem, x::ZZModRingElem)
-  R = parent(x)
-  @ccall libflint.fmpz_mod_inv(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
-end
-
-#
-
 function pow!(z::ZZModRingElem, x::ZZModRingElem, n::Integer)
   R = parent(z)
   @ccall libflint.fmpz_mod_pow_ui(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, n::UInt, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
@@ -419,12 +413,6 @@ function pow!(z::ZZModRingElem, x::ZZModRingElem, n::ZZRingElemOrPtr)
     error("not invertible")
   end
   return z
-end
-
-#
-
-function swap!(x::ZZModRingElem, y::ZZModRingElem)
-  swap!(x.data, y.data)
 end
 
 ###############################################################################

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -399,10 +399,6 @@ end
 
 #
 
-function inv!(x::ZZModRingElem)
-  return inv!(x, x)
-end
-
 function inv!(z::ZZModRingElem, x::ZZModRingElem)
   R = parent(x)
   @ccall libflint.fmpz_mod_inv(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Nothing

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -6,7 +6,7 @@
 ###############################################################################
 
 for (etype, rtype, ftype, ctype) in (
-  (FpMPolyRingElem, FpMPolyRing, gfp_fmpz_mpoly_factor, FpFieldElem),)
+                                     (FpMPolyRingElem, FpMPolyRing, gfp_fmpz_mpoly_factor, FpFieldElem),)
   @eval begin
 
     ###############################################################################
@@ -45,7 +45,7 @@ for (etype, rtype, ftype, ctype) in (
     function internal_ordering(a::($rtype))
       b = a.ord
       #   b = @ccall libflint.fmpz_mod_mpoly_ctx_ord(a::Ref{zzModMPolyRing})::Cint
-      return flint_orderings[b+1]
+      return flint_orderings[b + 1]
     end
 
     function gens(R::($rtype))
@@ -112,11 +112,11 @@ for (etype, rtype, ftype, ctype) in (
     end
 
     # TODO move this
-    function expressify(a::($rtype); context=nothing)
+    function expressify(a::($rtype); context = nothing)
       return Expr(:sequence, Expr(:text, "Multivariate Polynomial Ring in "),
-        Expr(:series, symbols(a)...),
-        Expr(:text, " over "),
-        expressify(coefficient_ring(a); context=context))
+                  Expr(:series, symbols(a)...),
+                  Expr(:text, " over "),
+                  expressify(coefficient_ring(a); context = context))
     end
 
     @enable_all_show_via_expressify ($rtype)
@@ -401,7 +401,7 @@ for (etype, rtype, ftype, ctype) in (
     #
     ################################################################################
 
-    function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool=true)
+    function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool = true)
       R = fac.parent
       F = Fac{($etype)}()
       for i in 0:fac.num-1
@@ -585,10 +585,10 @@ for (etype, rtype, ftype, ctype) in (
 
     # TODO have AA define evaluate(a, vals) for general vals
     # so we can get rid of this copy pasta
-    function (a::($etype))(vals::Union{NCRingElem,RingElement}...)
+    function (a::($etype))(vals::Union{NCRingElem, RingElement}...)
       length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
       R = base_ring(a)
-      powers = [Dict{Int,Any}() for i in 1:length(vals)]
+      powers = [Dict{Int, Any}() for i in 1:length(vals)]
       r = R()
       c = zero(R)
       U = Vector{Any}(undef, length(vals))
@@ -596,11 +596,11 @@ for (etype, rtype, ftype, ctype) in (
         W = typeof(vals[j])
         if ((W <: Integer && W != BigInt) ||
             (W <: Rational && W != Rational{BigInt}))
-          c = c * zero(W)
+          c = c*zero(W)
           U[j] = parent(c)
         else
           U[j] = parent(vals[j])
-          c = c * zero(parent(vals[j]))
+          c = c*zero(parent(vals[j]))
         end
       end
       cvzip = zip(coefficients(a), exponent_vectors(a))
@@ -611,7 +611,7 @@ for (etype, rtype, ftype, ctype) in (
           if !haskey(powers[j], exp)
             powers[j][exp] = (U[j](vals[j]))^exp
           end
-          t = t * powers[j][exp]
+          t = t*powers[j][exp]
         end
         r += t
       end
@@ -794,7 +794,7 @@ for (etype, rtype, ftype, ctype) in (
     # Set the coefficient of the term with the given exponent vector to the
     # given integer. Removal of a zero term is performed.
     setcoeff!(a::($etype), exps::Vector{Int}, b::Integer) =
-      setcoeff!(a, exps, base_ring(parent(a))(b))
+    setcoeff!(a, exps, base_ring(parent(a))(b))
 
     # Sort the terms according to the ordering. This is only needed if unsafe
     # functions such as those above have been called and terms have been inserted
@@ -829,7 +829,7 @@ for (etype, rtype, ftype, ctype) in (
     #
     ###############################################################################
 
-    promote_rule(::Type{($etype)}, ::Type{V}) where {V<:Integer} = ($etype)
+    promote_rule(::Type{($etype)}, ::Type{V}) where {V <: Integer} = ($etype)
 
     promote_rule(::Type{($etype)}, ::Type{ZZRingElem}) = ($etype)
 
@@ -859,18 +859,18 @@ for (etype, rtype, ftype, ctype) in (
     end
 
     # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-    function (R::($rtype))(a::Vector{($ctype)}, b::Vector{Vector{T}}) where {T<:Union{ZZRingElem,UInt,Int}}
+    function (R::($rtype))(a::Vector{($ctype)}, b::Vector{Vector{T}}) where {T <: Union{ZZRingElem, UInt, Int}}
       length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
       for i in 1:length(b)
         length(b[i]) != nvars(R) && error("Exponent vector $i has length $(length(b[i])) (expected $(nvars(R))")
-        T !== UInt && any(x -> x < 0, b[i]) && error("negative exponent")
+        T !== UInt && any(x->x<0, b[i]) && error("negative exponent")
       end
       z = ($etype)(R, a, b)
       return z
     end
 
     # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-    function (R::($rtype))(a::Vector, b::Vector{Vector{T}}) where {T}
+    function (R::($rtype))(a::Vector, b::Vector{Vector{T}}) where T
       n = nvars(R)
       length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
       newa = map(base_ring(R), a)
@@ -893,7 +893,7 @@ end #for
 ################################################################################
 
 function divexact(f::FpMPolyRingElem, a::fpFieldElem; check::Bool=true)
-  return f * inv(a)
+  return f*inv(a)
 end
 
 function divexact(f::FpMPolyRingElem, a::IntegerUnion; check::Bool=true)

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -672,7 +672,7 @@ for (etype, rtype, ftype, ctype) in (
     end
 
     function pow!(z::($etype), a::($etype), n::ZZRingElem)
-      ok = @ccall Bool(libflint.fmpz_mod_mpoly_pow_fmpz(z::Ref{($etype)}, a::Ref{($etype)}, n::Ref{ZZRingElem}, parent(a)::Ref{($rtype)})::Cint)
+      ok = Bool(@ccall libflint.fmpz_mod_mpoly_pow_fmpz(z::Ref{($etype)}, a::Ref{($etype)}, n::Ref{ZZRingElem}, parent(a)::Ref{($rtype)})::Cint)
       if !ok
         error("unable to compute power")
       end

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -6,7 +6,7 @@
 ###############################################################################
 
 for (etype, rtype, ftype, ctype) in (
-                                     (FpMPolyRingElem, FpMPolyRing, gfp_fmpz_mpoly_factor, FpFieldElem),)
+  (FpMPolyRingElem, FpMPolyRing, gfp_fmpz_mpoly_factor, FpFieldElem),)
   @eval begin
 
     ###############################################################################
@@ -45,7 +45,7 @@ for (etype, rtype, ftype, ctype) in (
     function internal_ordering(a::($rtype))
       b = a.ord
       #   b = @ccall libflint.fmpz_mod_mpoly_ctx_ord(a::Ref{zzModMPolyRing})::Cint
-      return flint_orderings[b + 1]
+      return flint_orderings[b+1]
     end
 
     function gens(R::($rtype))
@@ -112,11 +112,11 @@ for (etype, rtype, ftype, ctype) in (
     end
 
     # TODO move this
-    function expressify(a::($rtype); context = nothing)
+    function expressify(a::($rtype); context=nothing)
       return Expr(:sequence, Expr(:text, "Multivariate Polynomial Ring in "),
-                  Expr(:series, symbols(a)...),
-                  Expr(:text, " over "),
-                  expressify(coefficient_ring(a); context = context))
+        Expr(:series, symbols(a)...),
+        Expr(:text, " over "),
+        expressify(coefficient_ring(a); context=context))
     end
 
     @enable_all_show_via_expressify ($rtype)
@@ -365,9 +365,18 @@ for (etype, rtype, ftype, ctype) in (
     #
     ###############################################################################
 
-    function ^(a::($etype), n::IntegerUnionOrPtr)
+    # Cannot use IntegerUnion here to avoid ambiguity.
+
+    function ^(a::($etype), n::Int)
       if is_negative(n)
-        throw(DomainError(b, "Exponent must be non-negative"))
+        throw(DomainError(n, "Exponent must be non-negative"))
+      end
+      return pow!(parent(a)(), a, n)
+    end
+
+    function ^(a::($etype), n::ZZRingElem)
+      if is_negative(n)
+        throw(DomainError(n, "Exponent must be non-negative"))
       end
       return pow!(parent(a)(), a, n)
     end
@@ -392,7 +401,7 @@ for (etype, rtype, ftype, ctype) in (
     #
     ################################################################################
 
-    function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool = true)
+    function (::Type{Fac{($etype)}})(fac::($ftype), preserve_input::Bool=true)
       R = fac.parent
       F = Fac{($etype)}()
       for i in 0:fac.num-1
@@ -576,10 +585,10 @@ for (etype, rtype, ftype, ctype) in (
 
     # TODO have AA define evaluate(a, vals) for general vals
     # so we can get rid of this copy pasta
-    function (a::($etype))(vals::Union{NCRingElem, RingElement}...)
+    function (a::($etype))(vals::Union{NCRingElem,RingElement}...)
       length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
       R = base_ring(a)
-      powers = [Dict{Int, Any}() for i in 1:length(vals)]
+      powers = [Dict{Int,Any}() for i in 1:length(vals)]
       r = R()
       c = zero(R)
       U = Vector{Any}(undef, length(vals))
@@ -587,11 +596,11 @@ for (etype, rtype, ftype, ctype) in (
         W = typeof(vals[j])
         if ((W <: Integer && W != BigInt) ||
             (W <: Rational && W != Rational{BigInt}))
-          c = c*zero(W)
+          c = c * zero(W)
           U[j] = parent(c)
         else
           U[j] = parent(vals[j])
-          c = c*zero(parent(vals[j]))
+          c = c * zero(parent(vals[j]))
         end
       end
       cvzip = zip(coefficients(a), exponent_vectors(a))
@@ -602,7 +611,7 @@ for (etype, rtype, ftype, ctype) in (
           if !haskey(powers[j], exp)
             powers[j][exp] = (U[j](vals[j]))^exp
           end
-          t = t*powers[j][exp]
+          t = t * powers[j][exp]
         end
         r += t
       end
@@ -665,7 +674,7 @@ for (etype, rtype, ftype, ctype) in (
       @ccall libflint.fmpz_mod_mpoly_combine_like_terms(a::Ref{($etype)}, a.parent::Ref{($rtype)})::Nothing
       return a
     end
-    
+
     function pow!(z::($etype), a::($etype), n::Integer)
       @ccall libflint.fmpz_mod_mpoly_pow_ui(z::Ref{($etype)}, a::Ref{($etype)}, UInt(n)::UInt, parent(a)::Ref{($rtype)})::Nothing
       return z
@@ -785,7 +794,7 @@ for (etype, rtype, ftype, ctype) in (
     # Set the coefficient of the term with the given exponent vector to the
     # given integer. Removal of a zero term is performed.
     setcoeff!(a::($etype), exps::Vector{Int}, b::Integer) =
-    setcoeff!(a, exps, base_ring(parent(a))(b))
+      setcoeff!(a, exps, base_ring(parent(a))(b))
 
     # Sort the terms according to the ordering. This is only needed if unsafe
     # functions such as those above have been called and terms have been inserted
@@ -820,7 +829,7 @@ for (etype, rtype, ftype, ctype) in (
     #
     ###############################################################################
 
-    promote_rule(::Type{($etype)}, ::Type{V}) where {V <: Integer} = ($etype)
+    promote_rule(::Type{($etype)}, ::Type{V}) where {V<:Integer} = ($etype)
 
     promote_rule(::Type{($etype)}, ::Type{ZZRingElem}) = ($etype)
 
@@ -850,18 +859,18 @@ for (etype, rtype, ftype, ctype) in (
     end
 
     # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-    function (R::($rtype))(a::Vector{($ctype)}, b::Vector{Vector{T}}) where {T <: Union{ZZRingElem, UInt, Int}}
+    function (R::($rtype))(a::Vector{($ctype)}, b::Vector{Vector{T}}) where {T<:Union{ZZRingElem,UInt,Int}}
       length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
       for i in 1:length(b)
         length(b[i]) != nvars(R) && error("Exponent vector $i has length $(length(b[i])) (expected $(nvars(R))")
-        T !== UInt && any(x->x<0, b[i]) && error("negative exponent")
+        T !== UInt && any(x -> x < 0, b[i]) && error("negative exponent")
       end
       z = ($etype)(R, a, b)
       return z
     end
 
     # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-    function (R::($rtype))(a::Vector, b::Vector{Vector{T}}) where T
+    function (R::($rtype))(a::Vector, b::Vector{Vector{T}}) where {T}
       n = nvars(R)
       length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
       newa = map(base_ring(R), a)
@@ -884,7 +893,7 @@ end #for
 ################################################################################
 
 function divexact(f::FpMPolyRingElem, a::fpFieldElem; check::Bool=true)
-  return f*inv(a)
+  return f * inv(a)
 end
 
 function divexact(f::FpMPolyRingElem, a::IntegerUnion; check::Bool=true)

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -365,19 +365,11 @@ for (etype, rtype, ftype, ctype) in (
     #
     ###############################################################################
 
-    function ^(a::($etype), b::Int)
-      b >= 0 || throw(DomainError(b, "Exponent must be non-negative"))
-      z = parent(a)()
-      @ccall libflint.fmpz_mod_mpoly_pow_ui(z::Ref{($etype)}, a::Ref{($etype)}, UInt(b)::UInt, parent(a)::Ref{($rtype)})::Nothing
-      return z
-    end
-
-    function ^(a::($etype), b::ZZRingElem)
-      b >= 0 || throw(DomainError(b, "Exponent must be non-negative"))
-      z = parent(a)()
-      ok = @ccall libflint.fmpz_mod_mpoly_pow_fmpz(z::Ref{($etype)}, a::Ref{($etype)}, b::Ref{ZZRingElem}, parent(a)::Ref{($rtype)})::Cint
-      iszero(ok) && error("Unable to compute power")
-      return z
+    function ^(a::($etype), n::IntegerUnionOrPtr)
+      if is_negative(n)
+        throw(DomainError(b, "Exponent must be non-negative"))
+      end
+      return pow!(parent(a)(), a, n)
     end
 
     ################################################################################
@@ -672,6 +664,19 @@ for (etype, rtype, ftype, ctype) in (
     function combine_like_terms!(a::($etype))
       @ccall libflint.fmpz_mod_mpoly_combine_like_terms(a::Ref{($etype)}, a.parent::Ref{($rtype)})::Nothing
       return a
+    end
+    
+    function pow!(z::($etype), a::($etype), n::Integer)
+      @ccall libflint.fmpz_mod_mpoly_pow_ui(z::Ref{($etype)}, a::Ref{($etype)}, UInt(n)::UInt, parent(a)::Ref{($rtype)})::Nothing
+      return z
+    end
+
+    function pow!(z::($etype), a::($etype), n::ZZRingElem)
+      ok = @ccall Bool(libflint.fmpz_mod_mpoly_pow_fmpz(z::Ref{($etype)}, a::Ref{($etype)}, n::Ref{ZZRingElem}, parent(a)::Ref{($rtype)})::Cint)
+      if !ok
+        error("unable to compute power")
+      end
+      return z
     end
 
     ###############################################################################

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -313,9 +313,7 @@ end
 
 function reverse(x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   len < 0 && throw(DomainError(len, "Length must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fmpz_mod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ###############################################################################
@@ -802,6 +800,13 @@ end
 
 function mul!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
   @ccall libflint.fmpz_mod_poly_mul(z::Ref{T}, x::Ref{T}, y::Ref{T}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+  return z
+end
+
+#
+
+function reverse!(z::T, x::T, len::Int) where {T <: Zmodn_fmpz_poly}
+  @ccall libflint.fmpz_mod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
   return z
 end
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -238,11 +238,9 @@ end
 #
 ################################################################################
 
-function ^(x::T, y::Int) where {T <: Zmodn_fmpz_poly}
-  y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fmpz_mod_poly_pow(z::Ref{T}, x::Ref{T}, y::UInt, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
+function ^(x::T, y::IntegerUnion) where {T <: Zmodn_fmpz_poly}
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
+  return pow!(parent(x)(), x, y)
 end
 
 ################################################################################
@@ -803,7 +801,10 @@ function mul!(z::T, x::T, y::T) where {T <: Zmodn_fmpz_poly}
   return z
 end
 
-#
+function pow!(z::T, x::T, y::IntegerUnion) where {T <: Zmodn_fmpz_poly}
+  @ccall libflint.fmpz_mod_poly_pow(z::Ref{T}, x::Ref{T}, UInt(y)::UInt, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+  return z
+end
 
 function reverse!(z::T, x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   @ccall libflint.fmpz_mod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -321,6 +321,11 @@ function reverse(x::T, len::Int) where {T <: Zmodn_fmpz_poly}
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::T, x::T, len::Int) where {T <: Zmodn_fmpz_poly}
+  @ccall libflint.fmpz_mod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
+  return z
+end
+
 ###############################################################################
 #
 #   Shifting
@@ -810,11 +815,6 @@ end
 
 function pow!(z::T, x::T, y::IntegerUnion) where {T <: Zmodn_fmpz_poly}
   @ccall libflint.fmpz_mod_poly_pow(z::Ref{T}, x::Ref{T}, UInt(y)::UInt, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
-end
-
-function reverse!(z::T, x::T, len::Int) where {T <: Zmodn_fmpz_poly}
-  @ccall libflint.fmpz_mod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Nothing
   return z
 end
 

--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -238,7 +238,14 @@ end
 #
 ################################################################################
 
-function ^(x::T, y::IntegerUnion) where {T <: Zmodn_fmpz_poly}
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::T, y::Int) where {T <: Zmodn_fmpz_poly}
+  is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
+  return pow!(parent(x)(), x, y)
+end
+
+function ^(x::T, y::ZZRingElem) where {T <: Zmodn_fmpz_poly}
   is_negative(y) && throw(DomainError(y, "Exponent must be non-negative"))
   return pow!(parent(x)(), x, y)
 end

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -26,7 +26,7 @@ base_ring(a::ZZMPolyRing) = ZZ
 
 function internal_ordering(a::ZZMPolyRing)
   b = @ccall libflint.fmpz_mpoly_ctx_ord(a::Ref{ZZMPolyRing})::Cint
-  return flint_orderings[b+1]
+  return flint_orderings[b + 1]
 end
 
 function gens(R::ZZMPolyRing)
@@ -208,7 +208,7 @@ end
 function coeff(a::ZZMPolyRingElem, vars::Vector{Int}, exps::Vector{Int})
   unique(vars) != vars && error("Variables not unique")
   length(vars) != length(exps) &&
-    error("Number of variables does not match number of exponents")
+  error("Number of variables does not match number of exponents")
   z = parent(a)()
   vars = [UInt(i) - 1 for i in vars]
   for i = 1:length(vars)
@@ -330,7 +330,7 @@ end
 #
 ################################################################################
 
-function (::Type{Fac{ZZMPolyRingElem}})(fac::fmpz_mpoly_factor, preserve_input::Bool=true)
+function (::Type{Fac{ZZMPolyRingElem}})(fac::fmpz_mpoly_factor, preserve_input::Bool = true)
   R = fac.parent
   F = Fac{ZZMPolyRingElem}()
   empty!(F.fac)
@@ -438,7 +438,7 @@ end
 #
 ###############################################################################
 
-function divides(a::ZZMPolyRingElem, b::Union{IntegerUnion,ZZMPolyRingElem})
+function divides(a::ZZMPolyRingElem, b::Union{IntegerUnion, ZZMPolyRingElem})
   check_parent(a, b)
   z = zero(parent(a))
   iszero(a) && return true, z
@@ -534,7 +534,7 @@ function (a::ZZMPolyRingElem)(vals::Integer...)
   return evaluate(a, [vals...])
 end
 
-function (a::ZZMPolyRingElem)(vals::Union{NCRingElem,RingElement}...)
+function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
   R = base_ring(a)
   # The best we can do here is to cache previously used powers of the values
@@ -543,7 +543,7 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem,RingElement}...)
   # to optimise computing new powers in any way.
   # Note that this function accepts values in a non-commutative ring, so operations
   # must be done in a certain order.
-  powers = [Dict{Int,Any}() for i in 1:length(vals)]
+  powers = [Dict{Int, Any}() for i in 1:length(vals)]
   # First work out types of products
   r = R()
   c = zero(R)
@@ -552,11 +552,11 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem,RingElement}...)
     W = typeof(vals[j])
     if ((W <: Integer && W != BigInt) ||
         (W <: Rational && W != Rational{BigInt}))
-      c = c * zero(W)
+      c = c*zero(W)
       U[j] = parent(c)
     else
       U[j] = parent(vals[j])
-      c = c * zero(parent(vals[j]))
+      c = c*zero(parent(vals[j]))
     end
   end
   for i = 1:length(a)
@@ -567,7 +567,7 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem,RingElement}...)
       if !haskey(powers[j], exp)
         powers[j][exp] = (U[j](vals[j]))^exp
       end
-      t = t * powers[j][exp]
+      t = t*powers[j][exp]
     end
     r += t
   end
@@ -579,7 +579,7 @@ function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
   S = parent(bs[1])
 
   length(bs) != nvars(R) &&
-    error("Number of variables does not match number of values")
+  error("Number of variables does not match number of values")
 
   c = S()
   fl = @ccall libflint.fmpz_mpoly_compose_fmpz_mpoly(c::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZMPolyRingElem}}, R::Ref{ZZMPolyRing}, S::Ref{ZZMPolyRing})::Cint
@@ -592,7 +592,7 @@ function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZPolyRingElem})
   S = parent(bs[1])
 
   length(bs) != nvars(R) &&
-    error("Number of variables does not match number of values")
+  error("Number of variables does not match number of values")
 
   c = S()
   fl = @ccall libflint.fmpz_mpoly_compose_fmpz_poly(c::Ref{ZZPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZPolyRingElem}}, R::Ref{ZZMPolyRing})::Cint
@@ -643,7 +643,7 @@ function set!(z::ZZMPolyRingElem, a::UInt)
   return z
 end
 
-set!(z::ZZMPolyRingElem, a::Union{Integer,Rational}) = set!(z, flintify(a))
+set!(z::ZZMPolyRingElem, a::Union{Integer, Rational}) = set!(z, flintify(a))
 
 #
 
@@ -672,31 +672,31 @@ for (jT, cN, cT) in ((ZZRingElem, :fmpz, Ref{ZZRingElem}), (Int, :si, Int), (UIn
   @eval begin
     function add!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::$jT)
       @ccall libflint.$(string(:fmpz_mpoly_add_, cN))(z::Ref{ZZMPolyRingElem},
-        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function sub!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_sub_, cN))(z::Ref{ZZMPolyRingElem},
-        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function mul!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_scalar_mul_, cN))(z::Ref{ZZMPolyRingElem},
-        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function divexact!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_scalar_divexact_, cN))(z::Ref{ZZMPolyRingElem},
-        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function divides!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       d = @ccall libflint.$(string(:fmpz_mpoly_scalar_divides_, cN))(z::Ref{ZZMPolyRingElem},
-        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Cint
+                    a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Cint
       return Bool(d), z
     end
   end
@@ -861,7 +861,7 @@ end
 
 # Set the coefficient of the term with the given exponent vector to the
 setcoeff!(a::ZZMPolyRingElem, exps::Vector{Int}, b::Integer) =
-  setcoeff!(a, exps, ZZRingElem(b))
+setcoeff!(a, exps, ZZRingElem(b))
 
 # Sort the terms according to the ordering. This is only needed if unsafe
 # functions such as those above have been called and terms have been inserted
@@ -898,7 +898,7 @@ end
 #
 ###############################################################################
 
-promote_rule(::Type{ZZMPolyRingElem}, ::Type{V}) where {V<:Integer} = ZZMPolyRingElem
+promote_rule(::Type{ZZMPolyRingElem}, ::Type{V}) where {V <: Integer} = ZZMPolyRingElem
 
 promote_rule(::Type{ZZMPolyRingElem}, ::Type{ZZRingElem}) = ZZMPolyRingElem
 
@@ -924,7 +924,7 @@ function _push_term!(z::ZZMPolyRingElem, c::UInt, exp::Vector{Int})
 end
 
 function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
-  c::Union{ZZRingElem,Int,UInt}, expv::Vector{Int})
+    c::Union{ZZRingElem, Int, UInt}, expv::Vector{Int})
   if length(expv) != nvars(parent(M.poly))
     error("length of exponent vector should match the number of variables")
   end
@@ -933,7 +933,7 @@ function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
 end
 
 function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
-  c::RingElement, expv::Vector{Int})
+    c::RingElement, expv::Vector{Int})
   push_term!(M, ZZ(c), expv)
   return M
 end
@@ -969,7 +969,7 @@ function (R::ZZMPolyRing)(a::ZZMPolyRingElem)
 end
 
 # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{T}}) where {T<:Union{ZZRingElem,UInt}}
+function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{T}}) where {T <: Union{ZZRingElem, UInt}}
   length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
 
   for i in 1:length(b)
@@ -993,7 +993,7 @@ function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{Int}})
 end
 
 # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-function (R::ZZMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where {T}
+function (R::ZZMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where T
   n = nvars(R)
   length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
   newa = map(ZZ, a)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -26,7 +26,7 @@ base_ring(a::ZZMPolyRing) = ZZ
 
 function internal_ordering(a::ZZMPolyRing)
   b = @ccall libflint.fmpz_mpoly_ctx_ord(a::Ref{ZZMPolyRing})::Cint
-  return flint_orderings[b + 1]
+  return flint_orderings[b+1]
 end
 
 function gens(R::ZZMPolyRing)
@@ -208,7 +208,7 @@ end
 function coeff(a::ZZMPolyRingElem, vars::Vector{Int}, exps::Vector{Int})
   unique(vars) != vars && error("Variables not unique")
   length(vars) != length(exps) &&
-  error("Number of variables does not match number of exponents")
+    error("Number of variables does not match number of exponents")
   z = parent(a)()
   vars = [UInt(i) - 1 for i in vars]
   for i = 1:length(vars)
@@ -289,7 +289,14 @@ end
 #
 ###############################################################################
 
-function ^(a::ZZMPolyRingElem, b::IntegerUnionOrPtr)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(a::ZZMPolyRingElem, b::Int)
+  is_negative(b) && throw(DomainError(b, "Exponent must be non-negative"))
+  return pow!(parent(a)(), a, b)
+end
+
+function ^(a::ZZMPolyRingElem, b::ZZRingElem)
   is_negative(b) && throw(DomainError(b, "Exponent must be non-negative"))
   return pow!(parent(a)(), a, b)
 end
@@ -323,7 +330,7 @@ end
 #
 ################################################################################
 
-function (::Type{Fac{ZZMPolyRingElem}})(fac::fmpz_mpoly_factor, preserve_input::Bool = true)
+function (::Type{Fac{ZZMPolyRingElem}})(fac::fmpz_mpoly_factor, preserve_input::Bool=true)
   R = fac.parent
   F = Fac{ZZMPolyRingElem}()
   empty!(F.fac)
@@ -431,7 +438,7 @@ end
 #
 ###############################################################################
 
-function divides(a::ZZMPolyRingElem, b::Union{IntegerUnion, ZZMPolyRingElem})
+function divides(a::ZZMPolyRingElem, b::Union{IntegerUnion,ZZMPolyRingElem})
   check_parent(a, b)
   z = zero(parent(a))
   iszero(a) && return true, z
@@ -527,7 +534,7 @@ function (a::ZZMPolyRingElem)(vals::Integer...)
   return evaluate(a, [vals...])
 end
 
-function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
+function (a::ZZMPolyRingElem)(vals::Union{NCRingElem,RingElement}...)
   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
   R = base_ring(a)
   # The best we can do here is to cache previously used powers of the values
@@ -536,7 +543,7 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
   # to optimise computing new powers in any way.
   # Note that this function accepts values in a non-commutative ring, so operations
   # must be done in a certain order.
-  powers = [Dict{Int, Any}() for i in 1:length(vals)]
+  powers = [Dict{Int,Any}() for i in 1:length(vals)]
   # First work out types of products
   r = R()
   c = zero(R)
@@ -545,11 +552,11 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
     W = typeof(vals[j])
     if ((W <: Integer && W != BigInt) ||
         (W <: Rational && W != Rational{BigInt}))
-      c = c*zero(W)
+      c = c * zero(W)
       U[j] = parent(c)
     else
       U[j] = parent(vals[j])
-      c = c*zero(parent(vals[j]))
+      c = c * zero(parent(vals[j]))
     end
   end
   for i = 1:length(a)
@@ -560,7 +567,7 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
       if !haskey(powers[j], exp)
         powers[j][exp] = (U[j](vals[j]))^exp
       end
-      t = t*powers[j][exp]
+      t = t * powers[j][exp]
     end
     r += t
   end
@@ -572,7 +579,7 @@ function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
   S = parent(bs[1])
 
   length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+    error("Number of variables does not match number of values")
 
   c = S()
   fl = @ccall libflint.fmpz_mpoly_compose_fmpz_mpoly(c::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZMPolyRingElem}}, R::Ref{ZZMPolyRing}, S::Ref{ZZMPolyRing})::Cint
@@ -585,7 +592,7 @@ function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZPolyRingElem})
   S = parent(bs[1])
 
   length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+    error("Number of variables does not match number of values")
 
   c = S()
   fl = @ccall libflint.fmpz_mpoly_compose_fmpz_poly(c::Ref{ZZPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZPolyRingElem}}, R::Ref{ZZMPolyRing})::Cint
@@ -636,7 +643,7 @@ function set!(z::ZZMPolyRingElem, a::UInt)
   return z
 end
 
-set!(z::ZZMPolyRingElem, a::Union{Integer, Rational}) = set!(z, flintify(a))
+set!(z::ZZMPolyRingElem, a::Union{Integer,Rational}) = set!(z, flintify(a))
 
 #
 
@@ -665,31 +672,31 @@ for (jT, cN, cT) in ((ZZRingElem, :fmpz, Ref{ZZRingElem}), (Int, :si, Int), (UIn
   @eval begin
     function add!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::$jT)
       @ccall libflint.$(string(:fmpz_mpoly_add_, cN))(z::Ref{ZZMPolyRingElem},
-                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function sub!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_sub_, cN))(z::Ref{ZZMPolyRingElem},
-                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function mul!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_scalar_mul_, cN))(z::Ref{ZZMPolyRingElem},
-                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function divexact!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       @ccall libflint.$(string(:fmpz_mpoly_scalar_divexact_, cN))(z::Ref{ZZMPolyRingElem},
-                a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
+        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Nothing
       return z
     end
 
     function divides!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, b::($jT))
       d = @ccall libflint.$(string(:fmpz_mpoly_scalar_divides_, cN))(z::Ref{ZZMPolyRingElem},
-                    a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Cint
+        a::Ref{ZZMPolyRingElem}, b::$cT, parent(a)::Ref{ZZMPolyRing})::Cint
       return Bool(d), z
     end
   end
@@ -854,7 +861,7 @@ end
 
 # Set the coefficient of the term with the given exponent vector to the
 setcoeff!(a::ZZMPolyRingElem, exps::Vector{Int}, b::Integer) =
-setcoeff!(a, exps, ZZRingElem(b))
+  setcoeff!(a, exps, ZZRingElem(b))
 
 # Sort the terms according to the ordering. This is only needed if unsafe
 # functions such as those above have been called and terms have been inserted
@@ -891,7 +898,7 @@ end
 #
 ###############################################################################
 
-promote_rule(::Type{ZZMPolyRingElem}, ::Type{V}) where {V <: Integer} = ZZMPolyRingElem
+promote_rule(::Type{ZZMPolyRingElem}, ::Type{V}) where {V<:Integer} = ZZMPolyRingElem
 
 promote_rule(::Type{ZZMPolyRingElem}, ::Type{ZZRingElem}) = ZZMPolyRingElem
 
@@ -917,7 +924,7 @@ function _push_term!(z::ZZMPolyRingElem, c::UInt, exp::Vector{Int})
 end
 
 function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
-    c::Union{ZZRingElem, Int, UInt}, expv::Vector{Int})
+  c::Union{ZZRingElem,Int,UInt}, expv::Vector{Int})
   if length(expv) != nvars(parent(M.poly))
     error("length of exponent vector should match the number of variables")
   end
@@ -926,7 +933,7 @@ function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
 end
 
 function push_term!(M::MPolyBuildCtx{ZZMPolyRingElem},
-    c::RingElement, expv::Vector{Int})
+  c::RingElement, expv::Vector{Int})
   push_term!(M, ZZ(c), expv)
   return M
 end
@@ -962,7 +969,7 @@ function (R::ZZMPolyRing)(a::ZZMPolyRingElem)
 end
 
 # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{T}}) where {T <: Union{ZZRingElem, UInt}}
+function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{T}}) where {T<:Union{ZZRingElem,UInt}}
   length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
 
   for i in 1:length(b)
@@ -986,7 +993,7 @@ function (R::ZZMPolyRing)(a::Vector{ZZRingElem}, b::Vector{Vector{Int}})
 end
 
 # Create poly with given array of coefficients and array of exponent vectors (sorting is performed)
-function (R::ZZMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where T
+function (R::ZZMPolyRing)(a::Vector{Any}, b::Vector{Vector{T}}) where {T}
   n = nvars(R)
   length(a) != length(b) && error("Coefficient and exponent vector must have the same length")
   newa = map(ZZ, a)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -289,18 +289,9 @@ end
 #
 ###############################################################################
 
-function ^(a::ZZMPolyRingElem, b::Int)
-  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-  z = parent(a)()
-  @ccall libflint.fmpz_mpoly_pow_ui(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, b::Int, parent(a)::Ref{ZZMPolyRing})::Nothing
-  return z
-end
-
-function ^(a::ZZMPolyRingElem, b::ZZRingElem)
-  b < 0 && throw(DomainError(b, "Exponent must be non-negative"))
-  z = parent(a)()
-  @ccall libflint.fmpz_mpoly_pow_fmpz(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, b::Ref{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Nothing
-  return z
+function ^(a::ZZMPolyRingElem, b::IntegerUnionOrPtr)
+  is_negative(b) && throw(DomainError(b, "Exponent must be non-negative"))
+  return pow!(parent(a)(), a, b)
 end
 
 ################################################################################
@@ -736,6 +727,24 @@ setcoeff!(a::ZZMPolyRingElem, i::Int, c::Integer) = setcoeff!(a, i, ZZRingElem(c
 function combine_like_terms!(a::ZZMPolyRingElem)
   @ccall libflint.fmpz_mpoly_combine_like_terms(a::Ref{ZZMPolyRingElem}, a.parent::Ref{ZZMPolyRing})::Nothing
   return a
+end
+
+#
+
+function pow!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, n::Integer)
+  ok = Bool(@ccall libflint.fmpz_mpoly_pow_ui(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, UInt(n)::UInt, parent(a)::Ref{ZZMPolyRing})::Cint)
+  if !ok
+    error("unable to compute power")
+  end
+  return z
+end
+
+function pow!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, n::ZZRingElemOrPtr)
+  ok = Bool(@ccall libflint.fmpz_mpoly_pow_fmpz(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Cint)
+  if !ok
+    error("unable to compute power")
+  end
+  return z
 end
 
 ###############################################################################

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -243,6 +243,11 @@ function reverse(x::ZZPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
+  @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
+  return z
+end
+
 ###############################################################################
 #
 #   Shifting
@@ -940,13 +945,6 @@ submul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr, ::
 
 function pow!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, e::IntegerUnion)
   @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, UInt(e)::UInt)::Nothing
-  return z
-end
-
-#
-
-function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
-  @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -941,6 +941,12 @@ submul!(z::ZZPolyRingElemOrPtr, a::IntegerUnionOrPtr, b::ZZPolyRingElemOrPtr) = 
 submul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::IntegerUnionOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
 submul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
 
+#
+
+function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
+  @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
+  return z
+end
 
 ###############################################################################
 #

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -158,11 +158,16 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZPolyRingElem, y::Int)
-  y < 0 && throw(DomainError(y, "Exponent must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Int)::Nothing
+function pow!(z::ZZPolyRingElem, x::ZZPolyRingElem, e::Int)
+  @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, e::Int)::Nothing
   return z
+end
+
+function ^(x::ZZPolyRingElem, e::Int)
+  if e < 0
+    throw(DomainError(e, "exponent must be non-negative"))
+  end
+  pow!(parent(x)(), x, e)
 end
 
 ###############################################################################
@@ -235,7 +240,10 @@ end
 
 function reverse(x::ZZPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
-  z = parent(x)()
+  return reverse!(parent(x)(), x, len)
+end
+
+function reverse!(z::ZZPolyRingElem, x::ZZPolyRingElem, len::Int)
   @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -158,12 +158,7 @@ end
 #
 ###############################################################################
 
-function pow!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, e::Int)
-  @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, e::Int)::Nothing
-  return z
-end
-
-function ^(x::ZZPolyRingElem, e::Int)
+function ^(x::ZZPolyRingElem, e::IntegerUnion)
   if e < 0
     throw(DomainError(e, "exponent must be non-negative"))
   end
@@ -241,11 +236,6 @@ end
 function reverse(x::ZZPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
   return reverse!(parent(x)(), x, len)
-end
-
-function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
-  @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
-  return z
 end
 
 ###############################################################################
@@ -940,6 +930,13 @@ submul!(z::ZZPolyRingElemOrPtr, a::IntegerUnionOrPtr, b::ZZPolyRingElemOrPtr) = 
 # ignore fourth argument
 submul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::IntegerUnionOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
 submul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
+
+#
+
+function pow!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, e::IntegerUnion)
+  @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, UInt(e)::UInt)::Nothing
+  return z
+end
 
 #
 

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -158,7 +158,7 @@ end
 #
 ###############################################################################
 
-function pow!(z::ZZPolyRingElem, x::ZZPolyRingElem, e::Int)
+function pow!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, e::Int)
   @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, e::Int)::Nothing
   return z
 end
@@ -167,7 +167,7 @@ function ^(x::ZZPolyRingElem, e::Int)
   if e < 0
     throw(DomainError(e, "exponent must be non-negative"))
   end
-  pow!(parent(x)(), x, e)
+  return pow!(parent(x)(), x, e)
 end
 
 ###############################################################################
@@ -243,7 +243,7 @@ function reverse(x::ZZPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
-function reverse!(z::ZZPolyRingElem, x::ZZPolyRingElem, len::Int)
+function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
   @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -159,7 +159,7 @@ end
 ###############################################################################
 
 function ^(x::ZZPolyRingElem, e::IntegerUnion)
-  if e < 0
+  if is_negative(e)
     throw(DomainError(e, "exponent must be non-negative"))
   end
   return pow!(parent(x)(), x, e)

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -158,11 +158,16 @@ end
 #
 ###############################################################################
 
-function ^(x::ZZPolyRingElem, e::IntegerUnion)
-  if is_negative(e)
-    throw(DomainError(e, "exponent must be non-negative"))
-  end
-  return pow!(parent(x)(), x, e)
+# Cannot use IntegerUnion here to avoid ambiguity.
+
+function ^(x::ZZPolyRingElem, n::Int)
+  is_negative(n) && throw(DomainError(n, "Exponent must be non-negative"))
+  return pow!(parent(x)(), x, n)
+end
+
+function ^(x::ZZPolyRingElem, n::ZZRingElem)
+  is_negative(n) && throw(DomainError(n, "Exponent must be non-negative"))
+  return pow!(parent(x)(), x, n)
 end
 
 ###############################################################################

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -257,9 +257,7 @@ end
 
 function reverse(x::FqPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fq_default_poly_reverse(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqField})::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ################################################################################
@@ -653,6 +651,11 @@ end
 
 function sub!(z::FqPolyRingElem, x::FqPolyRingElem, y::FqPolyRingElem)
   @ccall libflint.fq_default_poly_sub(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, y::Ref{FqPolyRingElem}, base_ring(parent(x))::Ref{FqField})::Nothing
+  return z
+end
+
+function reverse!(z::FqPolyRingElem, x::FqPolyRingElem, len::Int)
+  @ccall libflint.fq_default_poly_reverse(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqField})::Nothing
   return z
 end
 

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -260,6 +260,11 @@ function reverse(x::FqPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::FqPolyRingElem, x::FqPolyRingElem, len::Int)
+  @ccall libflint.fq_default_poly_reverse(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqField})::Nothing
+  return z
+end
+
 ################################################################################
 #
 #   Shifting
@@ -651,11 +656,6 @@ end
 
 function sub!(z::FqPolyRingElem, x::FqPolyRingElem, y::FqPolyRingElem)
   @ccall libflint.fq_default_poly_sub(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, y::Ref{FqPolyRingElem}, base_ring(parent(x))::Ref{FqField})::Nothing
-  return z
-end
-
-function reverse!(z::FqPolyRingElem, x::FqPolyRingElem, len::Int)
-  @ccall libflint.fq_default_poly_reverse(z::Ref{FqPolyRingElem}, x::Ref{FqPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqField})::Nothing
   return z
 end
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -268,6 +268,11 @@ function reverse(x::fqPolyRepPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::fqPolyRepPolyRingElem, x::fqPolyRepPolyRingElem, len::Int)
+  @ccall libflint.fq_nmod_poly_reverse(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
+  return z
+end
+
 ################################################################################
 #
 #   Shifting
@@ -659,11 +664,6 @@ end
 
 function sub!(z::fqPolyRepPolyRingElem, x::fqPolyRepPolyRingElem, y::fqPolyRepPolyRingElem)
   @ccall libflint.fq_nmod_poly_sub(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, y::Ref{fqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
-  return z
-end
-
-function reverse!(z::fqPolyRepPolyRingElem, x::fqPolyRepPolyRingElem, len::Int)
-  @ccall libflint.fq_nmod_poly_reverse(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
   return z
 end
 

--- a/src/flint/fq_nmod_poly.jl
+++ b/src/flint/fq_nmod_poly.jl
@@ -265,9 +265,7 @@ end
 
 function reverse(x::fqPolyRepPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fq_nmod_poly_reverse(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ################################################################################
@@ -661,6 +659,11 @@ end
 
 function sub!(z::fqPolyRepPolyRingElem, x::fqPolyRepPolyRingElem, y::fqPolyRepPolyRingElem)
   @ccall libflint.fq_nmod_poly_sub(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, y::Ref{fqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
+  return z
+end
+
+function reverse!(z::fqPolyRepPolyRingElem, x::fqPolyRepPolyRingElem, len::Int)
+  @ccall libflint.fq_nmod_poly_reverse(z::Ref{fqPolyRepPolyRingElem}, x::Ref{fqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{fqPolyRepField})::Nothing
   return z
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -265,9 +265,7 @@ end
 
 function reverse(x::FqPolyRepPolyRingElem, len::Int)
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.fq_poly_reverse(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ################################################################################
@@ -656,6 +654,11 @@ end
 
 function sub!(z::FqPolyRepPolyRingElem, x::FqPolyRepPolyRingElem, y::FqPolyRepPolyRingElem)
   @ccall libflint.fq_poly_sub(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, y::Ref{FqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
+  return z
+end
+
+function reverse!(z::FqPolyRepPolyRingElem, x::FqPolyRepPolyRingElem, len::Int)
+  @ccall libflint.fq_poly_reverse(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
   return z
 end
 

--- a/src/flint/fq_poly.jl
+++ b/src/flint/fq_poly.jl
@@ -268,6 +268,11 @@ function reverse(x::FqPolyRepPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::FqPolyRepPolyRingElem, x::FqPolyRepPolyRingElem, len::Int)
+  @ccall libflint.fq_poly_reverse(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
+  return z
+end
+
 ################################################################################
 #
 #   Shifting
@@ -654,11 +659,6 @@ end
 
 function sub!(z::FqPolyRepPolyRingElem, x::FqPolyRepPolyRingElem, y::FqPolyRepPolyRingElem)
   @ccall libflint.fq_poly_sub(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, y::Ref{FqPolyRepPolyRingElem}, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
-  return z
-end
-
-function reverse!(z::FqPolyRepPolyRingElem, x::FqPolyRepPolyRingElem, len::Int)
-  @ccall libflint.fq_poly_reverse(z::Ref{FqPolyRepPolyRingElem}, x::Ref{FqPolyRepPolyRingElem}, len::Int, base_ring(parent(x))::Ref{FqPolyRepField})::Nothing
   return z
 end
 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -339,9 +339,7 @@ end
 
 function reverse(x::T, len::Int) where T <: Zmodn_poly
   len < 0 && throw(DomainError(len, "Index must be non-negative"))
-  z = parent(x)()
-  @ccall libflint.nmod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int)::Nothing
-  return z
+  return reverse!(parent(x)(), x, len)
 end
 
 ###############################################################################
@@ -882,6 +880,11 @@ end
 
 function mul!(z::T, x::T, y::UInt) where T <: Zmodn_poly
   @ccall libflint.nmod_poly_scalar_mul_nmod(z::Ref{T}, x::Ref{T}, y::UInt)::Nothing
+  return z
+end
+
+function reverse!(z::T, x::T, len::Int) where T <: Zmodn_poly
+  @ccall libflint.nmod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int)::Nothing
   return z
 end
 

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -342,6 +342,11 @@ function reverse(x::T, len::Int) where T <: Zmodn_poly
   return reverse!(parent(x)(), x, len)
 end
 
+function reverse!(z::T, x::T, len::Int) where T <: Zmodn_poly
+  @ccall libflint.nmod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int)::Nothing
+  return z
+end
+
 ###############################################################################
 #
 #   Shifting
@@ -880,11 +885,6 @@ end
 
 function mul!(z::T, x::T, y::UInt) where T <: Zmodn_poly
   @ccall libflint.nmod_poly_scalar_mul_nmod(z::Ref{T}, x::Ref{T}, y::UInt)::Nothing
-  return z
-end
-
-function reverse!(z::T, x::T, len::Int) where T <: Zmodn_poly
-  @ccall libflint.nmod_poly_reverse(z::Ref{T}, x::Ref{T}, len::Int)::Nothing
   return z
 end
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -536,7 +536,7 @@ end
   @test isone(a^0) && isone(a^ZZRingElem(0))
 
   a = ZZRingElem(2)
-  @test_throws InexactError a^(a^200)
+  @test_throws ErrorException a^(a^200)
 
   for a in ZZRingElem.(-5:5)
     for e = -5:-1


### PR DESCRIPTION
Currently, there are no exact bindings for `fmpz_poly_pow` and `fmpz_poly_reverse`, only `^` and `reverse`. This PR adds the exact matches.