### PR TITLE
Add linearhistory option to changelog config

### DIFF
--- a/dev/releases/config.toml
+++ b/dev/releases/config.toml
@@ -2,6 +2,7 @@ majorversion = 0
 reponame = "Nemocas/Nemo.jl"
 enabletwolevel = false
 requiretwolevel = false
+linearhistory = true
 
 [topics]
 "release notes: highlight" = "Highlights"


### PR DESCRIPTION
Add an option to changelog script config, so that entries in previous patch releases are not included in new "major" releases when history is linear ( pointed out by @lgoettgens in https://github.com/Nemocas/Nemo.jl/pull/2285 ). The corresponding change for the changelog script is in https://github.com/oscar-system/update-release-notes/pull/14 .