### PR TITLE
Added QadicField constructors from a defining polynomial (new in flint 3.5.0)

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2396,9 +2396,8 @@ A $p^n$-adic field for some prime power $p^n$.
   prec_max::Int
 
   function QadicField(p::ZZRingElem, d::Int, prec::Int = 64, var::String = "a"; cached::Bool = true, check::Bool = true, base_field::PadicField = PadicField(p, prec, cached = cached))
-
-    @assert p == prime(base_field)
-    check && !is_probable_prime(p) && throw(DomainError(p, "Integer must be prime"))
+    @req p == prime(base_field) "prime of base_field does not match p"
+    check && @req is_probable_prime(p) "Integer must be prime"
 
     z = get_cached!(QadicBase, (base_field, d), cached) do
       zz = new()
@@ -2411,9 +2410,53 @@ A $p^n$-adic field for some prime power $p^n$.
 
     return z, gen(z)
   end
+
+  function QadicField(f::T, prec::Int = 64, var::String = "a";
+                      cached::Bool = true, check::Bool = true,
+                      base_field::PadicField = PadicField(modulus(f), prec, cached = cached)
+                     ) where T <: Union{zzModPolyRingElem,fpPolyRingElem,ZZModPolyRingElem,FpPolyRingElem}
+    p = modulus(f)
+    @req p == prime(base_field) "prime of base_field does not match modulus of f"
+    check && @req is_irreducible(f) "Defining polynomial must be irreducible"
+    check && @req is_monic(f) "Defining polynomial must be monic"
+
+    z = get_cached!(_qadic_modulus_cache(T), (base_field, f), cached) do
+      zz = new()
+      _qadic_ctx_init_modulus!(zz, p, f, var)
+      finalizer(_qadic_ctx_clear_fn, zz)
+      return zz
+    end
+    z.prec_max = prec
+    set_attribute!(z, :base_field, base_field)
+
+    return z, gen(z)
+  end
+
+  # The QadicField(::FqPolyRingElem, ...) outer constructor lives in
+  # flint/fq_default_poly.jl, since FqPolyRingElem is not yet defined here.
 end
 
 const QadicBase = CacheDictType{Tuple{PadicField, Int}, QadicField}()
+
+const QadicBaseFmpzPol = CacheDictType{Tuple{PadicField, ZZModPolyRingElem}, QadicField}()
+const QadicBaseGFPPol = CacheDictType{Tuple{PadicField, FpPolyRingElem}, QadicField}()
+const QadicBaseNmodPol = CacheDictType{Tuple{PadicField, zzModPolyRingElem}, QadicField}()
+const QadicBaseGFPNmodPol = CacheDictType{Tuple{PadicField, fpPolyRingElem}, QadicField}()
+
+# Simple helper to pick correct cache on underlying poly type
+_qadic_modulus_cache(::Type{ZZModPolyRingElem}) = QadicBaseFmpzPol
+_qadic_modulus_cache(::Type{FpPolyRingElem}) = QadicBaseGFPPol
+_qadic_modulus_cache(::Type{zzModPolyRingElem}) = QadicBaseNmodPol
+_qadic_modulus_cache(::Type{fpPolyRingElem}) = QadicBaseGFPNmodPol
+
+# Function-barrier helper to get concrete type T
+function _qadic_ctx_init_modulus!(zz::QadicField, p::ZZRingElem, f::T, var::String) where {T}
+  @ccall libflint.qadic_ctx_init_modulus(zz::Ref{QadicField}, p::Ref{ZZRingElem}, f::Ref{T}, 0::Int, 0::Int, var::Cstring, 0::Cint)::Nothing
+end
+function _qadic_ctx_init_modulus!(zz::QadicField, p::UInt, f::T, var::String) where {T}
+  @ccall libflint.qadic_ctx_init_modulus_nmod(zz::Ref{QadicField}, p::UInt, f::Ref{T}, 0::Int, 0::Int, var::Cstring, 0::Cint)::Nothing
+end
+
 
 @doc raw"""
     QadicFieldElem <: FlintLocalFieldElem <: NonArchLocalFieldElem <: FieldElem

--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -773,3 +773,40 @@ function lift(R::ZZPolyRing, f::FqPolyRingElem)
     return z
   end
 end
+
+################################################################################
+#
+#  QadicField from FqPolyRingElem
+#
+################################################################################
+
+function QadicField(f::FqPolyRingElem, prec::Int = 64, var::String = "a"; cached::Bool = true, check::Bool = true, base_field::PadicField = PadicField(characteristic(base_ring(f)), prec, cached = cached))
+  K = base_ring(f)
+  absolute_degree(K) == 1 || throw(ArgumentError("base ring of polynomial must be a prime field"))
+
+  z = get_cached!(QadicBaseFqPol, (base_field, f), cached) do
+    ctx_type = _fq_default_ctx_type(K)
+    if ctx_type == _FQ_DEFAULT_NMOD
+      _K = _get_raw_type(fpField, K)
+    else
+      @assert ctx_type == _FQ_DEFAULT_FMPZ_NMOD
+      _K = _get_raw_type(FpField, K)
+    end
+    ff = map_coefficients(c -> _K(lift(ZZ, c)), f; cached = false)
+    return QadicField(ff, prec, var; cached = false, check = check, base_field = base_field)[1]
+  end
+  z.prec_max = prec
+  set_attribute!(z, :base_field, base_field)
+
+  return z, gen(z)
+end
+
+const QadicBaseFqPol = CacheDictType{Tuple{PadicField, FqPolyRingElem}, QadicField}()
+
+function qadic_field(f::FqPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+  return QadicField(f, precision, var; cached = cached, check = check)
+end
+
+function unramified_extension(K::PadicField, f::FqPolyRingElem, var::String = "a"; precision::Int=precision(K), cached::Bool = true, check::Bool = true)
+  return QadicField(f, precision, var; cached = cached, check = check, base_field = K)
+end

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -840,10 +840,19 @@ end
 @doc raw"""
     qadic_field(p::Integer, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
     qadic_field(p::ZZRingElem, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(f::ZZModPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(f::FpPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(f::zzModPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(f::fpPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
+    qadic_field(f::FqPolyRingElem, var::String = "a"; precision::Int=64, cached::Bool=true, check::Bool=true)
 
 Return an unramified extension $K$ of degree $d$ of a $p$-adic field for the given
 prime $p$.
 The generator of $K$ is printed as `var`.
+
+If a polynomial $f \in \mathbf{F}_p[X]$ is given instead, the unramified extension
+$K = \mathbf{Q}_p[X]/(f)$ defined by $f$ is returned. The polynomial $f$ must be
+irreducible.
 
 The default absolute precision of elements of $K$ may be set with `precision`.
 
@@ -859,18 +868,43 @@ function qadic_field(p::ZZRingElem, d::Int, var::String = "a"; precision::Int=64
   return QadicField(p, d, precision, var; cached=cached, check=check)
 end
 
+function qadic_field(f::T, var::String = "a";
+                     precision::Int = 64, cached::Bool = true, check::Bool = true
+                    ) where T <: Union{ZZModPolyRingElem,FpPolyRingElem,zzModPolyRingElem,fpPolyRingElem}
+  return QadicField(f, precision, var; cached=cached, check=check)
+end
+
+# The qadic_field(::FqPolyRingElem, ...) overload lives in
+# flint/fq_default_poly.jl, since FqPolyRingElem is not yet defined here.
+
 @doc raw"""
     unramified_extension(Qp::PadicField, d::Int, var::String = "a"; precision::Int=64, cached::Bool=true)
+    unramified_extension(Qp::PadicField, f::ZZModPolyRingElem, var::String = "a"; precision::Int=precision(Qp), cached::Bool=true, check::Bool=true)
+    unramified_extension(Qp::PadicField, f::FpPolyRingElem, var::String = "a"; precision::Int=precision(Qp), cached::Bool=true, check::Bool=true)
+    unramified_extension(Qp::PadicField, f::zzModPolyRingElem, var::String = "a"; precision::Int=precision(Qp), cached::Bool=true, check::Bool=true)
+    unramified_extension(Qp::PadicField, f::fpPolyRingElem, var::String = "a"; precision::Int=precision(Qp), cached::Bool=true, check::Bool=true)
+    unramified_extension(Qp::PadicField, f::FqPolyRingElem, var::String = "a"; precision::Int=precision(Qp), cached::Bool=true, check::Bool=true)
 
 Return an unramified extension $K$ of degree $d$ of the given $p$-adic field `Qp`.
 The generator of $K$ is printed as `var`.
 
+If a polynomial $f$ over the residue field of `Qp` is provided, the unramified
+extension defined by $f$ is returned; $f$ must be irreducible.
+
 The default absolute precision of elements of $K$ may be set with `precision`.
 """
 function unramified_extension(K::PadicField, d::Int, var::String = "a"; precision::Int=precision(K), cached::Bool = true)
-  L, a = QadicField(prime(K), d, precision, var, cached = cached, check = false, base_field = K)
-  return L, a
+  return QadicField(prime(K), d, precision, var, cached = cached, check = false, base_field = K)
 end
+
+function unramified_extension(K::PadicField, f::T, var::String = "a";
+                              precision::Int = precision(K), cached::Bool = true, check::Bool = true
+                             ) where T <: Union{ZZModPolyRingElem,FpPolyRingElem,zzModPolyRingElem,fpPolyRingElem}
+  return QadicField(f, precision, var; cached = cached, check = check, base_field = K)
+end
+
+# The unramified_extension(::PadicField, ::FqPolyRingElem, ...) overload lives
+# in flint/fq_default_poly.jl, since FqPolyRingElem is not yet defined here.
 
 ###############################################################################
 #

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -1,3 +1,54 @@
+@testset "QadicField.constructors" begin
+  # we have two cubic irreducible polynomials over F_2
+  # x^3 + x + 1 (conway polynomial)
+  # x^3 + x^2 + 1
+  # we do the most simple test: create qadic with custom modulus and check
+  #  that generator satisfies the polynomial relation provided
+  x1 = polynomial_ring(GF(2), :x; cached = false)[2]
+  x2 = polynomial_ring(GF(ZZ(2)), :x; cached = false)[2]
+  x3 = polynomial_ring(Native.GF(2), :x; cached = false)[2]
+  x4 = polynomial_ring(Native.GF(ZZ(2)), :x; cached = false)[2]
+  x5 = polynomial_ring(residue_ring(ZZ, 2)[1], :x; cached = false)[2]
+  x6 = polynomial_ring(residue_ring(ZZ, ZZ(2))[1], :x; cached = false)[2]
+
+  F, t = QadicField(2, 3, 1; cached = false)
+  @test is_zero(t^3 + t + 1) && !is_zero(t^3 + t^2 + 1)
+
+  for x in (x1, x2, x3, x4, x5, x6)
+    f = x^3 + x^2 + 1
+
+    F, t = QadicField(f, 1; cached = false)
+    @test !is_zero(t^3 + t + 1) && is_zero(t^3 + t^2 + 1)
+
+    F, t = qadic_field(f; precision = 1, cached = false)
+    @test !is_zero(t^3 + t + 1) && is_zero(t^3 + t^2 + 1)
+
+    K = padic_field(ZZ(2); cached = false)
+    F, t = unramified_extension(K, f; precision = 1, cached = false)
+    @test !is_zero(t^3 + t + 1) && is_zero(t^3 + t^2 + 1)
+  end
+
+  x = polynomial_ring(GF(5), :x; cached = false)[2]
+  @test_throws ArgumentError QadicField(x^5 + 1, 1; cached = false)
+  @test_throws ArgumentError QadicField(2*x^2 + 1, 1; cached = false)
+
+  K = padic_field(5; cached = false)
+  for x in (x1, x2, x3, x4, x5, x6)
+    f = x^3 + x^2 + 1
+    @test_throws ArgumentError unramified_extension(K, f)
+  end
+
+  # large characteristic
+  let p = ZZRingElem(2)^100 + 277
+    y = polynomial_ring(GF(p), :y; cached = false)[2]
+    f = y^2 + y + 1                    # irreducible since p == 2 (mod 3)
+    @assert is_irreducible(f)
+
+    F, t = QadicField(f, 1; cached = false)
+    @test is_zero(t^2 + t + 1)
+  end
+end
+
 @testset "QadicFieldElem.constructors" begin
   R, _     = @inferred QadicField(7, 1, 30)
   K, _     = @inferred QadicField(7, 3, 30) 


### PR DESCRIPTION
Adds new QadicField / qadic_field / unramified_extension constructors that take a user-supplied irreducible polynomial $f \in \mathbf{F}_p[X]$ as the defining modulus. This wraps FLINT's `qadic_ctx_init_modulus` (and the `_nmod` variant) and lets callers pin down a specific representation of $\mathbf{Q}_p[X]/(f)$ rather than getting whichever Conway-style polynomial FLINT happens to pick for $(p, d)$.

- New QadicField(f, prec, var; ...) inner constructor accepting `zzModPolyRingElem`, `fpPolyRingElem`, `ZZModPolyRingElem`, `FpPolyRingElem`; also `FqPolyRingElem` overload (living in `fq_default_poly.jl`).
- Matching `qadic_field(f, ...)` and `unramified_extension(K, f, ...)` overloads, with docstring updates listing the new signatures.
- Two new caches (`QadicBasePol`, `QadicBaseNmodPol`) keyed on `(base_field, f)`, selected by _qadic_modulus_cache based on polynomial type. 
