### PR TITLE
set gfp_mat or nmod_mat entry with Int value

### DIFF
--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -31,19 +31,6 @@ function getindex_raw(a::T, i::Int, j::Int) where T <: Zmodn_mat
   return GC.@preserve a unsafe_load(mat_entry_ptr(a, i, j))
 end
 
-@inline function _nmod_reduce_int(u::Int, n::UInt, ninv::UInt)
-  if reinterpret(Int, n) > 0 && u < 0
-    u %= Int(n)
-  end
-  d = reinterpret(UInt, u)
-  if u < 0
-    d += n
-  end
-  if d >= n
-    d = @ccall libflint.n_mod2_preinv(d::UInt, n::UInt, ninv::UInt)::UInt
-  end
-  return d
-end
 
 @inline function setindex!(a::T, u::UInt, i::Int, j::Int) where T <: Zmodn_mat
   @boundscheck _checkbounds(a, i, j)
@@ -53,7 +40,7 @@ end
 
 @inline function setindex!(a::T, u::Int, i::Int, j::Int) where T <: Zmodn_mat
   @boundscheck _checkbounds(a, i, j)
-  setindex_raw!(a, _nmod_reduce_int(u, a.n, a.ninv), i, j)
+  setindex_raw!(a, mod(u, a.n), i, j)
 end
 
 @inline function setindex!(a::T, u::ZZRingElem, i::Int, j::Int) where T <: Zmodn_mat

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -40,7 +40,8 @@ end
 
 @inline function setindex!(a::T, u::Int, i::Int, j::Int) where T <: Zmodn_mat
   @boundscheck _checkbounds(a, i, j)
-  setindex_raw!(a, mod(u, a.n), i, j)
+  R = base_ring(a)
+  setindex_raw!(a, mod(u, R.n), i, j)
 end
 
 @inline function setindex!(a::T, u::ZZRingElem, i::Int, j::Int) where T <: Zmodn_mat

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -31,10 +31,29 @@ function getindex_raw(a::T, i::Int, j::Int) where T <: Zmodn_mat
   return GC.@preserve a unsafe_load(mat_entry_ptr(a, i, j))
 end
 
+@inline function _nmod_reduce_int(u::Int, n::UInt, ninv::UInt)
+  if reinterpret(Int, n) > 0 && u < 0
+    u %= Int(n)
+  end
+  d = reinterpret(UInt, u)
+  if u < 0
+    d += n
+  end
+  if d >= n
+    d = @ccall libflint.n_mod2_preinv(d::UInt, n::UInt, ninv::UInt)::UInt
+  end
+  return d
+end
+
 @inline function setindex!(a::T, u::UInt, i::Int, j::Int) where T <: Zmodn_mat
   @boundscheck _checkbounds(a, i, j)
   R = base_ring(a)
   setindex_raw!(a, mod(u, R.n), i, j)
+end
+
+@inline function setindex!(a::T, u::Int, i::Int, j::Int) where T <: Zmodn_mat
+  @boundscheck _checkbounds(a, i, j)
+  setindex_raw!(a, _nmod_reduce_int(u, a.n, a.ninv), i, j)
 end
 
 @inline function setindex!(a::T, u::ZZRingElem, i::Int, j::Int) where T <: Zmodn_mat

--- a/test/flint/gfp_mat-test.jl
+++ b/test/flint/gfp_mat-test.jl
@@ -261,6 +261,14 @@ end
   @test a[1,2] == Z11(5)
   @test_throws BoundsError a[-2,2] = 5
 
+  a[1,2] = -17
+
+  @test a[1,2] == Z11(-17)
+
+  a[1,2] = typemax(Int)
+
+  @test a[1,2] == Z11(typemax(Int))
+
   @test a != b
 
   d = one(R)

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -257,6 +257,14 @@ end
   @test a[1,2] == Z10(5)
   @test_throws BoundsError a[-2,2] = 5
 
+  a[1,2] = -17
+
+  @test a[1,2] == Z10(-17)
+
+  a[1,2] = typemax(Int)
+
+  @test a[1,2] == Z10(typemax(Int))
+
   @test a != b
 
   d = one(R)


### PR DESCRIPTION
Before
```
julia> F = Hecke.Native.GF(17)
Finite field of characteristic 17

julia> A = F[1 2; 3 4];

julia> @btime A[1,1] = UInt(2);
  19.783 ns (0 allocations: 0 bytes)

julia> @btime A[1,1] = 2;
  44.078 ns (2 allocations: 32 bytes)
```
After 
```
julia> @btime A[1,1] = 2;
  25.585 ns (0 allocations: 0 bytes)
```
Maybe not optimal, but in any case it is an improvement. 
