### PR TITLE
Unify `one` methods for matrix spaces

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -167,6 +167,7 @@ import AbstractAlgebra: @attributes
 import AbstractAlgebra: @show_name
 import AbstractAlgebra: @show_special
 import AbstractAlgebra: @show_special_elem
+import AbstractAlgebra: check_square
 import AbstractAlgebra: Dedent
 import AbstractAlgebra: div
 import AbstractAlgebra: divrem

--- a/src/arb/ComplexMat.jl
+++ b/src/arb/ComplexMat.jl
@@ -69,6 +69,7 @@ setindex!(x::ComplexMatrix, y::Tuple{Rational{T}, Rational{T}}, r::Int, c::Int) 
 setindex!(x, map(QQFieldElem, y), r, c)
 
 function one(x::ComplexMatrixSpace)
+  check_square(x)
   return one!(x())
 end
 

--- a/src/arb/RealMat.jl
+++ b/src/arb/RealMat.jl
@@ -57,6 +57,7 @@ Base.@propagate_inbounds setindex!(x::RealMatrix, y::Rational{T},
 setindex!(x, ZZRingElem(y), r, c)
 
 function one(x::RealMatrixSpace)
+  check_square(x)
   return one!(x())
 end
 

--- a/src/arb/acb_mat.jl
+++ b/src/arb/acb_mat.jl
@@ -71,6 +71,7 @@ setindex!(x::AcbMatrix, y::Tuple{Rational{T}, Rational{T}}, r::Int, c::Int) wher
 setindex!(x, map(QQFieldElem, y), r, c)
 
 function one(x::AcbMatrixSpace)
+  check_square(x)
   return one!(x())
 end
 

--- a/src/arb/arb_mat.jl
+++ b/src/arb/arb_mat.jl
@@ -59,6 +59,7 @@ Base.@propagate_inbounds setindex!(x::ArbMatrix, y::Rational{T},
 setindex!(x, ZZRingElem(y), r, c)
 
 function one(x::ArbMatrixSpace)
+  check_square(x)
   return one!(x())
 end
 

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -78,7 +78,7 @@ number_of_columns(a::T) where T <: Zmod_fmpz_mat = a.c
 base_ring(a::T) where T <: Zmod_fmpz_mat = a.base_ring
 
 function one(a::ZZModMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
+  check_square(a)
   return one!(a())
 end
 

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -73,8 +73,8 @@ end
 base_ring(a::FqMatrix) = a.base_ring
 
 function one(a::FqMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
-  return a(one(base_ring(a)))
+  check_square(a)
+  return one!(a())
 end
 
 function iszero(a::FqMatrix)

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -76,8 +76,8 @@ number_of_columns(a::FqPolyRepMatrix) = a.c
 base_ring(a::FqPolyRepMatrix) = a.base_ring
 
 function one(a::FqPolyRepMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
-  return a(one(base_ring(a)))
+  check_square(a)
+  return one!(a())
 end
 
 function iszero(a::FqPolyRepMatrix)

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -76,8 +76,8 @@ number_of_columns(a::fqPolyRepMatrix) = a.c
 base_ring(a::fqPolyRepMatrix) = a.base_ring
 
 function one(a::fqPolyRepMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
-  return a(one(base_ring(a)))
+  check_square(a)
+  return one!(a())
 end
 
 function iszero(a::fqPolyRepMatrix)

--- a/src/flint/gfp_fmpz_mat.jl
+++ b/src/flint/gfp_fmpz_mat.jl
@@ -85,15 +85,8 @@ number_of_columns(a::FpMatrix) = a.c
 base_ring(a::FpMatrix) = a.base_ring
 
 function one(a::FpMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
-  z = a()
-  @ccall libflint.fmpz_mod_mat_one(z::Ref{FpMatrix}, base_ring(a).ninv::Ref{fmpz_mod_ctx_struct})::Nothing
-  return z
-end
-
-function iszero(a::FpMatrix)
-  r = @ccall libflint.fmpz_mod_mat_is_zero(a::Ref{FpMatrix}, base_ring(a).ninv::Ref{fmpz_mod_ctx_struct})::Cint
-  return Bool(r)
+  check_square(a)
+  return one!(a())
 end
 
 @inline function is_zero_entry(A::FpMatrix, i::Int, j::Int)

--- a/src/flint/gfp_mat.jl
+++ b/src/flint/gfp_mat.jl
@@ -52,7 +52,7 @@ function deepcopy_internal(a::fpMatrix, dict::IdDict)
 end
 
 function one(a::fpMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
+  check_square(a)
   return one!(a())
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -86,7 +86,7 @@ number_of_columns(a::T) where T <: Zmodn_mat = a.c
 base_ring(a::T) where T <: Zmodn_mat = a.base_ring
 
 function one(a::zzModMatrixSpace)
-  (nrows(a) != ncols(a)) && error("Matrices must be square")
+  check_square(a)
   return one!(a())
 end
 

--- a/test/flint/fmpz_mod_mat-test.jl
+++ b/test/flint/fmpz_mod_mat-test.jl
@@ -227,7 +227,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(residue_ring(ZZ, ZZ(2))[1], 1, 2))
+  @test_throws DomainError one(matrix_space(residue_ring(ZZ, ZZ(2))[1], 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/fq_default_mat-test.jl
+++ b/test/flint/fq_default_mat-test.jl
@@ -269,7 +269,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(F9, 1, 2))
+  @test_throws DomainError one(matrix_space(F9, 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/fq_mat-test.jl
+++ b/test/flint/fq_mat-test.jl
@@ -253,7 +253,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(F9, 1, 2))
+  @test_throws DomainError one(matrix_space(F9, 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/fq_nmod_mat-test.jl
+++ b/test/flint/fq_nmod_mat-test.jl
@@ -253,7 +253,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(F9, 1, 2))
+  @test_throws DomainError one(matrix_space(F9, 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/gfp_fmpz_mat-test.jl
+++ b/test/flint/gfp_fmpz_mat-test.jl
@@ -228,7 +228,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(Native.GF(ZZ(2)), 1, 2))
+  @test_throws DomainError one(matrix_space(Native.GF(ZZ(2)), 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -273,7 +273,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(Native.GF(2), 1, 2))
+  @test_throws DomainError one(matrix_space(Native.GF(2), 1, 2))
 
   @test is_square(a)
 

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -269,7 +269,7 @@ end
 
   @test iszero(e)
 
-  @test_throws ErrorException one(matrix_space(residue_ring(ZZ, 2)[1], 1, 2))
+  @test_throws DomainError one(matrix_space(residue_ring(ZZ, 2)[1], 1, 2))
 
   @test is_square(a)
 


### PR DESCRIPTION
Also remove a redundant `iszero(a::FpMatrix)` method.