### PR TITLE
Fix an issue with parallel testing

### DIFF
--- a/test/calcium/qqbar-test.jl
+++ b/test/calcium/qqbar-test.jl
@@ -1,3 +1,5 @@
+import Nemo: AbstractAlgebra.PrettyPrinting
+
 @testset "QQBarFieldElem.conformance_tests" begin
   R = algebraic_closure(QQ)
   ConformanceTests.test_Field_interface(R)


### PR DESCRIPTION
The tests later in this file fail if they run on a different worker than all of `fmpq-test.jl`, `fmpz-test.jl`, and `fq_default_extended-test.jl`, since these three files already contain the added line.