### PR TITLE
Improve performance of `is_divisible_by`

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -491,43 +491,21 @@ end
 divides(x::ZZRingElem, y::Integer) = divides(x, ZZRingElem(y))
 
 @doc raw"""
-    is_divisible_by(x::ZZRingElem, y::ZZRingElem)
+    is_divisible_by(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
 
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
-function is_divisible_by(x::ZZRingElem, y::ZZRingElem)
-  if iszero(x)
-    return true
-  elseif iszero(y)
-    return false
-  elseif iseven(y) && isodd(x)
-    return false
-  elseif nbits(y) > nbits(x)
-    return false
-  else
-    flag, q = divides(x, y)
-    return flag
-  end
+function is_divisible_by(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+  Bool(@ccall libflint.fmpz_divisible(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint)
 end
 
 @doc raw"""
-    is_divisible_by(x::ZZRingElem, y::ZZRingElem)
+    is_divisible_by(x::ZZRingElemOrPtr, y::Int)
 
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
-function is_divisible_by(x::ZZRingElem, y::Integer)
-  if iszero(x)
-    return true
-  elseif iszero(y)
-    return false
-  elseif iseven(y) && isodd(x)
-    return false
-  elseif ndigits(y, base=2) > nbits(x)
-    return false
-  else
-    r = mod(x, y)
-    return r == 0
-  end
+function is_divisible_by(x::ZZRingElemOrPtr, y::Int)
+  Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
 function is_divisible_by(x::Integer, y::ZZRingElem)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -508,6 +508,10 @@ function is_divisible_by(x::ZZRingElemOrPtr, y::Int)
   Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
+function is_divisible_by(x::ZZRingElemOrPtr, y::UInt)
+  Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::UInt)::Cint)
+end
+
 function is_divisible_by(x::Integer, y::ZZRingElem)
   return is_divisible_by(ZZRingElem(x), y)
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -508,8 +508,8 @@ function is_divisible_by(x::ZZRingElemOrPtr, y::Int)
   Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
-function is_divisible_by(x::ZZRingElemOrPtr, y::UInt)
-  Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::UInt)::Cint)
+function is_divisible_by(x::ZZRingElemOrPtr, y::Integer)
+  is_divisible_by(x, flintify(y))
 end
 
 function is_divisible_by(x::Integer, y::ZZRingElem)

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -496,7 +496,7 @@ divides(x::ZZRingElem, y::Integer) = divides(x, ZZRingElem(y))
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
 function is_divisible_by(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
-  Bool(@ccall libflint.fmpz_divisible(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint)
+  return Bool(@ccall libflint.fmpz_divisible(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint)
 end
 
 @doc raw"""
@@ -505,11 +505,11 @@ end
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
 function is_divisible_by(x::ZZRingElemOrPtr, y::Int)
-  Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
+  return Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
 function is_divisible_by(x::ZZRingElemOrPtr, y::Integer)
-  is_divisible_by(x, flintify(y))
+  return is_divisible_by(x, flintify(y))
 end
 
 function is_divisible_by(x::Integer, y::ZZRingElem)


### PR DESCRIPTION
This makes `is_divisible_by` allocation free and faster by relying on Flint instead of performing modular operations which allocate.

Here is an example Benchmark:
Nemo current stable version:
```
julia> a = ZZ(14822); sieben = ZZ(7)
7

julia> @be is_divisible_by(a, sieben)
Benchmark: 1875 samples with 249 evaluations
 min    113.181 ns (1 allocs: 16 bytes)
 median 134.699 ns (1 allocs: 16 bytes)
 mean   274.102 ns (1 allocs: 16 bytes, 0.04% gc time)
 max    255.429 μs (1 allocs: 16 bytes, 66.00% gc time)

julia> @be is_divisible_by(a, 7)
Benchmark: 2721 samples with 275 evaluations
 min    98.516 ns (2 allocs: 32 bytes)
 median 123.295 ns (2 allocs: 32 bytes)
 mean   123.056 ns (2 allocs: 32 bytes)
 max    599.160 ns (2 allocs: 32 bytes)
```
This pull request:
```
julia> a = ZZ(14822); sieben = ZZ(7)
7

julia> @be is_divisible_by(a, sieben)
Benchmark: 3016 samples with 427 evaluations
 min    67.623 ns
 median 71.489 ns
 mean   71.611 ns
 max    162.726 ns

julia> @be is_divisible_by(a, 7)
Benchmark: 3118 samples with 517 evaluations
 min    54.427 ns
 median 56.873 ns
 mean   57.224 ns
 max    150.797 ns
```