### PR TITLE
Replace uses of `...OrPtr` with `TypeOrPtr{...}`

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -86,7 +86,7 @@ numerator(::ZZRingElem)
 ```
 
 ```@docs
-set!(::ZZRingElemOrPtr, ::ZZRingElemOrPtr)
+set!(::TypeOrPtr{ZZRingElem}, ::TypeOrPtr{ZZRingElem})
 ```
 **Examples**
 

--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -1555,22 +1555,22 @@ end
 #
 ################################################################################
 
-function zero!(z::ComplexFieldElemOrPtr)
+function zero!(z::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_zero(z::Ref{ComplexFieldElem})::Nothing
   return z
 end
 
-function one!(z::ComplexFieldElemOrPtr)
+function one!(z::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_one(z::Ref{ComplexFieldElem})::Nothing
   return z
 end
 
-function onei!(z::ComplexFieldElemOrPtr)
+function onei!(z::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_onei(z::Ref{ComplexFieldElem})::Nothing
   return z
 end
 
-function neg!(z::ComplexFieldElemOrPtr, a::ComplexFieldElemOrPtr)
+function neg!(z::TypeOrPtr{ComplexFieldElem}, a::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_neg(z::Ref{ComplexFieldElem}, a::Ref{ComplexFieldElem})::Nothing
   return z
 end
@@ -1601,127 +1601,127 @@ end
 #
 ################################################################################
 
-_real_ptr(x::ComplexFieldElemOrPtr) = @ccall libflint.acb_real_ptr(x::Ref{ComplexFieldElem})::Ptr{RealFieldElem}
-_imag_ptr(x::ComplexFieldElemOrPtr) = @ccall libflint.acb_imag_ptr(x::Ref{ComplexFieldElem})::Ptr{RealFieldElem}
+_real_ptr(x::TypeOrPtr{ComplexFieldElem}) = @ccall libflint.acb_real_ptr(x::Ref{ComplexFieldElem})::Ptr{RealFieldElem}
+_imag_ptr(x::TypeOrPtr{ComplexFieldElem}) = @ccall libflint.acb_imag_ptr(x::Ref{ComplexFieldElem})::Ptr{RealFieldElem}
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Int)
   @ccall libflint.acb_set_si(x::Ref{ComplexFieldElem}, y::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::UInt)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::UInt)
   @ccall libflint.acb_set_ui(x::Ref{ComplexFieldElem}, y::UInt)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Float64)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Float64)
   @ccall libflint.acb_set_d(x::Ref{ComplexFieldElem}, y::Float64)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Union{Int,UInt,Float64}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Union{Int,UInt,Float64}, p::Int)
   _acb_set(x, y)
   @ccall libflint.acb_set_round(x::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::ZZRingElem)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::ZZRingElem)
   @ccall libflint.acb_set_fmpz(x::Ref{ComplexFieldElem}, y::Ref{ZZRingElem})::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::ZZRingElem, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::ZZRingElem, p::Int)
   @ccall libflint.acb_set_round_fmpz(x::Ref{ComplexFieldElem}, y::Ref{ZZRingElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::QQFieldElem, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::QQFieldElem, p::Int)
   @ccall libflint.acb_set_fmpq(x::Ref{ComplexFieldElem}, y::Ref{QQFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::RealFieldElem)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::RealFieldElem)
   @ccall libflint.acb_set_arb(x::Ref{ComplexFieldElem}, y::Ref{RealFieldElem})::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::RealFieldElem, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::RealFieldElem, p::Int)
   _acb_set(x, y)
   @ccall libflint.acb_set_round(x::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::ComplexFieldElemOrPtr)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_set(x::Ref{ComplexFieldElem}, y::Ref{ComplexFieldElem})::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Ptr{acb_struct})
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Ptr{acb_struct})
   @ccall libflint.acb_set(x::Ref{ComplexFieldElem}, y::Ptr{acb_struct})::Nothing
 end
 
-function _acb_set(x::Ptr{acb_struct}, y::ComplexFieldElemOrPtr)
+function _acb_set(x::Ptr{acb_struct}, y::TypeOrPtr{ComplexFieldElem})
   @ccall libflint.acb_set(x::Ptr{acb_struct}, y::Ref{ComplexFieldElem})::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::ComplexFieldElemOrPtr, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::TypeOrPtr{ComplexFieldElem}, p::Int)
   @ccall libflint.acb_set_round(x::Ref{ComplexFieldElem}, y::Ref{ComplexFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::AbstractString, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::AbstractString, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::BigFloat)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::BigFloat)
   r = _real_ptr(x)
   _arb_set(r, y)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::BigFloat, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::BigFloat, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{Int,Int}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{Int,Int}, p::Int)
   @ccall libflint.acb_set_si_si(x::Ref{ComplexFieldElem}, yz[1]::Int, yz[2]::Int)::Nothing
   @ccall libflint.acb_set_round(x::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{RealFieldElem,RealFieldElem})
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{RealFieldElem,RealFieldElem})
   @ccall libflint.acb_set_arb_arb(x::Ref{ComplexFieldElem}, yz[1]::Ref{RealFieldElem}, yz[2]::Ref{RealFieldElem})::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{RealFieldElem,RealFieldElem}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{RealFieldElem,RealFieldElem}, p::Int)
   _acb_set(x, yz)
   @ccall libflint.acb_set_round(x::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{QQFieldElem,QQFieldElem}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{QQFieldElem,QQFieldElem}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)
   _arb_set(i, yz[2], p)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{AbstractString,AbstractString}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{AbstractString,AbstractString}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)
   _arb_set(i, yz[2], p)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Real, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Real, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, y::Complex, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, y::Complex, p::Int)
   r = _real_ptr(x)
   _arb_set(r, real(y), p)
   i = _imag_ptr(x)
   _arb_set(i, imag(y), p)
 end
 
-function _acb_set(x::ComplexFieldElemOrPtr, yz::Tuple{IntegerUnion,IntegerUnion}, p::Int)
+function _acb_set(x::TypeOrPtr{ComplexFieldElem}, yz::Tuple{IntegerUnion,IntegerUnion}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)

--- a/src/arb/ComplexPoly.jl
+++ b/src/arb/ComplexPoly.jl
@@ -631,17 +631,17 @@ end
 #
 ###############################################################################
 
-function zero!(z::ComplexPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{ComplexPolyRingElem})
   @ccall libflint.acb_poly_zero(z::Ref{ComplexPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::ComplexPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{ComplexPolyRingElem})
   @ccall libflint.acb_poly_one(z::Ref{ComplexPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::ComplexPolyRingElemOrPtr, a::ComplexPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{ComplexPolyRingElem}, a::TypeOrPtr{ComplexPolyRingElem})
   @ccall libflint.acb_poly_neg(z::Ref{ComplexPolyRingElem}, a::Ref{ComplexPolyRingElem})::Nothing
   return z
 end

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -62,8 +62,8 @@ end
 
 characteristic(::RealField) = 0
 
-_mid_ptr(x::RealFieldElemOrPtr) = @ccall libflint.arb_mid_ptr(x::Ref{RealFieldElem})::Ptr{arf_struct}
-_rad_ptr(x::RealFieldElemOrPtr) = @ccall libflint.arb_rad_ptr(x::Ref{RealFieldElem})::Ptr{mag_struct}
+_mid_ptr(x::TypeOrPtr{RealFieldElem}) = @ccall libflint.arb_mid_ptr(x::Ref{RealFieldElem})::Ptr{arf_struct}
+_rad_ptr(x::TypeOrPtr{RealFieldElem}) = @ccall libflint.arb_rad_ptr(x::Ref{RealFieldElem})::Ptr{mag_struct}
 
 ################################################################################
 #
@@ -1873,17 +1873,17 @@ end
 #
 ################################################################################
 
-function zero!(z::RealFieldElemOrPtr)
+function zero!(z::TypeOrPtr{RealFieldElem})
   @ccall libflint.arb_zero(z::Ref{RealFieldElem})::Nothing
   return z
 end
 
-function one!(z::RealFieldElemOrPtr)
+function one!(z::TypeOrPtr{RealFieldElem})
   @ccall libflint.arb_one(z::Ref{RealFieldElem})::Nothing
   return z
 end
 
-function neg!(z::RealFieldElemOrPtr, a::RealFieldElemOrPtr)
+function neg!(z::TypeOrPtr{RealFieldElem}, a::TypeOrPtr{RealFieldElem})
   @ccall libflint.arb_neg(z::Ref{RealFieldElem}, a::Ref{RealFieldElem})::Nothing
   return z
 end
@@ -1891,7 +1891,7 @@ end
 for (s,f) in (("add!","arb_add"), ("mul!","arb_mul"), ("div!", "arb_div"),
               ("sub!","arb_sub"))
   @eval begin
-    function ($(Symbol(s)))(z::RealFieldElemOrPtr, x::RealFieldElemOrPtr, y::RealFieldElemOrPtr, prec::Int = precision(Balls))
+    function ($(Symbol(s)))(z::TypeOrPtr{RealFieldElem}, x::TypeOrPtr{RealFieldElem}, y::TypeOrPtr{RealFieldElem}, prec::Int = precision(Balls))
       @ccall libflint.$f(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
       return z
     end
@@ -1904,90 +1904,90 @@ end
 #
 ################################################################################
 
-function _arb_set(x::RealFieldElemOrPtr, y::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Int)
   @ccall libflint.arb_set_si(x::Ref{RealFieldElem}, y::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::UInt)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::UInt)
   @ccall libflint.arb_set_ui(x::Ref{RealFieldElem}, y::UInt)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Float64)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Float64)
   @ccall libflint.arb_set_d(x::Ref{RealFieldElem}, y::Float64)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Union{Int,UInt,Float64}, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Union{Int,UInt,Float64}, p::Int)
   _arb_set(x, y)
   @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, x::Ref{RealFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::ZZRingElem)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::ZZRingElem)
   @ccall libflint.arb_set_fmpz(x::Ref{RealFieldElem}, y::Ref{ZZRingElem})::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::ZZRingElem, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::ZZRingElem, p::Int)
   @ccall libflint.arb_set_round_fmpz(x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::QQFieldElem, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::QQFieldElem, p::Int)
   @ccall libflint.arb_set_fmpq(x::Ref{RealFieldElem}, y::Ref{QQFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::RealFieldElemOrPtr)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::TypeOrPtr{RealFieldElem})
   @ccall libflint.arb_set(x::Ref{RealFieldElem}, y::Ref{RealFieldElem})::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Ptr{arb_struct})
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Ptr{arb_struct})
   @ccall libflint.arb_set(x::Ref{RealFieldElem}, y::Ptr{arb_struct})::Nothing
 end
 
-function _arb_set(x::Ptr{arb_struct}, y::RealFieldElemOrPtr)
+function _arb_set(x::Ptr{arb_struct}, y::TypeOrPtr{RealFieldElem})
   @ccall libflint.arb_set(x::Ptr{arb_struct}, y::Ref{RealFieldElem})::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::RealFieldElemOrPtr, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::TypeOrPtr{RealFieldElem}, p::Int)
   @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::AbstractString, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::AbstractString, p::Int)
   s = string(y)
   err = @ccall libflint.arb_set_str(x::Ref{RealFieldElem}, s::Ptr{UInt8}, p::Int)::Int32
   err == 0 || error("Invalid real string: $(repr(s))")
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::BigFloat)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::BigFloat)
   m = _mid_ptr(x)
   r = _rad_ptr(x)
   @ccall libflint.arf_set_mpfr(m::Ptr{arf_struct}, y::Ref{BigFloat})::Nothing
   @ccall libflint.mag_zero(r::Ptr{mag_struct})::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::BigFloat, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::BigFloat, p::Int)
   _arb_set(x, y)
   @ccall libflint.arb_set_round(x::Ref{RealFieldElem}, x::Ref{RealFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Integer)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Integer)
   _arb_set(x, ZZRingElem(y))
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Integer, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Integer, p::Int)
   _arb_set(x, ZZRingElem(y), p)
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Real)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Real)
   _arb_set(x, BigFloat(y))
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Real, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Real, p::Int)
   _arb_set(x, BigFloat(y), p)
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Irrational)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Irrational)
   _arb_set(x, y, precision(Balls))
 end
 
-function _arb_set(x::RealFieldElemOrPtr, y::Irrational, p::Int)
+function _arb_set(x::TypeOrPtr{RealFieldElem}, y::Irrational, p::Int)
   if y == pi
     @ccall libflint.arb_const_pi(x::Ref{RealFieldElem}, p::Int)::Nothing
   elseif y == MathConstants.e

--- a/src/arb/RealPoly.jl
+++ b/src/arb/RealPoly.jl
@@ -539,17 +539,17 @@ end
 #
 ###############################################################################
 
-function zero!(z::RealPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{RealPolyRingElem})
   @ccall libflint.arb_poly_zero(z::Ref{RealPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::RealPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{RealPolyRingElem})
   @ccall libflint.arb_poly_one(z::Ref{RealPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::RealPolyRingElemOrPtr, a::RealPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{RealPolyRingElem}, a::TypeOrPtr{RealPolyRingElem})
   @ccall libflint.arb_poly_neg(z::Ref{RealPolyRingElem}, a::Ref{RealPolyRingElem})::Nothing
   return z
 end

--- a/src/arb/acb.jl
+++ b/src/arb/acb.jl
@@ -1539,22 +1539,22 @@ end
 #
 ################################################################################
 
-function zero!(z::AcbFieldElemOrPtr)
+function zero!(z::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_zero(z::Ref{AcbFieldElem})::Nothing
   return z
 end
 
-function one!(z::AcbFieldElemOrPtr)
+function one!(z::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_one(z::Ref{AcbFieldElem})::Nothing
   return z
 end
 
-function onei!(z::AcbFieldElemOrPtr)
+function onei!(z::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_onei(z::Ref{AcbFieldElem})::Nothing
   return z
 end
 
-function neg!(z::AcbFieldElemOrPtr, a::AcbFieldElemOrPtr)
+function neg!(z::TypeOrPtr{AcbFieldElem}, a::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_neg(z::Ref{AcbFieldElem}, a::Ref{AcbFieldElem})::Nothing
   return z
 end
@@ -1585,127 +1585,127 @@ end
 #
 ################################################################################
 
-_real_ptr(x::AcbFieldElemOrPtr) = @ccall libflint.acb_real_ptr(x::Ref{AcbFieldElem})::Ptr{ArbFieldElem}
-_imag_ptr(x::AcbFieldElemOrPtr) = @ccall libflint.acb_imag_ptr(x::Ref{AcbFieldElem})::Ptr{ArbFieldElem}
+_real_ptr(x::TypeOrPtr{AcbFieldElem}) = @ccall libflint.acb_real_ptr(x::Ref{AcbFieldElem})::Ptr{ArbFieldElem}
+_imag_ptr(x::TypeOrPtr{AcbFieldElem}) = @ccall libflint.acb_imag_ptr(x::Ref{AcbFieldElem})::Ptr{ArbFieldElem}
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Int)
   @ccall libflint.acb_set_si(x::Ref{AcbFieldElem}, y::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::UInt)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::UInt)
   @ccall libflint.acb_set_ui(x::Ref{AcbFieldElem}, y::UInt)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Float64)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Float64)
   @ccall libflint.acb_set_d(x::Ref{AcbFieldElem}, y::Float64)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Union{Int,UInt,Float64}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Union{Int,UInt,Float64}, p::Int)
   _acb_set(x, y)
   @ccall libflint.acb_set_round(x::Ref{AcbFieldElem}, x::Ref{AcbFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::ZZRingElem)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::ZZRingElem)
   @ccall libflint.acb_set_fmpz(x::Ref{AcbFieldElem}, y::Ref{ZZRingElem})::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::ZZRingElem, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::ZZRingElem, p::Int)
   @ccall libflint.acb_set_round_fmpz(x::Ref{AcbFieldElem}, y::Ref{ZZRingElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::QQFieldElem, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::QQFieldElem, p::Int)
   @ccall libflint.acb_set_fmpq(x::Ref{AcbFieldElem}, y::Ref{QQFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::ArbFieldElem)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::ArbFieldElem)
   @ccall libflint.acb_set_arb(x::Ref{AcbFieldElem}, y::Ref{ArbFieldElem})::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::ArbFieldElem, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::ArbFieldElem, p::Int)
   _acb_set(x, y)
   @ccall libflint.acb_set_round(x::Ref{AcbFieldElem}, x::Ref{AcbFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::AcbFieldElemOrPtr)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_set(x::Ref{AcbFieldElem}, y::Ref{AcbFieldElem})::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Ptr{acb_struct})
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Ptr{acb_struct})
   @ccall libflint.acb_set(x::Ref{AcbFieldElem}, y::Ptr{acb_struct})::Nothing
 end
 
-function _acb_set(x::Ptr{acb_struct}, y::AcbFieldElemOrPtr)
+function _acb_set(x::Ptr{acb_struct}, y::TypeOrPtr{AcbFieldElem})
   @ccall libflint.acb_set(x::Ptr{acb_struct}, y::Ref{AcbFieldElem})::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::AcbFieldElemOrPtr, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::TypeOrPtr{AcbFieldElem}, p::Int)
   @ccall libflint.acb_set_round(x::Ref{AcbFieldElem}, y::Ref{AcbFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::AbstractString, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::AbstractString, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::BigFloat)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::BigFloat)
   r = _real_ptr(x)
   _arb_set(r, y)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::BigFloat, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::BigFloat, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{Int,Int}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{Int,Int}, p::Int)
   @ccall libflint.acb_set_si_si(x::Ref{AcbFieldElem}, yz[1]::Int, yz[2]::Int)::Nothing
   @ccall libflint.acb_set_round(x::Ref{AcbFieldElem}, x::Ref{AcbFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{ArbFieldElem,ArbFieldElem})
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{ArbFieldElem,ArbFieldElem})
   @ccall libflint.acb_set_arb_arb(x::Ref{AcbFieldElem}, yz[1]::Ref{ArbFieldElem}, yz[2]::Ref{ArbFieldElem})::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{ArbFieldElem,ArbFieldElem}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{ArbFieldElem,ArbFieldElem}, p::Int)
   _acb_set(x, yz)
   @ccall libflint.acb_set_round(x::Ref{AcbFieldElem}, x::Ref{AcbFieldElem}, p::Int)::Nothing
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{QQFieldElem,QQFieldElem}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{QQFieldElem,QQFieldElem}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)
   _arb_set(i, yz[2], p)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{AbstractString,AbstractString}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{AbstractString,AbstractString}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)
   _arb_set(i, yz[2], p)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Real, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Real, p::Int)
   r = _real_ptr(x)
   _arb_set(r, y, p)
   i = _imag_ptr(x)
   zero!(i)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, y::Complex, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, y::Complex, p::Int)
   r = _real_ptr(x)
   _arb_set(r, real(y), p)
   i = _imag_ptr(x)
   _arb_set(i, imag(y), p)
 end
 
-function _acb_set(x::AcbFieldElemOrPtr, yz::Tuple{IntegerUnion,IntegerUnion}, p::Int)
+function _acb_set(x::TypeOrPtr{AcbFieldElem}, yz::Tuple{IntegerUnion,IntegerUnion}, p::Int)
   r = _real_ptr(x)
   _arb_set(r, yz[1], p)
   i = _imag_ptr(x)

--- a/src/arb/acb_poly.jl
+++ b/src/arb/acb_poly.jl
@@ -636,17 +636,17 @@ end
 #
 ###############################################################################
 
-function zero!(z::AcbPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{AcbPolyRingElem})
   @ccall libflint.acb_poly_zero(z::Ref{AcbPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::AcbPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{AcbPolyRingElem})
   @ccall libflint.acb_poly_one(z::Ref{AcbPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::AcbPolyRingElemOrPtr, a::AcbPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{AcbPolyRingElem}, a::TypeOrPtr{AcbPolyRingElem})
   @ccall libflint.acb_poly_neg(z::Ref{AcbPolyRingElem}, a::Ref{AcbPolyRingElem})::Nothing
   return z
 end

--- a/src/arb/arb.jl
+++ b/src/arb/arb.jl
@@ -52,8 +52,8 @@ end
 
 characteristic(::ArbField) = 0
 
-_mid_ptr(x::ArbFieldElemOrPtr) = @ccall libflint.arb_mid_ptr(x::Ref{ArbFieldElem})::Ptr{arf_struct}
-_rad_ptr(x::ArbFieldElemOrPtr) = @ccall libflint.arb_rad_ptr(x::Ref{ArbFieldElem})::Ptr{mag_struct}
+_mid_ptr(x::TypeOrPtr{ArbFieldElem}) = @ccall libflint.arb_mid_ptr(x::Ref{ArbFieldElem})::Ptr{arf_struct}
+_rad_ptr(x::TypeOrPtr{ArbFieldElem}) = @ccall libflint.arb_rad_ptr(x::Ref{ArbFieldElem})::Ptr{mag_struct}
 
 ################################################################################
 #
@@ -1857,17 +1857,17 @@ end
 #
 ################################################################################
 
-function zero!(z::Union{ArbFieldElemOrPtr})
+function zero!(z::Union{TypeOrPtr{ArbFieldElem}})
   @ccall libflint.arb_zero(z::Ref{ArbFieldElem})::Nothing
   return z
 end
 
-function one!(z::ArbFieldElemOrPtr)
+function one!(z::TypeOrPtr{ArbFieldElem})
   @ccall libflint.arb_one(z::Ref{ArbFieldElem})::Nothing
   return z
 end
 
-function neg!(z::ArbFieldElemOrPtr, a::ArbFieldElemOrPtr)
+function neg!(z::TypeOrPtr{ArbFieldElem}, a::TypeOrPtr{ArbFieldElem})
   @ccall libflint.arb_neg(z::Ref{ArbFieldElem}, a::Ref{ArbFieldElem})::Nothing
   return z
 end
@@ -1894,82 +1894,82 @@ end
 #
 ################################################################################
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Int)
   @ccall libflint.arb_set_si(x::Ref{ArbFieldElem}, y::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::UInt)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::UInt)
   @ccall libflint.arb_set_ui(x::Ref{ArbFieldElem}, y::UInt)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Float64)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Float64)
   @ccall libflint.arb_set_d(x::Ref{ArbFieldElem}, y::Float64)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Union{Int,UInt,Float64}, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Union{Int,UInt,Float64}, p::Int)
   _arb_set(x, y)
   @ccall libflint.arb_set_round(x::Ref{ArbFieldElem}, x::Ref{ArbFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::ZZRingElem)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::ZZRingElem)
   @ccall libflint.arb_set_fmpz(x::Ref{ArbFieldElem}, y::Ref{ZZRingElem})::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::ZZRingElem, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::ZZRingElem, p::Int)
   @ccall libflint.arb_set_round_fmpz(x::Ref{ArbFieldElem}, y::Ref{ZZRingElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::QQFieldElem, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::QQFieldElem, p::Int)
   @ccall libflint.arb_set_fmpq(x::Ref{ArbFieldElem}, y::Ref{QQFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::ArbFieldElemOrPtr)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::TypeOrPtr{ArbFieldElem})
   @ccall libflint.arb_set(x::Ref{ArbFieldElem}, y::Ref{ArbFieldElem})::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Ptr{arb_struct})
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Ptr{arb_struct})
   @ccall libflint.arb_set(x::Ref{ArbFieldElem}, y::Ptr{arb_struct})::Nothing
 end
 
-function _arb_set(x::Ptr{arb_struct}, y::ArbFieldElemOrPtr)
+function _arb_set(x::Ptr{arb_struct}, y::TypeOrPtr{ArbFieldElem})
   @ccall libflint.arb_set(x::Ptr{arb_struct}, y::Ref{ArbFieldElem})::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::ArbFieldElemOrPtr, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::TypeOrPtr{ArbFieldElem}, p::Int)
   @ccall libflint.arb_set_round(x::Ref{ArbFieldElem}, y::Ref{ArbFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::AbstractString, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::AbstractString, p::Int)
   s = string(y)
   err = @ccall libflint.arb_set_str(x::Ref{ArbFieldElem}, s::Ptr{UInt8}, p::Int)::Int32
   err == 0 || error("Invalid real string: $(repr(s))")
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::BigFloat)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::BigFloat)
   m = _mid_ptr(x)
   r = _rad_ptr(x)
   @ccall libflint.arf_set_mpfr(m::Ptr{arf_struct}, y::Ref{BigFloat})::Nothing
   @ccall libflint.mag_zero(r::Ptr{mag_struct})::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::BigFloat, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::BigFloat, p::Int)
   _arb_set(x, y)
   @ccall libflint.arb_set_round(x::Ref{ArbFieldElem}, x::Ref{ArbFieldElem}, p::Int)::Nothing
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Integer)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Integer)
   _arb_set(x, ZZRingElem(y))
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Integer, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Integer, p::Int)
   _arb_set(x, ZZRingElem(y), p)
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Real)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Real)
   _arb_set(x, BigFloat(y))
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Real, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Real, p::Int)
   _arb_set(x, BigFloat(y), p)
 end
 
@@ -1977,7 +1977,7 @@ function _arb_set(x::ArbFieldElem, y::Irrational)
   _arb_set(x, y, precision(parent(x)))
 end
 
-function _arb_set(x::ArbFieldElemOrPtr, y::Irrational, p::Int)
+function _arb_set(x::TypeOrPtr{ArbFieldElem}, y::Irrational, p::Int)
   if y == pi
     @ccall libflint.arb_const_pi(x::Ref{ArbFieldElem}, p::Int)::Nothing
   elseif y == MathConstants.e

--- a/src/arb/arb_poly.jl
+++ b/src/arb/arb_poly.jl
@@ -539,17 +539,17 @@ end
 #
 ###############################################################################
 
-function zero!(z::ArbPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{ArbPolyRingElem})
   @ccall libflint.arb_poly_zero(z::Ref{ArbPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::ArbPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{ArbPolyRingElem})
   @ccall libflint.arb_poly_one(z::Ref{ArbPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::ArbPolyRingElemOrPtr, a::ArbPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{ArbPolyRingElem}, a::TypeOrPtr{ArbPolyRingElem})
   @ccall libflint.arb_poly_neg(z::Ref{ArbPolyRingElem}, a::Ref{ArbPolyRingElem})::Nothing
   return z
 end

--- a/src/calcium/qqbar.jl
+++ b/src/calcium/qqbar.jl
@@ -1292,160 +1292,160 @@ convert(::Type{T}, a::QQBarFieldElem) where {T <: RationalUnion} = T(a)
 #
 ###############################################################################
 
-function zero!(z::QQBarFieldElemOrPtr)
+function zero!(z::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_zero(z::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function one!(z::QQBarFieldElemOrPtr)
+function one!(z::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_one(z::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function neg!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr)
+function neg!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_neg(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
 #
 
-function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+function add!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_add(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+function add!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.qqbar_add_fmpq(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+function add!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.qqbar_add_fmpz(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+function add!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::Int)
   @ccall libflint.qqbar_add_si(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Int)::Nothing
   return z
 end
 
-function add!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+function add!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::UInt)
   @ccall libflint.qqbar_add_ui(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::UInt)::Nothing
   return z
 end
 
-add!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = add!(c, a, flintify(b))
-add!(c::QQBarFieldElemOrPtr, a::Union{QQFieldElemOrPtr, ZZRingElemOrPtr, Integer, Rational}, b::QQBarFieldElemOrPtr) = add!(c, b, a)
+add!(c::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::Union{Integer, Rational}) = add!(c, a, flintify(b))
+add!(c::TypeOrPtr{QQBarFieldElem}, a::Union{TypeOrPtr{QQFieldElem}, TypeOrPtr{ZZRingElem}, Integer, Rational}, b::TypeOrPtr{QQBarFieldElem}) = add!(c, b, a)
 
 #
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_sub(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.qqbar_sub_fmpq(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.qqbar_sub_fmpz(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::Int)
   @ccall libflint.qqbar_sub_si(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Int)::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::UInt)
   @ccall libflint.qqbar_sub_ui(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::UInt)::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::QQFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQFieldElem}, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_fmpq_sub(z::Ref{QQBarFieldElem}, x::Ref{QQFieldElem}, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::ZZRingElemOrPtr, y::QQBarFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_fmpz_sub(z::Ref{QQBarFieldElem}, x::Ref{ZZRingElem}, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::Int, y::QQBarFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::Int, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_si_sub(z::Ref{QQBarFieldElem}, x::Int, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQBarFieldElemOrPtr, x::UInt, y::QQBarFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQBarFieldElem}, x::UInt, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_ui_sub(z::Ref{QQBarFieldElem}, x::UInt, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-sub!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = sub!(c, a, flintify(b))
-sub!(c::QQBarFieldElemOrPtr, a::Union{Integer, Rational}, b::QQBarFieldElemOrPtr) = sub!(c, flintify(a), b)
+sub!(c::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::Union{Integer, Rational}) = sub!(c, a, flintify(b))
+sub!(c::TypeOrPtr{QQBarFieldElem}, a::Union{Integer, Rational}, b::TypeOrPtr{QQBarFieldElem}) = sub!(c, flintify(a), b)
 
 #
 
-function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQBarFieldElemOrPtr)
+function mul!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQBarFieldElem})
   @ccall libflint.qqbar_mul(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQBarFieldElem})::Nothing
   return z
 end
 
-function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::QQFieldElemOrPtr)
+function mul!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.qqbar_mul_fmpq(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::ZZRingElemOrPtr)
+function mul!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.qqbar_mul_fmpz(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::Int)
+function mul!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::Int)
   @ccall libflint.qqbar_mul_si(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::Int)::Nothing
   return z
 end
 
-function mul!(z::QQBarFieldElemOrPtr, x::QQBarFieldElemOrPtr, y::UInt)
+function mul!(z::TypeOrPtr{QQBarFieldElem}, x::TypeOrPtr{QQBarFieldElem}, y::UInt)
   @ccall libflint.qqbar_mul_ui(z::Ref{QQBarFieldElem}, x::Ref{QQBarFieldElem}, y::UInt)::Nothing
   return z
 end
 
-mul!(c::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = mul!(c, a, flintify(b))
-mul!(c::QQBarFieldElemOrPtr, a::Union{QQFieldElemOrPtr, ZZRingElemOrPtr, Integer, Rational}, b::QQBarFieldElemOrPtr) = mul!(c, b, a)
+mul!(c::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::Union{Integer, Rational}) = mul!(c, a, flintify(b))
+mul!(c::TypeOrPtr{QQBarFieldElem}, a::Union{TypeOrPtr{QQFieldElem}, TypeOrPtr{ZZRingElem}, Integer, Rational}, b::TypeOrPtr{QQBarFieldElem}) = mul!(c, b, a)
 
 #
 
 
-function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::QQBarFieldElemOrPtr)
+function pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::TypeOrPtr{QQBarFieldElem})
   ok = Bool(@ccall libflint.qqbar_pow(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQBarFieldElem})::Cint)
   return ok, z
 end
 
-function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::ZZRingElemOrPtr)
+function pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.qqbar_pow_fmpz(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::QQFieldElemOrPtr)
+function pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.qqbar_pow_fmpq(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Int)
+function pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::Int)
   @ccall libflint.qqbar_pow_si(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::Int)::Nothing
   return z
 end
 
-function pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::UInt)
+function pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::UInt)
   @ccall libflint.qqbar_pow_ui(z::Ref{QQBarFieldElem}, a::Ref{QQBarFieldElem}, b::UInt)::Nothing
   return z
 end
 
-pow!(z::QQBarFieldElemOrPtr, a::QQBarFieldElemOrPtr, b::Union{Integer, Rational}) = pow!(z, a, flintify(b))
+pow!(z::TypeOrPtr{QQBarFieldElem}, a::TypeOrPtr{QQBarFieldElem}, b::Union{Integer, Rational}) = pow!(z, a, flintify(b))
 
 
 ###############################################################################

--- a/src/flint/FlintTypes.jl
+++ b/src/flint/FlintTypes.jl
@@ -5519,8 +5519,8 @@ const FlintPuiseuxSeriesFieldElemOrPtr{T <: RingElem} = TypeOrPtr{FlintPuiseuxSe
 const PadicFieldElemOrPtr = TypeOrPtr{PadicFieldElem}
 const QadicFieldElemOrPtr = TypeOrPtr{QadicFieldElem}
 
-const IntegerUnionOrPtr = Union{Integer, ZZRingElemOrPtr}
-const RationalUnionOrPtr = Union{Integer, ZZRingElemOrPtr, Rational, QQFieldElemOrPtr}
+const IntegerUnionOrPtr = Union{Integer, TypeOrPtr{ZZRingElem}}
+const RationalUnionOrPtr = Union{Integer, TypeOrPtr{ZZRingElem}, Rational, TypeOrPtr{QQFieldElem}}
 
 ###############################################################################
 #

--- a/src/flint/fmpq.jl
+++ b/src/flint/fmpq.jl
@@ -87,12 +87,12 @@ Return the sign of $a$ ($-1$, $0$ or $1$) as a fraction.
 """
 sign(a::QQFieldElem) = QQFieldElem(sign(numerator(a)))
 
-sign(::Type{Int}, a::QQFieldElemOrPtr) = sign(Int, _num_ptr(a))
+sign(::Type{Int}, a::TypeOrPtr{QQFieldElem}) = sign(Int, _num_ptr(a))
 
 Base.signbit(a::QQFieldElem) = signbit(sign(Int, a))
 
-is_negative(n::QQFieldElemOrPtr) = sign(Int, n) < 0
-is_positive(n::QQFieldElemOrPtr) = sign(Int, n) > 0
+is_negative(n::TypeOrPtr{QQFieldElem}) = sign(Int, n) < 0
+is_positive(n::TypeOrPtr{QQFieldElem}) = sign(Int, n) > 0
 
 function abs(a::QQFieldElem)
   z = QQFieldElem()
@@ -113,11 +113,11 @@ zero(::Type{QQFieldElem}) = QQFieldElem(0)
 one(::Type{QQFieldElem}) = QQFieldElem(1)
 
 
-is_one(a::QQFieldElemOrPtr) = isinteger(a) && is_one(_num_ptr(a))
+is_one(a::TypeOrPtr{QQFieldElem}) = isinteger(a) && is_one(_num_ptr(a))
 
-is_zero(a::QQFieldElemOrPtr) = is_zero(_num_ptr(a))
+is_zero(a::TypeOrPtr{QQFieldElem}) = is_zero(_num_ptr(a))
 
-isinteger(a::QQFieldElemOrPtr) = is_one(_den_ptr(a))
+isinteger(a::TypeOrPtr{QQFieldElem}) = is_one(_den_ptr(a))
 
 isfinite(::QQFieldElem) = true
 
@@ -334,7 +334,7 @@ end
 #
 ###############################################################################
 
-function cmp(a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function cmp(a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_cmp(a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Cint
 end
 
@@ -359,21 +359,21 @@ end
 #
 ###############################################################################
 
-function cmp(a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+function cmp(a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_cmp_fmpz(a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Cint
 end
 
-function cmp(a::QQFieldElemOrPtr, b::Int)
+function cmp(a::TypeOrPtr{QQFieldElem}, b::Int)
   @ccall libflint.fmpq_cmp_si(a::Ref{QQFieldElem}, b::Int)::Cint
 end
 
-function cmp(a::QQFieldElemOrPtr, b::UInt)
+function cmp(a::TypeOrPtr{QQFieldElem}, b::UInt)
   @ccall libflint.fmpq_cmp_ui(a::Ref{QQFieldElem}, b::UInt)::Cint
 end
 
-cmp(a::QQFieldElemOrPtr, b::Integer) = cmp(a, flintify(b))
+cmp(a::TypeOrPtr{QQFieldElem}, b::Integer) = cmp(a, flintify(b))
 
-cmp(a::Union{ZZRingElemOrPtr, Integer}, b::QQFieldElemOrPtr) = -cmp(b, a)
+cmp(a::Union{TypeOrPtr{ZZRingElem}, Integer}, b::TypeOrPtr{QQFieldElem}) = -cmp(b, a)
 
 
 for T in (Int, UInt, ZZRingElem, Integer)
@@ -1022,43 +1022,43 @@ end
 _num_ptr(c::QQFieldElem) = Ptr{ZZRingElem}(pointer_from_objref(c))
 _num_ptr(c::Ptr{QQFieldElem}) = Ptr{ZZRingElem}(c)
 _num_ptr(c::Ref{QQFieldElem}) = _num_ptr(c[])
-_den_ptr(c::QQFieldElemOrPtr) = _num_ptr(c) + sizeof(ZZRingElem)
+_den_ptr(c::TypeOrPtr{QQFieldElem}) = _num_ptr(c) + sizeof(ZZRingElem)
 
-function zero!(c::QQFieldElemOrPtr)
+function zero!(c::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_zero(c::Ref{QQFieldElem})::Nothing
   return c
 end
 
-function one!(c::QQFieldElemOrPtr)
+function one!(c::TypeOrPtr{QQFieldElem})
   set!(c, 1)
 end
 
-function neg!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
+function neg!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_neg(z::Ref{QQFieldElem}, a::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function set!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr)
+function set!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_set(c::Ref{QQFieldElem}, a::Ref{QQFieldElem})::Nothing
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::Int, b::UInt = UInt(1))
+function set!(c::TypeOrPtr{QQFieldElem}, a::Int, b::UInt = UInt(1))
   @ccall libflint.fmpq_set_si(c::Ref{QQFieldElem}, a::Int, b::UInt)::Nothing
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::UInt, b::UInt = UInt(1))
+function set!(c::TypeOrPtr{QQFieldElem}, a::UInt, b::UInt = UInt(1))
   @ccall libflint.fmpq_set_ui(c::Ref{QQFieldElem}, a::UInt, b::UInt)::Nothing
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function set!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_set_fmpz_frac(c::Ref{QQFieldElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return c
 end
 
-function set!(c::QQFieldElemOrPtr, a::Union{Integer,ZZRingElemOrPtr})
+function set!(c::TypeOrPtr{QQFieldElem}, a::Union{Integer,TypeOrPtr{ZZRingElem}})
   GC.@preserve c begin
     set!(_num_ptr(c), a)
     one!(_den_ptr(c))
@@ -1066,14 +1066,14 @@ function set!(c::QQFieldElemOrPtr, a::Union{Integer,ZZRingElemOrPtr})
   return c
 end
 
-function numerator!(z::ZZRingElemOrPtr, y::QQFieldElemOrPtr)
+function numerator!(z::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{QQFieldElem})
   GC.@preserve y begin
     set!(z, _num_ptr(y))
   end
   return z
 end
 
-function denominator!(z::ZZRingElemOrPtr, y::QQFieldElemOrPtr)
+function denominator!(z::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{QQFieldElem})
   GC.@preserve y begin
     set!(z, _den_ptr(y))
   end
@@ -1082,117 +1082,117 @@ end
 
 #
 
-function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function add!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_add(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return c
 end
 
-function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+function add!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_add_fmpz(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Nothing
   return c
 end
 
-function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
+function add!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Int)
   @ccall libflint.fmpq_add_si(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Int)::Nothing
   return c
 end
 
-function add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+function add!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::UInt)
   @ccall libflint.fmpq_add_ui(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Int)::Nothing
   return c
 end
 
-add!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Union{Integer, Rational}) = add!(c, a, flintify(b))
-add!(c::QQFieldElemOrPtr, a::Union{ZZRingElemOrPtr, Integer, Rational}, b::QQFieldElemOrPtr) = add!(c, b, a)
+add!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Union{Integer, Rational}) = add!(c, a, flintify(b))
+add!(c::TypeOrPtr{QQFieldElem}, a::Union{TypeOrPtr{ZZRingElem}, Integer, Rational}, b::TypeOrPtr{QQFieldElem}) = add!(c, b, a)
 
 #
 
-function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_sub(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_sub_fmpz(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
+function sub!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Int)
   @ccall libflint.fmpq_sub_si(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Int)::Nothing
   return z
 end
 
-function sub!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+function sub!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::UInt)
   @ccall libflint.fmpq_sub_ui(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::UInt)::Nothing
   return z
 end
 
-sub!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Union{Integer, Rational}) = sub!(c, a, flintify(b))
-sub!(c::QQFieldElemOrPtr, a::Union{ZZRingElemOrPtr, Integer, Rational}, b::QQFieldElemOrPtr) = neg!(sub!(c, b, a))
+sub!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Union{Integer, Rational}) = sub!(c, a, flintify(b))
+sub!(c::TypeOrPtr{QQFieldElem}, a::Union{TypeOrPtr{ZZRingElem}, Integer, Rational}, b::TypeOrPtr{QQFieldElem}) = neg!(sub!(c, b, a))
 
 #
 
-function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function mul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_mul(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return c
 end
 
-function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+function mul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_mul_fmpz(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Nothing
   return c
 end
 
-function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Int)
+function mul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Int)
   @ccall libflint.fmpq_mul_si(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Int)::Nothing
   return c
 end
 
-function mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::UInt)
+function mul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::UInt)
   @ccall libflint.fmpq_mul_ui(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::UInt)::Nothing
   return c
 end
 
-mul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::Union{Integer, Rational}) = mul!(c, a, flintify(b))
-mul!(c::QQFieldElemOrPtr, a::Union{ZZRingElemOrPtr, Integer, Rational}, b::QQFieldElemOrPtr) = mul!(c, b, a)
+mul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::Union{Integer, Rational}) = mul!(c, a, flintify(b))
+mul!(c::TypeOrPtr{QQFieldElem}, a::Union{TypeOrPtr{ZZRingElem}, Integer, Rational}, b::TypeOrPtr{QQFieldElem}) = mul!(c, b, a)
 
 #
 
-function addmul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function addmul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_addmul(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return c
 end
 
 # ignore fourth argument
-addmul!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, y::QQFieldElemOrPtr, ::QQFieldElemOrPtr) = addmul!(z, x, y)
+addmul!(z::TypeOrPtr{QQFieldElem}, x::TypeOrPtr{QQFieldElem}, y::TypeOrPtr{QQFieldElem}, ::TypeOrPtr{QQFieldElem}) = addmul!(z, x, y)
 
-function submul!(c::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function submul!(c::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_submul(c::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return c
 end
 
 # ignore fourth argument
-submul!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, y::QQFieldElemOrPtr, ::QQFieldElemOrPtr) = submul!(z, x, y)
+submul!(z::TypeOrPtr{QQFieldElem}, x::TypeOrPtr{QQFieldElem}, y::TypeOrPtr{QQFieldElem}, ::TypeOrPtr{QQFieldElem}) = submul!(z, x, y)
 
 #
 
-function divexact!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::QQFieldElemOrPtr)
+function divexact!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_div(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function divexact!(z::QQFieldElemOrPtr, a::QQFieldElemOrPtr, b::ZZRingElemOrPtr)
+function divexact!(z::TypeOrPtr{QQFieldElem}, a::TypeOrPtr{QQFieldElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_div_fmpz(z::Ref{QQFieldElem}, a::Ref{QQFieldElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
 #
 
-function pow!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, n::Integer)
+function pow!(z::TypeOrPtr{QQFieldElem}, x::TypeOrPtr{QQFieldElem}, n::Integer)
   @ccall libflint.fmpq_pow_si(z::Ref{QQFieldElem}, x::Ref{QQFieldElem}, Int(n)::Int)::Nothing
   return  z
 end
 
-function pow!(z::QQFieldElemOrPtr, x::QQFieldElemOrPtr, n::ZZRingElemOrPtr)
+function pow!(z::TypeOrPtr{QQFieldElem}, x::TypeOrPtr{QQFieldElem}, n::TypeOrPtr{ZZRingElem})
   ok = Bool(@ccall libflint.fmpq_pow_fmpz(z::Ref{QQFieldElem}, x::Ref{QQFieldElem}, n::Ref{ZZRingElem})::Cint)
   if !ok
     error("unable to compute power")

--- a/src/flint/fmpq_mat.jl
+++ b/src/flint/fmpq_mat.jl
@@ -750,12 +750,12 @@ end
 #
 # matrix x scalar, scalar x matrix
 #
-function mul!(z::QQMatrixOrPtr, a::QQMatrixOrPtr, b::QQFieldElemOrPtr)
+function mul!(z::QQMatrixOrPtr, a::QQMatrixOrPtr, b::TypeOrPtr{QQFieldElem})
    @ccall libflint.fmpq_mat_scalar_mul_fmpq(z::Ref{QQMatrix}, a::Ref{QQMatrix}, b::Ref{QQFieldElem})::Nothing
    return z
 end
 
-function mul!(z::QQMatrixOrPtr, a::QQMatrixOrPtr, b::ZZRingElemOrPtr)
+function mul!(z::QQMatrixOrPtr, a::QQMatrixOrPtr, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_mat_scalar_mul_fmpz(z::Ref{QQMatrix}, a::Ref{QQMatrix}, b::Ref{ZZRingElem})::Nothing
   return z
 end
@@ -766,7 +766,7 @@ mul!(z::QQMatrixOrPtr, a::QQMatrixOrPtr, b::Rational) = mul!(z, a, QQ(b))
 mul!(z::QQMatrixOrPtr, a::RationalUnionOrPtr, b::QQMatrixOrPtr) = mul!(z, b, a)
 
 
-function divexact!(z::QQMatrixOrPtr, x::QQMatrixOrPtr, y::QQFieldElemOrPtr)
+function divexact!(z::QQMatrixOrPtr, x::QQMatrixOrPtr, y::TypeOrPtr{QQFieldElem})
   GC.@preserve y begin
     divexact!(z, x, _num_ptr(y))
     mul!(z, z, _den_ptr(y))
@@ -774,7 +774,7 @@ function divexact!(z::QQMatrixOrPtr, x::QQMatrixOrPtr, y::QQFieldElemOrPtr)
   return z
 end
 
-function divexact!(z::QQMatrixOrPtr, x::QQMatrixOrPtr, y::ZZRingElemOrPtr)
+function divexact!(z::QQMatrixOrPtr, x::QQMatrixOrPtr, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_mat_scalar_div_fmpz(z::Ref{QQMatrix}, x::Ref{QQMatrix}, y::Ref{ZZRingElem})::Nothing
   return z
 end

--- a/src/flint/fmpq_mpoly.jl
+++ b/src/flint/fmpq_mpoly.jl
@@ -597,7 +597,7 @@ end
 _content_ptr(c::QQMPolyRingElem) = Ptr{QQFieldElem}(pointer_from_objref(c))
 _content_ptr(c::Ptr{QQMPolyRingElem}) = Ptr{QQFieldElem}(c)
 _content_ptr(c::Ref{QQMPolyRingElem}) = _content_ptr(c[])
-_zpoly_ptr(c::QQMPolyRingElemOrPtr) = Ptr{ZZMPolyRingElem}(_content_ptr(c) + sizeof(QQFieldElem))
+_zpoly_ptr(c::TypeOrPtr{QQMPolyRingElem}) = Ptr{ZZMPolyRingElem}(_content_ptr(c) + sizeof(QQFieldElem))
 
 function zero!(a::QQMPolyRingElem)
   @ccall libflint.fmpq_mpoly_zero(a::Ref{QQMPolyRingElem}, a.parent::Ref{QQMPolyRing})::Nothing
@@ -621,12 +621,12 @@ function set!(z::QQMPolyRingElem, a::QQMPolyRingElem)
   return z
 end
 
-function set!(z::QQMPolyRingElem, a::QQFieldElemOrPtr)
+function set!(z::QQMPolyRingElem, a::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_mpoly_set_fmpq(z::Ref{QQMPolyRingElem}, a::Ref{QQFieldElem}, parent(z)::Ref{QQMPolyRing})::Nothing
   return z
 end
 
-function set!(z::QQMPolyRingElem, a::ZZRingElemOrPtr)
+function set!(z::QQMPolyRingElem, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_mpoly_set_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{ZZRingElem}, parent(z)::Ref{QQMPolyRing})::Nothing
   return z
 end
@@ -750,7 +750,7 @@ function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::Integer)
   return z
 end
 
-function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::ZZRingElemOrPtr)
+function pow!(z::QQMPolyRingElem, a::QQMPolyRingElem, n::TypeOrPtr{ZZRingElem})
   ok = Bool(@ccall libflint.fmpq_mpoly_pow_fmpz(z::Ref{QQMPolyRingElem}, a::Ref{QQMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{QQMPolyRing})::Cint)
   if !ok
     error("unable to compute power")

--- a/src/flint/fmpq_poly.jl
+++ b/src/flint/fmpq_poly.jl
@@ -239,7 +239,7 @@ function reverse(x::QQPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
-function reverse!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
+function reverse!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, len::Int)
   @ccall libflint.fmpq_poly_reverse(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -255,7 +255,7 @@ function shift_left(x::QQPolyRingElem, len::Int)
   return shift_left!(parent(x)(), x, len)
 end
 
-function shift_left!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
+function shift_left!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, len::Int)
   @ccall libflint.fmpq_poly_shift_left(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -265,7 +265,7 @@ function shift_right(x::QQPolyRingElem, len::Int)
   return shift_right!(parent(x)(), x, len)
 end
 
-function shift_right!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, len::Int)
+function shift_right!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, len::Int)
   @ccall libflint.fmpq_poly_shift_right(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -656,181 +656,181 @@ end
 #
 ###############################################################################
 
-function zero!(z::QQPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_zero(z::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::QQPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_one(z::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::QQPolyRingElemOrPtr, a::QQPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{QQPolyRingElem}, a::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_neg(z::Ref{QQPolyRingElem}, a::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function fit!(z::QQPolyRingElemOrPtr, n::Int)
+function fit!(z::TypeOrPtr{QQPolyRingElem}, n::Int)
   @ccall libflint.fmpq_poly_fit_length(z::Ref{QQPolyRingElem}, n::Int)::Nothing
   return nothing
 end
 
 #
 
-function set!(z::QQPolyRingElemOrPtr, a::QQPolyRingElemOrPtr)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_set(z::Ref{QQPolyRingElem}, a::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function set!(z::QQPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpq_poly_set_fmpz_poly(z::Ref{QQPolyRingElem}, a::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function set!(z::QQPolyRingElemOrPtr, a::QQFieldElemOrPtr)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_poly_set_fmpq(z::Ref{QQPolyRingElem}, a::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function set!(z::QQPolyRingElemOrPtr, a::ZZRingElemOrPtr)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_poly_set_fmpz(z::Ref{QQPolyRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function set!(z::QQPolyRingElemOrPtr, a::Int)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::Int)
   @ccall libflint.fmpq_poly_set_si(z::Ref{QQPolyRingElem}, a::Int)::Nothing
   return z
 end
 
-function set!(z::QQPolyRingElemOrPtr, a::UInt)
+function set!(z::TypeOrPtr{QQPolyRingElem}, a::UInt)
   @ccall libflint.fmpq_poly_set_ui(z::Ref{QQPolyRingElem}, a::UInt)::Nothing
   return z
 end
 
-set!(z::QQPolyRingElemOrPtr, a::Union{Integer, Rational}) = set!(z, flintify(a))
+set!(z::TypeOrPtr{QQPolyRingElem}, a::Union{Integer, Rational}) = set!(z, flintify(a))
 
 #
 
-function setcoeff!(z::QQPolyRingElemOrPtr, n::Int, x::ZZRingElemOrPtr)
+function setcoeff!(z::TypeOrPtr{QQPolyRingElem}, n::Int, x::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_poly_set_coeff_fmpz(z::Ref{QQPolyRingElem}, n::Int, x::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function setcoeff!(z::QQPolyRingElemOrPtr, n::Int, x::QQFieldElemOrPtr)
+function setcoeff!(z::TypeOrPtr{QQPolyRingElem}, n::Int, x::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_poly_set_coeff_fmpq(z::Ref{QQPolyRingElem}, n::Int, x::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function setcoeff!(z::QQPolyRingElemOrPtr, n::Int, x::UInt)
+function setcoeff!(z::TypeOrPtr{QQPolyRingElem}, n::Int, x::UInt)
   @ccall libflint.fmpq_poly_set_coeff_ui(z::Ref{QQPolyRingElem}, n::Int, x::UInt)::Nothing
   return z
 end
 
-function setcoeff!(z::QQPolyRingElemOrPtr, n::Int, x::Int)
+function setcoeff!(z::TypeOrPtr{QQPolyRingElem}, n::Int, x::Int)
   @ccall libflint.fmpq_poly_set_coeff_si(z::Ref{QQPolyRingElem}, n::Int, x::Int)::Nothing
   return z
 end
 
-setcoeff!(z::QQPolyRingElemOrPtr, n::Int, x::Union{Integer, Rational}) = setcoeff!(z, n, flintify(x))
+setcoeff!(z::TypeOrPtr{QQPolyRingElem}, n::Int, x::Union{Integer, Rational}) = setcoeff!(z, n, flintify(x))
 
 #
 
-function add!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQPolyRingElemOrPtr)
+function add!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_add(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function add!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQFieldElemOrPtr)
+function add!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_poly_add_fmpq(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function add!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function add!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_poly_add_fmpz(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function add!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Int)
+function add!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Int)
   @ccall libflint.fmpq_poly_add_si(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-add!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Union{Integer, Rational}) = add!(z, x, flintify(y))
+add!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Union{Integer, Rational}) = add!(z, x, flintify(y))
 
-add!(z::QQPolyRingElemOrPtr, x::RationalUnionOrPtr, y::QQPolyRingElemOrPtr) = add!(z, y, x)
+add!(z::TypeOrPtr{QQPolyRingElem}, x::RationalUnionOrPtr, y::TypeOrPtr{QQPolyRingElem}) = add!(z, y, x)
 
 #
 
-function sub!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_sub(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
 
-function sub!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQFieldElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_poly_sub_fmpq(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function sub!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_poly_sub_fmpz(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function sub!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Int)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Int)
   @ccall libflint.fmpq_poly_sub_si(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-function sub!(z::QQPolyRingElemOrPtr, x::QQFieldElemOrPtr, y::QQPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQFieldElem}, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_fmpq_sub(z::Ref{QQPolyRingElem}, x::Ref{QQFieldElem}, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function sub!(z::QQPolyRingElemOrPtr, x::ZZRingElemOrPtr, y::QQPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_fmpz_sub(z::Ref{QQPolyRingElem}, x::Ref{ZZRingElem}, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function sub!(z::QQPolyRingElemOrPtr, x::Int, y::QQPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{QQPolyRingElem}, x::Int, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_si_sub(z::Ref{QQPolyRingElem}, x::Int, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-sub!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Union{Integer, Rational}) = sub!(z, x, flintify(y))
+sub!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Union{Integer, Rational}) = sub!(z, x, flintify(y))
 
-sub!(z::QQPolyRingElemOrPtr, x::Union{Integer, Rational}, y::QQPolyRingElemOrPtr) = sub!(z, flintify(x), y)
+sub!(z::TypeOrPtr{QQPolyRingElem}, x::Union{Integer, Rational}, y::TypeOrPtr{QQPolyRingElem}) = sub!(z, flintify(x), y)
 
 #
 
-function mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQPolyRingElemOrPtr)
+function mul!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQPolyRingElem})
   @ccall libflint.fmpq_poly_mul(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQPolyRingElem})::Nothing
   return z
 end
 
-function mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::QQFieldElemOrPtr)
+function mul!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{QQFieldElem})
   @ccall libflint.fmpq_poly_scalar_mul_fmpq(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{QQFieldElem})::Nothing
   return z
 end
 
-function mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function mul!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpq_poly_scalar_mul_fmpz(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Int)
+function mul!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Int)
   @ccall libflint.fmpq_poly_scalar_mul_si(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-mul!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, y::Union{Integer, Rational}) = mul!(z, x, flintify(y))
+mul!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, y::Union{Integer, Rational}) = mul!(z, x, flintify(y))
 
-mul!(z::QQPolyRingElemOrPtr, x::RationalUnionOrPtr, y::QQPolyRingElemOrPtr) = mul!(z, y, x)
+mul!(z::TypeOrPtr{QQPolyRingElem}, x::RationalUnionOrPtr, y::TypeOrPtr{QQPolyRingElem}) = mul!(z, y, x)
 
 #
 
-function pow!(z::QQPolyRingElemOrPtr, x::QQPolyRingElemOrPtr, n::IntegerUnion)
+function pow!(z::TypeOrPtr{QQPolyRingElem}, x::TypeOrPtr{QQPolyRingElem}, n::IntegerUnion)
   @ccall libflint.fmpq_poly_pow(z::Ref{QQPolyRingElem}, x::Ref{QQPolyRingElem}, UInt(n)::UInt)::Nothing
   return z
 end

--- a/src/flint/fmpz.jl
+++ b/src/flint/fmpz.jl
@@ -178,18 +178,18 @@ end
   return (unsigned(a) >> (Sys.WORD_SIZE - 2) != 1)
 end
 
-@inline function _fmpz_is_small(a::ZZRingElemOrPtr)
+@inline function _fmpz_is_small(a::TypeOrPtr{ZZRingElem})
   return __fmpz_is_small(data(a))
 end
 
 # "views" a non-small ZZRingElem as a readonly BigInt
 # the caller must ensure z is actually non-small, and
 # call GC.@preserve appropriately
-function _as_bigint(a::ZZRingElemOrPtr)
+function _as_bigint(a::TypeOrPtr{ZZRingElem})
   unsafe_load(Ptr{BigInt}(data(a) << 2))
 end
 
-@inline function _fmpz_size(a::ZZRingElemOrPtr)
+@inline function _fmpz_size(a::TypeOrPtr{ZZRingElem})
   return _fmpz_is_small(a) ? 1 : GC.@preserve a _as_bigint(a).size
 end
 
@@ -255,14 +255,14 @@ is_noetherian(::ZZRing) = true
 
 Return the sign of $a$, i.e. $+1$, $0$ or $-1$.
 """
-sign(a::ZZRingElemOrPtr) = ZZRingElem(sign(Int, a))
+sign(a::TypeOrPtr{ZZRingElem}) = ZZRingElem(sign(Int, a))
 
-sign(::Type{Int}, a::ZZRingElemOrPtr) = is_zero(a) ? 0 : (signbit(a) ? -1 : 1)
+sign(::Type{Int}, a::TypeOrPtr{ZZRingElem}) = is_zero(a) ? 0 : (signbit(a) ? -1 : 1)
 
-Base.signbit(a::ZZRingElemOrPtr) = _fmpz_is_small(a) ? signbit(data(a)) : signbit(_fmpz_size(a))
+Base.signbit(a::TypeOrPtr{ZZRingElem}) = _fmpz_is_small(a) ? signbit(data(a)) : signbit(_fmpz_size(a))
 
-is_negative(n::ZZRingElemOrPtr) = sign(Int, n) < 0
-is_positive(n::ZZRingElemOrPtr) = sign(Int, n) > 0
+is_negative(n::TypeOrPtr{ZZRingElem}) = sign(Int, n) < 0
+is_positive(n::TypeOrPtr{ZZRingElem}) = sign(Int, n) > 0
 
 @doc raw"""
     fits(::Type{Int}, a::ZZRingElem)
@@ -301,11 +301,11 @@ Return the number of limbs required to store the absolute value of $a$.
 """
 size(a::ZZRingElem) = _fmpz_is_small(a) ? 1 : abs(_fmpz_size(a))
 
-is_unit(a::ZZRingElemOrPtr) = data(a) == 1 || data(a) == -1
+is_unit(a::TypeOrPtr{ZZRingElem}) = data(a) == 1 || data(a) == -1
 
-is_zero(a::ZZRingElemOrPtr) = data(a) == 0
+is_zero(a::TypeOrPtr{ZZRingElem}) = data(a) == 0
 
-is_one(a::ZZRingElemOrPtr) = data(a) == 1
+is_one(a::TypeOrPtr{ZZRingElem}) = data(a) == 1
 
 isinteger(::ZZRingElem) = true
 
@@ -331,8 +331,8 @@ function numerator(a::ZZRingElem)
   return a
 end
 
-isodd(a::ZZRingElemOrPtr) = isodd(a % UInt)
-iseven(a::ZZRingElemOrPtr) = !isodd(a)
+isodd(a::TypeOrPtr{ZZRingElem}) = isodd(a % UInt)
+iseven(a::TypeOrPtr{ZZRingElem}) = !isodd(a)
 
 ###############################################################################
 #
@@ -494,24 +494,24 @@ end
 divides(x::ZZRingElem, y::Integer) = divides(x, ZZRingElem(y))
 
 @doc raw"""
-    is_divisible_by(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+    is_divisible_by(x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
 
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
-function is_divisible_by(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function is_divisible_by(x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   return Bool(@ccall libflint.fmpz_divisible(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint)
 end
 
 @doc raw"""
-    is_divisible_by(x::ZZRingElemOrPtr, y::Int)
+    is_divisible_by(x::TypeOrPtr{ZZRingElem}, y::Int)
 
 Return `true` if $x$ is divisible by $y$, otherwise return `false`.
 """
-function is_divisible_by(x::ZZRingElemOrPtr, y::Int)
+function is_divisible_by(x::TypeOrPtr{ZZRingElem}, y::Int)
   return Bool(@ccall libflint.fmpz_divisible_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
-function is_divisible_by(x::ZZRingElemOrPtr, y::Integer)
+function is_divisible_by(x::TypeOrPtr{ZZRingElem}, y::Integer)
   return is_divisible_by(x, flintify(y))
 end
 
@@ -519,7 +519,7 @@ function is_divisible_by(x::Integer, y::ZZRingElem)
   return is_divisible_by(ZZRingElem(x), y)
 end
 
-function rem(x::ZZRingElemOrPtr, ::Type{UInt})
+function rem(x::TypeOrPtr{ZZRingElem}, ::Type{UInt})
   return _fmpz_is_small(x) ? (data(x) % UInt) : GC.@preserve x (_as_bigint(x) % UInt)
 end
 
@@ -613,9 +613,9 @@ function div(f::ZZRingElem, g::Int)
   div!(z, f, g)
 end
 
-div!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = fdiv!(z, f, g)
+div!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem}) = fdiv!(z, f, g)
 
-div!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int) = fdiv!(z, f, g)
+div!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::Int) = fdiv!(z, f, g)
 
 function tdivpow2(x::ZZRingElem, c::Int)
   c < 0 && throw(DomainError(c, "Exponent must be non-negative"))
@@ -663,17 +663,17 @@ function tdiv(f::ZZRingElem, g::Int)
   return tdiv!(z, f, g)
 end
 
-function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+function tdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_tdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function tdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
+function tdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::Int)
   @ccall libflint.fmpz_tdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-tdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = tdiv!(f, f, g)
+tdiv!(f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem}) = tdiv!(f, f, g)
 
 @doc raw"""
     tdiv!(z, f, g)
@@ -692,7 +692,7 @@ julia> f = tdiv!(f, 7)
 14
 ```
 """
-tdiv!(f::ZZRingElemOrPtr, g::Int) = tdiv!(f, f, g)
+tdiv!(f::TypeOrPtr{ZZRingElem}, g::Int) = tdiv!(f, f, g)
 
 @doc raw"""
     fdiv(f::ZZRingElem, g::Int)
@@ -713,17 +713,17 @@ function fdiv(f::ZZRingElem, g::Int)
   return z
 end
 
-function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+function fdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_fdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function fdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
+function fdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::Int)
   @ccall libflint.fmpz_fdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-fdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = fdiv!(f, f, g)
+fdiv!(f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem}) = fdiv!(f, f, g)
 
 @doc raw"""
     fdiv!(z, f, g)
@@ -742,7 +742,7 @@ julia> f = fdiv!(f, 7)
 14
 ```
 """
-fdiv!(f::ZZRingElemOrPtr, g::Int) = fdiv!(f, f, g)
+fdiv!(f::TypeOrPtr{ZZRingElem}, g::Int) = fdiv!(f, f, g)
 
 @doc raw"""
     cdiv(f::ZZRingElem, g::Int)
@@ -762,17 +762,17 @@ function cdiv(f::ZZRingElem, g::Int)
   return cdiv!(z, f, g)
 end
 
-function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::ZZRingElemOrPtr)
+function cdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_cdiv_q(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function cdiv!(z::ZZRingElemOrPtr, f::ZZRingElemOrPtr, g::Int)
+function cdiv!(z::TypeOrPtr{ZZRingElem}, f::TypeOrPtr{ZZRingElem}, g::Int)
   @ccall libflint.fmpz_cdiv_q_si(z::Ref{ZZRingElem}, f::Ref{ZZRingElem}, g::Int)::Nothing
   return z
 end
 
-cdiv!(f::ZZRingElemOrPtr, g::ZZRingElemOrPtr) = cdiv!(f, f, g)
+cdiv!(f::TypeOrPtr{ZZRingElem}, g::TypeOrPtr{ZZRingElem}) = cdiv!(f, f, g)
 
 @doc raw"""
     cdiv!(z, f, g)
@@ -791,7 +791,7 @@ julia> f = cdiv!(f, 7)
 15
 ```
 """
-cdiv!(f::ZZRingElemOrPtr, g::Int) = cdiv!(f, f, g)
+cdiv!(f::TypeOrPtr{ZZRingElem}, g::Int) = cdiv!(f, f, g)
 
 rem(x::Integer, y::ZZRingElem) = rem(ZZRingElem(x), y)
 
@@ -805,7 +805,7 @@ mod(x::Integer, y::ZZRingElem) = mod(ZZRingElem(x), y)
 Return the remainder after division of $x$ by $y$. The remainder will be
 closer to zero than $y$ and have the same sign, or it will be zero.
 """
-mod(x::ZZRingElemOrPtr, y::Integer) = mod(x, ZZRingElem(y))
+mod(x::TypeOrPtr{ZZRingElem}, y::Integer) = mod(x, ZZRingElem(y))
 
 div(x::Integer, y::ZZRingElem) = div(ZZRingElem(x), y)
 
@@ -986,7 +986,7 @@ end
 #
 ###############################################################################
 
-function cmp(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function cmp(x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_cmp(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint
 end
 
@@ -996,7 +996,7 @@ end
 
 <(x::ZZRingElem, y::ZZRingElem) = cmp(x,y) < 0
 
-function cmpabs(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function cmpabs(x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   Int(@ccall libflint.fmpz_cmpabs(x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Cint)
 end
 
@@ -1022,17 +1022,17 @@ end
 #
 ###############################################################################
 
-function cmp(x::ZZRingElemOrPtr, y::Int)
+function cmp(x::TypeOrPtr{ZZRingElem}, y::Int)
   _fmpz_is_small(x) && return cmp(data(x), y)
   Int(@ccall libflint.fmpz_cmp_si(x::Ref{ZZRingElem}, y::Int)::Cint)
 end
 
-function cmp(x::ZZRingElemOrPtr, y::UInt)
+function cmp(x::TypeOrPtr{ZZRingElem}, y::UInt)
   _fmpz_is_small(x) && return cmp(data(x), y)
   Int(@ccall libflint.fmpz_cmp_ui(x::Ref{ZZRingElem}, y::UInt)::Cint)
 end
 
-cmp(x::ZZRingElemOrPtr, y::Integer) = cmp(x, flintify(y))
+cmp(x::TypeOrPtr{ZZRingElem}, y::Integer) = cmp(x, flintify(y))
 
 for T in (Int, UInt, Integer)
   @eval begin
@@ -1114,24 +1114,24 @@ end
 #
 ###############################################################################
 
-function mod!(r::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function mod!(r::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_fdiv_r(r::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return r
 end
 
-function mod(x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function mod(x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   iszero(y) && throw(DivideError())
   r = ZZRingElem()
   return mod!(r, x, y)
 end
 
-function mod(x::ZZRingElemOrPtr, c::UInt)
+function mod(x::TypeOrPtr{ZZRingElem}, c::UInt)
   c == 0 && throw(DivideError())
   @ccall libflint.fmpz_fdiv_ui(x::Ref{ZZRingElem}, c::UInt)::UInt
 end
 
 @doc raw"""
-    mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+    mod_sym!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
 
 Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
 $-b < 2x \le b$, possibly modifying the object $z$ in the process.
@@ -1150,13 +1150,13 @@ julia> z
 
 ```
 """
-function mod_sym!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function mod_sym!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_smod(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
 @doc raw"""
-    mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+    mod_sym!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
 
 Return the signed remainder of $a$ mod $b$, that is, the unique integer $x$ satisfying
 $-b < 2x \le b$, possibly modifying the object $a$ in the process.
@@ -1176,7 +1176,7 @@ julia> a
 
 ```
 """
-function mod_sym!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function mod_sym!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   return mod_sym!(a, a, b)
 end
 
@@ -1621,7 +1621,7 @@ lcm(a::Integer, b::ZZRingElem) = lcm(ZZRingElem(a), b)
 #
 ###############################################################################
 
-function gcdx!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr, c::ZZRingElemOrPtr, d::ZZRingElemOrPtr, e::ZZRingElemOrPtr)
+function gcdx!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}, c::TypeOrPtr{ZZRingElem}, d::TypeOrPtr{ZZRingElem}, e::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_xgcd_canonical_bezout(a::Ref{ZZRingElem}, b::Ref{ZZRingElem}, c::Ref{ZZRingElem}, d::Ref{ZZRingElem}, e::Ref{ZZRingElem})::Nothing
   return a, b, c
 end
@@ -1691,7 +1691,7 @@ function isqrt(x::ZZRingElem)
 end
 
 @doc raw"""
-    isqrt!(x::ZZRingElemOrPtr)
+    isqrt!(x::TypeOrPtr{ZZRingElem})
 
 Return the floor of the square root of $x$, possibly modifying the object $x$ in the process.
 This is a shorthand for isqrt!(x, x).
@@ -1710,12 +1710,12 @@ julia> a
 
 ```
 """
-function isqrt!(x::ZZRingElemOrPtr)
+function isqrt!(x::TypeOrPtr{ZZRingElem})
   return isqrt!(x,x)
 end
 
 @doc raw"""
-    isqrt!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr)
+    isqrt!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem})
 
 Return the floor of the square root of $x$, possibly modifying the object $z$ in the process.
 
@@ -1733,7 +1733,7 @@ julia> z
 
 ```
 """
-function isqrt!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr)
+function isqrt!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_sqrt(z::Ref{ZZRingElem}, x::Ref{ZZRingElem})::Nothing
   return z
 end
@@ -1989,12 +1989,12 @@ function next_prime(x::Int, proved::Bool = true)
   return x < 2 ? 2 : Int(next_prime(x % UInt, proved))
 end
 
-function remove!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function remove!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   v = @ccall libflint.fmpz_remove(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Clong
   return Int(v), z
 end
 
-remove!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr) = remove!(a, a, b)
+remove!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}) = remove!(a, a, b)
 
 function remove(x::ZZRingElem, y::ZZRingElem)
   iszero(y) && throw(DivideError())
@@ -2565,7 +2565,7 @@ julia> nbits(ZZ(12))
 4
 ```
 """
-nbits(x::ZZRingElemOrPtr) = Int(@ccall libflint.fmpz_bits(x::Ref{ZZRingElem})::Culong)
+nbits(x::TypeOrPtr{ZZRingElem}) = Int(@ccall libflint.fmpz_bits(x::Ref{ZZRingElem})::Culong)
 
 @doc raw"""
     nbits(a::Integer) -> Int
@@ -2729,23 +2729,23 @@ end
 #
 ###############################################################################
 
-function zero!(z::ZZRingElemOrPtr)
+function zero!(z::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_zero(z::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function one!(z::ZZRingElemOrPtr)
+function one!(z::TypeOrPtr{ZZRingElem})
   set!(z, UInt(1))
 end
 
-function neg!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+function neg!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_neg(z::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
 @doc raw"""
-    set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
-    set!(z::ZZRingElemOrPtr, a::Integer)
+    set!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem})
+    set!(z::TypeOrPtr{ZZRingElem}, a::Integer)
 
 Change `z` to be equal to `a` and return `z`.
 
@@ -2797,148 +2797,148 @@ julia> A
  3  3
 ```
 """
-function set!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr)
+function set!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_set(z::Ref{ZZRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function set!(z::ZZRingElemOrPtr, a::Int)
+function set!(z::TypeOrPtr{ZZRingElem}, a::Int)
   @ccall libflint.fmpz_set_si(z::Ref{ZZRingElem}, a::Int)::Nothing
   return z
 end
 
-function set!(z::ZZRingElemOrPtr, a::UInt)
+function set!(z::TypeOrPtr{ZZRingElem}, a::UInt)
   @ccall libflint.fmpz_set_ui(z::Ref{ZZRingElem}, a::UInt)::Nothing
   return z
 end
 
-set!(z::ZZRingElemOrPtr, a::Integer) = set!(z, flintify(a))
+set!(z::TypeOrPtr{ZZRingElem}, a::Integer) = set!(z, flintify(a))
 
-function swap!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function swap!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_swap(a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
 end
 
 #
 
-function add!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function add!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_add(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function add!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Int)
+function add!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Int)
   @ccall libflint.fmpz_add_si(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Int)::Nothing
   return z
 end
 
-function add!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::UInt)
+function add!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::UInt)
   @ccall libflint.fmpz_add_ui(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::UInt)::Nothing
   return z
 end
 
-function add!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr, c::Ptr{Int})
+function add!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}, c::Ptr{Int})
   @ccall libflint.fmpz_add(a::Ref{ZZRingElem}, b::Ref{ZZRingElem}, c::Ptr{Int})::Nothing
   return a
 end
 
-add!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Integer) = add!(z, a, flintify(b))
-add!(z::ZZRingElemOrPtr, x::Integer, y::ZZRingElemOrPtr) = add!(z, y, x)
+add!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Integer) = add!(z, a, flintify(b))
+add!(z::TypeOrPtr{ZZRingElem}, x::Integer, y::TypeOrPtr{ZZRingElem}) = add!(z, y, x)
 
 #
 
-function sub!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function sub!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_sub(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function sub!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Int)
+function sub!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Int)
   @ccall libflint.fmpz_sub_si(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Int)::Nothing
   return z
 end
 
-function sub!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::UInt)
+function sub!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::UInt)
   @ccall libflint.fmpz_sub_ui(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::UInt)::Nothing
   return z
 end
 
-sub!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Integer) = sub!(z, a, flintify(b))
-sub!(z::ZZRingElemOrPtr, a::Integer, b::ZZRingElemOrPtr) = neg!(sub!(z, b, a))
+sub!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Integer) = sub!(z, a, flintify(b))
+sub!(z::TypeOrPtr{ZZRingElem}, a::Integer, b::TypeOrPtr{ZZRingElem}) = neg!(sub!(z, b, a))
 
 #
 
-function mul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function mul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_mul(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function mul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Int)
+function mul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Int)
   @ccall libflint.fmpz_mul_si(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Int)::Nothing
   return z
 end
 
-function mul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::UInt)
+function mul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::UInt)
   @ccall libflint.fmpz_mul_ui(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::UInt)::Nothing
   return z
 end
 
-mul!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Integer) = mul!(z, a, flintify(b))
-mul!(z::ZZRingElemOrPtr, x::Integer, y::ZZRingElemOrPtr) = mul!(z, y, x)
+mul!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Integer) = mul!(z, a, flintify(b))
+mul!(z::TypeOrPtr{ZZRingElem}, x::Integer, y::TypeOrPtr{ZZRingElem}) = mul!(z, y, x)
 
-function mul!(a::ZZRingElemOrPtr, b::ZZRingElemOrPtr, c::Ptr{Int})
+function mul!(a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}, c::Ptr{Int})
   @ccall libflint.fmpz_mul(a::Ref{ZZRingElem}, b::Ref{ZZRingElem}, c::Ptr{Int})::Nothing
   return a
 end
 
 #
 
-function addmul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function addmul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_addmul(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function addmul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Int)
+function addmul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Int)
   @ccall libflint.fmpz_addmul_si(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Int)::Nothing
   return z
 end
 
-function addmul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::UInt)
+function addmul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::UInt)
   @ccall libflint.fmpz_addmul_ui(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::UInt)::Nothing
   return z
 end
 
-addmul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Integer) = addmul!(z, x, flintify(y))
-addmul!(z::ZZRingElemOrPtr, x::Integer, y::ZZRingElemOrPtr) = addmul!(z, y, x)
+addmul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Integer) = addmul!(z, x, flintify(y))
+addmul!(z::TypeOrPtr{ZZRingElem}, x::Integer, y::TypeOrPtr{ZZRingElem}) = addmul!(z, y, x)
 
 # ignore fourth argument
-addmul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Union{ZZRingElemOrPtr,Integer}, ::ZZRingElemOrPtr) = addmul!(z, x, y)
-addmul!(z::ZZRingElemOrPtr, x::Integer, y::ZZRingElemOrPtr, ::ZZRingElemOrPtr) = addmul!(z, x, y)
+addmul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Union{TypeOrPtr{ZZRingElem},Integer}, ::TypeOrPtr{ZZRingElem}) = addmul!(z, x, y)
+addmul!(z::TypeOrPtr{ZZRingElem}, x::Integer, y::TypeOrPtr{ZZRingElem}, ::TypeOrPtr{ZZRingElem}) = addmul!(z, x, y)
 
-function submul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function submul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_submul(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function submul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Int)
+function submul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Int)
   @ccall libflint.fmpz_submul_si(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Int)::Nothing
   return z
 end
 
-function submul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::UInt)
+function submul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::UInt)
   @ccall libflint.fmpz_submul_ui(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::UInt)::Nothing
   return z
 end
 
-submul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Integer) = submul!(z, x, flintify(y))
+submul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Integer) = submul!(z, x, flintify(y))
 
 # ignore fourth argument
-submul!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::Union{ZZRingElemOrPtr,Integer}, ::ZZRingElemOrPtr) = submul!(z, x, y)
-submul!(z::ZZRingElemOrPtr, x::Integer, y::ZZRingElemOrPtr, ::ZZRingElemOrPtr) = submul!(z, x, y)
+submul!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::Union{TypeOrPtr{ZZRingElem},Integer}, ::TypeOrPtr{ZZRingElem}) = submul!(z, x, y)
+submul!(z::TypeOrPtr{ZZRingElem}, x::Integer, y::TypeOrPtr{ZZRingElem}, ::TypeOrPtr{ZZRingElem}) = submul!(z, x, y)
 
 @doc raw"""
     fmma!(r::ZZRingElem, a::ZZRingElem, b::ZZRingElem, c::ZZRingElem, d::ZZRingElem)
 
 Return $r = a b + c d$, changing $r$ in-place.
 """
-function fmma!(r::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr, c::ZZRingElemOrPtr, d::ZZRingElemOrPtr)
+function fmma!(r::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}, c::TypeOrPtr{ZZRingElem}, d::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_fmma(r::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem}, c::Ref{ZZRingElem}, d::Ref{ZZRingElem})::Nothing
   return r
 end
@@ -2948,29 +2948,29 @@ end
 
 Return $r = a b - c d$, changing $r$ in-place.
 """
-function fmms!(r::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr, c::ZZRingElemOrPtr, d::ZZRingElemOrPtr)
+function fmms!(r::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem}, c::TypeOrPtr{ZZRingElem}, d::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_fmms(r::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem}, c::Ref{ZZRingElem}, d::Ref{ZZRingElem})::Nothing
   return r
 end
 
 #
 
-function divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::ZZRingElemOrPtr)
+function divexact!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_divexact(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Int)
+function divexact!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Int)
   @ccall libflint.fmpz_divexact_si(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::Int)::Nothing
   return z
 end
 
-function divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::UInt)
+function divexact!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::UInt)
   @ccall libflint.fmpz_divexact_ui(z::Ref{ZZRingElem}, a::Ref{ZZRingElem}, b::UInt)::Nothing
   return z
 end
 
-divexact!(z::ZZRingElemOrPtr, a::ZZRingElemOrPtr, b::Integer) = divexact!(z, a, flintify(b))
+divexact!(z::TypeOrPtr{ZZRingElem}, a::TypeOrPtr{ZZRingElem}, b::Integer) = divexact!(z, a, flintify(b))
 
 #
 
@@ -2992,12 +2992,12 @@ end
 
 #
 
-function pow!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, n::Integer)
+function pow!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, n::Integer)
   @ccall libflint.fmpz_pow_ui(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, UInt(n)::UInt)::Nothing
   return z
 end
 
-function pow!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, n::ZZRingElemOrPtr)
+function pow!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, n::TypeOrPtr{ZZRingElem})
   ok = Bool(@ccall libflint.fmpz_pow_fmpz(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, n::Ref{ZZRingElem})::Cint)
   if !ok
     error("unable to compute power")
@@ -3007,12 +3007,12 @@ end
 
 #
 
-function lcm!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function lcm!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_lcm(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function gcd!(z::ZZRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZRingElemOrPtr)
+function gcd!(z::TypeOrPtr{ZZRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_gcd(z::Ref{ZZRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end

--- a/src/flint/fmpz_mat.jl
+++ b/src/flint/fmpz_mat.jl
@@ -1557,7 +1557,7 @@ end
 #
 ###############################################################################
 
-function AbstractAlgebra.multiply_row!(A::ZZMatrix, s::Union{Int, ZZRingElemOrPtr}, i::Int, cols::UnitRange{Int}=1:ncols(A))
+function AbstractAlgebra.multiply_row!(A::ZZMatrix, s::Union{Int, TypeOrPtr{ZZRingElem}}, i::Int, cols::UnitRange{Int}=1:ncols(A))
   @assert 1 <= i <= nrows(A)
   @assert 1 <= first(cols) && last(cols) <= ncols(A)
   c = first(cols)
@@ -1572,7 +1572,7 @@ function AbstractAlgebra.multiply_row!(A::ZZMatrix, s::Union{Int, ZZRingElemOrPt
   return A
 end
 
-function AbstractAlgebra.multiply_column!(A::ZZMatrix, s::Union{Int, ZZRingElemOrPtr}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
+function AbstractAlgebra.multiply_column!(A::ZZMatrix, s::Union{Int, TypeOrPtr{ZZRingElem}}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
   @assert 1 <= j <= ncols(A)
   @assert 1 <= first(rows)
   @assert last(rows) <= nrows(A)
@@ -1586,7 +1586,7 @@ function AbstractAlgebra.multiply_column!(A::ZZMatrix, s::Union{Int, ZZRingElemO
 end
 
 
-function AbstractAlgebra.add_row!(A::ZZMatrix, s::Union{ZZRingElemOrPtr, Int}, i::Int, j::Int, cols::UnitRange{Int}=1:ncols(A))
+function AbstractAlgebra.add_row!(A::ZZMatrix, s::Union{TypeOrPtr{ZZRingElem}, Int}, i::Int, j::Int, cols::UnitRange{Int}=1:ncols(A))
   @assert 1 <= i <= nrows(A)
   @assert 1 <= j <= nrows(A)
   @assert 1 <= first(cols) && last(cols) <= ncols(A)
@@ -1603,7 +1603,7 @@ function AbstractAlgebra.add_row!(A::ZZMatrix, s::Union{ZZRingElemOrPtr, Int}, i
   return A
 end
 
-function AbstractAlgebra.add_column!(A::ZZMatrix, s::Union{ZZRingElemOrPtr, Int}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
+function AbstractAlgebra.add_column!(A::ZZMatrix, s::Union{TypeOrPtr{ZZRingElem}, Int}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
   @assert 1 <= i <= ncols(A)
   @assert 1 <= j <= ncols(A)
   @assert 1 <= first(rows)
@@ -2077,7 +2077,7 @@ function mul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::UInt)
   return z
 end
 
-function mul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::ZZRingElemOrPtr)
+function mul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_mat_scalar_mul_fmpz(z::Ref{ZZMatrix}, a::Ref{ZZMatrix}, b::Ref{ZZRingElem})::Nothing
   return z
 end
@@ -2085,7 +2085,7 @@ end
 mul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::Integer) = mul!(z, a, flintify(b))
 mul!(z::ZZMatrixOrPtr, a::IntegerUnionOrPtr, b::ZZMatrixOrPtr) = mul!(z, b, a)
 
-function addmul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::ZZRingElemOrPtr)
+function addmul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_mat_scalar_addmul_fmpz(z::Ref{ZZMatrix}, a::Ref{ZZMatrix}, b::Ref{ZZRingElem})::Nothing
   return z
 end
@@ -2107,7 +2107,7 @@ addmul!(z::ZZMatrixOrPtr, a::IntegerUnionOrPtr, b::ZZMatrixOrPtr) = addmul!(z, b
 addmul!(z::ZZMatrixOrPtr, x::ZZMatrixOrPtr, y::IntegerUnionOrPtr, ::ZZMatrixOrPtr) = addmul!(z, x, y)
 addmul!(z::ZZMatrixOrPtr, x::IntegerUnionOrPtr, y::ZZMatrixOrPtr, ::ZZMatrixOrPtr) = addmul!(z, x, y)
 
-function submul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::ZZRingElemOrPtr)
+function submul!(z::ZZMatrixOrPtr, a::ZZMatrixOrPtr, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_mat_scalar_submul_fmpz(z::Ref{ZZMatrix}, a::Ref{ZZMatrix}, b::Ref{ZZRingElem})::Nothing
   return z
 end

--- a/src/flint/fmpz_mod.jl
+++ b/src/flint/fmpz_mod.jl
@@ -420,7 +420,7 @@ function pow!(z::ZZModRingElem, x::ZZModRingElem, n::Integer)
   return z
 end
 
-function pow!(z::ZZModRingElem, x::ZZModRingElem, n::ZZRingElemOrPtr)
+function pow!(z::ZZModRingElem, x::ZZModRingElem, n::TypeOrPtr{ZZRingElem})
   R = parent(z)
   ok = Bool(@ccall libflint.fmpz_mod_pow_fmpz(z.data::Ref{ZZRingElem}, x.data::Ref{ZZRingElem}, n::Ref{ZZRingElem}, R.ninv::Ref{fmpz_mod_ctx_struct})::Cint)
   if !ok

--- a/src/flint/fmpz_mod_mat.jl
+++ b/src/flint/fmpz_mod_mat.jl
@@ -165,7 +165,7 @@ function AbstractAlgebra.multiply_row!(A::Zmod_fmpz_mat, s::ZZModRingElem, i::In
   return A
 end
 
-function AbstractAlgebra.multiply_column!(A::Zmod_fmpz_mat, s::ZZModRingElemOrPtr, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
+function AbstractAlgebra.multiply_column!(A::Zmod_fmpz_mat, s::TypeOrPtr{ZZModRingElem}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
   @assert 1 <= j <= ncols(A)
   @assert 1 <= first(rows)
   @assert last(rows) <= nrows(A)
@@ -202,7 +202,7 @@ function AbstractAlgebra.add_row!(A::Zmod_fmpz_mat, s::ZZModRingElem, i::Int, j:
   return A
 end
 
-function AbstractAlgebra.add_column!(A::Zmod_fmpz_mat, s::ZZModRingElemOrPtr, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
+function AbstractAlgebra.add_column!(A::Zmod_fmpz_mat, s::TypeOrPtr{ZZModRingElem}, i::Int, j::Int, rows::UnitRange{Int}=1:nrows(A))
   @assert 1 <= i <= ncols(A)
   @assert 1 <= j <= ncols(A)
   @assert 1 <= first(rows)

--- a/src/flint/fmpz_mpoly.jl
+++ b/src/flint/fmpz_mpoly.jl
@@ -597,7 +597,7 @@ function set!(z::ZZMPolyRingElem, a::ZZMPolyRingElem)
   return z
 end
 
-function set!(z::ZZMPolyRingElem, a::ZZRingElemOrPtr)
+function set!(z::ZZMPolyRingElem, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_mpoly_set_fmpz(z::Ref{ZZMPolyRingElem}, a::Ref{ZZRingElem}, parent(z)::Ref{ZZMPolyRing})::Nothing
   return z
 end
@@ -715,7 +715,7 @@ function pow!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, n::Integer)
   return z
 end
 
-function pow!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, n::ZZRingElemOrPtr)
+function pow!(z::ZZMPolyRingElem, a::ZZMPolyRingElem, n::TypeOrPtr{ZZRingElem})
   ok = Bool(@ccall libflint.fmpz_mpoly_pow_fmpz(z::Ref{ZZMPolyRingElem}, a::Ref{ZZMPolyRingElem}, n::Ref{ZZRingElem}, parent(a)::Ref{ZZMPolyRing})::Cint)
   if !ok
     error("unable to compute power")

--- a/src/flint/fmpz_poly.jl
+++ b/src/flint/fmpz_poly.jl
@@ -238,7 +238,7 @@ function reverse(x::ZZPolyRingElem, len::Int)
   return reverse!(parent(x)(), x, len)
 end
 
-function reverse!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
+function reverse!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, len::Int)
   @ccall libflint.fmpz_poly_reverse(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -254,7 +254,7 @@ function shift_left(x::ZZPolyRingElem, len::Int)
   return shift_left!(parent(x)(), x, len)
 end
 
-function shift_left!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
+function shift_left!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, len::Int)
   @ccall libflint.fmpz_poly_shift_left(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -264,7 +264,7 @@ function shift_right(x::ZZPolyRingElem, len::Int)
   return shift_right!(parent(x)(), x, len)
 end
 
-function shift_right!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, len::Int)
+function shift_right!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, len::Int)
   @ccall libflint.fmpz_poly_shift_right(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, len::Int)::Nothing
   return z
 end
@@ -783,188 +783,188 @@ end
 #
 ###############################################################################
 
-function zero!(z::ZZPolyRingElemOrPtr)
+function zero!(z::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_zero(z::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function one!(z::ZZPolyRingElemOrPtr)
+function one!(z::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_one(z::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function neg!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr)
+function neg!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_neg(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function fit!(z::ZZPolyRingElemOrPtr, n::Int)
+function fit!(z::TypeOrPtr{ZZPolyRingElem}, n::Int)
   @ccall libflint.fmpz_poly_fit_length(z::Ref{ZZPolyRingElem}, n::Int)::Nothing
   return nothing
 end
 
 #
 
-function set!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr)
+function set!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_set(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function set!(z::ZZPolyRingElemOrPtr, a::ZZRingElemOrPtr)
+function set!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_set_fmpz(z::Ref{ZZPolyRingElem}, a::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function set!(z::ZZPolyRingElemOrPtr, a::Int)
+function set!(z::TypeOrPtr{ZZPolyRingElem}, a::Int)
   @ccall libflint.fmpz_poly_set_si(z::Ref{ZZPolyRingElem}, a::Int)::Nothing
   return z
 end
 
-function set!(z::ZZPolyRingElemOrPtr, a::UInt)
+function set!(z::TypeOrPtr{ZZPolyRingElem}, a::UInt)
   @ccall libflint.fmpz_poly_set_ui(z::Ref{ZZPolyRingElem}, a::UInt)::Nothing
   return z
 end
 
-set!(z::ZZPolyRingElemOrPtr, a::Integer) = set!(z, flintify(a))
+set!(z::TypeOrPtr{ZZPolyRingElem}, a::Integer) = set!(z, flintify(a))
 
 #
 
-function setcoeff!(z::ZZPolyRingElemOrPtr, n::Int, x::ZZRingElemOrPtr)
+function setcoeff!(z::TypeOrPtr{ZZPolyRingElem}, n::Int, x::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_set_coeff_fmpz(z::Ref{ZZPolyRingElem}, n::Int, x::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function setcoeff!(z::ZZPolyRingElemOrPtr, n::Int, x::Int)
+function setcoeff!(z::TypeOrPtr{ZZPolyRingElem}, n::Int, x::Int)
   @ccall libflint.fmpz_poly_set_coeff_si(z::Ref{ZZPolyRingElem}, n::Int, x::Int)::Nothing
   return z
 end
 
-function setcoeff!(z::ZZPolyRingElemOrPtr, n::Int, x::UInt)
+function setcoeff!(z::TypeOrPtr{ZZPolyRingElem}, n::Int, x::UInt)
   @ccall libflint.fmpz_poly_set_coeff_ui(z::Ref{ZZPolyRingElem}, n::Int, x::UInt)::Nothing
   return z
 end
 
-setcoeff!(z::ZZPolyRingElemOrPtr, n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
+setcoeff!(z::TypeOrPtr{ZZPolyRingElem}, n::Int, x::Integer) = setcoeff!(z, n, flintify(x))
 
 #
 
-function add!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZPolyRingElemOrPtr)
+function add!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_add(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function add!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function add!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_add_fmpz(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function add!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Int)
+function add!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Int)
   @ccall libflint.fmpz_poly_add_si(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-add!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Integer) = add!(z, x, flintify(y))
+add!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Integer) = add!(z, x, flintify(y))
 
-add!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr) = add!(z, y, x)
+add!(z::TypeOrPtr{ZZPolyRingElem}, x::IntegerUnionOrPtr, y::TypeOrPtr{ZZPolyRingElem}) = add!(z, y, x)
 
 #
 
-function sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_sub(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function sub!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_sub_fmpz(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Int)
+function sub!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Int)
   @ccall libflint.fmpz_poly_sub_si(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-function sub!(z::ZZPolyRingElemOrPtr, x::ZZRingElemOrPtr, y::ZZPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZRingElem}, y::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_fmpz_sub(z::Ref{ZZPolyRingElem}, x::Ref{ZZRingElem}, y::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function sub!(z::ZZPolyRingElemOrPtr, x::Int, y::ZZPolyRingElemOrPtr)
+function sub!(z::TypeOrPtr{ZZPolyRingElem}, x::Int, y::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_si_sub(z::Ref{ZZPolyRingElem}, x::Int, y::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-sub!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Integer) = sub!(z, x, flintify(y))
+sub!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Integer) = sub!(z, x, flintify(y))
 
-sub!(z::ZZPolyRingElemOrPtr, x::Integer, y::ZZPolyRingElemOrPtr) = sub!(z, flintify(x), y)
+sub!(z::TypeOrPtr{ZZPolyRingElem}, x::Integer, y::TypeOrPtr{ZZPolyRingElem}) = sub!(z, flintify(x), y)
 
 #
 
-function mul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZPolyRingElemOrPtr)
+function mul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fmpz_poly_mul(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZPolyRingElem})::Nothing
   return z
 end
 
-function mul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::ZZRingElemOrPtr)
+function mul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_scalar_mul_fmpz(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function mul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Int)
+function mul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Int)
   @ccall libflint.fmpz_poly_scalar_mul_si(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::Int)::Nothing
   return z
 end
 
-function mul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::UInt)
+function mul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::UInt)
   @ccall libflint.fmpz_poly_scalar_mul_ui(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, y::UInt)::Nothing
   return z
 end
 
-mul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::Integer) = mul!(z, x, flintify(y))
+mul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::Integer) = mul!(z, x, flintify(y))
 
-mul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr) = mul!(z, y, x)
+mul!(z::TypeOrPtr{ZZPolyRingElem}, x::IntegerUnionOrPtr, y::TypeOrPtr{ZZPolyRingElem}) = mul!(z, y, x)
 
 #
 
-function addmul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::ZZRingElemOrPtr)
+function addmul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_scalar_addmul_fmpz(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-function addmul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::Int)
+function addmul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::Int)
   @ccall libflint.fmpz_poly_scalar_addmul_si(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem}, b::Int)::Nothing
   return z
 end
 
-function addmul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::UInt)
+function addmul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::UInt)
   @ccall libflint.fmpz_poly_scalar_addmul_ui(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem}, b::UInt)::Nothing
   return z
 end
 
-addmul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::Integer) = addmul!(z, a, flintify(b))
-addmul!(z::ZZPolyRingElemOrPtr, a::IntegerUnionOrPtr, b::ZZPolyRingElemOrPtr) = addmul!(z, b, a)
+addmul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::Integer) = addmul!(z, a, flintify(b))
+addmul!(z::TypeOrPtr{ZZPolyRingElem}, a::IntegerUnionOrPtr, b::TypeOrPtr{ZZPolyRingElem}) = addmul!(z, b, a)
 
 # ignore fourth argument
-addmul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::IntegerUnionOrPtr, ::ZZPolyRingElemOrPtr) = addmul!(z, x, y)
-addmul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr, ::ZZPolyRingElemOrPtr) = addmul!(z, x, y)
+addmul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::IntegerUnionOrPtr, ::TypeOrPtr{ZZPolyRingElem}) = addmul!(z, x, y)
+addmul!(z::TypeOrPtr{ZZPolyRingElem}, x::IntegerUnionOrPtr, y::TypeOrPtr{ZZPolyRingElem}, ::TypeOrPtr{ZZPolyRingElem}) = addmul!(z, x, y)
 
 #
 
-function submul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::ZZRingElemOrPtr)
+function submul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::TypeOrPtr{ZZRingElem})
   @ccall libflint.fmpz_poly_scalar_submul_fmpz(z::Ref{ZZPolyRingElem}, a::Ref{ZZPolyRingElem}, b::Ref{ZZRingElem})::Nothing
   return z
 end
 
-submul!(z::ZZPolyRingElemOrPtr, a::ZZPolyRingElemOrPtr, b::Integer) = addmul!(z, a, ZZRingElem(b))
-submul!(z::ZZPolyRingElemOrPtr, a::IntegerUnionOrPtr, b::ZZPolyRingElemOrPtr) = addmul!(z, b, a)
+submul!(z::TypeOrPtr{ZZPolyRingElem}, a::TypeOrPtr{ZZPolyRingElem}, b::Integer) = addmul!(z, a, ZZRingElem(b))
+submul!(z::TypeOrPtr{ZZPolyRingElem}, a::IntegerUnionOrPtr, b::TypeOrPtr{ZZPolyRingElem}) = addmul!(z, b, a)
 
 # ignore fourth argument
-submul!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, y::IntegerUnionOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
-submul!(z::ZZPolyRingElemOrPtr, x::IntegerUnionOrPtr, y::ZZPolyRingElemOrPtr, ::ZZPolyRingElemOrPtr) = submul!(z, x, y)
+submul!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, y::IntegerUnionOrPtr, ::TypeOrPtr{ZZPolyRingElem}) = submul!(z, x, y)
+submul!(z::TypeOrPtr{ZZPolyRingElem}, x::IntegerUnionOrPtr, y::TypeOrPtr{ZZPolyRingElem}, ::TypeOrPtr{ZZPolyRingElem}) = submul!(z, x, y)
 
 #
 
-function pow!(z::ZZPolyRingElemOrPtr, x::ZZPolyRingElemOrPtr, e::IntegerUnion)
+function pow!(z::TypeOrPtr{ZZPolyRingElem}, x::TypeOrPtr{ZZPolyRingElem}, e::IntegerUnion)
   @ccall libflint.fmpz_poly_pow(z::Ref{ZZPolyRingElem}, x::Ref{ZZPolyRingElem}, UInt(e)::UInt)::Nothing
   return z
 end

--- a/src/flint/fq.jl
+++ b/src/flint/fq.jl
@@ -457,7 +457,7 @@ end
 
 #
 
-function set!(z::FqPolyRepFieldElem, a::FqPolyRepFieldElemOrPtr)
+function set!(z::FqPolyRepFieldElem, a::TypeOrPtr{FqPolyRepFieldElem})
   @ccall libflint.fq_set(z::Ref{FqPolyRepFieldElem}, a::Ref{FqPolyRepFieldElem}, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 
@@ -469,21 +469,21 @@ function set!(z::FqPolyRepFieldElem, a::UInt)
   @ccall libflint.fq_set_ui(z::Ref{FqPolyRepFieldElem}, a::UInt, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 
-function set!(z::FqPolyRepFieldElem, a::ZZRingElemOrPtr)
+function set!(z::FqPolyRepFieldElem, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fq_set_fmpz(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 
 set!(z::FqPolyRepFieldElem, a::Integer) = set!(z, flintify(a))
 
-function set!(z::FqPolyRepFieldElem, a::ZZPolyRingElemOrPtr)
+function set!(z::FqPolyRepFieldElem, a::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fq_set_fmpz_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 
-function set!(z::FqPolyRepFieldElem, a::ZZModPolyRingElemOrPtr)
+function set!(z::FqPolyRepFieldElem, a::TypeOrPtr{ZZModPolyRingElem})
   @ccall libflint.fq_set_fmpz_mod_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{ZZModPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 
-function set!(z::FqPolyRepFieldElem, a::FpPolyRingElemOrPtr)
+function set!(z::FqPolyRepFieldElem, a::TypeOrPtr{FpPolyRingElem})
   @ccall libflint.fq_set_fmpz_mod_poly(z::Ref{FqPolyRepFieldElem}, a::Ref{FpPolyRingElem}, parent(z)::Ref{FqPolyRepField})::Nothing
 end
 

--- a/src/flint/fq_default.jl
+++ b/src/flint/fq_default.jl
@@ -613,7 +613,7 @@ end
 
 #
 
-function set!(z::FqFieldElem, a::FqFieldElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{FqFieldElem})
   @ccall libflint.fq_default_set(z::Ref{FqFieldElem}, a::Ref{FqFieldElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
@@ -631,7 +631,7 @@ function set!(z::FqFieldElem, a::UInt)
   return z
 end
 
-function set!(z::FqFieldElem, a::ZZRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{ZZRingElem})
   @ccall libflint.fq_default_set_fmpz(z::Ref{FqFieldElem}, a::Ref{ZZRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
@@ -639,31 +639,31 @@ end
 
 set!(z::FqFieldElem, a::Integer) = set!(z, flintify(a))
 
-function set!(z::FqFieldElem, a::ZZPolyRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{ZZPolyRingElem})
   @ccall libflint.fq_default_set_fmpz_poly(z::Ref{FqFieldElem}, a::Ref{ZZPolyRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
 end
 
-function set!(z::FqFieldElem, a::zzModPolyRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{zzModPolyRingElem})
   @ccall libflint.fq_default_set_nmod_poly(z::Ref{FqFieldElem}, a::Ref{zzModPolyRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
 end
 
-function set!(z::FqFieldElem, a::fpPolyRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{fpPolyRingElem})
   @ccall libflint.fq_default_set_nmod_poly(z::Ref{FqFieldElem}, a::Ref{fpPolyRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
 end
 
-function set!(z::FqFieldElem, a::ZZModPolyRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{ZZModPolyRingElem})
   @ccall libflint.fq_default_set_fmpz_mod_poly(z::Ref{FqFieldElem}, a::Ref{ZZModPolyRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
 end
 
-function set!(z::FqFieldElem, a::FpPolyRingElemOrPtr)
+function set!(z::FqFieldElem, a::TypeOrPtr{FpPolyRingElem})
   @ccall libflint.fq_default_set_fmpz_mod_poly(z::Ref{FqFieldElem}, a::Ref{FpPolyRingElem}, parent(z)::Ref{FqField})::Nothing
   z.poly = nothing
   return z
@@ -693,7 +693,7 @@ function mul!(z::FqFieldElem, x::FqFieldElem, y::FqFieldElem)
   return z
 end
 
-function mul!(z::FqFieldElem, x::FqFieldElem, y::ZZRingElemOrPtr)
+function mul!(z::FqFieldElem, x::FqFieldElem, y::TypeOrPtr{ZZRingElem})
   @ccall libflint.fq_default_mul_fmpz(z::Ref{FqFieldElem}, x::Ref{FqFieldElem}, y::Ref{ZZRingElem}, x.parent::Ref{FqField})::Nothing
   z.poly = nothing
   return z
@@ -713,7 +713,7 @@ end
 
 mul!(z::FqFieldElem, x::FqFieldElem, y::Integer) = mul!(z, x, flintify(y))
 
-mul!(z::FqFieldElem, x::ZZRingElemOrPtr, y::FqFieldElem) = mul!(z, y, x)
+mul!(z::FqFieldElem, x::TypeOrPtr{ZZRingElem}, y::FqFieldElem) = mul!(z, y, x)
 mul!(z::FqFieldElem, x::Integer, y::FqFieldElem) = mul!(z, y, x)
 
 ###############################################################################

--- a/src/flint/fq_default_mat.jl
+++ b/src/flint/fq_default_mat.jl
@@ -33,7 +33,7 @@ end
   return z
 end
 
-@inline function setindex!(a::FqMatrix, u::FqFieldElemOrPtr, i::Int, j::Int)
+@inline function setindex!(a::FqMatrix, u::TypeOrPtr{FqFieldElem}, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
   uu = base_ring(a)(u)
   @ccall libflint.fq_default_mat_entry_set(

--- a/src/flint/fq_mat.jl
+++ b/src/flint/fq_mat.jl
@@ -39,7 +39,7 @@ end
   return z
 end
 
-@inline function setindex!(a::FqPolyRepMatrix, u::FqPolyRepFieldElemOrPtr, i::Int, j::Int)
+@inline function setindex!(a::FqPolyRepMatrix, u::TypeOrPtr{FqPolyRepFieldElem}, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
   @ccall libflint.fq_mat_entry_set(
     a::Ref{FqPolyRepMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{FqPolyRepFieldElem}, base_ring(a)::Ref{FqPolyRepField}

--- a/src/flint/fq_nmod.jl
+++ b/src/flint/fq_nmod.jl
@@ -438,11 +438,11 @@ function neg!(z::fqPolyRepFieldElem, a::fqPolyRepFieldElem)
   return z
 end
 
-function set!(z::fqPolyRepFieldElem, x::fqPolyRepFieldElemOrPtr)
+function set!(z::fqPolyRepFieldElem, x::TypeOrPtr{fqPolyRepFieldElem})
   @ccall libflint.fq_nmod_set(z::Ref{fqPolyRepFieldElem}, x::Ref{fqPolyRepFieldElem}, parent(z)::Ref{fqPolyRepField})::Nothing
 end
 
-function set!(z::fqPolyRepFieldElem, x::ZZRingElemOrPtr)
+function set!(z::fqPolyRepFieldElem, x::TypeOrPtr{ZZRingElem})
   @ccall libflint.fq_nmod_set_fmpz(z::Ref{fqPolyRepFieldElem}, x::Ref{ZZRingElem}, parent(z)::Ref{fqPolyRepField})::Nothing
 end
 
@@ -454,7 +454,7 @@ function set!(z::fqPolyRepFieldElem, x::UInt)
   @ccall libflint.fq_nmod_set_ui(z::Ref{fqPolyRepFieldElem}, x::UInt, parent(z)::Ref{fqPolyRepField})::Nothing
 end
 
-function set!(z::fqPolyRepFieldElem, x::fpPolyRingElemOrPtr)
+function set!(z::fqPolyRepFieldElem, x::TypeOrPtr{fpPolyRingElem})
   @ccall libflint.fq_nmod_set_nmod_poly(z::Ref{fqPolyRepFieldElem}, x::Ref{fpPolyRingElem}, parent(z)::Ref{fqPolyRepField})::Nothing
 end
 

--- a/src/flint/fq_nmod_mat.jl
+++ b/src/flint/fq_nmod_mat.jl
@@ -39,7 +39,7 @@ end
   return z
 end
 
-@inline function setindex!(a::fqPolyRepMatrix, u::fqPolyRepFieldElemOrPtr, i::Int, j::Int)
+@inline function setindex!(a::fqPolyRepMatrix, u::TypeOrPtr{fqPolyRepFieldElem}, i::Int, j::Int)
   @boundscheck _checkbounds(a, i, j)
   @ccall libflint.fq_nmod_mat_entry_set(
     a::Ref{fqPolyRepMatrix}, (i-1)::Int, (j-1)::Int, u::Ref{fqPolyRepFieldElem}, base_ring(a)::Ref{fqPolyRepField}


### PR DESCRIPTION
The replacement was performed using a small script written by Codex.