### PR TITLE
rand for ComplexField & AcbField

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -1761,3 +1761,48 @@ end
 ################################################################################
 
 # see internal constructor
+
+################################################################################
+#
+#  Random generation
+#
+################################################################################
+
+@doc raw"""
+    rand(r::ComplexField; randtype::Symbol=:urandom)
+
+Return a random element in given Acb field.
+
+The `randtype` default is `:urandom` which return an `AcbFieldElem` contained in
+$[0,1]$.
+
+The rest of the methods return non-uniformly distributed values in order to
+exercise corner cases. The option `:randtest` will return a finite number, and
+`:randtest_exact` the same but with a zero radius. The option
+`:randtest_precise` return an `ArbFieldElem` with a radius around $2^{-\mathrm{prec}}$
+the magnitude of the midpoint, while `:randtest_wide` return a radius that
+might be big relative to its midpoint. The `:randtest_special`-option might
+return a midpoint and radius whose values are `NaN` or `inf`.
+"""
+function rand(r::ComplexField, prec::Int = precision(Balls); randtype::Symbol=:urandom)
+  state = _flint_rand_states[Threads.threadid()]
+  x = r()
+
+  if randtype == :urandom
+    @ccall libflint.acb_urandom(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int)::Nothing
+  elseif randtype == :randtest
+    @ccall libflint.acb_randtest(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_exact
+    @ccall libflint.acb_randtest_exact(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_precise
+    @ccall libflint.acb_randtest_precise(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_wide
+    @ccall libflint.acb_randtest_wide(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_special
+    @ccall libflint.acb_randtest_special(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  else
+    error("Acb random generation `" * String(randtype) * "` is not defined")
+  end
+
+  return x
+end

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -1771,18 +1771,20 @@ end
 @doc raw"""
     rand(r::ComplexField; randtype::Symbol=:urandom)
 
-Return a random element in given Acb field.
+Return a random element in the ComplexField.
 
-The `randtype` default is `:urandom` which return an `AcbFieldElem` contained in
-$[0,1]$.
+The `randtype` default is `:urandom` which generates a random complex
+number with precise real and imaginary parts, uniformly in the unit disk.
 
 The rest of the methods return non-uniformly distributed values in order to
-exercise corner cases. The option `:randtest` will return a finite number, and
-`:randtest_exact` the same but with a zero radius. The option
-`:randtest_precise` return an `ArbFieldElem` with a radius around $2^{-\mathrm{prec}}$
-the magnitude of the midpoint, while `:randtest_wide` return a radius that
-might be big relative to its midpoint. The `:randtest_special`-option might
-return a midpoint and radius whose values are `NaN` or `inf`.
+exercise corner cases.  The type `:randtest` will generate a random
+complex number by generating separate random real and imaginary parts.
+The type `:randtest_precise` generates a random complex number with precise
+real and imaginary parts.
+The type `:randtest_special` generates a random complex number by generating
+separate random real and imaginary parts; it may generate NaNs and infinities.
+The type `:randtest_param` generates a random complex number, with very high
+probability of generating integers and half-integers.
 """
 function rand(r::ComplexField, prec::Int = precision(Balls); randtype::Symbol=:urandom)
   state = _flint_rand_states[Threads.threadid()]
@@ -1792,16 +1794,14 @@ function rand(r::ComplexField, prec::Int = precision(Balls); randtype::Symbol=:u
     @ccall libflint.acb_urandom(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int)::Nothing
   elseif randtype == :randtest
     @ccall libflint.acb_randtest(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_exact
-    @ccall libflint.acb_randtest_exact(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_precise
-    @ccall libflint.acb_randtest_precise(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_wide
-    @ccall libflint.acb_randtest_wide(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
   elseif randtype == :randtest_special
     @ccall libflint.acb_randtest_special(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_precise
+    @ccall libflint.acb_randtest_precise(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_param
+    @ccall libflint.acb_randtest_param(x::Ref{ComplexFieldElem}, state::Ref{rand_ctx}, prec::Int, 30::Int)::Nothing
   else
-    error("Acb random generation `" * String(randtype) * "` is not defined")
+    error("ComplexField random generation `" * String(randtype) * "` is not defined")
   end
 
   return x

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1772,3 +1772,48 @@ end
 ################################################################################
 
 # see internal constructor
+
+################################################################################
+#
+#  Random generation
+#
+################################################################################
+
+@doc raw"""
+    rand(r::AcbField; randtype::Symbol=:urandom)
+
+Return a random element in given Acb field.
+
+The `randtype` default is `:urandom` which returns an `AcbFieldElem` contained in
+the closed unit disc.
+
+The rest of the methods return non-uniformly distributed values in order to
+exercise corner cases. The option `:randtest` will return a finite number, and
+`:randtest_exact` the same but with a zero radius. The option
+`:randtest_precise` return an `ArbFieldElem` with a radius around $2^{-\mathrm{prec}}$
+the magnitude of the midpoint, while `:randtest_wide` return a radius that
+might be big relative to its midpoint. The `:randtest_special`-option might
+return a midpoint and radius whose values are `NaN` or `inf`.
+"""
+function rand(r::AcbField; randtype::Symbol=:urandom)
+  state = _flint_rand_states[Threads.threadid()]
+  x = r()
+
+  if randtype == :urandom
+    @ccall libflint.acb_urandom(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int)::Nothing
+  elseif randtype == :randtest
+    @ccall libflint.acb_randtest(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_exact
+    @ccall libflint.acb_randtest_exact(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_precise
+    @ccall libflint.acb_randtest_precise(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_wide
+    @ccall libflint.acb_randtest_wide(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_special
+    @ccall libflint.acb_randtest_special(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  else
+    error("Acb random generation `" * String(randtype) * "` is not defined")
+  end
+
+  return x
+end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1784,16 +1784,18 @@ end
 
 Return a random element in given Acb field.
 
-The `randtype` default is `:urandom` which returns an `AcbFieldElem` contained in
-the closed unit disc.
+The `randtype` default is `:urandom` which generates a random complex
+number with precise real and imaginary parts, uniformly in the unit disk.
 
 The rest of the methods return non-uniformly distributed values in order to
-exercise corner cases. The option `:randtest` will return a finite number, and
-`:randtest_exact` the same but with a zero radius. The option
-`:randtest_precise` return an `ArbFieldElem` with a radius around $2^{-\mathrm{prec}}$
-the magnitude of the midpoint, while `:randtest_wide` return a radius that
-might be big relative to its midpoint. The `:randtest_special`-option might
-return a midpoint and radius whose values are `NaN` or `inf`.
+exercise corner cases.  The type `:randtest` will generate a random
+complex number by generating separate random real and imaginary parts.
+The type `:randtest_precise` generates a random complex number with precise
+real and imaginary parts.
+The type `:randtest_special` generates a random complex number by generating
+separate random real and imaginary parts; it may generate NaNs and infinities.
+The type `:randtest_param` generates a random complex number, with very high
+probability of generating integers and half-integers.
 """
 function rand(r::AcbField; randtype::Symbol=:urandom)
   state = _flint_rand_states[Threads.threadid()]
@@ -1803,14 +1805,12 @@ function rand(r::AcbField; randtype::Symbol=:urandom)
     @ccall libflint.acb_urandom(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int)::Nothing
   elseif randtype == :randtest
     @ccall libflint.acb_randtest(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_exact
-    @ccall libflint.acb_randtest_exact(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_precise
-    @ccall libflint.acb_randtest_precise(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
-  elseif randtype == :randtest_wide
-    @ccall libflint.acb_randtest_wide(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
   elseif randtype == :randtest_special
     @ccall libflint.acb_randtest_special(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_precise
+    @ccall libflint.acb_randtest_precise(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
+  elseif randtype == :randtest_param
+    @ccall libflint.acb_randtest_param(x::Ref{AcbFieldElem}, state::Ref{rand_ctx}, r.prec::Int, 30::Int)::Nothing
   else
     error("Acb random generation `" * String(randtype) * "` is not defined")
   end

--- a/test/arb/Complex-test.jl
+++ b/test/arb/Complex-test.jl
@@ -493,6 +493,29 @@ end
   end
 end
 
+@testset "ComplexFieldElem.rand" begin
+  C = ComplexField()
+
+  n = 100
+  for _ in 1:n
+    rnd_default = rand(C)
+    rnd_urandom = rand(C; randtype = :urandom)
+    rnd_randtest = rand(C; randtype = :randtest)
+    rnd_special = rand(C; randtype = :randtest_special)
+    rnd_precise = rand(C; randtype = :randtest_precise)
+    rnd_param = rand(C; randtype = :randtest_param)
+
+    @test abs(rnd_default) <= 1
+    @test abs(rnd_urandom) <= 1
+    @test isfinite(rnd_randtest)
+    @test isfinite(rnd_precise)
+    @test isfinite(rnd_param)
+    @test rnd_special isa ComplexFieldElem
+    @test rnd_param isa ComplexFieldElem
+  end
+end
+
+
 @testset "ComplexFieldElem.integration" begin
   res = Nemo.integrate(CC, x->x,  -1, 1)
   @test contains(res, CC(0))

--- a/test/arb/acb-test.jl
+++ b/test/arb/acb-test.jl
@@ -478,3 +478,25 @@ end
 
   CC = AcbField(64)
 end
+
+@testset "AcbFieldElem.rand" begin
+  C = AcbField(64)
+
+  n = 100
+  for _ in 1:n
+    rnd_default = rand(C)
+    rnd_urandom = rand(C; randtype = :urandom)
+    rnd_randtest = rand(C; randtype = :randtest)
+    rnd_special = rand(C; randtype = :randtest_special)
+    rnd_precise = rand(C; randtype = :randtest_precise)
+    rnd_param = rand(C; randtype = :randtest_param)
+
+    @test abs(rnd_default) <= 1
+    @test abs(rnd_urandom) <= 1
+    @test isfinite(rnd_randtest)
+    @test isfinite(rnd_precise)
+    @test isfinite(rnd_param)
+    @test rnd_special isa AcbFieldElem
+    @test rnd_param isa AcbFieldElem
+  end
+end


### PR DESCRIPTION
Resolves #2094. I copied the `rand` functions for `RealField` and `ArbField`.  It seems to compile fine.  No tests -- how to do so?