### PR TITLE
Add allocation-free signed remainder `mod_sym!`

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -604,6 +604,7 @@ export swap_rows!
 export swinnerton_dyer
 export symbols
 export SymmetricGroup
+export sym_mod
 export sym_mod!
 export tan
 export tanh

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -604,8 +604,6 @@ export swap_rows!
 export swinnerton_dyer
 export symbols
 export SymmetricGroup
-export sym_mod
-export sym_mod!
 export tan
 export tanh
 export tanpi

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -604,6 +604,7 @@ export swap_rows!
 export swinnerton_dyer
 export symbols
 export SymmetricGroup
+export sym_mod!
 export tan
 export tanh
 export tanpi

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1020,6 +1020,47 @@ function mod_sym!(a::ZZRingElem, b::ZZRingElem)
   return a
 end
 
+@doc raw"""
+    sym_mod!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+
+Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $z$ in the process. See also Nemo.smod.
+
+# Examples
+
+```jldoctest
+julia> z = ZZ()
+0
+
+julia> sym_mod!(z, ZZ(12341), ZZ(312))
+-139
+
+julia> z
+-139
+
+```
+"""
+function sym_mod!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+  @ccall libflint.fmpz_smod(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+@doc raw"""
+    sym_mod!(a::ZZRingElem, b::ZZRingElem)
+
+Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$. See also Nemo.smod.
+
+# Examples
+
+```jldoctest
+julia> sym_mod!(ZZ(12341), ZZ(312))
+-139
+
+```
+"""
+function sym_mod!(a::ZZRingElem, b::ZZRingElem)
+  z = ZZRingElem()
+  return sym_mod!(z, a, b)
+end
 
 @doc raw"""
     powermod(x::ZZRingElem, p::ZZRingElem, m::ZZRingElem)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1045,19 +1045,19 @@ function sym_mod!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
 end
 
 @doc raw"""
-    sym_mod!(a::ZZRingElem, b::ZZRingElem)
+    sym_mod(a::ZZRingElem, b::ZZRingElem)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$. See also Nemo.smod.
 
 # Examples
 
 ```jldoctest
-julia> sym_mod!(ZZ(12341), ZZ(312))
+julia> sym_mod(ZZ(12341), ZZ(312))
 -139
 
 ```
 """
-function sym_mod!(a::ZZRingElem, b::ZZRingElem)
+function sym_mod(a::ZZRingElem, b::ZZRingElem)
   z = ZZRingElem()
   return sym_mod!(z, a, b)
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1027,7 +1027,7 @@ julia> z
 
 ```
 """
-function mod_sym!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+function mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
   @ccall libflint.fmpz_smod(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1009,7 +1009,7 @@ function mod(x::ZZRingElemOrPtr, c::UInt)
 end
 
 @doc raw"""
-    mod_sym!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+    mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $z$ in the process. See also Nemo.smod.
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1033,7 +1033,7 @@ function mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 end
 
 @doc raw"""
-    mod_sym!(a::ZZRingElem, b::ZZRingElem)
+    mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $a$ in the process. See also Nemo.smod.
 This is a shorthand for mod_sym!(a, a, b).
@@ -1052,7 +1052,7 @@ julia> a
 
 ```
 """
-function mod_sym!(a::ZZRingElem, b::ZZRingElem)
+function mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
   return mod_sym!(a, a, b)
 end
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1037,7 +1037,7 @@ end
     mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 
 Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
-$-b < 2x \le b$, possibly modifying the object $z$ in the process.
+$-b < 2x \le b$, possibly modifying the object $a$ in the process.
 This is a shorthand for mod_sym!(a, a, b).
 
 # Examples

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1038,7 +1038,7 @@ end
 
 Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
 $-b < 2x \le b$, possibly modifying the object $a$ in the process.
-This is a shorthand for mod_sym!(a, a, b).
+This is a shorthand for `mod_sym!(a, a, b)`.
 
 # Examples
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1008,20 +1008,8 @@ function mod(x::ZZRingElemOrPtr, c::UInt)
   @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, c::UInt)::UInt
 end
 
-function mod_sym(a::ZZRingElem, b::ZZRingElem)
-  return mod_sym!(deepcopy(a), b)
-end
-
-function mod_sym!(a::ZZRingElem, b::ZZRingElem)
-  mod!(a, a, b)
-  if (b > 0 && a > div(b, 2)) || (b < 0 && a < div(b, 2))
-    sub!(a, a, b)
-  end
-  return a
-end
-
 @doc raw"""
-    sym_mod!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+    mod_sym!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $z$ in the process. See also Nemo.smod.
 
@@ -1031,7 +1019,7 @@ Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ sati
 julia> z = ZZ()
 0
 
-julia> sym_mod!(z, ZZ(12341), ZZ(312))
+julia> mod_sym!(z, ZZ(12341), ZZ(312))
 -139
 
 julia> z
@@ -1039,27 +1027,27 @@ julia> z
 
 ```
 """
-function sym_mod!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
+function mod_sym!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
   @ccall libflint.fmpz_smod(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
 @doc raw"""
-    sym_mod(a::ZZRingElem, b::ZZRingElem)
+    mod_sym(a::ZZRingElem, b::ZZRingElem)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$. See also Nemo.smod.
 
 # Examples
 
 ```jldoctest
-julia> sym_mod(ZZ(12341), ZZ(312))
+julia> mod_sym(ZZ(12341), ZZ(312))
 -139
 
 ```
 """
-function sym_mod(a::ZZRingElem, b::ZZRingElem)
+function mod_sym(a::ZZRingElem, b::ZZRingElem)
   z = ZZRingElem()
-  return sym_mod!(z, a, b)
+  return mod_sym!(z, a, b)
 end
 
 @doc raw"""

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1011,7 +1011,8 @@ end
 @doc raw"""
     mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 
-Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $z$ in the process. See also Nemo.smod.
+Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
+$-b < 2x \le b$, possibly modifying the object $z$ in the process.
 
 # Examples
 
@@ -1035,7 +1036,8 @@ end
 @doc raw"""
     mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
 
-Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $a$ in the process. See also Nemo.smod.
+Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
+$-b < 2x \le b$, possibly modifying the object $z$ in the process.
 This is a shorthand for mod_sym!(a, a, b).
 
 # Examples
@@ -1059,7 +1061,8 @@ end
 @doc raw"""
     mod_sym(a::ZZRingElem, b::ZZRingElem)
 
-Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$. See also Nemo.smod.
+Return the signed remainder of $a$ mod $b$, that is,
+the unique integer $x$ satisfying $-b < 2x \le b$.
 
 # Examples
 

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -1033,6 +1033,30 @@ function mod_sym!(z::ZZRingElem, a::ZZRingElem, b::ZZRingElem)
 end
 
 @doc raw"""
+    mod_sym!(a::ZZRingElem, b::ZZRingElem)
+
+Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$, possibly modifying the object $a$ in the process. See also Nemo.smod.
+This is a shorthand for mod_sym!(a, a, b).
+
+# Examples
+
+```jldoctest
+julia> a = ZZ(12341)
+12341
+
+julia> mod_sym!(a, ZZ(312))
+-139
+
+julia> a
+-139
+
+```
+"""
+function mod_sym!(a::ZZRingElem, b::ZZRingElem)
+  return mod_sym!(a, a, b)
+end
+
+@doc raw"""
     mod_sym(a::ZZRingElem, b::ZZRingElem)
 
 Returns the signed remainder of $a$ mod $b$, that is the unique integer $x$ satisfying -$b$ < 2*$x$ <= $b$. See also Nemo.smod.


### PR DESCRIPTION
So far, there are already ways to compute the signed remainder of a mod b (that is the unique integer x such that -b < 2*x <= b). These are, however, not allocation-free yet. This pull request closes this gap.