### PR TITLE
Simplify type definitions using `TypeOrPtr`

### DIFF
--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5432,6 +5432,8 @@ end
 #
 ################################################################################
 
+const TypeOrPtr{T} = Union{T, Ref{T}, Ptr{T}} where T
+
 const ZmodNFmpzPolyRing = Union{ZZModPolyRing, FpPolyRing}
 
 const Zmodn_poly = Union{zzModPolyRingElem, fpPolyRingElem}
@@ -5451,73 +5453,73 @@ const FlintMPolyUnion = Union{ZZMPolyRingElem, QQMPolyRingElem, zzModMPolyRingEl
                               fqPolyRepMPolyRingElem, FpMPolyRingElem}
 
 
-const ZZRingElemOrPtr = Union{ZZRingElem, Ref{ZZRingElem}, Ptr{ZZRingElem}}
-const QQFieldElemOrPtr = Union{QQFieldElem, Ref{QQFieldElem}, Ptr{QQFieldElem}}
-const zzModRingElemOrPtr = Union{zzModRingElem, Ref{zzModRingElem}, Ptr{zzModRingElem}}
-const ZZModRingElemOrPtr = Union{ZZModRingElem, Ref{ZZModRingElem}, Ptr{ZZModRingElem}}
-const fpFieldElemOrPtr = Union{fpFieldElem, Ref{fpFieldElem}, Ptr{fpFieldElem}}
-const FpFieldElemOrPtr = Union{FpFieldElem, Ref{FpFieldElem}, Ptr{FpFieldElem}}
-const fqPolyRepFieldElemOrPtr = Union{fqPolyRepFieldElem, Ref{fqPolyRepFieldElem}, Ptr{fqPolyRepFieldElem}}
-const FqPolyRepFieldElemOrPtr = Union{FqPolyRepFieldElem, Ref{FqPolyRepFieldElem}, Ptr{FqPolyRepFieldElem}}
-const FqFieldElemOrPtr = Union{FqFieldElem, Ref{FqFieldElem}, Ptr{FqFieldElem}}
+const ZZRingElemOrPtr = TypeOrPtr{ZZRingElem}
+const QQFieldElemOrPtr = TypeOrPtr{QQFieldElem}
+const zzModRingElemOrPtr = TypeOrPtr{zzModRingElem}
+const ZZModRingElemOrPtr = TypeOrPtr{ZZModRingElem}
+const fpFieldElemOrPtr = TypeOrPtr{fpFieldElem}
+const FpFieldElemOrPtr = TypeOrPtr{FpFieldElem}
+const fqPolyRepFieldElemOrPtr = TypeOrPtr{fqPolyRepFieldElem}
+const FqPolyRepFieldElemOrPtr = TypeOrPtr{FqPolyRepFieldElem}
+const FqFieldElemOrPtr = TypeOrPtr{FqFieldElem}
 
-const ZZPolyRingElemOrPtr = Union{ZZPolyRingElem, Ref{ZZPolyRingElem}, Ptr{ZZPolyRingElem}}
-const QQPolyRingElemOrPtr = Union{QQPolyRingElem, Ref{QQPolyRingElem}, Ptr{QQPolyRingElem}}
-const zzModPolyRingElemOrPtr = Union{zzModPolyRingElem, Ref{zzModPolyRingElem}, Ptr{zzModPolyRingElem}}
-const ZZModPolyRingElemOrPtr = Union{ZZModPolyRingElem, Ref{ZZModPolyRingElem}, Ptr{ZZModPolyRingElem}}
-const fpPolyRingElemOrPtr = Union{fpPolyRingElem, Ref{fpPolyRingElem}, Ptr{fpPolyRingElem}}
-const FpPolyRingElemOrPtr = Union{FpPolyRingElem, Ref{FpPolyRingElem}, Ptr{FpPolyRingElem}}
-const fqPolyRepPolyRingElemOrPtr = Union{fqPolyRepPolyRingElem, Ref{fqPolyRepPolyRingElem}, Ptr{fqPolyRepPolyRingElem}}
-const FqPolyRepPolyRingElemOrPtr = Union{FqPolyRepPolyRingElem, Ref{FqPolyRepPolyRingElem}, Ptr{FqPolyRepPolyRingElem}}
-const FqPolyRingElemOrPtr = Union{FqPolyRingElem, Ref{FqPolyRingElem}, Ptr{FqPolyRingElem}}
+const ZZPolyRingElemOrPtr = TypeOrPtr{ZZPolyRingElem}
+const QQPolyRingElemOrPtr = TypeOrPtr{QQPolyRingElem}
+const zzModPolyRingElemOrPtr = TypeOrPtr{zzModPolyRingElem}
+const ZZModPolyRingElemOrPtr = TypeOrPtr{ZZModPolyRingElem}
+const fpPolyRingElemOrPtr = TypeOrPtr{fpPolyRingElem}
+const FpPolyRingElemOrPtr = TypeOrPtr{FpPolyRingElem}
+const fqPolyRepPolyRingElemOrPtr = TypeOrPtr{fqPolyRepPolyRingElem}
+const FqPolyRepPolyRingElemOrPtr = TypeOrPtr{FqPolyRepPolyRingElem}
+const FqPolyRingElemOrPtr = TypeOrPtr{FqPolyRingElem}
 
-const ZZMPolyRingElemOrPtr = Union{ZZMPolyRingElem, Ref{ZZMPolyRingElem}, Ptr{ZZMPolyRingElem}}
-const QQMPolyRingElemOrPtr = Union{QQMPolyRingElem, Ref{QQMPolyRingElem}, Ptr{QQMPolyRingElem}}
-const zzModMPolyRingElemOrPtr = Union{zzModMPolyRingElem, Ref{zzModMPolyRingElem}, Ptr{zzModMPolyRingElem}}
+const ZZMPolyRingElemOrPtr = TypeOrPtr{ZZMPolyRingElem}
+const QQMPolyRingElemOrPtr = TypeOrPtr{QQMPolyRingElem}
+const zzModMPolyRingElemOrPtr = TypeOrPtr{zzModMPolyRingElem}
 # ZZModMPolyRingElem does not exits
-const fpMPolyRingElemOrPtr = Union{fpMPolyRingElem, Ref{fpMPolyRingElem}, Ptr{fpMPolyRingElem}}
-const FpMPolyRingElemOrPtr = Union{FpMPolyRingElem, Ref{FpMPolyRingElem}, Ptr{FpMPolyRingElem}}
-const fqPolyRepMPolyRingElemOrPtr = Union{fqPolyRepMPolyRingElem, Ref{fqPolyRepMPolyRingElem}, Ptr{fqPolyRepMPolyRingElem}}
+const fpMPolyRingElemOrPtr = TypeOrPtr{fpMPolyRingElem}
+const FpMPolyRingElemOrPtr = TypeOrPtr{FpMPolyRingElem}
+const fqPolyRepMPolyRingElemOrPtr = TypeOrPtr{fqPolyRepMPolyRingElem}
 # FqPolyRepMPolyRingElem does not exits
-const FqMPolyRingElemOrPtr = Union{FqMPolyRingElem, Ref{FqMPolyRingElem}, Ptr{FqMPolyRingElem}}
+const FqMPolyRingElemOrPtr = TypeOrPtr{FqMPolyRingElem}
 
-const ZZRelPowerSeriesRingElemOrPtr = Union{ZZRelPowerSeriesRingElem, Ref{ZZRelPowerSeriesRingElem}, Ptr{ZZRelPowerSeriesRingElem}}
-const ZZAbsPowerSeriesRingElemOrPtr = Union{ZZAbsPowerSeriesRingElem, Ref{ZZAbsPowerSeriesRingElem}, Ptr{ZZAbsPowerSeriesRingElem}}
-const QQRelPowerSeriesRingElemOrPtr = Union{QQRelPowerSeriesRingElem, Ref{QQRelPowerSeriesRingElem}, Ptr{QQRelPowerSeriesRingElem}}
-const QQAbsPowerSeriesRingElemOrPtr = Union{QQAbsPowerSeriesRingElem, Ref{QQAbsPowerSeriesRingElem}, Ptr{QQAbsPowerSeriesRingElem}}
-const zzModRelPowerSeriesRingElemOrPtr = Union{zzModRelPowerSeriesRingElem, Ref{zzModRelPowerSeriesRingElem}, Ptr{zzModRelPowerSeriesRingElem}}
-const zzModAbsPowerSeriesRingElemOrPtr = Union{zzModAbsPowerSeriesRingElem, Ref{zzModAbsPowerSeriesRingElem}, Ptr{zzModAbsPowerSeriesRingElem}}
-const ZZModRelPowerSeriesRingElemOrPtr = Union{ZZModRelPowerSeriesRingElem, Ref{ZZModRelPowerSeriesRingElem}, Ptr{ZZModRelPowerSeriesRingElem}}
-const ZZModAbsPowerSeriesRingElemOrPtr = Union{ZZModAbsPowerSeriesRingElem, Ref{ZZModAbsPowerSeriesRingElem}, Ptr{ZZModAbsPowerSeriesRingElem}}
-const fpRelPowerSeriesRingElemOrPtr = Union{fpRelPowerSeriesRingElem, Ref{fpRelPowerSeriesRingElem}, Ptr{fpRelPowerSeriesRingElem}}
-const fpAbsPowerSeriesRingElemOrPtr = Union{fpAbsPowerSeriesRingElem, Ref{fpAbsPowerSeriesRingElem}, Ptr{fpAbsPowerSeriesRingElem}}
-const FpRelPowerSeriesRingElemOrPtr = Union{FpRelPowerSeriesRingElem, Ref{FpRelPowerSeriesRingElem}, Ptr{FpRelPowerSeriesRingElem}}
-const FpAbsPowerSeriesRingElemOrPtr = Union{FpAbsPowerSeriesRingElem, Ref{FpAbsPowerSeriesRingElem}, Ptr{FpAbsPowerSeriesRingElem}}
-const fqPolyRepRelPowerSeriesRingElemOrPtr = Union{fqPolyRepRelPowerSeriesRingElem, Ref{fqPolyRepRelPowerSeriesRingElem}, Ptr{fqPolyRepRelPowerSeriesRingElem}}
-const fqPolyRepAbsPowerSeriesRingElemOrPtr = Union{fqPolyRepAbsPowerSeriesRingElem, Ref{fqPolyRepAbsPowerSeriesRingElem}, Ptr{fqPolyRepAbsPowerSeriesRingElem}}
-const FqPolyRepRelPowerSeriesRingElemOrPtr = Union{FqPolyRepRelPowerSeriesRingElem, Ref{FqPolyRepRelPowerSeriesRingElem}, Ptr{FqPolyRepRelPowerSeriesRingElem}}
-const FqPolyRepAbsPowerSeriesRingElemOrPtr = Union{FqPolyRepAbsPowerSeriesRingElem, Ref{FqPolyRepAbsPowerSeriesRingElem}, Ptr{FqPolyRepAbsPowerSeriesRingElem}}
-const FqRelPowerSeriesRingElemOrPtr = Union{FqRelPowerSeriesRingElem, Ref{FqRelPowerSeriesRingElem}, Ptr{FqRelPowerSeriesRingElem}}
-const FqAbsPowerSeriesRingElemOrPtr = Union{FqAbsPowerSeriesRingElem, Ref{FqAbsPowerSeriesRingElem}, Ptr{FqAbsPowerSeriesRingElem}}
+const ZZRelPowerSeriesRingElemOrPtr = TypeOrPtr{ZZRelPowerSeriesRingElem}
+const ZZAbsPowerSeriesRingElemOrPtr = TypeOrPtr{ZZAbsPowerSeriesRingElem}
+const QQRelPowerSeriesRingElemOrPtr = TypeOrPtr{QQRelPowerSeriesRingElem}
+const QQAbsPowerSeriesRingElemOrPtr = TypeOrPtr{QQAbsPowerSeriesRingElem}
+const zzModRelPowerSeriesRingElemOrPtr = TypeOrPtr{zzModRelPowerSeriesRingElem}
+const zzModAbsPowerSeriesRingElemOrPtr = TypeOrPtr{zzModAbsPowerSeriesRingElem}
+const ZZModRelPowerSeriesRingElemOrPtr = TypeOrPtr{ZZModRelPowerSeriesRingElem}
+const ZZModAbsPowerSeriesRingElemOrPtr = TypeOrPtr{ZZModAbsPowerSeriesRingElem}
+const fpRelPowerSeriesRingElemOrPtr = TypeOrPtr{fpRelPowerSeriesRingElem}
+const fpAbsPowerSeriesRingElemOrPtr = TypeOrPtr{fpAbsPowerSeriesRingElem}
+const FpRelPowerSeriesRingElemOrPtr = TypeOrPtr{FpRelPowerSeriesRingElem}
+const FpAbsPowerSeriesRingElemOrPtr = TypeOrPtr{FpAbsPowerSeriesRingElem}
+const fqPolyRepRelPowerSeriesRingElemOrPtr = TypeOrPtr{fqPolyRepRelPowerSeriesRingElem}
+const fqPolyRepAbsPowerSeriesRingElemOrPtr = TypeOrPtr{fqPolyRepAbsPowerSeriesRingElem}
+const FqPolyRepRelPowerSeriesRingElemOrPtr = TypeOrPtr{FqPolyRepRelPowerSeriesRingElem}
+const FqPolyRepAbsPowerSeriesRingElemOrPtr = TypeOrPtr{FqPolyRepAbsPowerSeriesRingElem}
+const FqRelPowerSeriesRingElemOrPtr = TypeOrPtr{FqRelPowerSeriesRingElem}
+const FqAbsPowerSeriesRingElemOrPtr = TypeOrPtr{FqAbsPowerSeriesRingElem}
 
-const ZZMatrixOrPtr = Union{ZZMatrix, Ref{ZZMatrix}, Ptr{ZZMatrix}}
-const QQMatrixOrPtr = Union{QQMatrix, Ref{QQMatrix}, Ptr{QQMatrix}}
-const ZZPolyRingMatrixOrPtr = Union{ZZPolyRingMatrix, Ref{ZZPolyRingMatrix}, Ptr{ZZPolyRingMatrix}}
-const zzModMatrixOrPtr = Union{zzModMatrix, Ref{zzModMatrix}, Ptr{zzModMatrix}}
-const ZZModMatrixOrPtr = Union{ZZModMatrix, Ref{ZZModMatrix}, Ptr{ZZModMatrix}}
-const fpMatrixOrPtr = Union{fpMatrix, Ref{fpMatrix}, Ptr{fpMatrix}}
-const FpMatrixOrPtr = Union{FpMatrix, Ref{FpMatrix}, Ptr{FpMatrix}}
-const fqPolyRepMatrixOrPtr = Union{fqPolyRepMatrix, Ref{fqPolyRepMatrix}, Ptr{fqPolyRepMatrix}}
-const FqPolyRepMatrixOrPtr = Union{FqPolyRepMatrix, Ref{FqPolyRepMatrix}, Ptr{FqPolyRepMatrix}}
-const FqMatrixOrPtr = Union{FqMatrix, Ref{FqMatrix}, Ptr{FqMatrix}}
+const ZZMatrixOrPtr = TypeOrPtr{ZZMatrix}
+const QQMatrixOrPtr = TypeOrPtr{QQMatrix}
+const ZZPolyRingMatrixOrPtr = TypeOrPtr{ZZPolyRingMatrix}
+const zzModMatrixOrPtr = TypeOrPtr{zzModMatrix}
+const ZZModMatrixOrPtr = TypeOrPtr{ZZModMatrix}
+const fpMatrixOrPtr = TypeOrPtr{fpMatrix}
+const FpMatrixOrPtr = TypeOrPtr{FpMatrix}
+const fqPolyRepMatrixOrPtr = TypeOrPtr{fqPolyRepMatrix}
+const FqPolyRepMatrixOrPtr = TypeOrPtr{FqPolyRepMatrix}
+const FqMatrixOrPtr = TypeOrPtr{FqMatrix}
 
-const ZZLaurentSeriesRingElemOrPtr = Union{ZZLaurentSeriesRingElem, Ref{ZZLaurentSeriesRingElem}, Ptr{ZZLaurentSeriesRingElem}}
+const ZZLaurentSeriesRingElemOrPtr = TypeOrPtr{ZZLaurentSeriesRingElem}
 
-const FlintPuiseuxSeriesRingElemOrPtr{T <: RingElem} = Union{FlintPuiseuxSeriesRingElem{T}, Ref{FlintPuiseuxSeriesRingElem{T}}, Ptr{FlintPuiseuxSeriesRingElem{T}}}
-const FlintPuiseuxSeriesFieldElemOrPtr{T <: RingElem} = Union{FlintPuiseuxSeriesFieldElem{T}, Ref{FlintPuiseuxSeriesFieldElem{T}}, Ptr{FlintPuiseuxSeriesFieldElem{T}}}
+const FlintPuiseuxSeriesRingElemOrPtr{T <: RingElem} = TypeOrPtr{FlintPuiseuxSeriesRingElem{T}}
+const FlintPuiseuxSeriesFieldElemOrPtr{T <: RingElem} = TypeOrPtr{FlintPuiseuxSeriesFieldElem{T}}
 
-const PadicFieldElemOrPtr = Union{PadicFieldElem, Ref{PadicFieldElem}, Ptr{PadicFieldElem}}
-const QadicFieldElemOrPtr = Union{QadicFieldElem, Ref{QadicFieldElem}, Ptr{QadicFieldElem}}
+const PadicFieldElemOrPtr = TypeOrPtr{PadicFieldElem}
+const QadicFieldElemOrPtr = TypeOrPtr{QadicFieldElem}
 
 const IntegerUnionOrPtr = Union{Integer, ZZRingElemOrPtr}
 const RationalUnionOrPtr = Union{Integer, ZZRingElemOrPtr, Rational, QQFieldElemOrPtr}


### PR DESCRIPTION
Replace 56 Union{T, Ref{T}, Ptr{T}} patterns with TypeOrPtr{T} for conciseness and maintainability.

This allows us to write signatures in a way where we can extract the type using a type parameter. Consider the following function that accepts both QQMatrix and ZZMatrix:
```julia
function foo(x::Union{QQMatrixOrPtr, ZZMatrixOrPtr})
  # do something
end
```
in the body of that function, we can not efficiently pass the underlying type of the argument to another function (only with a 
```
if x isa QQMatrixOrPtr
  QQMatrix
else
  ZZMatrix
end
```
construct.

With this new syntax, we can instead write
```julia
function foo(x::TypeOrPtr{T}) where T <: Union{ZZMatrix, QQMatrix}
  # do something
end
```
and have the underlying argument type available in the type parameter `T`.

This might become useful when trying to call into the `gr` module of flint (which I am playing around with right now).

I am not certain about the name of this construct. This is the IMO best approach that the AI has come up with.

