### PR TITLE
Add `nf_elem_to_poly!` helper

### DIFF
--- a/src/Deprecations.jl
+++ b/src/Deprecations.jl
@@ -101,3 +101,9 @@ import Base: Array, view
 
 # to be deprecated in a future minor release
 fq_default_mat_entry_ptr(F::FqMatrix, i::Int, j::Int) = mat_entry_ptr(F, i, j)
+
+# Prepared for deprecation in 0.54
+nf_elem_to_nmod_poly!(r::zzModPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
+nf_elem_to_fmpz_mod_poly!(r::ZZModPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
+nf_elem_to_gfp_poly!(r::fpPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
+nf_elem_to_gfp_fmpz_poly!(r::FpPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)

--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -791,12 +791,6 @@ function (R::ZZModPolyRing)(a::AbsSimpleNumFieldElem) = nf_elem_to_poly!(R(), a)
 function (R::fpPolyRing)(a::AbsSimpleNumFieldElem) = nf_elem_to_poly!(R(), a)
 function (R::FpPolyRing)(a::AbsSimpleNumFieldElem) = nf_elem_to_poly!(R(), a)
 
-# deprecate the following?
-nf_elem_to_nmod_poly!(r::zzModPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
-nf_elem_to_fmpz_mod_poly!(r::ZZModPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
-nf_elem_to_gfp_poly!(r::fpPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
-nf_elem_to_gfp_fmpz_poly!(r::FpPolyRingElem, a::AbsSimpleNumFieldElem, useden::Bool=true) = nf_elem_to_poly!(r, a, useden)
-
 ################################################################################
 #
 #


### PR DESCRIPTION
Also add a "missing" coercion from `AbsSimpleNumFieldElem` to `FpPolyRingElem`.

But considering the work @thofma just went through to get rid of a bunch of non-"canonical" coercions, perhaps instead of adding this one, the other three should be removed?
(I don't know if anything *uses* these... would need upstream tests to know)

Note that the functions `nf_elem_to_gfp_fmpz_poly!` etc. are used in Hecke. Once Hecke switched to the new name `nf_elem_to_poly!`, the old names could be deprecated/removed.
