### PR TITLE
Throw an error when calling `residue_field(ZZ, n)` if  `n` is not a prime number

### DIFF
--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -971,7 +971,7 @@ similar(F::FqField, deg::Int, s::VarName = :o; cached::Bool = true) = finite_fie
 ################################################################################
 
 function residue_field(R::ZZRing, p::IntegerUnion; cached::Bool = true, check::Bool = true)
-  check && !is_prime(p) && error("Integer must be prime")
+  check && @req is_prime(p) "Integer must be prime"
   S = finite_field(p, 1; cached = cached, check = false)[1]
   f = Generic.EuclideanRingResidueMap(R, S)
   return S, f

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -970,8 +970,9 @@ similar(F::FqField, deg::Int, s::VarName = :o; cached::Bool = true) = finite_fie
 #
 ################################################################################
 
-function residue_field(R::ZZRing, p::IntegerUnion; cached::Bool = true)
-  S = GF(p; cached = cached)
+function residue_field(R::ZZRing, p::IntegerUnion; cached::Bool = true, check::Bool = true)
+  check && !is_prime(p) && error("Integer must be prime")
+  S = finite_field(p, 1; cached = cached, check = false)[1]
   f = Generic.EuclideanRingResidueMap(R, S)
   return S, f
 end

--- a/test/flint/fq_default-test.jl
+++ b/test/flint/fq_default-test.jl
@@ -353,7 +353,7 @@ end
   @test x isa ZZRingElem && x == 1
   
   # issue #2303
-  @test_throws ErrorException residue_field(ZZ, 4)
+  @test_throws ArgumentError residue_field(ZZ, 4)
 end
 
 @testset "FqFieldElem.krull_dim" begin

--- a/test/flint/fq_default-test.jl
+++ b/test/flint/fq_default-test.jl
@@ -352,6 +352,8 @@ end
   x = preimage(f, R(1))
   @test x isa ZZRingElem && x == 1
   
+  # issue #2303
+  @test_throws ErrorException residue_field(ZZ, 4)
 end
 
 @testset "FqFieldElem.krull_dim" begin


### PR DESCRIPTION
Fix for issue #2303.

