### PR TITLE
Change the `prec` positional argument to a keyword argument for `derivative` and `integral` methods for `ComplexPolyRingElem` and `RealPolyRingElem`

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -764,14 +764,6 @@ function zeros(f::ZZPolyRingElem)
   return zeros
 end
 
-#This should probably go somewhere else. (Taking the nth derivative)
-function derivative(x::AcbPolyRingElem, n::Int64)
-  for i in (1:n)
-    x = derivative(x)
-  end
-  return x
-end
-
 function lift!(x::fpFieldElem, z::ZZRingElem)
   set!(z, x.data)
   return z

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -396,13 +396,13 @@ end
 #
 ###############################################################################
 
-function derivative(x::ComplexPolyRingElem, prec::Int = precision(Balls))
+function derivative(x::ComplexPolyRingElem; prec::Int = precision(Balls))
   z = parent(x)()
   @ccall libflint.acb_poly_derivative(z::Ref{ComplexPolyRingElem}, x::Ref{ComplexPolyRingElem}, prec::Int)::Nothing
   return z
 end
 
-function integral(x::ComplexPolyRingElem, prec::Int = precision(Balls))
+function integral(x::ComplexPolyRingElem; prec::Int = precision(Balls))
   z = parent(x)()
   @ccall libflint.acb_poly_integral(z::Ref{ComplexPolyRingElem}, x::Ref{ComplexPolyRingElem}, prec::Int)::Nothing
   return z

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -397,13 +397,13 @@ end
 #
 ###############################################################################
 
-function derivative(x::RealPolyRingElem, prec::Int = precision(Balls))
+function derivative(x::RealPolyRingElem; prec::Int = precision(Balls))
   z = parent(x)()
   @ccall libflint.arb_poly_derivative(z::Ref{RealPolyRingElem}, x::Ref{RealPolyRingElem}, prec::Int)::Nothing
   return z
 end
 
-function integral(x::RealPolyRingElem, prec::Int = precision(Balls))
+function integral(x::RealPolyRingElem; prec::Int = precision(Balls))
   z = parent(x)()
   @ccall libflint.arb_poly_integral(z::Ref{RealPolyRingElem}, x::Ref{RealPolyRingElem}, prec::Int)::Nothing
   return z

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -406,6 +406,15 @@ function derivative(x::AcbPolyRingElem)
   return z
 end
 
+function derivative(x::AcbPolyRingElem, n::Int64)
+  # TODO: reimplement using _acb_poly_nth_derivative
+  # and then do the equivalent for {Complex,Arb,Real}PolyRingElem
+  for i in (1:n)
+    x = derivative(x)
+  end
+  return x
+end
+
 function integral(x::AcbPolyRingElem)
   z = parent(x)()
   @ccall libflint.acb_poly_integral(z::Ref{AcbPolyRingElem}, x::Ref{AcbPolyRingElem}, precision(parent(x))::Int)::Nothing


### PR DESCRIPTION
For *multivariate* polynomials, `derivative(f, i)` indicates the derivative with respect to `gen(parent(f), i)`.

For *unary* polynomials, there is no common documented definition for what it might mean, and it does not exist in general. But people have added some such methods, unfortunately with two different meanings:

1. the `i` sometimes stands for a precision
2. the `i` sometimes indicates the `i`-th derivative

This ambiguity is especially unfortunate when one contrasts `derivative(x::ComplexPolyRingElem, prec::Int = precision(Balls))` with meaning 1, with `derivative(x::AcbPolyRingElem, n::Int64)` with meaning 2.

My proposed solution is that we change the `prec` positional argument into a keyword argument (it will also make calling code clearer IMHO). In fact I would suggest to do this for many more positional `prec` arguments.

We could also think about officially defining and documenting meaning 2, and adding a general fallback method for it to AA.