### PR TITLE
Added precomputed Artin-Schreier LUP for characteristic 2 qadic sqrt (new in flint 3.5.0)

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -2436,6 +2436,25 @@ mutable struct QadicFieldElem <: FlintLocalFieldElem
   end
 end
 
+@doc raw"""
+    Qadic2SqrtPrecomp
+
+Opaque precomputation used to speed up square roots in a $q$-adic field of
+characteristic 2. Wraps a FLINT `struct qadic2_sqrt_precomp *`.
+"""
+mutable struct Qadic2SqrtPrecomp
+  ptr::Ptr{Nothing}
+  parent::QadicField
+
+  function Qadic2SqrtPrecomp(R::QadicField)
+    prime(R) == 2 || throw(DomainError(prime(R), "characteristic must be 2"))
+    ptr = @ccall libflint._qadic_char2_sqrt_precomp_init(R::Ref{QadicField})::Ptr{Nothing}
+    z = new(ptr, R)
+    finalizer(_qadic_char2_sqrt_precomp_clear_fn, z)
+    return z
+  end
+end
+
 ###############################################################################
 #
 #   ZZRelPowerSeriesRing / ZZRelPowerSeriesRingElem
@@ -5313,6 +5332,10 @@ end
 
 function _qadic_ctx_clear_fn(a::QadicField)
   @ccall libflint.qadic_ctx_clear(a::Ref{QadicField})::Nothing
+end
+
+function _qadic_char2_sqrt_precomp_clear_fn(a::Qadic2SqrtPrecomp)
+  @ccall libflint._qadic_char2_sqrt_precomp_clear(a.ptr::Ptr{Nothing})::Nothing
 end
 
 function _rand_ctx_clear_fn(a::rand_ctx)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -496,9 +496,17 @@ end
 ###############################################################################
 
 function Base.sqrt(a::QadicFieldElem; check::Bool=true)
+  ctx = parent(a)
+  if prime(ctx) == 2
+    precomp_data = get_attribute!(ctx, :char2_sqrt_precomp) do
+      Qadic2SqrtPrecomp(ctx)
+    end::Qadic2SqrtPrecomp
+
+    return _qadic_char2_sqrt(a, precomp_data; check=check)
+  end
+
   av = valuation(a)
   check && (av % 2) != 0 && error("Unable to take qadic square root")
-  ctx = parent(a)
   z = QadicFieldElem(a.N - div(av, 2))
   z.parent = ctx
   res = Bool(@ccall libflint.qadic_sqrt(z::Ref{QadicFieldElem}, a::Ref{QadicFieldElem}, ctx::Ref{QadicField})::Cint)

--- a/src/flint/qadic.jl
+++ b/src/flint/qadic.jl
@@ -506,6 +506,23 @@ function Base.sqrt(a::QadicFieldElem; check::Bool=true)
   return z
 end
 
+# Internal: square root in characteristic 2 using a precomputed Artin-Schreier LUP decomposition.
+function _qadic_char2_sqrt(a::QadicFieldElem, data::Qadic2SqrtPrecomp; check::Bool=true)
+  ctx = parent(a)
+  ctx === data.parent || throw(ArgumentError("precomputation belongs to a different qadic field"))
+  av = valuation(a)
+  check && (av % 2) != 0 && error("Unable to take qadic square root")
+  z = QadicFieldElem(a.N - div(av, 2))
+  z.parent = ctx
+
+  GC.@preserve data begin
+    res = Bool(@ccall libflint._qadic_char2_sqrt_with_precomp(z::Ref{QadicFieldElem}, a::Ref{QadicFieldElem}, ctx::Ref{QadicField}, data.ptr::Ptr{Nothing})::Cint)
+  end
+
+  check && !res && error("Square root of p-adic does not exist")
+  return z
+end
+
 ###############################################################################
 #
 #   Special functions

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -330,6 +330,21 @@ end
   @test sqrt(R(121))^2 == R(121)
 end
 
+@testset "QadicFieldElem.square_root_char2_precomp" begin
+  R, _ = QadicField(2, 3)
+  user_data = Nemo.Qadic2SqrtPrecomp(R)
+
+  a = 1 + 2^3 + O(R, 2^4)
+  @test Nemo._qadic_char2_sqrt(a, user_data)^2 == a
+
+  a = 1 + 2^3 + 2^4 + O(R, 2^10)
+  @test Nemo._qadic_char2_sqrt(a, user_data)^2 == a
+
+  @test_throws DomainError Nemo.Qadic2SqrtPrecomp(QadicField(3, 2)[1])
+  S, _ = QadicField(2, 5)
+  @test_throws ArgumentError Nemo._qadic_char2_sqrt(S(1), user_data)
+end
+
 @testset "QadicFieldElem.special_functions" begin
   R, _ = QadicField(7, 1, 30)
 

--- a/test/flint/qadic-test.jl
+++ b/test/flint/qadic-test.jl
@@ -345,6 +345,20 @@ end
   @test_throws ArgumentError Nemo._qadic_char2_sqrt(S(1), user_data)
 end
 
+@testset "QadicFieldElem.square_root_char2" begin
+  R, _ = QadicField(2, 3)
+
+  a = 1 + 2^3 + O(R, 2^4)
+  @test sqrt(a)^2 == a
+  @test has_attribute(R, :char2_sqrt_precomp)
+
+  precomp = get_attribute(R, :char2_sqrt_precomp)
+
+  a = 1 + 2^3 + 2^4 + O(R, 2^10)
+  @test sqrt(a)^2 == a
+  @test precomp === get_attribute(R, :char2_sqrt_precomp)
+end
+
 @testset "QadicFieldElem.special_functions" begin
   R, _ = QadicField(7, 1, 30)
 


### PR DESCRIPTION
Wraps FLINT 3.5.0's new precomputation-based char-2 qadic square root.
Repeated `sqrt` calls on a fixed char-2 qadic field repeatedly recompute the same Artin-Schreier LUP decomposition; the new FLINT API lets us compute it once and reuse it.

Adds:
  - `Qadic2SqrtPrecomp(R)`: opaque wrapper around the FLINT precomp pointer with finalizer
  - `Nemo._qadic_char2_sqrt(a, data; check=true)`: internal helper that takes an existing Qadic2SqrtPrecomp and calls FLINT's _qadic_char2_sqrt_with_precomp.

Changes:
  - `Base.sqrt` in characteristic 2 now reads the char2_sqrt_precomp attribute from the qadic field, lazily building it on the first call.
