### PR TITLE
Fix `gcd`/`lcm` of a singleton ZZ vector to be non-negative

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1373,7 +1373,7 @@ function gcd(x::Vector{ZZRingElem})
   if length(x) == 0
     error("Array must not be empty")
   elseif length(x) == 1
-    return x[1]
+    return abs(only(x))
   end
 
   z = ZZRingElem()
@@ -1416,7 +1416,7 @@ function lcm(x::Vector{ZZRingElem})
   if length(x) == 0
     error("Array must not be empty")
   elseif length(x) == 1
-    return x[1]
+    return abs(only(x))
   end
 
   z = ZZRingElem()

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -398,6 +398,7 @@ end
   @test_throws ErrorException gcd(ZZRingElem[])
 
   @test gcd(ZZRingElem[8]) == 8
+  @test gcd(ZZRingElem[-3]) == 3
 
   @test gcd([ZZRingElem(10), ZZRingElem(2)]) == 2
 
@@ -420,6 +421,7 @@ end
   @test_throws ErrorException lcm(ZZRingElem[])
 
   @test lcm(ZZRingElem[2]) == 2
+  @test lcm(ZZRingElem[-3]) == 3
 
   @test lcm(ZZRingElem[2, 3]) == 6
 


### PR DESCRIPTION
As this is what the docstring states.
Resolves the issue from https://github.com/oscar-system/Oscar.jl/pull/5734#issuecomment-3823553420.

cc @benlorenz @HechtiDerLachs