### PR TITLE
Fix docstring inclusion of `is_square`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ RandomExtensions = "fb686558-2515-59ef-acaa-46db3789a887"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
-AbstractAlgebra = "0.47.4"
+AbstractAlgebra = "0.47.6"
 FLINT_jll = "~301.400.0"
 LinearAlgebra = "1.6"
 Random = "1.6"

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -325,8 +325,8 @@ is_divisible_by(::ZZRingElem, ::Int)
 is_divisible_by(::ZZRingElem, ::ZZRingElem)
 ```
 
-```@docs
-is_square(::ZZRingElem)
+```@docs; canonical=false
+is_square(::NCRingElement)
 ```
 
 ```@docs

--- a/docs/src/padic.md
+++ b/docs/src/padic.md
@@ -157,8 +157,8 @@ julia> q = lift(QQ, divexact(a, b))
 
 ### Square root
 
-```@docs
-Base.sqrt(::PadicFieldElem)
+```@docs; canonical=false
+is_square(::NCRingElement)
 ```
 
 **Examples**

--- a/docs/src/puiseux.md
+++ b/docs/src/puiseux.md
@@ -63,8 +63,8 @@ for specific rings provided by Nemo.
 
 ### Special functions
 
-```@docs
-Base.sqrt(a::FlintPuiseuxSeriesElem{ZZLaurentSeriesRingElem})
+```@docs; canonical=false
+is_square(::NCRingElement)
 ```
 
 ```@docs

--- a/docs/src/qadic.md
+++ b/docs/src/qadic.md
@@ -143,8 +143,8 @@ q = lift(Zy, divexact(a, b))
 
 ### Square root
 
-```@docs
-Base.sqrt(::QadicFieldElem)
+```@docs; canonical=false
+is_square(::NCRingElement)
 ```
 
 **Examples**


### PR DESCRIPTION
This (together with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2242) fixes building the Nemo docs, at least it does so locally for me.