### PR TITLE
Check parents in multivariate evaluation

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -596,6 +596,7 @@ function (a::QQMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
 end
 
 function evaluate(a::QQMPolyRingElem, bs::Vector{QQMPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
 
@@ -609,6 +610,7 @@ function evaluate(a::QQMPolyRingElem, bs::Vector{QQMPolyRingElem})
 end
 
 function evaluate(a::QQMPolyRingElem, bs::Vector{QQPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
 

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -572,6 +572,7 @@ function (a::ZZMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
 end
 
 function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
 
@@ -585,6 +586,7 @@ function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
 end
 
 function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
 

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -583,6 +583,7 @@ function (a::fqPolyRepMPolyRingElem)(vals::Union{NCRingElem, RingElement}...)
 end
 
 function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepMPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
   @assert base_ring(R) === base_ring(S)
@@ -597,6 +598,7 @@ function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepMPolyRingElem})
 end
 
 function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepPolyRingElem})
+  allequal(map(parent, bs)) || error("parents do not match")
   R = parent(a)
   S = parent(bs[1])
   @assert base_ring(R) === base_ring(S)

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -629,6 +629,7 @@ for (etype, rtype, ftype, ctype, utype) in (
     end
 
     function evaluate(a::$(etype), bs::Vector{$etype})
+      allequal(map(parent, bs)) || error("parents do not match")
       R = parent(a)
       S = parent(bs[1])
       @assert base_ring(R) === base_ring(S)
@@ -644,6 +645,7 @@ for (etype, rtype, ftype, ctype, utype) in (
 
 
     function evaluate(a::($etype), bs::Vector{$utype})
+      allequal(map(parent, bs)) || error("parents do not match")
       R = parent(a)
       S = parent(bs[1])
       @assert base_ring(R) === base_ring(S)

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -632,6 +632,8 @@ end
   r3 = evaluate(f + g, [xx + yy, yy + zz])
   @test r3 == r1 + r2
 
+  @test_throws ErrorException evaluate(x, [x,xx])
+
   SS, z = polynomial_ring(R, "z")
   @test_throws ErrorException evaluate(x, [z])
   @test_throws ErrorException evaluate(x, [z, z, z])

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -616,6 +616,8 @@ end
   r3 = evaluate(f + g, [xx + yy, yy + zz])
   @test r3 == r1 + r2
 
+  @test_throws ErrorException evaluate(x, [x,xx])
+
   SS, z = polynomial_ring(R, "z")
   @test_throws ErrorException evaluate(x, [z])
   @test_throws ErrorException evaluate(x, [z, z, z])


### PR DESCRIPTION
This fixes https://github.com/oscar-system/Oscar.jl/issues/5561. Have I missed other instances of this problem? Do we want to check the parents if we evaluate at univariate polynomials? In these cases it is debatable if the result makes sense, at least it isn't "random" as in the example from the Oscar issue.