### PR TITLE
Restrict to FLINT 3.1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 AbstractAlgebra = "0.44.8"
-FLINT_jll = "^300.100.100"
+FLINT_jll = "~300.100.100"
 Libdl = "1.6"
 LinearAlgebra = "1.6"
 Random = "1.6"


### PR DESCRIPTION
To fix the doctest failures on master.

The alternative would be to adapt to the doctest changes (see https://github.com/Nemocas/Nemo.jl/pull/2051), but that would make Nemo and Oscar incompatible.

Ideally, I shoud've caught this when running the Nemo testsuite with the new FLINT_jll local build, but I must have forgotten the doctests.