### PR TITLE
Fix closure box and test for them in CI

### DIFF
--- a/src/flint/fq_default_poly.jl
+++ b/src/flint/fq_default_poly.jl
@@ -786,12 +786,8 @@ function QadicField(f::FqPolyRingElem, prec::Int = 64, var::String = "a"; cached
 
   z = get_cached!(QadicBaseFqPol, (base_field, f), cached) do
     ctx_type = _fq_default_ctx_type(K)
-    if ctx_type == _FQ_DEFAULT_NMOD
-      _K = _get_raw_type(fpField, K)
-    else
-      @assert ctx_type == _FQ_DEFAULT_FMPZ_NMOD
-      _K = _get_raw_type(FpField, K)
-    end
+    @assert ctx_type in (_FQ_DEFAULT_NMOD, _FQ_DEFAULT_FMPZ_NMOD)
+    _K = ctx_type == _FQ_DEFAULT_NMOD ? _get_raw_type(fpField, K) : _get_raw_type(FpField, K)
     ff = map_coefficients(c -> _K(lift(ZZ, c)), f; cached = false)
     return QadicField(ff, prec, var; cached = false, check = check, base_field = base_field)[1]
   end

--- a/test/ClosureBoxes.jl
+++ b/test/ClosureBoxes.jl
@@ -1,0 +1,12 @@
+# Captured variables that are reassigned force Julia to allocate a `Core.Box`,
+# which defeats type inference. `Test.detect_closure_boxes` exists since
+# Julia 1.14.
+if isdefined(Test, :detect_closure_boxes)
+  @testset "Closure boxes" begin
+    boxes = Test.detect_closure_boxes(Nemo)
+    for (m, vars) in boxes
+      println("Boxed variable(s) ", join(vars, ", "), " in ", m)
+    end
+    @test length(boxes) == 0
+  end
+end

--- a/test/Nemo-test.jl
+++ b/test/Nemo-test.jl
@@ -1,6 +1,7 @@
 testlist = [
 # Aqua.jl
   "Aqua.jl",
+  "ClosureBoxes.jl",
 # Flint integration,
   "Flint_error_handling-test.jl",
 # Julia extensions


### PR DESCRIPTION
Julia 1.14 adds `Test.detect_closure_boxes` (JuliaLang/julia#60478), which lists methods whose lowered code allocates a `Core.Box`. A box appears when a closure captures a variable that is assigned more than once, and it defeats type inference for that variable.

Running it on Nemo found one method: `QadicField(::FqPolyRingElem, ...)` assigned `_K` in two branches of an `if` and then captured it in the coefficient-mapping closure. A ternary keeps it single-assigned.

A new test (`test/ClosureBoxes.jl`) runs the detector and requires zero hits. It is skipped on Julia versions lacking the function, so only the nightly CI job covers it until 1.14 is released. No workflow change is needed.

Companion to Nemocas/AbstractAlgebra.jl#2498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)