### PR TITLE
chore: Bump version to 0.54.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.54.1"
+version = "0.54.2"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
to release https://github.com/Nemocas/Nemo.jl/pull/2278, so we can proceed with https://github.com/Nemocas/AbstractAlgebra.jl/pull/2394.

corresponding changelog PR is https://github.com/Nemocas/Nemo.jl/pull/2248