### PR TITLE
Add inplace operations for integer divisions with divisors of type `ZZRingElem`

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -610,6 +610,8 @@ function div(f::ZZRingElem, g::Int)
   div!(z, f, g)
 end
 
+div!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = fdiv!(z, f, g)
+
 div!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int) = fdiv!(z, f, g)
 
 function tdivpow2(x::ZZRingElem, c::Int)
@@ -659,6 +661,27 @@ function tdiv(f::ZZRingElem, g::Int)
 end
 
 @doc raw"""
+    tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
+the object $z$ in the process.
+
+# Examples
+
+```jldoctest
+julia> z = ZZ()
+0
+
+julia> z = tdiv!(z, ZZ(100), ZZ(7))
+14
+```
+"""
+function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+  @ccall libflint.fmpz_tdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+@doc raw"""
     tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
 
 Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
@@ -678,6 +701,24 @@ function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_tdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
+
+@doc raw"""
+    tdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
+the object $f$ in the process. This is a shorthand for `tdiv!(f, f, g)`.
+
+# Examples
+
+```jldoctest
+julia> f = ZZ(100)
+100
+
+julia> f = tdiv!(f, ZZ(7))
+14
+```
+"""
+tdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = tdiv!(f, f, g)
 
 @doc raw"""
     tdiv!(f::ZZRingElemOrPtr, g::Int)
@@ -717,6 +758,27 @@ function fdiv(f::ZZRingElem, g::Int)
 end
 
 @doc raw"""
+    fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
+object $z$ in the process.
+
+# Examples
+
+```jldoctest
+julia> z = ZZ()
+0
+
+julia> z = fdiv!(z, ZZ(100), ZZ(7))
+14
+```
+"""
+function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+  @ccall libflint.fmpz_fdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+@doc raw"""
     fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
 
 Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
@@ -735,6 +797,26 @@ julia> z = fdiv!(z, ZZ(100), 7)
 function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_fdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
+end
+
+@doc raw"""
+    fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
+object $f$ in the process. This is a shorthand for `fdiv!(f, f, g)`.
+
+# Examples
+
+```jldoctest
+julia> f = ZZ(100)
+100
+
+julia> f = fdiv!(f, ZZ(7))
+14
+```
+"""
+function fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+  return fdiv!(f, f, g)
 end
 
 @doc raw"""
@@ -776,6 +858,27 @@ function cdiv(f::ZZRingElem, g::Int)
 end
 
 @doc raw"""
+    cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
+object $z$ in the process.
+
+# Examples
+
+```jldoctest
+julia> z = ZZ()
+0
+
+julia> z = cdiv!(z, ZZ(100), ZZ(7))
+15
+```
+"""
+function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+  @ccall libflint.fmpz_cdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
+  return z
+end
+
+@doc raw"""
     cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
 
 Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
@@ -794,6 +897,26 @@ julia> z = cdiv!(z, ZZ(100), 7)
 function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_cdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
+end
+
+@doc raw"""
+    cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+
+Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
+object $f$ in the process. This is a shorthand for `cdiv!(f, f, g)`.
+
+# Examples
+
+```jldoctest
+julia> f = ZZ(100)
+100
+
+julia> f = cdiv!(f, ZZ(7))
+15
+```
+"""
+function cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+  return cdiv!(f, f, g)
 end
 
 @doc raw"""

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -660,71 +660,24 @@ function tdiv(f::ZZRingElem, g::Int)
   return tdiv!(z, f, g)
 end
 
-@doc raw"""
-    tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
-the object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = tdiv!(z, ZZ(100), ZZ(7))
-14
-```
-"""
 function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
   @ccall libflint.fmpz_tdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-@doc raw"""
-    tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
-
-Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
-the object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = tdiv!(z, ZZ(100), 7)
-14
-```
-"""
 function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_tdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-@doc raw"""
-    tdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
-the object $f$ in the process. This is a shorthand for `tdiv!(f, f, g)`.
-
-# Examples
-
-```jldoctest
-julia> f = ZZ(100)
-100
-
-julia> f = tdiv!(f, ZZ(7))
-14
-```
-"""
 tdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = tdiv!(f, f, g)
 
 @doc raw"""
-    tdiv!(f::ZZRingElemOrPtr, g::Int)
+    tdiv!(z, f, g)
+    tdiv!(f, g)
 
 Return the quotient of $f$ by $g$ via truncation rounding, possibly modifying
-the object $f$ in the process. This is a shorthand for `tdiv!(f, f, g)`.
+the object $z$ in the process. `tdiv!(f, g)` is a shorthand for `tdiv!(f, f, g)`.
 
 # Examples
 
@@ -757,73 +710,24 @@ function fdiv(f::ZZRingElem, g::Int)
   return z
 end
 
-@doc raw"""
-    fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
-object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = fdiv!(z, ZZ(100), ZZ(7))
-14
-```
-"""
 function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
   @ccall libflint.fmpz_fdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-@doc raw"""
-    fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
-
-Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
-object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = fdiv!(z, ZZ(100), 7)
-14
-```
-"""
 function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_fdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-@doc raw"""
-    fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
-object $f$ in the process. This is a shorthand for `fdiv!(f, f, g)`.
-
-# Examples
-
-```jldoctest
-julia> f = ZZ(100)
-100
-
-julia> f = fdiv!(f, ZZ(7))
-14
-```
-"""
-function fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-  return fdiv!(f, f, g)
-end
+fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = fdiv!(f, f, g)
 
 @doc raw"""
-    fdiv!(f::ZZRingElemOrPtr, g::Int)
+    fdiv!(z, f, g)
+    fdiv!(f, g)
 
 Return the quotient of $f$ by $g$ via floor rounding, possibly modifying the
-object $f$ in the process. This is a shorthand for `fdiv!(f, f, g)`.
+object $z$ in the process. `fdiv!(f, g)` is a shorthand for `fdiv!(f, f, g)`.
 
 # Examples
 
@@ -835,9 +739,7 @@ julia> f = fdiv!(f, 7)
 14
 ```
 """
-function fdiv!(f::ZZRingElemOrPtr, g::Int)
-  return fdiv!(f, f, g)
-end
+fdiv!(f::ZZRingElemOrPtr, g::Int) = fdiv!(f, f, g)
 
 @doc raw"""
     cdiv(f::ZZRingElem, g::Int)
@@ -857,73 +759,24 @@ function cdiv(f::ZZRingElem, g::Int)
   return cdiv!(z, f, g)
 end
 
-@doc raw"""
-    cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
-object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = cdiv!(z, ZZ(100), ZZ(7))
-15
-```
-"""
 function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
   @ccall libflint.fmpz_cdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-@doc raw"""
-    cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
-
-Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
-object $z$ in the process.
-
-# Examples
-
-```jldoctest
-julia> z = ZZ()
-0
-
-julia> z = cdiv!(z, ZZ(100), 7)
-15
-```
-"""
 function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
   @ccall libflint.fmpz_cdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-@doc raw"""
-    cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-
-Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
-object $f$ in the process. This is a shorthand for `cdiv!(f, f, g)`.
-
-# Examples
-
-```jldoctest
-julia> f = ZZ(100)
-100
-
-julia> f = cdiv!(f, ZZ(7))
-15
-```
-"""
-function cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
-  return cdiv!(f, f, g)
-end
+cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = cdiv!(f, f, g)
 
 @doc raw"""
-    cdiv!(f::ZZRingElemOrPtr, g::Int)
+    cdiv!(z, f, g)
+    cdiv!(f, g)
 
 Return the quotient of $f$ by $g$ via ceil rounding, possibly modifying the
-object $f$ in the process. This is a shorthand for `cdiv!(f, f, g)`.
+object $z$ in the process. `cdiv!(f, g)` is a shorthand for `cdiv!(f, f, g)`.
 
 # Examples
 
@@ -935,9 +788,7 @@ julia> f = cdiv!(f, 7)
 15
 ```
 """
-function cdiv!(f::ZZRingElemOrPtr, g::Int)
-  return cdiv!(f, f, g)
-end
+cdiv!(f::ZZRingElemOrPtr, g::Int) = cdiv!(f, f, g)
 
 rem(x::Integer, y::ZZRingElem) = rem(ZZRingElem(x), y)
 


### PR DESCRIPTION
This pull request makes inplace integer division (`ZZRingElem` by `ZZRingElem`) allocation-free. It is completely analogous to https://github.com/Nemocas/Nemo.jl/pull/2272: The only difference is that this pull request considers divisors of type `ZZRingElem` whereas the other one considered divisors of type `Int`.

Here is a small benchmark:
```
julia> a = ZZ(83729571); b = ZZ(378719);

julia> @time div!(a,b)
  0.000012 seconds
221

julia> a = ZZ(2)^65536 + 1; b = ZZ(5)^22345 - 1;

julia> @time div!(a,b);
  0.000382 seconds
```
In the current Nemo version:
```
julia> a = ZZ(83729571); b = ZZ(378719);

julia> @time div!(a,b)
  0.000014 seconds (1 allocation: 16 bytes)
221

julia> a = ZZ(2)^65536 + 1; b = ZZ(5)^22345 - 1;

julia> @time div!(a,b);
  0.000397 seconds (2 allocations: 1.680 KiB)
```