### PR TITLE
fix: dispatch for minpoly(::ZZPolyRingElem) and QQPolyRingElem

### DIFF
--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -404,6 +404,8 @@ function minpoly(R::QQPolyRing, x::QQMatrix)
   return z
 end
 
+minpoly(x::QQMatrix) = minpoly(polynomial_ring(QQ; cached = false)[1], x)
+
 ###############################################################################
 #
 #   Determinant

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -630,6 +630,8 @@ function minpoly(R::ZZPolyRing, x::ZZMatrix)
   return z
 end
 
+minpoly(x::ZZMatrix) = minpoly(polynomial_ring(ZZ; cached = false)[1], x)
+
 ###############################################################################
 #
 #   Determinant

--- a/test/flint/fmpq_mat-test.jl
+++ b/test/flint/fmpq_mat-test.jl
@@ -838,6 +838,10 @@ end
   A = S([QQFieldElem(2) 3 5; 1 4 7; 9 6 3])
 
   @test charpoly(R, A) == x^3 - 9*x^2 - 64*x + 30
+
+  M = QQ[1 1 0 0; 0 1 0 0; 0 0 1 1; 0 0 0 1]
+  Qx, x = QQ[:x]
+  @test charpoly(M)(x) == (x^2 - 2*x + 1)^2
 end
 
 @testset "QQMatrix.minpoly" begin
@@ -858,6 +862,10 @@ end
   end
 
   @test degree(minpoly(R, M)) == 5
+
+  M = QQ[1 1 0 0; 0 1 0 0; 0 0 1 1; 0 0 0 1]
+  Qx, x = QQ[:x]
+  @test minpoly(M)(x) == x^2 - 2*x + 1
 end
 
 @testset "QQMatrix.rand" begin

--- a/test/flint/fmpz_mat-test.jl
+++ b/test/flint/fmpz_mat-test.jl
@@ -554,6 +554,13 @@ end
   end
 end
 
+@testset "ZZMatrix.minpoly_charpoly" begin
+  M = ZZ[1 1 0 0; 0 1 0 0; 0 0 1 1; 0 0 0 1]
+  Zx, x = ZZ[:x]
+  @test minpoly(M)(x) == x^2 - 2*x + 1
+  @test charpoly(M)(x) == (x^2 - 2*x + 1)^2
+end
+
 @testset "ZZMatrix.hnf" begin
   S = matrix_space(ZZ, 3, 3)
 


### PR DESCRIPTION
We would expect to charpoly(::MatElem) to fall back to
charpoly(R::PolyRingElem, M::MatElem), but the "generic"
charpoly(::MatElem) method in AbstractAlgebra has an additional
non-generic optional argument, which messes up everything.
