### PR TITLE
Fix correctness bug in `*(::fpMatrix, ::UInt)` for large UInts

### DIFF
--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -237,7 +237,7 @@ function mul!(z::Vector{UInt}, a::Vector{UInt}, b::T) where T <: Zmodn_mat
   return z
 end
 
-# entries of c required to be in [0,n)
+# c required to be in [0,n)
 function mul!(a::T, b::T, c::UInt) where T <: Zmodn_mat
   @ccall libflint.nmod_mat_scalar_mul(a::Ref{T}, b::Ref{T}, c::UInt)::Nothing
   return a

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -237,8 +237,8 @@ function mul!(z::Vector{UInt}, a::Vector{UInt}, b::T) where T <: Zmodn_mat
   return z
 end
 
+# entries of c required to be in [0,n)
 function mul!(a::T, b::T, c::UInt) where T <: Zmodn_mat
-  c = @ccall libflint.n_mod2_preinv(c::UInt, b.n::UInt, b.ninv::UInt)::UInt
   @ccall libflint.nmod_mat_scalar_mul(a::Ref{T}, b::Ref{T}, c::UInt)::Nothing
   return a
 end
@@ -286,6 +286,7 @@ end
 ################################################################################
 
 function *(x::T, y::UInt) where T <: Zmodn_mat
+  y = @ccall libflint.n_mod2_preinv(y::UInt, x.n::UInt, x.ninv::UInt)::UInt
   return mul!(similar(x), x, y)
 end
 

--- a/src/flint/nmod_mat.jl
+++ b/src/flint/nmod_mat.jl
@@ -238,6 +238,7 @@ function mul!(z::Vector{UInt}, a::Vector{UInt}, b::T) where T <: Zmodn_mat
 end
 
 function mul!(a::T, b::T, c::UInt) where T <: Zmodn_mat
+  c = @ccall libflint.n_mod2_preinv(c::UInt, b.n::UInt, b.ninv::UInt)::UInt
   @ccall libflint.nmod_mat_scalar_mul(a::Ref{T}, b::Ref{T}, c::UInt)::Nothing
   return a
 end

--- a/test/flint/nmod_mat-test.jl
+++ b/test/flint/nmod_mat-test.jl
@@ -1108,3 +1108,11 @@ end
   mul!(C, b, A)
   @test C == b * A
 end
+
+@testset "#2309" begin
+  F = Native.GF(13)
+  x = matrix(F, 1, 1, [1])
+  s = 0x0678e92a8604bc8e
+  r = F(s)
+  @test x * s == x * r
+end


### PR DESCRIPTION
According to https://flintlib.org/doc/nmod_mat.html#c.nmod_mat_scalar_mul, FLINT expects the UInt to be reduced modulo the modulus (which we didn't enforce previously).