### PR TITLE
Restructure `evaluate` for mpolys

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -553,7 +553,6 @@ end
 ###############################################################################
 
 function evaluate(a::QQMPolyRingElem, b::Vector{QQFieldElem})
-  iszero(length(b)) && error("need at least one value")
   length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
   z = QQFieldElem()
   GC.@preserve b @ccall libflint.fmpq_mpoly_evaluate_all_fmpq(z::Ref{QQFieldElem}, a::Ref{QQMPolyRingElem}, b::Ptr{QQFieldElem}, parent(a)::Ref{QQMPolyRing})::Nothing

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -552,39 +552,36 @@ end
 #
 ###############################################################################
 
-function evaluate(a::QQMPolyRingElem, b::Vector{QQFieldElem})
-  length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
+function evaluate(a::QQMPolyRingElem, vals::Vector{QQFieldElem})
+  R = parent(a)
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
   z = QQFieldElem()
-  GC.@preserve b @ccall libflint.fmpq_mpoly_evaluate_all_fmpq(z::Ref{QQFieldElem}, a::Ref{QQMPolyRingElem}, b::Ptr{QQFieldElem}, parent(a)::Ref{QQMPolyRing})::Nothing
+  GC.@preserve vals @ccall libflint.fmpq_mpoly_evaluate_all_fmpq(z::Ref{QQFieldElem}, a::Ref{QQMPolyRingElem}, vals::Ptr{QQFieldElem}, R::Ref{QQMPolyRing})::Nothing
   return z
 end
 
-evaluate(a::QQMPolyRingElem, b::Vector{<:IntegerUnion}) = evaluate(a, QQFieldElem.(b))
+evaluate(a::QQMPolyRingElem, vals::Vector{<:IntegerUnion}) = evaluate(a, QQFieldElem.(vals))
 
-function evaluate(a::QQMPolyRingElem, bs::Vector{QQMPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::QQMPolyRingElem, vals::Vector{QQMPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
-
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
 
   c = S()
-  fl = @ccall libflint.fmpq_mpoly_compose_fmpq_mpoly(c::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, bs::Ptr{Ref{QQMPolyRingElem}}, R::Ref{QQMPolyRing}, S::Ref{QQMPolyRing})::Cint
+  fl = @ccall libflint.fmpq_mpoly_compose_fmpq_mpoly(c::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, vals::Ptr{Ref{QQMPolyRingElem}}, R::Ref{QQMPolyRing}, S::Ref{QQMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end
 
-function evaluate(a::QQMPolyRingElem, bs::Vector{QQPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::QQMPolyRingElem, vals::Vector{QQPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
-
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
 
   c = S()
-  fl = @ccall libflint.fmpq_mpoly_compose_fmpq_poly(c::Ref{QQPolyRingElem}, a::Ref{QQMPolyRingElem}, bs::Ptr{Ref{QQPolyRingElem}}, R::Ref{QQMPolyRing})::Cint
+  fl = @ccall libflint.fmpq_mpoly_compose_fmpq_poly(c::Ref{QQPolyRingElem}, a::Ref{QQMPolyRingElem}, vals::Ptr{Ref{QQPolyRingElem}}, R::Ref{QQMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -559,7 +559,7 @@ function evaluate(a::QQMPolyRingElem, b::Vector{QQFieldElem})
   return z
 end
 
-evaluate(a::QQMPolyRingElem, b::Vector{<:Union{ZZRingElem, Integer}}) = evaluate(a, QQFieldElem.(b))
+evaluate(a::QQMPolyRingElem, b::Vector{<:IntegerUnion}) = evaluate(a, QQFieldElem.(b))
 
 function evaluate(a::QQMPolyRingElem, bs::Vector{QQMPolyRingElem})
   @req allequal(map(parent, bs)) "parents do not match"

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -563,6 +563,7 @@ end
 evaluate(a::QQMPolyRingElem, vals::Vector{<:IntegerUnion}) = evaluate(a, QQFieldElem.(vals))
 
 function evaluate(a::QQMPolyRingElem, vals::Vector{QQMPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"
@@ -575,6 +576,7 @@ function evaluate(a::QQMPolyRingElem, vals::Vector{QQMPolyRingElem})
 end
 
 function evaluate(a::QQMPolyRingElem, vals::Vector{QQPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -553,37 +553,17 @@ end
 ###############################################################################
 
 function evaluate(a::QQMPolyRingElem, b::Vector{QQFieldElem})
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
+  iszero(length(b)) && error("need at least one value")
+  length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
   z = QQFieldElem()
   GC.@preserve b @ccall libflint.fmpq_mpoly_evaluate_all_fmpq(z::Ref{QQFieldElem}, a::Ref{QQMPolyRingElem}, b::Ptr{QQFieldElem}, parent(a)::Ref{QQMPolyRing})::Nothing
   return z
 end
 
-function evaluate(a::QQMPolyRingElem, b::Vector{ZZRingElem})
-  fmpq_vec = [QQFieldElem(s) for s in b]
-  return evaluate(a, fmpq_vec)
-end
+evaluate(a::QQMPolyRingElem, b::Vector{<:Union{ZZRingElem, Integer}}) = evaluate(a, QQFieldElem.(b))
 
-function evaluate(a::QQMPolyRingElem, b::Vector{<:Integer})
-  fmpq_vec = [QQFieldElem(s) for s in b]
-  return evaluate(a, fmpq_vec)
-end
-
-function (a::QQMPolyRingElem)()
-  error("need at least one value")
-end
-
-function (a::QQMPolyRingElem)(vals::QQFieldElem...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::QQMPolyRingElem)(vals::Integer...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::QQMPolyRingElem)(vals::NCRingElement...)
+function evaluate(a::QQMPolyRingElem, vals::Vector{<:NCRingElement})
+  iszero(length(vals)) && error("need at least one value")
   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
   R = base_ring(a)
   # The best we can do here is to cache previously used powers of the values

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -562,47 +562,6 @@ end
 
 evaluate(a::QQMPolyRingElem, b::Vector{<:Union{ZZRingElem, Integer}}) = evaluate(a, QQFieldElem.(b))
 
-function evaluate(a::QQMPolyRingElem, vals::Vector{<:NCRingElement})
-  iszero(length(vals)) && error("need at least one value")
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  R = base_ring(a)
-  # The best we can do here is to cache previously used powers of the values
-  # being substituted, as we cannot assume anything about the relative
-  # performance of powering vs multiplication. The function should not try
-  # to optimise computing new powers in any way.
-  # Note that this function accepts values in a non-commutative ring, so operations
-  # must be done in a certain order.
-  powers = [Dict{Int, Any}() for i in 1:length(vals)]
-  # First work out types of products
-  r = R()
-  c = zero(R)
-  U = Vector{Any}(undef, length(vals))
-  for j = 1:length(vals)
-    W = typeof(vals[j])
-    if ((W <: Integer && W != BigInt) ||
-        (W <: Rational && W != Rational{BigInt}))
-      c = c*zero(W)
-      U[j] = parent(c)
-    else
-      U[j] = parent(vals[j])
-      c = c*zero(parent(vals[j]))
-    end
-  end
-  for i = 1:length(a)
-    v = exponent_vector(a, i)
-    t = coeff(a, i)
-    for j = 1:length(vals)
-      exp = v[j]
-      if !haskey(powers[j], exp)
-        powers[j][exp] = (U[j](vals[j]))^exp
-      end
-      t = t*powers[j][exp]
-    end
-    r += t
-  end
-  return r
-end
-
 function evaluate(a::QQMPolyRingElem, bs::Vector{QQMPolyRingElem})
   @req allequal(map(parent, bs)) "parents do not match"
   R = parent(a)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -540,10 +540,7 @@ function evaluate(a::ZZMPolyRingElem, b::Vector{ZZRingElem})
   return z
 end
 
-function evaluate(a::ZZMPolyRingElem, b::Vector{<:Integer})
-  fmpz_vec = [ZZRingElem(s) for s in b]
-  return evaluate(a, fmpz_vec)
-end
+evaluate(a::ZZMPolyRingElem, b::Vector{<:Integer}) = evaluate(a, ZZRingElem.(b))
 
 function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
   @req allequal(map(parent, bs)) "parents do not match"

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -534,7 +534,8 @@ end
 ###############################################################################
 
 function evaluate(a::ZZMPolyRingElem, b::Vector{ZZRingElem})
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
+  iszero(length(b)) && error("need at least one value")
+  length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
   z = ZZRingElem()
   GC.@preserve b @ccall libflint.fmpz_mpoly_evaluate_all_fmpz(z::Ref{ZZRingElem}, a::Ref{ZZMPolyRingElem}, b::Ptr{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Nothing
   return z
@@ -545,21 +546,8 @@ function evaluate(a::ZZMPolyRingElem, b::Vector{<:Integer})
   return evaluate(a, fmpz_vec)
 end
 
-function (a::ZZMPolyRingElem)()
-  error("need at least one value")
-end
-
-function (a::ZZMPolyRingElem)(vals::ZZRingElem...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::ZZMPolyRingElem)(vals::Integer...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::ZZMPolyRingElem)(vals::NCRingElement...)
+function evaluate(a::ZZMPolyRingElem, vals::Vector{<:NCRingElement})
+  iszero(length(vals)) && error("need at least one value")
   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
   R = base_ring(a)
   # The best we can do here is to cache previously used powers of the values

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -544,6 +544,7 @@ end
 evaluate(a::ZZMPolyRingElem, vals::Vector{<:Integer}) = evaluate(a, ZZRingElem.(vals))
 
 function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZMPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"
@@ -556,6 +557,7 @@ function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZMPolyRingElem})
 end
 
 function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -534,7 +534,6 @@ end
 ###############################################################################
 
 function evaluate(a::ZZMPolyRingElem, b::Vector{ZZRingElem})
-  iszero(length(b)) && error("need at least one value")
   length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
   z = ZZRingElem()
   GC.@preserve b @ccall libflint.fmpz_mpoly_evaluate_all_fmpz(z::Ref{ZZRingElem}, a::Ref{ZZMPolyRingElem}, b::Ptr{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Nothing

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -533,39 +533,36 @@ end
 #
 ###############################################################################
 
-function evaluate(a::ZZMPolyRingElem, b::Vector{ZZRingElem})
-  length(b) != nvars(parent(a)) && error("Number of variables does not match number of values")
+function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZRingElem})
+  R = parent(a)
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
   z = ZZRingElem()
-  GC.@preserve b @ccall libflint.fmpz_mpoly_evaluate_all_fmpz(z::Ref{ZZRingElem}, a::Ref{ZZMPolyRingElem}, b::Ptr{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Nothing
+  GC.@preserve vals @ccall libflint.fmpz_mpoly_evaluate_all_fmpz(z::Ref{ZZRingElem}, a::Ref{ZZMPolyRingElem}, vals::Ptr{ZZRingElem}, R::Ref{ZZMPolyRing})::Nothing
   return z
 end
 
-evaluate(a::ZZMPolyRingElem, b::Vector{<:Integer}) = evaluate(a, ZZRingElem.(b))
+evaluate(a::ZZMPolyRingElem, vals::Vector{<:Integer}) = evaluate(a, ZZRingElem.(vals))
 
-function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZMPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
-
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
 
   c = S()
-  fl = @ccall libflint.fmpz_mpoly_compose_fmpz_mpoly(c::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZMPolyRingElem}}, R::Ref{ZZMPolyRing}, S::Ref{ZZMPolyRing})::Cint
+  fl = @ccall libflint.fmpz_mpoly_compose_fmpz_mpoly(c::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, vals::Ptr{Ref{ZZMPolyRingElem}}, R::Ref{ZZMPolyRing}, S::Ref{ZZMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end
 
-function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::ZZMPolyRingElem, vals::Vector{ZZPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
-
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
 
   c = S()
-  fl = @ccall libflint.fmpz_mpoly_compose_fmpz_poly(c::Ref{ZZPolyRingElem}, a::Ref{ZZMPolyRingElem}, bs::Ptr{Ref{ZZPolyRingElem}}, R::Ref{ZZMPolyRing})::Cint
+  fl = @ccall libflint.fmpz_mpoly_compose_fmpz_poly(c::Ref{ZZPolyRingElem}, a::Ref{ZZMPolyRingElem}, vals::Ptr{Ref{ZZPolyRingElem}}, R::Ref{ZZMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -546,47 +546,6 @@ function evaluate(a::ZZMPolyRingElem, b::Vector{<:Integer})
   return evaluate(a, fmpz_vec)
 end
 
-function evaluate(a::ZZMPolyRingElem, vals::Vector{<:NCRingElement})
-  iszero(length(vals)) && error("need at least one value")
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  R = base_ring(a)
-  # The best we can do here is to cache previously used powers of the values
-  # being substituted, as we cannot assume anything about the relative
-  # performance of powering vs multiplication. The function should not try
-  # to optimise computing new powers in any way.
-  # Note that this function accepts values in a non-commutative ring, so operations
-  # must be done in a certain order.
-  powers = [Dict{Int, Any}() for i in 1:length(vals)]
-  # First work out types of products
-  r = R()
-  c = zero(R)
-  U = Vector{Any}(undef, length(vals))
-  for j = 1:length(vals)
-    W = typeof(vals[j])
-    if ((W <: Integer && W != BigInt) ||
-        (W <: Rational && W != Rational{BigInt}))
-      c = c*zero(W)
-      U[j] = parent(c)
-    else
-      U[j] = parent(vals[j])
-      c = c*zero(parent(vals[j]))
-    end
-  end
-  for i = 1:length(a)
-    v = exponent_vector(a, i)
-    t = coeff(a, i)
-    for j = 1:length(vals)
-      exp = v[j]
-      if !haskey(powers[j], exp)
-        powers[j][exp] = (U[j](vals[j]))^exp
-      end
-      t = t*powers[j][exp]
-    end
-    r += t
-  end
-  return r
-end
-
 function evaluate(a::ZZMPolyRingElem, bs::Vector{ZZMPolyRingElem})
   @req allequal(map(parent, bs)) "parents do not match"
   R = parent(a)

--- a/src/flint/fq_default_mpoly.jl
+++ b/src/flint/fq_default_mpoly.jl
@@ -390,47 +390,6 @@ end
 
 ###############################################################################
 #
-#   Evaluation
-#
-###############################################################################
-
-# TODO have AA define evaluate(a, vals) for general vals
-# so we can get rid of this copy pasta
-function (a::FqMPolyRingElem)(vals::NCRingElement...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  R = base_ring(a)
-  powers = [Dict{Int, Any}() for i in 1:length(vals)]
-  r = R()
-  c = zero(R)
-  U = Vector{Any}(undef, length(vals))
-  for j = 1:length(vals)
-    W = typeof(vals[j])
-    if ((W <: Integer && W != BigInt) ||
-        (W <: Rational && W != Rational{BigInt}))
-      c = c*zero(W)
-      U[j] = parent(c)
-    else
-      U[j] = parent(vals[j])
-      c = c*zero(parent(vals[j]))
-    end
-  end
-  cvzip = zip(coefficients(a), exponent_vectors(a))
-  for (c, v) in cvzip
-    t = c
-    for j = 1:length(vals)
-      exp = v[j]
-      if !haskey(powers[j], exp)
-        powers[j][exp] = (U[j](vals[j]))^exp
-      end
-      t = t*powers[j][exp]
-    end
-    r += t
-  end
-  return r
-end
-
-###############################################################################
-#
 #   Unsafe functions
 #
 ###############################################################################

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -504,82 +504,11 @@ function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{fqPolyRepFieldElem})
   return z
 end
 
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{Int})
+function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{T}) where T <: IntegerUnion
   length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
   R = base_ring(parent(a))
   b2 = [R(d) for d in b]
   return evaluate(a, b2)
-end
-
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{T}) where T <: Integer
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-  R = base_ring(parent(a))
-  b2 = [R(d) for d in b]
-  return evaluate(a, b2)
-end
-
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{ZZRingElem})
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-  R = base_ring(parent(a))
-  b2 = [R(d) for d in b]
-  return evaluate(a, b2)
-end
-
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{UInt})
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-  R = base_ring(parent(a))
-  b2 = [R(d) for d in b]
-  return evaluate(a, b2)
-end
-
-function (a::fqPolyRepMPolyRingElem)(vals::fqPolyRepFieldElem...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::fqPolyRepMPolyRingElem)(vals::Integer...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  return evaluate(a, [vals...])
-end
-
-function (a::fqPolyRepMPolyRingElem)(vals::NCRingElement...)
-  length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-  R = base_ring(a)
-  # The best we can do here is to cache previously used powers of the values
-  # being substituted, as we cannot assume anything about the relative
-  # performance of powering vs multiplication. The function should not try
-  # to optimise computing new powers in any way.
-  # Note that this function accepts values in a non-commutative ring, so operations
-  # must be done in a certain order.
-  powers = [Dict{Int, Any}() for i in 1:length(vals)]
-  # First work out types of products
-  r = R()
-  c = zero(R)
-  U = Vector{Any}(undef, length(vals))
-  for j = 1:length(vals)
-    W = typeof(vals[j])
-    if ((W <: Integer && W != BigInt) ||
-        (W <: Rational && W != Rational{BigInt}))
-      c = c*zero(W)
-      U[j] = parent(c)
-    else
-      U[j] = parent(vals[j])
-      c = c*zero(parent(vals[j]))
-    end
-  end
-  for i = 1:length(a)
-    v = exponent_vector(a, i)
-    t = coeff(a, i)
-    for j = 1:length(vals)
-      exp = v[j]
-      if !haskey(powers[j], exp)
-        powers[j][exp] = (U[j](vals[j]))^exp
-      end
-      t = t*powers[j][exp]
-    end
-    r += t
-  end
-  return r
 end
 
 function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepMPolyRingElem})

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -512,7 +512,6 @@ function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepMPolyRingElem
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"
   S = parent(vals[1])
-  @assert base_ring(R) === base_ring(S)
 
   c = S()
   fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_mpoly(c::Ref{fqPolyRepMPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, vals::Ptr{Ref{fqPolyRepMPolyRingElem}}, R::Ref{fqPolyRepMPolyRing}, S::Ref{fqPolyRepMPolyRing})::Cint
@@ -525,7 +524,6 @@ function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepPolyRingElem}
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"
   S = parent(vals[1])
-  @assert base_ring(R) === base_ring(S)
 
   c = S()
   fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_poly(c::Ref{fqPolyRepPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, vals::Ptr{Ref{fqPolyRepPolyRingElem}}, R::Ref{fqPolyRepMPolyRing})::Cint

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -504,12 +504,7 @@ function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{fqPolyRepFieldElem})
   return z
 end
 
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{T}) where T <: IntegerUnion
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-  R = base_ring(parent(a))
-  b2 = [R(d) for d in b]
-  return evaluate(a, b2)
-end
+evaluate(a::fqPolyRepMPolyRingElem, b::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(b))
 
 function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepMPolyRingElem})
   @req allequal(map(parent, bs)) "parents do not match"

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -508,6 +508,7 @@ end
 evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(vals))
 
 function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepMPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"
@@ -520,6 +521,7 @@ function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepMPolyRingElem
 end
 
 function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepPolyRingElem})
+  @req !isempty(vals) "No values supplied"
   R = parent(a)
   @req length(vals) == nvars(R) "Number of variables does not match number of values"
   @req allequal(map(parent, vals)) "Parents do not match"

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -532,10 +532,6 @@ function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{UInt})
   return evaluate(a, b2)
 end
 
-function (a::fqPolyRepMPolyRingElem)()
-  error("need at least one value")
-end
-
 function (a::fqPolyRepMPolyRingElem)(vals::fqPolyRepFieldElem...)
   length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
   return evaluate(a, [vals...])

--- a/src/flint/fq_nmod_mpoly.jl
+++ b/src/flint/fq_nmod_mpoly.jl
@@ -497,41 +497,38 @@ end
 #
 ###############################################################################
 
-function evaluate(a::fqPolyRepMPolyRingElem, b::Vector{fqPolyRepFieldElem})
-  length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-  z = base_ring(parent(a))()
-  @ccall libflint.fq_nmod_mpoly_evaluate_all_fq_nmod(z::Ref{fqPolyRepFieldElem}, a::Ref{fqPolyRepMPolyRingElem}, b::Ptr{Ref{fqPolyRepFieldElem}}, parent(a)::Ref{fqPolyRepMPolyRing})::Nothing
+function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepFieldElem})
+  R = parent(a)
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  z = base_ring(R)()
+  @ccall libflint.fq_nmod_mpoly_evaluate_all_fq_nmod(z::Ref{fqPolyRepFieldElem}, a::Ref{fqPolyRepMPolyRingElem}, vals::Ptr{Ref{fqPolyRepFieldElem}}, R::Ref{fqPolyRepMPolyRing})::Nothing
   return z
 end
 
-evaluate(a::fqPolyRepMPolyRingElem, b::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(b))
+evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(vals))
 
-function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepMPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepMPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
   @assert base_ring(R) === base_ring(S)
 
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
-
   c = S()
-  fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_mpoly(c::Ref{fqPolyRepMPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, bs::Ptr{Ref{fqPolyRepMPolyRingElem}}, R::Ref{fqPolyRepMPolyRing}, S::Ref{fqPolyRepMPolyRing})::Cint
+  fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_mpoly(c::Ref{fqPolyRepMPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, vals::Ptr{Ref{fqPolyRepMPolyRingElem}}, R::Ref{fqPolyRepMPolyRing}, S::Ref{fqPolyRepMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end
 
-function evaluate(a::fqPolyRepMPolyRingElem, bs::Vector{fqPolyRepPolyRingElem})
-  @req allequal(map(parent, bs)) "parents do not match"
+function evaluate(a::fqPolyRepMPolyRingElem, vals::Vector{fqPolyRepPolyRingElem})
   R = parent(a)
-  S = parent(bs[1])
+  @req length(vals) == nvars(R) "Number of variables does not match number of values"
+  @req allequal(map(parent, vals)) "Parents do not match"
+  S = parent(vals[1])
   @assert base_ring(R) === base_ring(S)
 
-  length(bs) != nvars(R) &&
-  error("Number of variables does not match number of values")
-
   c = S()
-  fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_poly(c::Ref{fqPolyRepPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, bs::Ptr{Ref{fqPolyRepPolyRingElem}}, R::Ref{fqPolyRepMPolyRing})::Cint
+  fl = @ccall libflint.fq_nmod_mpoly_compose_fq_nmod_poly(c::Ref{fqPolyRepPolyRingElem}, a::Ref{fqPolyRepMPolyRingElem}, vals::Ptr{Ref{fqPolyRepPolyRingElem}}, R::Ref{fqPolyRepMPolyRing})::Cint
   fl == 0 && error("Something wrong in evaluation.")
   return c
 end

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -544,41 +544,38 @@ for (etype, rtype, ftype, ctype, utype) in (
     #
     ###############################################################################
 
-    function evaluate(a::($etype), b::Vector{$ctype})
-      length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-      b2 = [d.data for d in b]
-      z = @ccall libflint.nmod_mpoly_evaluate_all_ui(a::Ref{($etype)}, b2::Ptr{UInt}, parent(a)::Ref{($rtype)})::UInt
-      return base_ring(parent(a))(z)
+    function evaluate(a::($etype), vals::Vector{$ctype})
+      R = parent(a)
+      @req length(vals) == nvars(R) "Number of variables does not match number of values"
+      vals2 = [val.data for val in vals]
+      z = @ccall libflint.nmod_mpoly_evaluate_all_ui(a::Ref{($etype)}, vals2::Ptr{UInt}, R::Ref{($rtype)})::UInt
+      return base_ring(R)(z)
     end
 
-    evaluate(a::($etype), b::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(b))
+    evaluate(a::($etype), vals::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(vals))
 
-    function evaluate(a::$(etype), bs::Vector{$etype})
-      @req allequal(map(parent, bs)) "parents do not match"
+    function evaluate(a::$(etype), vals::Vector{$etype})
       R = parent(a)
-      S = parent(bs[1])
+      @req length(vals) == nvars(R) "Number of variables does not match number of values"
+      @req allequal(map(parent, vals)) "Parents do not match"
+      S = parent(vals[1])
       @assert base_ring(R) === base_ring(S)
 
-      length(bs) != nvars(R) &&
-      error("Number of variables does not match number of values")
-
       c = S()
-      fl = @ccall libflint.nmod_mpoly_compose_nmod_mpoly(c::Ref{$etype}, a::Ref{$etype}, bs::Ptr{Ref{$etype}}, R::Ref{$rtype}, S::Ref{$rtype})::Cint
+      fl = @ccall libflint.nmod_mpoly_compose_nmod_mpoly(c::Ref{$etype}, a::Ref{$etype}, vals::Ptr{Ref{$etype}}, R::Ref{$rtype}, S::Ref{$rtype})::Cint
       fl == 0 && error("Something wrong in evaluation.")
       return c
     end
 
-    function evaluate(a::($etype), bs::Vector{$utype})
-      @req allequal(map(parent, bs)) "parents do not match"
+    function evaluate(a::($etype), vals::Vector{$utype})
       R = parent(a)
-      S = parent(bs[1])
+      @req length(vals) == nvars(R) "Number of variables does not match number of values"
+      @req allequal(map(parent, vals)) "Parents do not match"
+      S = parent(vals[1])
       @assert base_ring(R) === base_ring(S)
 
-      length(bs) != nvars(R) &&
-      error("Number of variables does not match number of values")
-
       c = S()
-      fl = @ccall libflint.nmod_mpoly_compose_nmod_poly(c::Ref{$utype}, a::Ref{$etype}, bs::Ptr{Ref{$utype}}, R::Ref{$rtype})::Cint
+      fl = @ccall libflint.nmod_mpoly_compose_nmod_poly(c::Ref{$utype}, a::Ref{$etype}, vals::Ptr{Ref{$utype}}, R::Ref{$rtype})::Cint
       fl == 0 && error("Something wrong in evaluation.")
       return c
     end

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -555,6 +555,7 @@ for (etype, rtype, ftype, ctype, utype) in (
     evaluate(a::($etype), vals::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(vals))
 
     function evaluate(a::$(etype), vals::Vector{$etype})
+      @req !isempty(vals) "No values supplied"
       R = parent(a)
       @req length(vals) == nvars(R) "Number of variables does not match number of values"
       @req allequal(map(parent, vals)) "Parents do not match"
@@ -567,6 +568,7 @@ for (etype, rtype, ftype, ctype, utype) in (
     end
 
     function evaluate(a::($etype), vals::Vector{$utype})
+      @req !isempty(vals) "No values supplied"
       R = parent(a)
       @req length(vals) == nvars(R) "Number of variables does not match number of values"
       @req allequal(map(parent, vals)) "Parents do not match"

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -559,7 +559,6 @@ for (etype, rtype, ftype, ctype, utype) in (
       @req length(vals) == nvars(R) "Number of variables does not match number of values"
       @req allequal(map(parent, vals)) "Parents do not match"
       S = parent(vals[1])
-      @assert base_ring(R) === base_ring(S)
 
       c = S()
       fl = @ccall libflint.nmod_mpoly_compose_nmod_mpoly(c::Ref{$etype}, a::Ref{$etype}, vals::Ptr{Ref{$etype}}, R::Ref{$rtype}, S::Ref{$rtype})::Cint
@@ -572,7 +571,6 @@ for (etype, rtype, ftype, ctype, utype) in (
       @req length(vals) == nvars(R) "Number of variables does not match number of values"
       @req allequal(map(parent, vals)) "Parents do not match"
       S = parent(vals[1])
-      @assert base_ring(R) === base_ring(S)
 
       c = S()
       fl = @ccall libflint.nmod_mpoly_compose_nmod_poly(c::Ref{$utype}, a::Ref{$etype}, vals::Ptr{Ref{$utype}}, R::Ref{$rtype})::Cint

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -579,60 +579,6 @@ for (etype, rtype, ftype, ctype, utype) in (
       return evaluate(a, b2)
     end
 
-    function (a::($etype))()
-      error("need at least one value")
-    end
-
-    function (a::($etype))(vals::zzModRingElem...)
-      length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-      return evaluate(a, [vals...])
-    end
-
-    function (a::($etype))(vals::Integer...)
-      length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-      return evaluate(a, [vals...])
-    end
-
-    function (a::($etype))(vals::NCRingElement...)
-      length(vals) != nvars(parent(a)) && error("Number of variables does not match number of values")
-      R = base_ring(a)
-      # The best we can do here is to cache previously used powers of the values
-      # being substituted, as we cannot assume anything about the relative
-      # performance of powering vs multiplication. The function should not try
-      # to optimise computing new powers in any way.
-      # Note that this function accepts values in a non-commutative ring, so operations
-      # must be done in a certain order.
-      powers = [Dict{Int, Any}() for i in 1:length(vals)]
-      # First work out types of products
-      r = R()
-      c = zero(R)
-      U = Vector{Any}(undef, length(vals))
-      for j = 1:length(vals)
-        W = typeof(vals[j])
-        if ((W <: Integer && W != BigInt) ||
-            (W <: Rational && W != Rational{BigInt}))
-          c = c*zero(W)
-          U[j] = parent(c)
-        else
-          U[j] = parent(vals[j])
-          c = c*zero(parent(vals[j]))
-        end
-      end
-      for i = 1:length(a)
-        v = exponent_vector(a, i)
-        t = coeff(a, i)
-        for j = 1:length(vals)
-          exp = v[j]
-          if !haskey(powers[j], exp)
-            powers[j][exp] = (U[j](vals[j]))^exp
-          end
-          t = t*powers[j][exp]
-        end
-        r += t
-      end
-      return r
-    end
-
     function evaluate(a::$(etype), bs::Vector{$etype})
       @req allequal(map(parent, bs)) "parents do not match"
       R = parent(a)

--- a/src/flint/nmod_mpoly.jl
+++ b/src/flint/nmod_mpoly.jl
@@ -551,33 +551,7 @@ for (etype, rtype, ftype, ctype, utype) in (
       return base_ring(parent(a))(z)
     end
 
-    function evaluate(a::($etype), b::Vector{Int})
-      length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-      R = base_ring(parent(a))
-      b2 = [R(d) for d in b]
-      return evaluate(a, b2)
-    end
-
-    function evaluate(a::($etype), b::Vector{T}) where T <: Integer
-      length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-      R = base_ring(parent(a))
-      b2 = [R(d) for d in b]
-      return evaluate(a, b2)
-    end
-
-    function evaluate(a::($etype), b::Vector{ZZRingElem})
-      length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-      R = base_ring(parent(a))
-      b2 = [R(d) for d in b]
-      return evaluate(a, b2)
-    end
-
-    function evaluate(a::($etype), b::Vector{UInt})
-      length(b) != nvars(parent(a)) && error("Vector size incorrect in evaluate")
-      R = base_ring(parent(a))
-      b2 = [R(d) for d in b]
-      return evaluate(a, b2)
-    end
+    evaluate(a::($etype), b::Vector{<:IntegerUnion}) = evaluate(a, coefficient_ring(a).(b))
 
     function evaluate(a::$(etype), bs::Vector{$etype})
       @req allequal(map(parent, bs)) "parents do not match"
@@ -593,7 +567,6 @@ for (etype, rtype, ftype, ctype, utype) in (
       fl == 0 && error("Something wrong in evaluation.")
       return c
     end
-
 
     function evaluate(a::($etype), bs::Vector{$utype})
       @req allequal(map(parent, bs)) "parents do not match"

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -614,8 +614,8 @@ end
   # Individual tests
 
   S, (x, y) = polynomial_ring(R, ["x", "y"])
-  @test_throws ErrorException evaluate(x, [x])
-  @test_throws ErrorException evaluate(x, [x, x, x])
+  @test_throws ArgumentError evaluate(x, [x])
+  @test_throws ArgumentError evaluate(x, [x, x, x])
 
   f = x + y
   g = x - y
@@ -635,8 +635,8 @@ end
   @test_throws ArgumentError evaluate(x, [x,xx])
 
   SS, z = polynomial_ring(R, "z")
-  @test_throws ErrorException evaluate(x, [z])
-  @test_throws ErrorException evaluate(x, [z, z, z])
+  @test_throws ArgumentError evaluate(x, [z])
+  @test_throws ArgumentError evaluate(x, [z, z, z])
   w = [z, (z + 1)^2]
   r1 = @inferred evaluate(f, w)
   r2 = evaluate(g, w)

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -598,8 +598,8 @@ end
   # Individual tests
 
   S, (x, y) = polynomial_ring(R, ["x", "y"])
-  @test_throws ErrorException evaluate(x, [x])
-  @test_throws ErrorException evaluate(x, [x, x, x])
+  @test_throws ArgumentError evaluate(x, [x])
+  @test_throws ArgumentError evaluate(x, [x, x, x])
 
   f = x + y
   g = x - y
@@ -619,8 +619,8 @@ end
   @test_throws ArgumentError evaluate(x, [x,xx])
 
   SS, z = polynomial_ring(R, "z")
-  @test_throws ErrorException evaluate(x, [z])
-  @test_throws ErrorException evaluate(x, [z, z, z])
+  @test_throws ArgumentError evaluate(x, [z])
+  @test_throws ArgumentError evaluate(x, [z, z, z])
   w = [z, (z + 1)^2]
   r1 = @inferred evaluate(f, w)
   r2 = evaluate(g, w)

--- a/test/flint/fq_nmod_mpoly-test.jl
+++ b/test/flint/fq_nmod_mpoly-test.jl
@@ -621,8 +621,8 @@ end
   # Individual tests
 
   S, (x, y) = polynomial_ring(R, ["x", "y"])
-  @test_throws ErrorException evaluate(x, [x])
-  @test_throws ErrorException evaluate(x, [x, x, x])
+  @test_throws ArgumentError evaluate(x, [x])
+  @test_throws ArgumentError evaluate(x, [x, x, x])
 
   f = x + y
   g = x - y
@@ -640,8 +640,8 @@ end
   @test r3 == r1 + r2
 
   SS, z = polynomial_ring(R, "z")
-  @test_throws ErrorException evaluate(x, [z])
-  @test_throws ErrorException evaluate(x, [z, z, z])
+  @test_throws ArgumentError evaluate(x, [z])
+  @test_throws ArgumentError evaluate(x, [z, z, z])
   w = [z, (z + 1)^2]
   r1 = @inferred evaluate(f, w)
   r2 = evaluate(g, w)

--- a/test/flint/gfp_mpoly-test.jl
+++ b/test/flint/gfp_mpoly-test.jl
@@ -615,8 +615,8 @@ end
   # Individual tests
 
   S, (x, y) = polynomial_ring(R, ["x", "y"])
-  @test_throws ErrorException evaluate(x, [x])
-  @test_throws ErrorException evaluate(x, [x, x, x])
+  @test_throws ArgumentError evaluate(x, [x])
+  @test_throws ArgumentError evaluate(x, [x, x, x])
 
   @test (@which evaluate(f, [R(1), R(1)])).module === Nemo
 
@@ -636,8 +636,8 @@ end
   @test r3 == r1 + r2
 
   SS, z = polynomial_ring(R, "z")
-  @test_throws ErrorException evaluate(x, [z])
-  @test_throws ErrorException evaluate(x, [z, z, z])
+  @test_throws ArgumentError evaluate(x, [z])
+  @test_throws ArgumentError evaluate(x, [z, z, z])
   w = [z, (z + 1)^2]
   r1 = @inferred evaluate(f, w)
   r2 = evaluate(g, w)

--- a/test/flint/nmod_mpoly-test.jl
+++ b/test/flint/nmod_mpoly-test.jl
@@ -648,8 +648,8 @@ end
   # Individual tests
 
   S, (x, y) = polynomial_ring(R, ["x", "y"])
-  @test_throws ErrorException evaluate(x, [x])
-  @test_throws ErrorException evaluate(x, [x, x, x])
+  @test_throws ArgumentError evaluate(x, [x])
+  @test_throws ArgumentError evaluate(x, [x, x, x])
 
   @test (@which evaluate(f, [R(1), R(1)])).module === Nemo
 
@@ -669,8 +669,8 @@ end
   @test r3 == r1 + r2
 
   SS, z = polynomial_ring(R, "z")
-  @test_throws ErrorException evaluate(x, [z])
-  @test_throws ErrorException evaluate(x, [z, z, z])
+  @test_throws ArgumentError evaluate(x, [z])
+  @test_throws ArgumentError evaluate(x, [z, z, z])
   w = [z, (z + 1)^2]
   r1 = @inferred evaluate(f, w)
   r2 = evaluate(g, w)


### PR DESCRIPTION
This is a work in progress towards https://github.com/Nemocas/AbstractAlgebra.jl/issues/2225 and https://github.com/Nemocas/Nemo.jl/issues/2180. At the moment this introduces some method ambiguities which need to be resolved first. I think if I readjusted this PR to make the `f(...)` syntax the default I should be able to resolve them without a new AbstractAlgebra release.

Note that I started with the `fmpq` mpolys and that the other mpoly types of Nemo are still missing.

Edit: fixes #2180 