### PR TITLE
fix: `max` for `Real[Arb]FieldElem`

### DIFF
--- a/src/Nemo.jl
+++ b/src/Nemo.jl
@@ -90,6 +90,7 @@ import Base: ldexp
 import Base: length
 import Base: log
 import Base: log1p
+import Base: max
 import Base: maximum
 import Base: minimum
 import Base: mod

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -433,6 +433,13 @@ end
 <=(x::Rational{T}, y::RealFieldElem) where {T <: Integer} = QQFieldElem(x) <= y
 <(x::Rational{T}, y::RealFieldElem) where {T <: Integer} = QQFieldElem(x) < y
 
+function max(x::RealFieldElem, y::RealFieldElem)
+  z = parent(x)()
+  prec = precision(parent(x))
+  @ccall libflint.arb_max(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Cvoid
+  return z
+end
+
 ################################################################################
 #
 #  Predicates
@@ -2056,4 +2063,11 @@ function rand(r::RealField, prec::Int = precision(Balls); randtype::Symbol=:uran
   end
 
   return x
+end
+
+function _rand_rational_in_ball(x::RealFieldElem)
+  state = _flint_rand_states[Threads.threadid()]
+  z = QQ()
+  @ccall libflint.arb_get_rand_fmpq(z::Ref{QQFieldElem}, state::Ref{rand_ctx}, x::Ref{RealFieldElem}, precision(parent(x))::Int)::Nothing
+  return z
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -438,6 +438,13 @@ end
 <=(x::Rational{T}, y::ArbFieldElem) where {T <: Integer} = QQFieldElem(x) <= y
 <(x::Rational{T}, y::ArbFieldElem) where {T <: Integer} = QQFieldElem(x) < y
 
+function max(x::ArbFieldElem, y::ArbFieldElem)
+  z = parent(x)()
+  prec = precision(parent(x))
+  @ccall libflint.arb_max(z::Ref{ArbFieldElem}, x::Ref{ArbFieldElem}, y::Ref{ArbFieldElem}, prec::Int)::Cvoid
+  return z
+end
+
 ################################################################################
 #
 #  Predicates
@@ -2052,4 +2059,11 @@ function rand(r::ArbField; randtype::Symbol=:urandom)
   end
 
   return x
+end
+
+function _rand_rational_in_ball(x::ArbFieldElem)
+  state = _flint_rand_states[Threads.threadid()]
+  z = QQ()
+  @ccall libflint.arb_get_rand_fmpq(z::Ref{QQFieldElem}, state::Ref{rand_ctx}, x::Ref{ArbFieldElem}, precision(parent(x))::Int)::Nothing
+  return z
 end

--- a/test/arb/Real-test.jl
+++ b/test/arb/Real-test.jl
@@ -185,6 +185,17 @@ end
   @test contains_positive(approx3 - 3)
   @test contains_nonpositive(approx3 - 3)
   @test contains_nonnegative(approx3 - 3)
+
+  x = RR("[1 +/- 0.5]")
+  y = RR("[1.1 +/- 0.2]")
+  z = max(x, y)
+  zz = maximum([x, y])
+  for i in 1:10
+    xx = Nemo._rand_rational_in_ball(x)
+    yy = Nemo._rand_rational_in_ball(y)
+    @test contains(z, max(xx, yy))
+    @test contains(zz, max(xx, yy))
+  end
 end
 
 @testset "RealFieldElem.adhoc_comparison" begin

--- a/test/arb/arb-test.jl
+++ b/test/arb/arb-test.jl
@@ -143,6 +143,17 @@ end
   @test contains_positive(approx3 - 3)
   @test contains_nonpositive(approx3 - 3)
   @test contains_nonnegative(approx3 - 3)
+
+  x = RR("[1 +/- 0.5]")
+  y = RR("[1.1 +/- 0.2]")
+  z = max(x, y)
+  zz = maximum([x, y])
+  for i in 1:10
+    xx = Nemo._rand_rational_in_ball(x)
+    yy = Nemo._rand_rational_in_ball(y)
+    @test contains(z, max(xx, yy))
+    @test contains(zz, max(xx, yy))
+  end
 end
 
 @testset "ArbFieldElem.adhoc_comparison" begin


### PR DESCRIPTION
CC: @Tobias271828 @simonbrandhorst 

It seems that this also gives a correct `maximum` function for those arguments.