### PR TITLE
chg: `//(a::QQMPolyRingElem, b::($jT))`

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -283,7 +283,7 @@ for jT in (QQFieldElem, ZZRingElem, Integer, Rational)
 
     divexact(a::QQMPolyRingElem, b::($jT); check::Bool=true) = divexact!(parent(a)(), a, b)
 
-    //(a::QQMPolyRingElem, b::($jT)) = a//parent(a)(b)
+    //(a::QQMPolyRingElem, b::($jT)) = a*(1/QQ(b))
   end
 end
 


### PR DESCRIPTION
Make `//(a::QQMPolyRingElem, b::($jT))` return `QQMPolyRingElem` and not `FracFieldElem{QQMPolyRingElem}`

Coefficients are displayed using `//`, so it would be good if using `//` does not change the type.

```
julia> R,(x,y,z) = QQ["x","y","z"]
(Multivariate polynomial ring in 3 variables over QQ, QQMPolyRingElem[x, y, z])

julia> x/3
1//3*x

julia> typeof(x//3)
AbstractAlgebra.Generic.FracFieldElem{QQMPolyRingElem}
```