### PR TITLE
Fix `MPoly` constructors to enforce exponents being nonnegative

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1123,6 +1123,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{Int}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1138,6 +1139,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{ZZRingElem}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1252,6 +1254,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{Int}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1267,6 +1270,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{ZZRingElem}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1390,6 +1394,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{Int}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1405,6 +1410,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{ZZRingElem}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1533,6 +1539,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{Int}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1548,6 +1555,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{ZZRingElem}})
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1668,6 +1676,7 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
   end
 
   function FpMPolyRingElem(ctx::FpMPolyRing, a::Vector{FpFieldElem}, b::Vector{Vector{T}}) where T <: Union{UInt, Int, ZZRingElem}
+    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mod_mpoly_init2(z::Ref{FpMPolyRingElem}, length(a)::Int, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1123,7 +1123,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{Int}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1139,7 +1139,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1254,7 +1254,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{Int}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1270,7 +1270,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1394,7 +1394,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{Int}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1410,7 +1410,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1539,7 +1539,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{Int}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1555,7 +1555,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1676,7 +1676,7 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
   end
 
   function FpMPolyRingElem(ctx::FpMPolyRing, a::Vector{FpFieldElem}, b::Vector{Vector{T}}) where T <: Union{UInt, Int, ZZRingElem}
-    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
+    @req all(x -> all(!is_negative, x), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mod_mpoly_init2(z::Ref{FpMPolyRingElem}, length(a)::Int, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -1123,7 +1123,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{Int}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1139,7 +1139,7 @@ mutable struct ZZMPolyRingElem <: MPolyRingElem{ZZRingElem}
   end
 
   function ZZMPolyRingElem(ctx::ZZMPolyRing, a::Vector{ZZRingElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mpoly_init2(z::Ref{ZZMPolyRingElem}, length(a)::Int, ctx::Ref{ZZMPolyRing})::Nothing
     z.parent = ctx
@@ -1254,7 +1254,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{Int}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1270,7 +1270,7 @@ mutable struct QQMPolyRingElem <: MPolyRingElem{QQFieldElem}
   end
 
   function QQMPolyRingElem(ctx::QQMPolyRing, a::Vector{QQFieldElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpq_mpoly_init2(z::Ref{QQMPolyRingElem}, length(a)::Int, ctx::Ref{QQMPolyRing})::Nothing
     z.parent = ctx
@@ -1394,7 +1394,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{Int}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1410,7 +1410,7 @@ mutable struct zzModMPolyRingElem <: MPolyRingElem{zzModRingElem}
   end
 
   function zzModMPolyRingElem(ctx::zzModMPolyRing, a::Vector{zzModRingElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{zzModMPolyRingElem}, length(a)::Int, ctx::Ref{zzModMPolyRing})::Nothing
     z.parent = ctx
@@ -1539,7 +1539,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{Int}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1555,7 +1555,7 @@ mutable struct fpMPolyRingElem <: MPolyRingElem{fpFieldElem}
   end
 
   function fpMPolyRingElem(ctx::fpMPolyRing, a::Vector{fpFieldElem}, b::Vector{Vector{ZZRingElem}})
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.nmod_mpoly_init2(z::Ref{fpMPolyRingElem}, length(a)::Int, ctx::Ref{fpMPolyRing})::Nothing
     z.parent = ctx
@@ -1676,7 +1676,7 @@ mutable struct FpMPolyRingElem <: MPolyRingElem{FpFieldElem}
   end
 
   function FpMPolyRingElem(ctx::FpMPolyRing, a::Vector{FpFieldElem}, b::Vector{Vector{T}}) where T <: Union{UInt, Int, ZZRingElem}
-    @req all(x -> all(>=(0),x), b) "Negative exponents are not allowed"
+    @req all(x -> !any(is_negative.(x)), b) "Negative exponents are not allowed"
     z = new()
     @ccall libflint.fmpz_mod_mpoly_init2(z::Ref{FpMPolyRingElem}, length(a)::Int, ctx::Ref{FpMPolyRing})::Nothing
     z.parent = ctx


### PR DESCRIPTION
Fixes #2276.
One of the checks is redundant because the `FpMPolyRingElem` function is defined for a union of exponent types including `UInt` which will never contain negative values. Perhaps all constructors should be restructured to follow a common pattern?