### PR TITLE
Document and export `set!`

### DIFF
--- a/docs/src/developer/topics.md
+++ b/docs/src/developer/topics.md
@@ -279,6 +279,13 @@ performance characteristics of a new object being created per operation will
 result, meaning that the developer will not be able to reason about the likely
 performance of unsafe operators.
 
+The function `set!` changes the value of an element to be the value of another
+element of the same mutable type and returns that value. Moreover, `set!` also
+provides type casting, that is, the types of the inputs may differ. For example,
+often ring elements can be set to values of type `Int`. More information on using
+`set!` in the context of `ZZRingElem` and `Int` can be found [here](@ref basic_manipulation_of_integers). Warning: Bad things
+can happen if this method is used incorrectly, including memory corruption and crashes.
+
 ### Interaction of unsafe operators and immutable types
 
 Because not all objects in Nemo are mutable, the unsafe operators somehow have

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -63,8 +63,7 @@ ZZ(n::BigFloat)
 Coerce the given floating point number into the integer ring, assuming that it
 can be exactly represented as an integer.
 
-### Basic manipulation
-
+### [Basic manipulation](@id basic_manipulation_of_integers)
 ```@docs
 sign(::ZZRingElem)
 ```
@@ -84,6 +83,14 @@ denominator(::ZZRingElem)
 
 ```@docs
 numerator(::ZZRingElem)
+```
+
+```@docs
+set!(::ZZRingElemOrPtr, ::ZZRingElemOrPtr)
+```
+
+```@docs
+set!(::ZZRingElemOrPtr, ::Int)
 ```
 
 **Examples**

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -86,7 +86,7 @@ numerator(::ZZRingElem)
 ```
 
 ```@docs
-set!(::ZZRingElemOrPtr, ::Integer)
+set!(::ZZRingElemOrPtr, ::ZZRingElemOrPtr)
 ```
 **Examples**
 

--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -86,13 +86,8 @@ numerator(::ZZRingElem)
 ```
 
 ```@docs
-set!(::ZZRingElemOrPtr, ::ZZRingElemOrPtr)
+set!(::ZZRingElemOrPtr, ::Integer)
 ```
-
-```@docs
-set!(::ZZRingElemOrPtr, ::Int)
-```
-
 **Examples**
 
 ```jldoctest

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -555,6 +555,7 @@ export round!
 export rref
 export rref!
 export rsqrt
+export set!
 export set_exponent_vector!
 export set_printing_mode
 export setbit!

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2497,6 +2497,7 @@ end
 
 @doc raw"""
     set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+    set!(z::ZZRingElemOrPtr, a::Integer)
 
 Change `z` to be equal to `a` and return `z`.
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2525,7 +2525,6 @@ julia> z += 3
 
 julia> z, a
 (307, 304)
-
 ```
 """
 function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
@@ -2536,7 +2535,7 @@ end
 @doc raw"""
     set!(z::ZZRingElemOrPtr, a::Int)
 
-Change `z` to be equal to the value of `a`, casted into a `ZZRingElem`, and return `z`.
+Change `z` to be equal to `a` and return `z`.
 
 The command `set!(z, a)` has the same effect as `z = ZZ(a)`, however,
 `set!(z, a)` is allocation-free and, thus, usually faster than `z = ZZ(a)`.
@@ -2558,7 +2557,6 @@ julia> z
 
 julia> typeof(z)
 ZZRingElem
-
 ```
 """
 function set!(z::ZZRingElemOrPtr, a::Int)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2495,11 +2495,70 @@ function neg!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
   return z
 end
 
+@doc raw"""
+    set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+
+Change `z` to be equal to `a` and return `z`.
+
+The command `set!(z, a)` has the same effect as `z = ZZ(a)`, however,
+`set!(z, a)` is allocation-free and, thus, usually faster than `z = ZZ(a)`.
+
+In contrast to `z = a`, the command `set!` copies the value of `a` instead
+of turning `z` into a new label of `a`.
+
+# Examples
+
+```jldoctest
+julia> a = ZZ(304)
+304
+
+julia> z = ZZ(936)
+936
+
+julia> set!(z, a)
+304
+
+julia> z += 3
+307
+
+julia> z, a
+(307, 304)
+
+```
+"""
 function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
   @ccall libflint.fmpz_set(z::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
+@doc raw"""
+    set!(z::ZZRingElemOrPtr, a::Int)
+
+Change `z` to be equal to the value of `a`, casted into a `ZZRingElem`, and return `z`.
+
+The command `set!(z, a)` has the same effect as `z = ZZ(a)`, however,
+`set!(z, a)` is allocation-free and, thus, usually faster than `z = ZZ(a)`.
+
+In contrast to `z = a`, the command `set!` copies the value of `a` and
+keeps `z` of type `ZZRingElem` instead of turning `z` into an `Int`.
+
+# Examples
+
+```jldoctest
+julia> z = ZZ(936)
+936
+
+julia> set!(z, 304)
+304
+
+julia> z
+304
+
+julia> typeof(z)
+ZZRingElem
+
+```
+"""
 function set!(z::ZZRingElemOrPtr, a::Int)
   @ccall libflint.fmpz_set_si(z::Ref{ZZRingElem}, a::Int)::Nothing
   return z

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2514,20 +2514,39 @@ other variable references the same object as `z`.
 # Examples
 
 ```jldoctest
-julia> a = ZZ(304)
-304
-
-julia> z = ZZ(936)
+julia> a = ZZ(304); z = ZZ(936); x = z
 936
 
 julia> set!(z, a)
 304
 
-julia> z += 3
-307
+julia> add!(z, 123)
+427
 
-julia> z, a
-(307, 304)
+julia> (a, x, z)
+(304, 427, 427)
+
+julia> x === z
+true
+
+julia> A = zeros(ZZRingElem, 2, 2) # All entries of `A` point to the same object.
+2×2 Matrix{ZZRingElem}:
+ 0  0
+ 0  0
+
+julia> A[1,1] = ZZ(5) # Create a new object and let `A[1,1]` point to it.
+5
+
+julia> set!(A[1,1], 8) # So, changing `A[1,1]` using `set!` does not change the other entries of `A`.
+8
+
+julia> set!(A[1,2], 3) # The other three matrix entries are still pointing to the same object. Changing one of them using `set!` changes all of them.
+3
+
+julia> A
+2×2 Matrix{ZZRingElem}:
+ 8  3
+ 3  3
 ```
 """
 function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2500,11 +2500,13 @@ end
 
 Change `z` to be equal to `a` and return `z`.
 
-The command `set!(z, a)` has the same effect as `z = ZZ(a)`, however,
-`set!(z, a)` is allocation-free and, thus, usually faster than `z = ZZ(a)`.
+The command `set!(z, a)` has the same effect as `z = ZZ(a)`,
+but `set!(z, a)` is usually faster. This is because the latter
+always allocates, whereas the former does not if `a` is small
+enough to fit in the pre-allocated space for `z`.
 
-In contrast to `z = a`, the command `set!` copies the value of `a` instead
-of turning `z` into a new label of `a`.
+In contrast to `z = a`, the command `set!` copies the value
+of `a` instead of turning `z` into a new label of `a`.
 
 # Examples
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2533,33 +2533,6 @@ function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
   return z
 end
 
-@doc raw"""
-    set!(z::ZZRingElemOrPtr, a::Int)
-
-Change `z` to be equal to `a` and return `z`.
-
-The command `set!(z, a)` has the same effect as `z = ZZ(a)`, however,
-`set!(z, a)` is allocation-free and, thus, usually faster than `z = ZZ(a)`.
-
-In contrast to `z = a`, the command `set!` copies the value of `a` and
-keeps `z` of type `ZZRingElem` instead of turning `z` into an `Int`.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ(936)
-936
-
-julia> set!(z, 304)
-304
-
-julia> z
-304
-
-julia> typeof(z)
-ZZRingElem
-```
-"""
 function set!(z::ZZRingElemOrPtr, a::Int)
   @ccall libflint.fmpz_set_si(z::Ref{ZZRingElem}, a::Int)::Nothing
   return z

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2501,13 +2501,15 @@ end
 
 Change `z` to be equal to `a` and return `z`.
 
-The command `set!(z, a)` has the same effect as `z = ZZ(a)`,
-but `set!(z, a)` is usually faster. This is because the latter
-always allocates, whereas the former does not if `a` is small
-enough to fit in the pre-allocated space for `z`.
+The command `set!(z, a)` has essentially the same effect as `z = ZZ(a)`,
+except that in the former case, the existing object `z` references is modified
+while in the latter `z` is changed to point to a new object.
 
-In contrast to `z = a`, the command `set!` copies the value
-of `a` instead of turning `z` into a new label of `a`.
+A benefit of this that it generally is faster and avoids allocations,
+at least if `a` is small enough to fit in the already allocated storage of `z`.
+
+However, this can also have unintended consequences if for example some
+other variable references the same object as `z`.
 
 # Examples
 


### PR DESCRIPTION
To perform fast integer computations in Nemo, it seems that low-level helper functions such as `add!, mul!, set!, ...` are inevitable. However, the `set!` command, which creates a FLINT-deepcopy, is not exported yet, so that one needs to call `Nemo.set!` to access it.