### PR TITLE
`hash(::ZZRingElem)` part that breaks printing

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -163,9 +163,7 @@ function hash_integer(a::ZZRingElem, h::UInt)
 end
 
 function hash(a::ZZRingElem, h::UInt)
-  @static if VERSION >= v"1.13.0-DEV.570" # TODO: remove the condition and instead always run the _is_small shortcut in a future breaking release of Nemo
-    _fmpz_is_small(a) && return Base.hash(data(a), h)
-  end
+  _fmpz_is_small(a) && return Base.hash(data(a), h)
   return hash_integer(a, h)
 end
 


### PR DESCRIPTION
This was taken out of https://github.com/Nemocas/Nemo.jl/pull/2077 to make that one non-breaking concerning doctests.