### PR TITLE
Bump version to 0.56.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Nemo"
 uuid = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-version = "0.56.0"
+version = "0.56.1"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
Changelog changes in https://github.com/Nemocas/Nemo.jl/pull/2335.

This is mostly for getting FLINT foward. It will not land in Oscar yet, as there is also a bump in Hecke needed (cf https://github.com/thofma/Hecke.jl/pull/2291).