### PR TITLE
Use `flint_set_throw` to throw julia errors from FLINT

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -214,8 +214,61 @@ using FLINT_jll: libflint
 
 const pkgdir = realpath(joinpath(dirname(@__DIR__)))
 
+###############################################################################
+#
+#   Flint Exception handling
+#
+###############################################################################
+
 function flint_abort()
   error("Problem in the FLINT-Subsystem")
+end
+
+@enum FlintExceptionType begin
+  FLINT_ERROR
+  FLINT_OVERFLOW
+  FLINT_IMPINV
+  FLINT_DOMERR
+  FLINT_DIVZERO
+  FLINT_EXPOF
+  FLINT_INEXACT
+  FLINT_TEST_FAIL
+end
+
+struct FlintException <: Exception
+  type::FlintExceptionType
+  msg::String
+end
+
+function Base.showerror(io::IO, e::FlintException)
+  print(io, "Flint Exception (")
+  if e.type == FLINT_ERROR
+    print(io, "General error")
+  elseif e.type == FLINT_OVERFLOW
+    print(io, "Overflow")
+  elseif e.type == FLINT_IMPINV
+    print(io, "Impossible inverse")
+  elseif e.type == FLINT_DOMERR
+    print(io, "Domain error")
+  elseif e.type == FLINT_DIVZERO
+    print(io, "Divide by zero")
+  elseif e.type == FLINT_EXPOF
+    print(io, "Exponent overflow")
+  elseif e.type == FLINT_INEXACT
+    print(io, "Inexact")
+  elseif e.type == FLINT_TEST_FAIL
+    print(io, "Test failure")
+  else
+    print(io, "Unknown exception")
+  end
+  print(io, "):\n")
+  print(io, strip(e.msg))
+end
+
+function flint_throw(err_type::FlintExceptionType, cmsg::Cstring)
+  msg = unsafe_string(cmsg)
+
+  throw(FlintException(err_type, msg))
 end
 
 ################################################################################
@@ -355,6 +408,7 @@ function __init__()
   end
 
   @ccall libflint.flint_set_abort(@cfunction(flint_abort, Nothing, ())::Ptr{Nothing})::Nothing
+  @ccall libflint.flint_set_throw(@cfunction(flint_throw, Nothing, (FlintExceptionType, Cstring))::Ptr{Nothing})::Nothing
 
   add_verbosity_scope(:UnimodVerif)
 


### PR DESCRIPTION
This works ok now. In particular, if an error is caught it does no longer print anything.
However, interpolation of variables into the message does not work, leading to messages like

```julia
julia> @ccall Nemo.libflint.n_invmod(2::UInt, 4::UInt)::UInt
ERROR: Flint Exception (Impossible inverse):
Cannot invert modulo %wd*%wd
Stacktrace:
 [1] flint_throw(err_type::Nemo.FlintExceptionType, cmsg::Cstring)
   @ Nemo ~/code/julia/Nemo.jl/src/Nemo.jl:271
 [2] top-level scope
   @ ./REPL[2]:1
```

To propely interpolate, on needs to take care of the `va_list` argument from FLINT (which is not officiallly supported by julia), but as long as we just pass it back to FLINT it is fine to assume it is a `Ptr{Cvoid}` in julia. This can get passed to `flint_vprintf` for interpolation, but this needs a workaround to be redirected to a string (as this needs to all happen inside of `flint_throw` and not only later when the error is printed).
The main problem with adding this is that I don't manage to access `va_end` from `stdarg.h` from within julia to clean up the `va_list` argument after it has been used. This leads to parts of the current error message getting included into the next error message again.