### PR TITLE
Update FLINT to v3.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 AbstractAlgebra = "0.44.8"
-FLINT_jll = "~300.100.100"
+FLINT_jll = "~300.200.000"
 Libdl = "1.6"
 LinearAlgebra = "1.6"
 Random = "1.6"

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -112,8 +112,8 @@ julia> r = roots(n);
 
 julia> sort(r; by=x->(real(x), imag(x))) # sort roots to make printing consistent
 2-element Vector{ComplexFieldElem}:
- [-1.00 +/- 1.01e-4] + [-1.414 +/- 3.14e-4]*im
- [-1.00 +/- 1.01e-4] + [1.414 +/- 3.14e-4]*im
+ [-1.000 +/- 1.01e-4] + [-1.414 +/- 3.14e-4]*im
+ [-1.000 +/- 1.01e-4] + [1.414 +/- 3.14e-4]*im
 
 julia> p = y^7 - 1
 y^7 - 1.0000000000000000000
@@ -122,8 +122,8 @@ julia> r = roots(n, isolate_real = true);
 
 julia> sort(r; by=x->(real(x), imag(x))) # sort roots to make printing consistent
 2-element Vector{ComplexFieldElem}:
- [-1.00 +/- 1.01e-4] + [-1.414 +/- 3.14e-4]*im
- [-1.00 +/- 1.01e-4] + [1.414 +/- 3.14e-4]*im
+ [-1.000 +/- 1.01e-4] + [-1.414 +/- 3.14e-4]*im
+ [-1.000 +/- 1.01e-4] + [1.414 +/- 3.14e-4]*im
 ```
 
 ### Construction from roots


### PR DESCRIPTION
All other dependencies of Oscar are updated to use FLINT 3.2.0, this is the final piece in enabling it in Oscar.
The downstream tests will tell us if there are any issues.

Resolves https://github.com/oscar-system/Oscar.jl/issues/4732.