### PR TITLE
FracField type param must be a RingElem

### DIFF
--- a/src/flint/adhoc.jl
+++ b/src/flint/adhoc.jl
@@ -502,7 +502,7 @@ function divexact(a::ZZRingElem, b::FracElem; check::Bool=true)
   return parent(b)(n, d)
 end
 
-function (a::Generic.FracField{T})(b::ZZRingElem) where {T <: RingElement}
+function (a::Generic.FracField{T})(b::ZZRingElem) where {T <: RingElem}
   z = Generic.FracFieldElem{T}(base_ring(a)(b), one(base_ring(a)))
   z.parent = a
   return z


### PR DESCRIPTION
... not a `RingElement`. Of course the existing code was valid anyway (trying to use e.g. `BigInt` for `T` would have been caught).

But this change is required for https://github.com/Nemocas/AbstractAlgebra.jl/pull/2248 to avoid an ambiguity with the code changes there:
```
Error During Test at /home/runner/.julia/packages/Oscar/eTXAp/test/AlgebraicGeometry/Schemes/FunctionFields.jl:108
  Test threw exception
  Expression: 2 // h == ZZ(2) // h
  MethodError: (::AbstractAlgebra.Generic.FracField{FqMPolyRingElem})(::ZZRingElem) is ambiguous.
  
  Candidates:
    (a::AbstractAlgebra.Generic.FracField{T})(b::ZZRingElem) where T<:RingElement
      @ Nemo ~/.julia/packages/Nemo/i8LKC/src/flint/adhoc.jl:505
    (a::AbstractAlgebra.Generic.FracField{T})(b::RingElement) where T<:RingElem
      @ AbstractAlgebra.Generic ~/work/AbstractAlgebra.jl/AbstractAlgebra.jl/src/generic/Fraction.jl:79
  
  Possible fix, define
    (::AbstractAlgebra.Generic.FracField{T})(::ZZRingElem) where T<:RingElem
  

```
