### PR TITLE
Bump julia compat to 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6'
           - '1.10'
           - '1.11'
           - 'nightly'

--- a/.github/workflows/hecke.yml
+++ b/.github/workflows/hecke.yml
@@ -104,9 +104,6 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
-      - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
-        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         if: steps.setupdev.outputs.skiptests != 'true'
         run: |

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -104,9 +104,6 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
-      - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
-        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         if: steps.setupdev.outputs.skiptests != 'true'
         run: |

--- a/.github/workflows/singular.yml
+++ b/.github/workflows/singular.yml
@@ -104,9 +104,6 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
-      - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
-        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         if: steps.setupdev.outputs.skiptests != 'true'
         run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.50.3"
+version = "0.51.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -12,11 +12,11 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-AbstractAlgebra = "0.45.0"
+AbstractAlgebra = "0.46.0"
 FLINT_jll = "~301.300.000"
 LinearAlgebra = "1.6"
 Random = "1.6"
 RandomExtensions = "0.4.2"
 SHA = "~1.6, ~1.7, 0.7"
 TOML = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -40,7 +40,7 @@ Nemo depends on AbstractAlgebra.jl which provides Nemo with generic routines for
 
 ## Installation
 
-To use Nemo we require Julia 1.6 or higher. Please see
+To use Nemo we require Julia 1.10 or higher. Please see
 <https://julialang.org/downloads/> for instructions on
 how to obtain julia for your system.
 

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -1654,7 +1654,7 @@ end
   @test range(ZZRingElem(0); step=2, stop=6) == ZZRingElem(0):ZZRingElem(2):ZZRingElem(6)
   @test range(0; step=ZZRingElem(2), stop=6) == ZZRingElem(0):ZZRingElem(2):ZZRingElem(6)
   @test range(ZZRingElem(0); step=2, length=4) == ZZRingElem(0):ZZRingElem(2):ZZRingElem(6)
-  VERSION >= v"1.7" && @test range(; stop=ZZRingElem(0), length=3) == ZZRingElem(-2):ZZRingElem(0)
+  @test range(; stop=ZZRingElem(0), length=3) == ZZRingElem(-2):ZZRingElem(0)
 
   @test 1 .+ r04 == ZZRingElem(1):ZZRingElem(5)
   @test ZZRingElem(1) .+ r04 == ZZRingElem(1):ZZRingElem(5)


### PR DESCRIPTION
This gets a breaking label as we wanna release this in a minor release. This makes it possible to still backport things to julia 1.6 with the 0.50.x release series.

Closes #2124. 