### PR TITLE
Add "cyclotomic" to detailed printing of cyclotomic fields

### DIFF
--- a/src/antic/nf_elem.jl
+++ b/src/antic/nf_elem.jl
@@ -1143,9 +1143,8 @@ function show_cyclo(io::IO, a::AbsSimpleNumField)
 end
 
 function show_cyclo(io::IO, ::MIME"text/plain", a::AbsSimpleNumField)
-  # TODO: change to print something with "cyclotomic" in it
   @assert is_cyclo_type(a)
-  print(io, "Number field with defining polynomial ", defining_polynomial(a))
+  print(io, "Cyclotomic field of order $(get_attribute(a, :cyclo)) with defining polynomial ", defining_polynomial(a))
   println(io)
   io = pretty(io)
   print(io, Indent(), "over ", Lowercase(), QQ, Dedent())


### PR DESCRIPTION
Change the detailed printing of a cyclotomic field from
```
Number field with defining polynomial _$^4 + _$^3 + _$^2 + _$ + 1
  over rational field
```
to
```
Cyclotomic field of order 5 with defining polynomial _$^4 + _$^3 + _$^2 + _$ + 1
  over rational field
```
which I find much more helpful.

The only downside I see is that this needs at least 15 more characters. (But this grows only logarithmically in the order and the size of the polynomial already grows linear :))

Feel free to suggest other wordings.

If people are happy with this, I will start facing the fallout and fix doc tests.
