### PR TITLE
Add `change_base_ring`, `map_entries!` methods

### DIFF
--- a/src/ZZMatrix-linalg.jl
+++ b/src/ZZMatrix-linalg.jl
@@ -24,13 +24,6 @@ function _det(a::fpMatrix)
   return r
 end
 
-function map_entries!(k::Nemo.fpField, a::fpMatrix, A::ZZMatrix)
-  @ccall libflint.nmod_mat_set_mod(a::Ref{fpMatrix}, k.n::UInt)::Cvoid
-  @ccall libflint.fmpz_mat_get_nmod_mat(a::Ref{fpMatrix}, A::Ref{ZZMatrix})::Cvoid
-  a.base_ring = k  # exploiting that the internal repr is the indep of char
-  return a
-end
-
 # Use this function with great care!
 function _unsafe_change_base_ring!(k::Nemo.fpField, a::fpMatrix)
   @ccall libflint.nmod_mat_set_mod(a::Ref{fpMatrix}, k.n::UInt)::Cvoid


### PR DESCRIPTION
Makes e.g. multiplication of `ZZMatrix` with `zzModMatrix` faster.

Before:

    julia> MZ = matrix(ZZ, rand(Int8, (20, 20)));
    
    julia> MR = matrix(R, rand(Int8, (20, 20)));
    
    julia> @b MZ * MR
    11.688 μs (409 allocs: 17.031 KiB)

After:

    julia> MZ = matrix(ZZ, rand(Int8, (20, 20)));
    
    julia> MR = matrix(R, rand(Int8, (20, 20)));
    
    julia> @b MZ * MR
    4.725 μs (9 allocs: 10.781 KiB)

Progress towards resolving #2209. However, to fully resolve that issue, we should also clarify the delegation between `map_entries`, `change_base_ring` and `matrix`.