### PR TITLE
add `size(::FqField)`, delegating to `order`

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -460,6 +460,10 @@ function size(F::FpField)
   return order(F)
 end
 
+function size(F::FqField)
+  return order(F)
+end
+
 function order(R::zzModRing)
   return ZZRingElem(R.n)
 end


### PR DESCRIPTION
This was missing, `Oscar.DiscLog.generator(GF(4))` runs into an error.