### PR TITLE
chore: bump to 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,6 @@ The following gives an overview of the changes compared to the previous releases
 complete, many more internal or minor changes were made, but we tried to only list those changes
 which we think might affect some users directly.
 
-## [0.55.2](https://github.com/Nemocas/Nemo.jl/releases/tag/v0.55.2) - 2026-06-09
-
-### New or extended functionality
-
-- [#2152](https://github.com/Nemocas/Nemo.jl/pull/2152) Add new function `is_probably_zero_det` (for `ZZMatrix`, `QQMatrix`)
-- [#2296](https://github.com/Nemocas/Nemo.jl/pull/2296) Improve conversion from ZZMatrix to QQMatrix
-- [#2297](https://github.com/Nemocas/Nemo.jl/pull/2297) Improve snf_with_transform for ZZMatrix
-- [#2299](https://github.com/Nemocas/Nemo.jl/pull/2299) Add discrete `convolution` of two vectors
-- [#2212](https://github.com/Nemocas/Nemo.jl/pull/2212) New determinant function `det_hcol_hnf` for ZZMatrix
-
-### Fixed bugs that returned incorrect results
-
-- [#2302](https://github.com/Nemocas/Nemo.jl/pull/2302) Throw error when calling ill-defined FqFieldElem coercion
-- [#2304](https://github.com/Nemocas/Nemo.jl/pull/2304) Throw an error when calling `residue_field(ZZ, n)` if  `n` is not a prime number
-
 ## [0.55.1](https://github.com/Nemocas/Nemo.jl/releases/tag/v0.55.1) - 2026-05-16
 
 ### New or extended functionality

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.55.2"
+version = "0.53.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
- remove 0.55.2 from CHANGELOG, since we won't do this
