### PR TITLE
Fix three-arg `+`, `-`, `*`, `//` for real and complex fields

### DIFF
--- a/src/arb/Complex.jl
+++ b/src/arb/Complex.jl
@@ -195,9 +195,9 @@ end
 
 for (s,f) in ((:+,"acb_add"), (:*,"acb_mul"), (://, "acb_div"), (:-,"acb_sub"), (:^,"acb_pow"))
   @eval begin
-    function ($s)(x::ComplexFieldElem, y::ComplexFieldElem, prec::Int = precision(Balls))
+    function ($s)(x::ComplexFieldElem, y::ComplexFieldElem; precision::Int = precision(Balls))
       z = ComplexFieldElem()
-      @ccall libflint.$f(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{ComplexFieldElem}, prec::Int)::Nothing
+      @ccall libflint.$f(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{ComplexFieldElem}, precision::Int)::Nothing
       return z
     end
   end
@@ -206,27 +206,27 @@ end
 for (f,s) in ((:+, "add"), (:-, "sub"), (:*, "mul"), (://, "div"), (:^, "pow"))
   @eval begin
 
-    function ($f)(x::ComplexFieldElem, y::UInt, prec::Int = precision(Balls))
+    function ($f)(x::ComplexFieldElem, y::UInt; precision::Int = precision(Balls))
       z = ComplexFieldElem()
-      @ccall libflint.$("acb_"*s*"_ui")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::UInt, prec::Int)::Nothing
+      @ccall libflint.$("acb_"*s*"_ui")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::UInt, precision::Int)::Nothing
       return z
     end
 
-    function ($f)(x::ComplexFieldElem, y::Int, prec::Int = precision(Balls))
+    function ($f)(x::ComplexFieldElem, y::Int; precision::Int = precision(Balls))
       z = ComplexFieldElem()
-      @ccall libflint.$("acb_"*s*"_si")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Int, prec::Int)::Nothing
+      @ccall libflint.$("acb_"*s*"_si")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Int, precision::Int)::Nothing
       return z
     end
 
-    function ($f)(x::ComplexFieldElem, y::ZZRingElem, prec::Int = precision(Balls))
+    function ($f)(x::ComplexFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
       z = ComplexFieldElem()
-      @ccall libflint.$("acb_"*s*"_fmpz")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{ZZRingElem}, prec::Int)::Nothing
+      @ccall libflint.$("acb_"*s*"_fmpz")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{ZZRingElem}, precision::Int)::Nothing
       return z
     end
 
-    function ($f)(x::ComplexFieldElem, y::RealFieldElem, prec::Int = precision(Balls))
+    function ($f)(x::ComplexFieldElem, y::RealFieldElem; precision::Int = precision(Balls))
       z = ComplexFieldElem()
-      @ccall libflint.$("acb_"*s*"_arb")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
+      @ccall libflint.$("acb_"*s*"_arb")(z::Ref{ComplexFieldElem}, x::Ref{ComplexFieldElem}, y::Ref{RealFieldElem}, precision::Int)::Nothing
       return z
     end
   end

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -614,9 +614,9 @@ end
 
 for (s,f) in ((:+,"arb_add"), (:*,"arb_mul"), (://, "arb_div"), (:-,"arb_sub"))
   @eval begin
-    function ($s)(x::RealFieldElem, y::RealFieldElem, prec::Int = precision(Balls))
+    function ($s)(x::RealFieldElem, y::RealFieldElem; precision::Int = precision(Balls))
       z = RealFieldElem()
-      @ccall libflint.$f(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
+      @ccall libflint.$f(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, precision::Int)::Nothing
       return z
     end
   end
@@ -632,29 +632,29 @@ for (f,s) in ((:+, "add"), (:*, "mul"))
 
     #($f)(x::arf, y::RealFieldElem) = ($f)(y, x)
 
-    function ($f)(x::RealFieldElem, y::UInt, prec::Int = precision(Balls))
+    function ($f)(x::RealFieldElem, y::UInt; precision::Int = precision(Balls))
       z = RealFieldElem()
-      @ccall libflint.$("arb_$(s)_ui")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, prec::Int)::Nothing
+      @ccall libflint.$("arb_$(s)_ui")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, precision::Int)::Nothing
       return z
     end
 
     ($f)(x::UInt, y::RealFieldElem) = ($f)(y, x)
 
-    function ($f)(x::RealFieldElem, y::Int, prec::Int = precision(Balls))
+    function ($f)(x::RealFieldElem, y::Int; precision::Int = precision(Balls))
       z = RealFieldElem()
-      @ccall libflint.$("arb_$(s)_si")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, prec::Int)::Nothing
+      @ccall libflint.$("arb_$(s)_si")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, precision::Int)::Nothing
       return z
     end
 
-    ($f)(x::Int, y::RealFieldElem, prec::Int = precision(Balls)) = ($f)(y, x, prec)
+    ($f)(x::Int, y::RealFieldElem; precision::Int = precision(Balls)) = ($f)(y, x; precision)
 
-    function ($f)(x::RealFieldElem, y::ZZRingElem, prec::Int = precision(Balls))
+    function ($f)(x::RealFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
       z = RealFieldElem()
-      @ccall libflint.$("arb_$(s)_fmpz")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, prec::Int)::Nothing
+      @ccall libflint.$("arb_$(s)_fmpz")(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, precision::Int)::Nothing
       return z
     end
 
-    ($f)(x::ZZRingElem, y::RealFieldElem, prec::Int = precision(Balls)) = ($f)(y, x, prec)
+    ($f)(x::ZZRingElem, y::RealFieldElem; precision::Int = precision(Balls)) = ($f)(y, x; precision)
   end
 end
 
@@ -667,25 +667,25 @@ end
 
 #-(x::arf, y::RealFieldElem) = -(y - x)
 
-function -(x::RealFieldElem, y::UInt, prec::Int = precision(Balls))
+function -(x::RealFieldElem, y::UInt; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_sub_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, prec::Int)::Nothing
+  @ccall libflint.arb_sub_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, precision::Int)::Nothing
   return z
 end
 
 -(x::UInt, y::RealFieldElem) = -(y - x)
 
-function -(x::RealFieldElem, y::Int, prec::Int = precision(Balls))
+function -(x::RealFieldElem, y::Int; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_sub_si(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, prec::Int)::Nothing
+  @ccall libflint.arb_sub_si(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, precision::Int)::Nothing
   return z
 end
 
 -(x::Int, y::RealFieldElem) = -(y - x)
 
-function -(x::RealFieldElem, y::ZZRingElem, prec::Int = precision(Balls))
+function -(x::RealFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_sub_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, prec::Int)::Nothing
+  @ccall libflint.arb_sub_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, precision::Int)::Nothing
   return z
 end
 
@@ -714,67 +714,67 @@ end
 #  return z
 #end
 
-function //(x::RealFieldElem, y::UInt, prec::Int = precision(Balls))
+function //(x::RealFieldElem, y::UInt; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_div_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, prec::Int)::Nothing
+  @ccall libflint.arb_div_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, precision::Int)::Nothing
   return z
 end
 
-function //(x::RealFieldElem, y::Int, prec::Int = precision(Balls))
+function //(x::RealFieldElem, y::Int; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_div_si(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, prec::Int)::Nothing
+  @ccall libflint.arb_div_si(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Int, precision::Int)::Nothing
   return z
 end
 
-function //(x::RealFieldElem, y::ZZRingElem, prec::Int = precision(Balls))
+function //(x::RealFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_div_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, prec::Int)::Nothing
+  @ccall libflint.arb_div_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, precision::Int)::Nothing
   return z
 end
 
-function //(x::UInt, y::RealFieldElem, prec::Int = precision(Balls))
+function //(x::UInt, y::RealFieldElem; precision::Int = precision(Balls))
   z = parent(y)()
-  @ccall libflint.arb_ui_div(z::Ref{RealFieldElem}, x::UInt, y::Ref{RealFieldElem}, prec::Int)::Nothing
+  @ccall libflint.arb_ui_div(z::Ref{RealFieldElem}, x::UInt, y::Ref{RealFieldElem}, precision::Int)::Nothing
   return z
 end
 
-function //(x::Int, y::RealFieldElem, prec::Int = precision(Balls))
-  z = parent(y)()
-  t = RealFieldElem(x)
-  @ccall libflint.arb_div(z::Ref{RealFieldElem}, t::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
-  return z
-end
-
-function //(x::ZZRingElem, y::RealFieldElem, prec::Int = precision(Balls))
+function //(x::Int, y::RealFieldElem; precision::Int = precision(Balls))
   z = parent(y)()
   t = RealFieldElem(x)
-  @ccall libflint.arb_div(z::Ref{RealFieldElem}, t::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
+  @ccall libflint.arb_div(z::Ref{RealFieldElem}, t::Ref{RealFieldElem}, y::Ref{RealFieldElem}, precision::Int)::Nothing
   return z
 end
 
-function ^(x::RealFieldElem, y::RealFieldElem, prec::Int = precision(Balls))
-  z = RealFieldElem()
-  @ccall libflint.arb_pow(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, prec::Int)::Nothing
+function //(x::ZZRingElem, y::RealFieldElem; precision::Int = precision(Balls))
+  z = parent(y)()
+  t = RealFieldElem(x)
+  @ccall libflint.arb_div(z::Ref{RealFieldElem}, t::Ref{RealFieldElem}, y::Ref{RealFieldElem}, precision::Int)::Nothing
   return z
 end
 
-function ^(x::RealFieldElem, y::ZZRingElem, prec::Int = precision(Balls))
+function ^(x::RealFieldElem, y::RealFieldElem; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_pow_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, prec::Int)::Nothing
+  @ccall libflint.arb_pow(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{RealFieldElem}, precision::Int)::Nothing
   return z
 end
 
-^(x::RealFieldElem, y::Integer, prec::Int = precision(Balls)) = ^(x, ZZRingElem(y), prec)
-
-function ^(x::RealFieldElem, y::UInt, prec::Int = precision(Balls))
+function ^(x::RealFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_pow_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, prec::Int)::Nothing
+  @ccall libflint.arb_pow_fmpz(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{ZZRingElem}, precision::Int)::Nothing
   return z
 end
 
-function ^(x::RealFieldElem, y::QQFieldElem, prec::Int = precision(Balls))
+^(x::RealFieldElem, y::Integer; precision::Int = precision(Balls)) = ^(x, ZZRingElem(y), precision)
+
+function ^(x::RealFieldElem, y::UInt; precision::Int = precision(Balls))
   z = RealFieldElem()
-  @ccall libflint.arb_pow_fmpq(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{QQFieldElem}, prec::Int)::Nothing
+  @ccall libflint.arb_pow_ui(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::UInt, precision::Int)::Nothing
+  return z
+end
+
+function ^(x::RealFieldElem, y::QQFieldElem; precision::Int = precision(Balls))
+  z = RealFieldElem()
+  @ccall libflint.arb_pow_fmpq(z::Ref{RealFieldElem}, x::Ref{RealFieldElem}, y::Ref{QQFieldElem}, precision::Int)::Nothing
   return z
 end
 

--- a/src/arb/Real.jl
+++ b/src/arb/Real.jl
@@ -764,7 +764,7 @@ function ^(x::RealFieldElem, y::ZZRingElem; precision::Int = precision(Balls))
   return z
 end
 
-^(x::RealFieldElem, y::Integer; precision::Int = precision(Balls)) = ^(x, ZZRingElem(y), precision)
+^(x::RealFieldElem, y::Integer; precision::Int = precision(Balls)) = ^(x, ZZRingElem(y); precision)
 
 function ^(x::RealFieldElem, y::UInt; precision::Int = precision(Balls))
   z = RealFieldElem()

--- a/test/arb/Complex-test.jl
+++ b/test/arb/Complex-test.jl
@@ -565,3 +565,12 @@ end
   @test overlaps(res, CC(const_e(parent(real(zero(CC))))) - 1)
   @test radius(real(res)) < 1.0e-6
 end
+
+@testset "#1925" begin
+  C = complex_field()
+
+  @test C(1)+C(1)+1 == (C(1)+C(1))+1
+  @test C(1)+1+1 == (C(1)+1)+1
+  @test C(2)*C(2)*2 == (C(2)*C(2))*2
+  @test C(2)*2*2 == (C(2)*2)*2
+end

--- a/test/arb/Real-test.jl
+++ b/test/arb/Real-test.jl
@@ -639,3 +639,12 @@ end
     @test r_special isa RealFieldElem
   end
 end
+
+@testset "#1925" begin
+  R = real_field()
+
+  @test R(1)+R(1)+1 == (R(1)+R(1))+1
+  @test R(1)+1+1 == (R(1)+1)+1
+  @test R(2)*R(2)*2 == (R(2)*R(2))*2
+  @test R(2)*2*2 == (R(2)*2)*2
+end


### PR DESCRIPTION
Resolves https://github.com/Nemocas/Nemo.jl/issues/2339. Resolves parts of https://github.com/Nemocas/Nemo.jl/issues/1925 (but does not close that yet as that issue is also about consistency with other arithmetic operations like `inv` and `sqrt`).

This is the clear bugfix and thus uncontroversial part of https://github.com/Nemocas/Nemo.jl/issues/1925.