### PR TITLE
Add resultant/discriminant for QQ/ZZ/FpMPolyRingElem

### DIFF
--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -524,6 +524,30 @@ end
 
 ###############################################################################
 #
+#   Resultant, discriminant
+#
+###############################################################################
+
+function resultant(a::QQMPolyRingElem, b::QQMPolyRingElem, i::Int)
+  n = nvars(parent(a))
+  (i <= 0 || i > n) && error("Index must be between 1 and $n")
+  z = parent(a)()
+  r = @ccall libflint.fmpq_mpoly_resultant(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, b::Ref{QQMPolyRingElem}, (i - 1)::Int, parent(a)::Ref{QQMPolyRing})::Cint
+  r == 0 && error("Unable to compute resultant")
+  return z
+end
+
+function discriminant(a::QQMPolyRingElem, i::Int)
+  n = nvars(parent(a))
+  (i <= 0 || i > n) && error("Index must be between 1 and $n")
+  z = parent(a)()
+  r = @ccall libflint.fmpq_mpoly_discriminant(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, (i - 1)::Int, parent(a)::Ref{QQMPolyRing})::Cint
+  r == 0 && error("Unable to compute discriminant")
+  return z
+end
+
+###############################################################################
+#
 #   Evaluation
 #
 ###############################################################################

--- a/src/flint/fmpz_mod_mpoly.jl
+++ b/src/flint/fmpz_mod_mpoly.jl
@@ -576,6 +576,30 @@ for (etype, rtype, ftype, ctype) in (
 
     ###############################################################################
     #
+    #   Resultant, discriminant
+    #
+    ###############################################################################
+
+    function resultant(a::($etype), b::($etype), i::Int)
+      n = nvars(parent(a))
+      (i <= 0 || i > n) && error("Index must be between 1 and $n")
+      z = parent(a)()
+      r = @ccall libflint.fmpz_mod_mpoly_resultant(z::Ref{($etype)}, a::Ref{($etype)}, b::Ref{($etype)}, (i - 1)::Int, parent(a)::Ref{($rtype)})::Cint
+      r == 0 && error("Unable to compute resultant")
+      return z
+    end
+
+    function discriminant(a::($etype), i::Int)
+      n = nvars(parent(a))
+      (i <= 0 || i > n) && error("Index must be between 1 and $n")
+      z = parent(a)()
+      r = @ccall libflint.fmpz_mod_mpoly_discriminant(z::Ref{($etype)}, a::Ref{($etype)}, (i - 1)::Int, parent(a)::Ref{($rtype)})::Cint
+      r == 0 && error("Unable to compute discriminant")
+      return z
+    end
+
+    ###############################################################################
+    #
     #   Evaluation
     #
     ###############################################################################

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -505,6 +505,30 @@ end
 
 ###############################################################################
 #
+#   Resultant, discriminant
+#
+###############################################################################
+
+function resultant(a::ZZMPolyRingElem, b::ZZMPolyRingElem, i::Int)
+  n = nvars(parent(a))
+  (i <= 0 || i > n) && error("Index must be between 1 and $n")
+  z = parent(a)()
+  r = @ccall libflint.fmpz_mpoly_resultant(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, b::Ref{ZZMPolyRingElem}, (i - 1)::Int, parent(a)::Ref{ZZMPolyRing})::Cint
+  r == 0 && error("Unable to compute resultant")
+  return z
+end
+
+function discriminant(a::ZZMPolyRingElem, i::Int)
+  n = nvars(parent(a))
+  (i <= 0 || i > n) && error("Index must be between 1 and $n")
+  z = parent(a)()
+  r = @ccall libflint.fmpz_mpoly_discriminant(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, (i - 1)::Int, parent(a)::Ref{ZZMPolyRing})::Cint
+  r == 0 && error("Unable to compute discriminant")
+  return z
+end
+
+###############################################################################
+#
 #   Evaluation
 #
 ###############################################################################

--- a/test/flint/fmpq_mpoly-test.jl
+++ b/test/flint/fmpq_mpoly-test.jl
@@ -712,6 +712,23 @@ end
   end
 end
 
+@testset "QQMPolyRingElem.resultant" begin
+  R, (x, y) = polynomial_ring(QQ, [:x, :y])
+
+  f = 3x*y^2 + (x + 1)*y + 3
+  g = 6(x + 1)*y + (x^3 + 2x + 2)
+
+  @test resultant(f, g, 2) == 3*x^7+6*x^5-6*x^3+96*x^2+192*x+96
+end
+
+@testset "QQMPolyRingElem.discriminant" begin
+  R, (x, y) = polynomial_ring(QQ, [:x, :y])
+
+  f = x*y^2 + (x + 1)*y + 3
+
+  @test discriminant(f, 2) == x^2-10*x+1
+end
+
 @testset "QQMPolyRingElem.combine_like_terms" begin
   for num_vars = 1:10
     var_names = ["x$j" for j in 1:num_vars]

--- a/test/flint/fmpz_mpoly-test.jl
+++ b/test/flint/fmpz_mpoly-test.jl
@@ -697,6 +697,23 @@ end
   end
 end
 
+@testset "ZZMPolyRingElem.resultant" begin
+  R, (x, y) = polynomial_ring(ZZ, [:x, :y])
+
+  f = 3x*y^2 + (x + 1)*y + 3
+  g = 6(x + 1)*y + (x^3 + 2x + 2)
+
+  @test resultant(f, g, 2) == 3*x^7+6*x^5-6*x^3+96*x^2+192*x+96
+end
+
+@testset "ZZMPolyRingElem.discriminant" begin
+  R, (x, y) = polynomial_ring(ZZ, [:x, :y])
+
+  f = x*y^2 + (x + 1)*y + 3
+
+  @test discriminant(f, 2) == x^2-10*x+1
+end
+
 @testset "ZZMPolyRingElem.combine_like_terms" begin
   for num_vars = 1:10
     var_names = ["x$j" for j in 1:num_vars]

--- a/test/flint/gfp_fmpz_mpoly-test.jl
+++ b/test/flint/gfp_fmpz_mpoly-test.jl
@@ -668,6 +668,25 @@ end
   end
 end
 
+@testset "FpMPolyRingElem.resultant" begin
+  F = Native.GF(ZZ(23))
+  R, (x, y) = polynomial_ring(F, [:x, :y])
+
+  f = 3x*y^2 + (x + 1)*y + 3
+  g = 6(x + 1)*y + (x^3 + 2x + 2)
+
+  @test resultant(f, g, 2) == 3*x^7+6*x^5+17*x^3+4*x^2+8*x+4
+end
+
+@testset "FpMPolyRingElem.discriminant" begin
+  F = Native.GF(ZZ(23))
+  R, (x, y) = polynomial_ring(F, [:x, :y])
+
+  f = x*y^2 + (x + 1)*y + 3
+
+  @test discriminant(f, 2) == x^2+13*x+1
+end
+
 @testset "FpMPolyRingElem.unsafe" begin
   R23 = Native.GF(ZZRingElem(23))
 


### PR DESCRIPTION
Surprisingly, Nemo.jl does not provide wrappers for `{fmpq,fmpz,fmpz_mod}_mpoly_{resultant,discriminant}`, so I added them in this PR. Hopefully, this will allow us to benefit from future improvements to these functions in FLINT (as far as I know, at least four people are working on this).