### PR TITLE
Throw error when calling ill-defined FqFieldElem coercion

### DIFF
--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -700,7 +700,7 @@ function (a::FqField)(b::FqFieldElem)
   if k === a
     return b
   end
-  0 ≠ characteristic(k) ≠ characteristic(a) && error("Coercion impossible")
+   characteristic(k) != characteristic(a) && error("Coercion impossible")
   if is_absolute(a)
     da = degree(a)
     dk = degree(k)

--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -700,7 +700,8 @@ function (a::FqField)(b::FqFieldElem)
   if k === a
     return b
   end
-
+  ck = characteristic(k)
+  ck ≠ 0 && ck ≠ characteristic(a) && error("Coercion impossible")
   if is_absolute(a)
     da = degree(a)
     dk = degree(k)

--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -700,7 +700,7 @@ function (a::FqField)(b::FqFieldElem)
   if k === a
     return b
   end
-   characteristic(k) != characteristic(a) && error("Coercion impossible")
+  characteristic(k) != characteristic(a) && error("Coercion impossible")
   if is_absolute(a)
     da = degree(a)
     dk = degree(k)

--- a/src/flint/fq_default_extended.jl
+++ b/src/flint/fq_default_extended.jl
@@ -700,8 +700,7 @@ function (a::FqField)(b::FqFieldElem)
   if k === a
     return b
   end
-  ck = characteristic(k)
-  ck ≠ 0 && ck ≠ characteristic(a) && error("Coercion impossible")
+  0 ≠ characteristic(k) ≠ characteristic(a) && error("Coercion impossible")
   if is_absolute(a)
     da = degree(a)
     dk = degree(k)


### PR DESCRIPTION
So far, the following coercion is possible, albeit being mathematically absurd. 
```
julia> a = GF(7)(3)
3

julia> GF(5)(a) # This is ill-defined
3
```
This pull request fixes this issue. It throws an error as follws.
```
julia> a = GF(7)(3)
3

julia> GF(5)(a) # This is ill-defined
ERROR: Coercion impossible
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] (::FqField)(b::FqFieldElem)
   @ Nemo ~/Dokumente/Repositories/Nemo.jl/src/flint/fq_default_extended.jl:704
 [3] top-level scope
   @ REPL[3]:1
```

Ping @simonbrandhorst 