### PR TITLE
chore: Bump to 0.49.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.49.1"
+version = "0.49.2"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
To be merged and released immediately after https://github.com/Nemocas/Nemo.jl/pull/2052 to have working CI on the latest release, thus making downstream testing in AA work again.