### PR TITLE
fix: vcat/hcat with empty matrices

### DIFF
--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1561,9 +1561,13 @@ function AbstractAlgebra._vcat(A::AbstractVector{ZZMatrix})
   end
 
   M = zero_matrix(ZZ, sum(nrows, A, init = 0), ncols(A[1]))
+
   s = 0
   for N in A
     GC.@preserve M N begin
+      if ncols(N) == 0
+        continue
+      end
       for j in 1:nrows(N)
         M_ptr = mat_entry_ptr(M, s+j, 1)
         N_ptr = mat_entry_ptr(N, j, 1)
@@ -1582,13 +1586,17 @@ end
 
 function AbstractAlgebra._hcat(A::AbstractVector{ZZMatrix})
   if any(x -> nrows(x) != nrows(A[1]), A)
-    error("Matrices must have the same number of columns")
+    error("Matrices must have the same number of rows")
   end
 
   M = zero_matrix(ZZ, nrows(A[1]), sum(ncols, A, init = 0))
+
   s = 0
   for N in A
     GC.@preserve M N begin
+      if ncols(N) == 0
+        continue
+      end
       for j in 1:nrows(N)
         M_ptr = mat_entry_ptr(M, j, s+1)
         N_ptr = mat_entry_ptr(N, j, 1)

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -867,6 +867,15 @@ end
   @test reduce(vcat, [A, A]) == vcat(A, A) # -> _vcat
   @test cat(A, A, dims = 2) == vcat(A, A)
   @test_throws ErrorException cat(A, A, dims = 3)
+
+  @test reduce(vcat, [zero_matrix(ZZ, 0, 1), zero_matrix(ZZ, 0, 1)]) == zero_matrix(ZZ, 0, 1)
+  @test reduce(vcat, [zero_matrix(ZZ, 0, 0), zero_matrix(ZZ, 0, 0)]) == zero_matrix(ZZ, 0, 0)
+  @test reduce(vcat, [zero_matrix(ZZ, 1, 1), zero_matrix(ZZ, 0, 1)]) == zero_matrix(ZZ, 1, 1)
+  @test reduce(hcat, [zero_matrix(ZZ, 1, 0), zero_matrix(ZZ, 1, 0)]) == zero_matrix(ZZ, 1, 0)
+  @test reduce(hcat, [zero_matrix(ZZ, 1, 1), zero_matrix(ZZ, 1, 0)]) == zero_matrix(ZZ, 1, 1)
+
+  @test_throws ErrorException reduce(vcat, [ZZ[1 0;], ZZ[1 2 3;]])
+  @test_throws ErrorException reduce(hcat, [ZZ[1 0; 2 3], ZZ[1 2 3;]])
 end
 
 @testset "ZZMatrix.rand" begin


### PR DESCRIPTION
Otherwise the `mat_entry_ptr` call is not safe
