### PR TITLE
Implement `krull_dim` and `is_noetherian` for `ZZRing`, `ZZModRing` and `zzModRing`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /docs/build/
 Manifest.toml
 .DS_Store
+docs/src/developer/img/types.svg
+docs/src/developer/img/types2.svg

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -389,6 +389,7 @@ export j_invariant
 export jacobi_symbol
 export jacobi_theta
 export kronecker_symbol
+export krull_dim
 export laurent_series_field
 export laurent_series_ring
 export lcm

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -350,6 +350,7 @@ export is_less_root_order
 export is_lower_triangular
 export is_negative
 export is_negative_entry
+export is_noetherian
 export is_nonnegative
 export is_nonpositive
 export is_nonzero

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -180,6 +180,7 @@ import AbstractAlgebra: get_cached!
 import AbstractAlgebra: Group
 import AbstractAlgebra: howell_form!
 import AbstractAlgebra: Indent
+import AbstractAlgebra: is_noetherian
 import AbstractAlgebra: is_terse
 import AbstractAlgebra: is_zero_initialized
 import AbstractAlgebra: krull_dim

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -182,6 +182,7 @@ import AbstractAlgebra: howell_form!
 import AbstractAlgebra: Indent
 import AbstractAlgebra: is_terse
 import AbstractAlgebra: is_zero_initialized
+import AbstractAlgebra: krull_dim
 import AbstractAlgebra: Lowercase
 import AbstractAlgebra: LowercaseOff
 import AbstractAlgebra: Module

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -209,6 +209,8 @@ one(::Type{ZZRingElem}) = ZZRingElem(1)
 
 zero(::Type{ZZRingElem}) = ZZRingElem(0)
 
+krull_dim(::ZZRing) = 1
+
 @doc raw"""
     sign(a::ZZRingElem)
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -211,6 +211,8 @@ zero(::Type{ZZRingElem}) = ZZRingElem(0)
 
 krull_dim(::ZZRing) = 1
 
+is_noetherian(::ZZRing) = true
+
 @doc raw"""
     sign(a::ZZRingElem)
 

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -61,6 +61,8 @@ function krull_dim(R::ZZModRing)
   return is_prime(modulus(R)) ? 0 : 1
 end
 
+is_noetherian(::ZZModRing) = true
+
 characteristic(R::ZZModRing) = modulus(R)
 
 is_trivial(a::ZZModRing) = is_one(modulus(a))  # constructor ensures the modulus is > 0

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -56,6 +56,11 @@ is_unit(a::ZZModRingElem) = a.parent.n == 1 ? iszero(a.data) : isone(gcd(a.data,
 
 modulus(R::ZZModRing) = R.n
 
+function krull_dim(R::ZZModRing)
+  modulus(R) == 1 && error("Function `krull_dim` gives wrong answers if the base ring is the zero ring.")
+  return is_prime(modulus(R)) ? 0 : 1
+end
+
 characteristic(R::ZZModRing) = modulus(R)
 
 is_trivial(a::ZZModRing) = is_one(modulus(a))  # constructor ensures the modulus is > 0

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -54,6 +54,11 @@ isone(a::zzModRingElem) = (a.parent.n == 1) || (a.data == 1)
 
 modulus(R::zzModRing) = R.n
 
+function krull_dim(R::zzModRing)
+  modulus(R) == 1 && error("Function `krull_dim` gives wrong answers if the base ring is the zero ring.")
+  return is_prime(modulus(R)) ? 0 : 1
+end
+
 characteristic(R::zzModRing) = ZZRingElem(modulus(R))
 
 is_trivial(a::zzModRing) = is_unit(modulus(a))

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -59,6 +59,8 @@ function krull_dim(R::zzModRing)
   return is_prime(modulus(R)) ? 0 : 1
 end
 
+is_noetherian(::zzModRing) = true
+
 characteristic(R::zzModRing) = ZZRingElem(modulus(R))
 
 is_trivial(a::zzModRing) = is_unit(modulus(a))


### PR DESCRIPTION
Added krull_dim for some rings not covered in AbstractAlgebra. This partially has the PR oscar-system/Oscar.jl#4967 and issue oscar-system/Oscar.jl#4606 in mind.
@fingolfin 