### PR TITLE
Unify behavior of `isone` for truncated identity matrices

### DIFF
--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -94,7 +94,10 @@ number_of_columns(a::QQMatrix) = a.c
 
 iszero(a::QQMatrix) = @ccall libflint.fmpq_mat_is_zero(a::Ref{QQMatrix})::Bool
 
-isone(a::QQMatrix) = @ccall libflint.fmpq_mat_is_one(a::Ref{QQMatrix})::Bool
+function isone(a::QQMatrix)
+  is_square(a) || return false
+  return @ccall libflint.fmpq_mat_is_one(a::Ref{QQMatrix})::Bool
+end
 
 @inline function is_zero_entry(A::QQMatrix, i::Int, j::Int)
   @boundscheck _checkbounds(A, i, j)

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -111,7 +111,10 @@ end
 
 iszero(a::ZZMatrix) = @ccall libflint.fmpz_mat_is_zero(a::Ref{ZZMatrix})::Bool
 
-isone(a::ZZMatrix) = @ccall libflint.fmpz_mat_is_one(a::Ref{ZZMatrix})::Bool
+function isone(a::ZZMatrix)
+  is_square(a) || return false
+  return @ccall libflint.fmpz_mat_is_one(a::Ref{ZZMatrix})::Bool
+end
 
 @inline function is_zero_entry(A::ZZMatrix, i::Int, j::Int)
   @boundscheck _checkbounds(A, i, j)


### PR DESCRIPTION
Resolves https://github.com/Nemocas/Nemo.jl/issues/2265.

As mentioned in https://github.com/Nemocas/Nemo.jl/issues/2265#issuecomment-3984700607, the behavior between AbstractAlgebra.Generic.MatSpaceElem (returns false) and ZZMatrix/QQMatrix (returns true) differs. This PR makes it consistently `false`, as that seems to be the smaller change (just changing it for two types, instead of the generic fallback type).

Tests will be added to the conformance tests in AA in https://github.com/Nemocas/AbstractAlgebra.jl/pull/2394.