### PR TITLE
Add workaround for GLIBCXX issue with julia 1.6

### DIFF
--- a/.github/workflows/hecke.yml
+++ b/.github/workflows/hecke.yml
@@ -105,7 +105,7 @@ jobs:
                                            filename=\"${GITHUB_ENV}\");"
 
       - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '1.6' # && runner.os == 'Linux'
+        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         if: steps.setupdev.outputs.skiptests != 'true'

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -105,7 +105,7 @@ jobs:
                                            filename=\"${GITHUB_ENV}\");"
 
       - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '1.6' # && runner.os == 'Linux'
+        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         if: steps.setupdev.outputs.skiptests != 'true'


### PR DESCRIPTION
Like this @benlorenz?

I think we only need this for the Hecke and Oscar tests as those two may load Polymake.jl and run into the error mentioned in https://github.com/oscar-system/Oscar.jl/pull/3928#issuecomment-2894942860.
If this works, I'll provide similar PRs for the other packages with Oscar or Hecke downstream tests (AA, Hecke, Singular)