### PR TITLE
Add two missing `set_length!` methods for univariate polys

### DIFF
--- a/src/flint/fmpz_mod_poly.jl
+++ b/src/flint/fmpz_mod_poly.jl
@@ -35,6 +35,11 @@ end
 
 length(x::T) where {T <: Zmodn_fmpz_poly} = x.length
 
+function set_length!(x::T, n::Int) where {T <: Zmodn_fmpz_poly}
+  @ccall libflint._fmpz_mod_poly_set_length(x::Ref{T}, n::Int)::Nothing
+  return x
+end
+
 function degree(x::T) where {T <: Zmodn_fmpz_poly}
   return x.length - 1
   #   return @ccall libflint.fmpz_mod_poly_degree(x::Ref{T}, x.parent.base_ring.ninv::Ref{fmpz_mod_ctx_struct})::Int

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -64,7 +64,10 @@ end
 
 normalise(f::ZZPolyRingElem, ::Int) = degree(f) + 1
 
-set_length!(f::ZZPolyRingElem, ::Int) = nothing
+function set_length!(x::ZZPolyRingElem, n::Int)
+  @ccall libflint._fmpz_poly_set_length(x::Ref{ZZPolyRingElem}, n::Int)::Nothing
+  return x
+end
 
 ###############################################################################
 #

--- a/src/flint/nmod_poly.jl
+++ b/src/flint/nmod_poly.jl
@@ -54,6 +54,11 @@ end
 
 length(x::T) where T <: Zmodn_poly = x.length
 
+function set_length!(x::T, n::Int) where {T <: Zmodn_poly}
+  @ccall libflint._nmod_poly_set_length(x::Ref{T}, n::Int)::Nothing
+  return x
+end
+
 degree(x::T) where T <: Zmodn_poly = @ccall libflint.nmod_poly_degree(x::Ref{T})::Int
 
 function coeff(x::T, n::Int) where T <: Zmodn_poly


### PR DESCRIPTION
The univ poly interface of AA requires these methods to exist, but they were somehow missing for two types.

This should fix the downstream tests in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2039. 

cc @felix-roehrich 