### PR TITLE
Add `expressify(::QQBarFieldElem)`

### DIFF
--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -87,7 +87,9 @@ end
 function expressify(a::QQBarFieldElem; context = nothing)
   R, _ = polynomial_ring(ZZ, :x; cached=false)
   f = minpoly(R, a)
-  return Expr(:sequence, Expr(:text, "Root "), Expr(:text, _native_string(a)), Expr(:text, " of "), expressify(f))
+
+  f_str = replace(string(f), "*" => "")
+  return Expr(:sequence, Expr(:text, "Root "), Expr(:text, _native_string(a)), Expr(:text, " of "), Expr(:text, f_str))
 end
 @enable_all_show_via_expressify QQBarFieldElem
 

--- a/test/calcium/qqbar-test.jl
+++ b/test/calcium/qqbar-test.jl
@@ -89,9 +89,7 @@ end
   @test PrettyPrinting.oneline(R) == "Algebraic closure of rational field"
   @test PrettyPrinting.supercompact(R) == "QQBar"
 
-  a = R(1)
-
-  @test string(a) == "Root 1.00000 of x - 1"
+  @test string(R(1)) == "Root 1.00000 of x - 1"
 
   @test string(-(QQBarFieldElem(10) ^ 20)) == "Root -1.00000e+20 of x + 100000000000000000000"
   @test string(root_of_unity(R, 3)) == "Root -0.500000 + 0.866025*im of x^2 + x + 1"


### PR DESCRIPTION
This fixes the printing of polys over qqbar, as reported by @laurentbartholdi on slack.

comparison of before/after:
```julia
julia> R = algebraic_closure(QQ);

julia> Ry, y = polynomial_ring(R, :y);

julia> f = 2 * y^3 - root(R(5), 3) * y^2 + sqrt(R(-1))
Root 2.00000 of x - 2*y^3 + Root -1.70998 of x^3 + 5*y^2 + Root 1.00000*im of x^2 + 1 # before
(Root 2.00000 of x - 2)*y^3 + (Root -1.70998 of x^3 + 5)*y^2 + (Root 1.00000*im of x^2 + 1) # after