### PR TITLE
RFC: redesign of the flint wrapper

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5279,6 +5279,19 @@ else
   end
 end
 
+# done right
+
+struct ZZRingElemDR
+  ptr::Ptr{ZZRingElem}
+  data #= can be anything where ptr points to (fmpz, fmpz_mat, fmpz_poly, ...) =#
+
+  ZZRingElemDR(x::ZZRingElem) = new(convert(Ptr{ZZRingElem}, pointer_from_objref(x)), x)
+  
+  ZZRingElemDR(x::ZZMatrix, i, j) = new(mat_entry_ptr(x, i, j), x)
+
+  ZZRingElemDR(x::ZZPolyRingElem, i) = new(x.coeffs + i * sizeof(Ptr{Nothing}), x)
+end
+
 ################################################################################
 #
 #   Type unions
@@ -5367,7 +5380,7 @@ const FlintMPolyUnion = Union{ZZMPolyRingElem, QQMPolyRingElem, zzModMPolyRingEl
                               fqPolyRepMPolyRingElem, FpMPolyRingElem}
 
 
-const ZZRingElemOrPtr = Union{ZZRingElem, Ref{ZZRingElem}, Ptr{ZZRingElem}}
+const ZZRingElemOrPtr = Union{ZZRingElem, Ref{ZZRingElem}, Ptr{ZZRingElem}, ZZRingElemDR}
 const QQFieldElemOrPtr = Union{QQFieldElem, Ref{QQFieldElem}, Ptr{QQFieldElem}}
 const zzModRingElemOrPtr = Union{zzModRingElem, Ref{zzModRingElem}, Ptr{zzModRingElem}}
 const ZZModRingElemOrPtr = Union{ZZModRingElem, Ref{ZZModRingElem}, Ptr{ZZModRingElem}}
@@ -5487,4 +5500,5 @@ for base in keys(base_rings), suffix in keys(constructions)
   name = Symbol(String(base)*String(suffix))
   Core.eval(parentmodule(DocstringInfo), :(Core.@doc $d $name))
 end
+
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -64,6 +64,15 @@ is_domain_type(::Type{ZZRingElem}) = true
 data(a::ZZRingElem) = a.d
 data(a::Ref{ZZRingElem}) = a[].d
 data(a::Ptr{ZZRingElem}) = unsafe_load(reinterpret(Ptr{Int}, a))
+data(a::ZZRingElemDR) = data(a.ptr)
+
+Base.cconvert(::Type{Ref{ZZRingElem}}, a::ZZRingElemDR) = a.ptr
+
+function ZZRingElem(a::ZZRingElemDR) 
+  b = ZZRingElem()
+  @ccall libflint.fmpz_set(b::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Bool
+  return b 
+end
 
 ###############################################################################
 #
@@ -311,6 +320,8 @@ string(x::ZZRingElem) = dec(x)
 
 show(io::IO, x::ZZRingElem) = print(io, string(x))
 
+show(io::IO, x::ZZRingElemDR) = print(io, ZZRingElem(x))
+
 function show(io::IO, a::ZZRing)
   # deliberately no @show_name or @show_special here as this is a singleton type
   if is_terse(io)
@@ -334,7 +345,7 @@ canonical_unit(x::ZZRingElem) = x < 0 ? ZZRingElem(-1) : ZZRingElem(1)
 #
 ###############################################################################
 
-function -(x::ZZRingElem)
+function -(x::Union{ZZRingElem, ZZRingElemDR})
   z = ZZRingElem()
   neg!(z, x)
   return z


### PR DESCRIPTION
## Motivation

The FLINT wrapper is inefficient when accessing elements of matrices or polynomials (or anything else nested). The problem is that to acesss `M[i, j]` we first create a new `fmpz` and then `fmpz_set` the elements. As a consequence, we now have a lot of `mat_entry_ptr` functions, which are very (very) unsafe and plenty of `ZZRingElemOrPtr` occurences.

## Possible solution

I had many discussions with @fieker and Dan over the last few years and here is one altenative design which is distilled from these discussions:

```julia
struct ZZRingElemDR
  ptr::Ptr{ZZRingElem}
  data #= can be anything where ptr points to (fmpz, fmpz_mat, fmpz_poly, ...) =#
end
```

("DR" stands for "done right", a tribute to Dan.)

The idea is to have an (immutable) layer on top of the raw `fmpz`, which holds a pointer to an `fmpz` together with "data". The "data" part is only there to keep the memory alive for the sake of the GC. It can be a `ZZRingElem`, or a `ZZMatrix` or a `ZZPolyRingElem`, and so on.

Together with some `Base.cconvert`, it is relatively easy to make this fly, see the diff:

```julia-repl
julia> a = Nemo.ZZRingElemDR(ZZ(2))
2

julia> -a
-2

julia> a = Nemo.ZZRingElemDR(ZZ[1 2; 1 1], 1, 2)
2

julia> is_unit(a)
false

julia> Zx, x = ZZ["x"]; f = x^3 + 213*x + 1;

julia> -Nemo.ZZRingElemDR(f, 1)
-213
```

The important point is that this is allocation free:

```julia-repl
julia> M = ZZ[1 2; 3 4];

julia> @ballocated getindex(M, 1, 1)
16

julia> @ballocated Nemo.ZZRingElemDR(M, 1, 2)
0
```

## What we gain

It will be easy to write generically fast code:
```julia
a = M[i, j]
mul!(b, a)
```
would be fast for any type (it is slow for FLINT types at the moment).

## Drawback

This increases the size of FLINT types. We add 16 bytes per object. For small `fmpz`, this makes them 2x(?) times larger. (At the moment they should be 8 bytes for the pointer/small int + 8 bytes because mutable).

## How much do we have to rewrte? Is it breaking?

It should be relatively easy. One would rename the current `ZZRingElem` to something else, like `ZZRingElemRaw` or `fmpz`. Then rename `ZZRingElemDR` to `ZZRingElem`. With the `Base.cconvert` trick, even the ccalls in Hecke/Oscar would be "easy" to adjust.

It "should" not be too breaking.

## Other advantage

We might even use this to have the raw flint layer (that can be constructed "automatically" from the headers as @lgoettgens demonstrated) and put all other things in the top layer (like parent objects etc).

CC: @fieker @fingolfin @lgoettgens 