### PR TITLE
Remove `replace!(::typeof(-), m::ZZMatrix)`

### DIFF
--- a/src/HeckeMoreStuff.jl
+++ b/src/HeckeMoreStuff.jl
@@ -794,8 +794,6 @@ function mod_sym!(a::T, b::T) where {T}
   return mod!(a, b)
 end
 
-Base.replace!(::typeof(-), m::ZZMatrix) = -m
-
 function (A::AbsSimpleNumField)(a::ZZPolyRingElem)
   return A(QQ["x"][1](a))
 end


### PR DESCRIPTION
This is a really strange method. I also found nothing calling it
in Hecke or elsewhere, so hopefull it is safe to remove.
