### PR TITLE
Add `krull_dim` tests for trivial rings

### DIFF
--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -57,7 +57,7 @@ is_unit(a::ZZModRingElem) = a.parent.n == 1 ? iszero(a.data) : isone(gcd(a.data,
 modulus(R::ZZModRing) = R.n
 
 function krull_dim(R::ZZModRing)
-  @req !is_trivial(R) "`krull_dim` is not supported for trivial rings"
+  is_trivial(R) && return -inf
   return is_prime(modulus(R)) ? 0 : 1
 end
 

--- a/src/flint/nmod.jl
+++ b/src/flint/nmod.jl
@@ -55,7 +55,7 @@ isone(a::zzModRingElem) = (a.parent.n == 1) || (a.data == 1)
 modulus(R::zzModRing) = R.n
 
 function krull_dim(R::zzModRing)
-  @req !is_trivial(R) "`krull_dim` is not supported for trivial rings"
+  is_trivial(R) && return -inf
   return is_prime(modulus(R)) ? 0 : 1
 end
 

--- a/test/flint/fmpz_mod-test.jl
+++ b/test/flint/fmpz_mod-test.jl
@@ -3,6 +3,7 @@
   # right, e.g. isone(one(S))==false when S is a univariate polynomial ring
   # over the null ring
   ConformanceTests.test_Ring_interface(residue_ring(ZZ, ZZ(1))[1])
+  @test krull_dim(residue_ring(ZZ, ZZ(1))[1]) == -inf
   for i in [6, 13, 2^8, 2^16, 2^32, next_prime(2^8), next_prime(2^16), next_prime(2^32)]
     ConformanceTests.test_Ring_interface_recursive(residue_ring(ZZ, ZZ(i))[1])
   end

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -68,6 +68,10 @@
   Rx,  = polynomial_ring(R, "x")
   @test base_ring(Rx) === R
   @test Rx === polynomial_ring(R, "x")[1]
+
+  R, = residue_ring(ZZ, ZZ(1))
+  Rx,  = polynomial_ring(R, "x")
+  @test krull_dim(Rx) == -inf
 end
 
 @testset "ZZModPolyRingElem.printing" begin

--- a/test/flint/nmod-test.jl
+++ b/test/flint/nmod-test.jl
@@ -3,6 +3,7 @@
   # right, e.g. isone(one(S))==false when S is a univariate polynomial ring
   # over the null ring
   ConformanceTests.test_Ring_interface(residue_ring(ZZ, 1)[1])
+  @test krull_dim(residue_ring(ZZ, 1)[1]) == -inf
   for i in [6, 13, 2^8, 2^16, 2^32, next_prime(2^8), next_prime(2^16), next_prime(2^32)]
     ConformanceTests.test_Ring_interface_recursive(residue_ring(ZZ, i)[1])
   end

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -93,6 +93,12 @@
   @test_throws ErrorException push_term!(M, one(RR), zeros(Int, 2))
 end
 
+@testset "zzModMPolyRingElem.trivial_rings"
+  R, = residue_ring(ZZ, 1)
+  S, = polynomial_ring(R, ["x", "y"])
+  @test krull_dim(S) == -inf
+end
+
 @testset "zzModMPolyRingElem.printing" begin
   S, (x, y) = polynomial_ring(residue_ring(ZZ, 23)[1], ["x", "y"])
 

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -14,6 +14,10 @@
   @test parent_type(zzModPolyRingElem) == zzModPolyRing
   @test dense_poly_type(zzModRingElem) == zzModPolyRingElem
 
+  R2, = residue_ring(ZZ, 1)
+  R2x,  = polynomial_ring(R2, "x")
+  @test krull_dim(R2x) == -inf
+
   S, = residue_ring(ZZ, 19)
   Sy, y = polynomial_ring(R, "y")
 


### PR DESCRIPTION
This is based on  #2116 . 
The only trivial rings I found were `residue_ring(ZZ, 1)`, `residue_ring(ZZ, ZZ(1))` and constructions were these were the coefficient ring. I could of course add some tests for regular rings here, though a lot of them are covered by tests in AA already.
CC @fingolfin 