### PR TITLE
Avoid `PolyRing(R)` in tests

### DIFF
--- a/test/arb/ComplexPoly-test.jl
+++ b/test/arb/ComplexPoly-test.jl
@@ -7,8 +7,8 @@ coeff_types = [Int8, Int, UInt, BigInt,
                ZZRingElem, QQFieldElem]
 
 @testset "ComplexPolyRingElem.constructors" begin
-  S1 = PolyRing(CC)
-  S2 = PolyRing(CC)
+  S1 = polynomial_ring(CC; cached=false)[1]
+  S2 = polynomial_ring(CC; cached=false)[1]
 
   @test isa(S1, ComplexPolyRing)
   @test S1 !== S2

--- a/test/arb/RealPoly-test.jl
+++ b/test/arb/RealPoly-test.jl
@@ -5,8 +5,8 @@ coeff_types = [Int8, Int, UInt, BigInt,
                ZZRingElem, QQFieldElem]
 
 @testset "RealPolyRingElem.constructors" begin
-  S1 = PolyRing(RR)
-  S2 = PolyRing(RR)
+  S1 = polynomial_ring(RR; cached=false)[1]
+  S2 = polynomial_ring(RR; cached=false)[1]
 
   @test isa(S1, RealPolyRing)
   @test S1 !== S2

--- a/test/arb/acb_poly-test.jl
+++ b/test/arb/acb_poly-test.jl
@@ -7,8 +7,8 @@ coeff_types = [Int8, Int, UInt, BigInt,
                ZZRingElem, QQFieldElem]
 
 @testset "AcbPolyRingElem.constructors" begin
-  S1 = PolyRing(CC)
-  S2 = PolyRing(CC)
+  S1 = polynomial_ring(CC; cached=false)[1]
+  S2 = polynomial_ring(CC; cached=false)[1]
 
   @test isa(S1, AcbPolyRing)
   @test S1 !== S2

--- a/test/arb/arb_poly-test.jl
+++ b/test/arb/arb_poly-test.jl
@@ -5,8 +5,8 @@ coeff_types = [Int8, Int, UInt, BigInt,
                ZZRingElem, QQFieldElem]
 
 @testset "ArbPolyRingElem.constructors" begin
-  S1 = PolyRing(RR)
-  S2 = PolyRing(RR)
+  S1 = polynomial_ring(RR; cached=false)[1]
+  S2 = polynomial_ring(RR; cached=false)[1]
 
   @test isa(S1, ArbPolyRing)
   @test S1 !== S2

--- a/test/flint/fmpq_poly-test.jl
+++ b/test/flint/fmpq_poly-test.jl
@@ -1,6 +1,6 @@
 @testset "QQPolyRingElem.constructors" begin
-  S1 = PolyRing(QQ)
-  S2 = PolyRing(QQ)
+  S1 = polynomial_ring(QQ; cached=false)[1]
+  S2 = polynomial_ring(QQ; cached=false)[1]
 
   @test isa(S1, QQPolyRing)
   @test S1 !== S2

--- a/test/flint/fmpz_mod_poly-test.jl
+++ b/test/flint/fmpz_mod_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "ZZModPolyRingElem.constructors" begin
   R, = residue_ring(ZZ, 123456789012345678949)
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, ZZModPolyRing)
   @test S1 !== S2

--- a/test/flint/fmpz_poly-test.jl
+++ b/test/flint/fmpz_poly-test.jl
@@ -1,6 +1,6 @@
 @testset "ZZPolyRingElem.constructors" begin
-  S1 = PolyRing(ZZ)
-  S2 = PolyRing(ZZ)
+  S1 = polynomial_ring(ZZ; cached=false)[1]
+  S2 = polynomial_ring(ZZ; cached=false)[1]
 
   @test isa(S1, ZZPolyRing)
   @test S1 !== S2

--- a/test/flint/fq_nmod_poly-test.jl
+++ b/test/flint/fq_nmod_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "fqPolyRepPolyRingElem.constructors" begin
   R, x = Native.finite_field(23, 5, "x")
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, fqPolyRepPolyRing)
   @test S1 !== S2

--- a/test/flint/fq_poly-test.jl
+++ b/test/flint/fq_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "FqPolyRepPolyRingElem.constructors" begin
   R, x = Native.finite_field(ZZRingElem(23), 5, "x")
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, FqPolyRepPolyRing)
   @test S1 !== S2

--- a/test/flint/gfp_fmpz_poly-test.jl
+++ b/test/flint/gfp_fmpz_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "FpPolyRingElem.constructors" begin
   R = Native.GF(ZZRingElem(123456789012345678949))
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, FpPolyRing)
   @test S1 !== S2

--- a/test/flint/gfp_poly-test.jl
+++ b/test/flint/gfp_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "fpPolyRingElem.constructors" begin
   R = Native.GF(17)
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, fpPolyRing)
   @test S1 !== S2

--- a/test/flint/nmod_poly-test.jl
+++ b/test/flint/nmod_poly-test.jl
@@ -1,8 +1,8 @@
 @testset "zzModPolyRingElem.constructors" begin
   R, = residue_ring(ZZ, 17)
 
-  S1 = PolyRing(R)
-  S2 = PolyRing(R)
+  S1 = polynomial_ring(R; cached=false)[1]
+  S2 = polynomial_ring(R; cached=false)[1]
 
   @test isa(S1, zzModPolyRing)
   @test S1 !== S2

--- a/test/generic_poly_tests.jl
+++ b/test/generic_poly_tests.jl
@@ -1,8 +1,8 @@
 function test_poly_constructors(R)
 
   @testset "poly.constructors for $(R) of type $(typeof(R))" begin
-    S1 = PolyRing(R)
-    S2 = PolyRing(R)
+    S1 = polynomial_ring(R; cached=false)[1]
+    S2 = polynomial_ring(R; cached=false)[1]
 
     #@test isa(S1, GFPPolyRing)
     @test S1 !== S2


### PR DESCRIPTION
This is motivated by https://github.com/Nemocas/AbstractAlgebra.jl/pull/1729 but I think it is of independent value to avoid this undocumented internal constructor (which the mentioned PR deprecates)