### PR TITLE
Trivial rings have Krull dimension -inf

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -57,7 +57,7 @@ is_unit(a::ZZModRingElem) = a.parent.n == 1 ? iszero(a.data) : isone(gcd(a.data,
 modulus(R::ZZModRing) = R.n
 
 function krull_dim(R::ZZModRing)
-  is_trivial(R) && -inf
+  is_trivial(R) && return -inf
   return is_prime(modulus(R)) ? 0 : 1
 end
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -55,7 +55,7 @@ isone(a::zzModRingElem) = (a.parent.n == 1) || (a.data == 1)
 modulus(R::zzModRing) = R.n
 
 function krull_dim(R::zzModRing)
-  is_trivial(R) && -inf
+  is_trivial(R) && return -inf
   return is_prime(modulus(R)) ? 0 : 1
 end
 


### PR DESCRIPTION
This is based on the discussion at <https://github.com/oscar-system/Oscar.jl/pull/4967#discussion_r2162234215>

If we ultimately agree to do that, then we should apply this PR for consistency.

@emikelsons please prepare another PR for Nemo.jl which adds some `krull_dim` tests to Nemo. Basically `fmpz-test.jl`, `fmpz_poly-test.jl`, `fmpz_mpoly-test.jl`, and their `fmpq`/`fmpz_mod`/`nmod` counterparts could get some short tests inserted. (You can prepare one now and hopefully at the latest during next triage we know how the tests for the trivial rings among them should look like ;-) ).

CC @thofma @fieker @lgoettgens 