### PR TITLE
Fix a subtle bug in `digits!` for negative inputs

### DIFF
--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -2536,8 +2536,7 @@ function Base.digits!(a::AbstractVector{T}, n::ZZRingElem; base::T = 10) where T
   if nbits(n)/ndigits(base, base = 2) > 100
     c = div(div(nbits(n), ndigits(base, base = 2)), 2)
     nn = ZZRingElem(base)^c
-    q, r = divrem(n, nn)
-
+    q, r = Base.divrem(n, nn, RoundToZero)
     digits!(view(a, 1:c), r, base = base)
     digits!(view(a, c+1:length(a)), q, base = base)
     return a

--- a/test/flint/fmpz-test.jl
+++ b/test/flint/fmpz-test.jl
@@ -930,6 +930,10 @@ end
   @test digits(a) == digits(BigInt(a))
   @test digits(a, base = 17) == digits(BigInt(a), base = 17)
   @test digits(a, base = 5, pad = 50) == digits(BigInt(a), base = 5, pad = 50)
+
+  # Nemo PR #2325
+  p = -primorial(ZZ(307))
+  @test maximum(digits(p; base=ZZ(10))) <= 0
 end
 
 @testset "ZZRingElem.string_io" begin


### PR DESCRIPTION
Fix "subtle" bug in `digits!`: `divrem` did not work as expected from reading the doc, so i have added an explicit instruction to use `RoundToZero`
