### PR TITLE
Use `Base.pkgversion` to query Nemo version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 AbstractAlgebra = "0.46.0"
@@ -18,5 +17,4 @@ LinearAlgebra = "1.6"
 Random = "1.6"
 RandomExtensions = "0.4.2"
 SHA = "~1.6, ~1.7, 0.7"
-TOML = "<0.0.1, 1"
 julia = "1.10"

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -12,8 +12,6 @@ import Random: rand!
 
 using RandomExtensions: RandomExtensions, make, Make2, Make3
 
-import TOML
-
 import SHA
 
 # N.B: do not import div, divrem from Base

--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -331,14 +331,15 @@ end
 
 const __isthreaded = Ref(false)
 
+const NEMO_VERSION = Base.pkgversion(@__MODULE__)
+
 function show_banner()
-  PROJECT_TOML = TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))
-  VERSION_NUMBER = PROJECT_TOML["version"]
+  version_string = string(NEMO_VERSION)
   if isdir(joinpath(@__DIR__, "..", ".git"))
-    VERSION_NUMBER *= "-dev"
+    version_string *= "-dev"
   end
   println("")
-  println("Welcome to Nemo version $VERSION_NUMBER")
+  println("Welcome to Nemo version $(version_string)")
   println("")
   println("Nemo comes with absolutely no warranty whatsoever")
 end


### PR DESCRIPTION
instead of parsing the Project.toml ourselves. This function is available since julia 1.9.